### PR TITLE
Improvement: create Token::get_ident_name function

### DIFF
--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -77,6 +77,13 @@ impl Token {
         };
         pos.clone()
     }
+
+    pub fn get_ident_name(token: &Token) -> &String {
+        match token {
+            Token::Ident(_, ident) => ident,
+            _ => unreachable!()
+        }
+    }
 }
 
 impl Display for Token {

--- a/src/typechecker/typechecker.rs
+++ b/src/typechecker/typechecker.rs
@@ -159,10 +159,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
             return Err(TypecheckerError::MissingRequiredAssignment { ident });
         }
 
-        let name = match &ident {
-            Token::Ident(_, ident_name) => ident_name,
-            _ => unreachable!()
-        };
+        let name = Token::get_ident_name(&ident);
 
         if let Some(ScopeBinding(orig_ident, _, _)) = self.scope.bindings.get(name) {
             let orig_ident = orig_ident.clone();
@@ -189,10 +186,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
     }
 
     fn visit_ident(&mut self, token: Token) -> Result<TypedAstNode, TypecheckerError> {
-        let name = match &token {
-            Token::Ident(_, ident_name) => ident_name,
-            _ => unreachable!()
-        };
+        let name = Token::get_ident_name(&token);
 
         match self.scope.bindings.get(name) {
             None => Err(TypecheckerError::UnknownIdentifier { ident: token }),
@@ -210,10 +204,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                 _ => unreachable!()
             };
             if !is_mutable {
-                let name = match &ident_tok {
-                    Token::Ident(_, ident_name) => ident_name,
-                    _ => unreachable!()
-                };
+                let name = Token::get_ident_name(&ident_tok);
                 let orig_ident = match self.scope.bindings.get(name) {
                     Some(ScopeBinding(orig_ident, _, _)) => orig_ident.clone(),
                     None => unreachable!()

--- a/src/typechecker/typechecker_error.rs
+++ b/src/typechecker/typechecker_error.rs
@@ -87,10 +87,7 @@ impl DisplayError for TypecheckerError {
                 format!("Invalid operator ({}:{})\n{}\n{}", pos.line, pos.col, cursor_line, message)
             }
             TypecheckerError::MissingRequiredAssignment { ident } => {
-                let ident = match ident {
-                    Token::Ident(_, ident) => ident,
-                    _ => unreachable!()
-                };
+                let ident = Token::get_ident_name(&ident);
                 let message = format!("'val' bindings must be initialized");
                 format!(
                     "Expected assignment for variable '{}' ({}:{})\n{}\n{}",
@@ -98,10 +95,7 @@ impl DisplayError for TypecheckerError {
                 )
             }
             TypecheckerError::DuplicateBinding { ident, orig_ident } => {
-                let ident = match ident {
-                    Token::Ident(_, ident) => ident,
-                    _ => unreachable!()
-                };
+                let ident = Token::get_ident_name(&ident);
                 let first_msg = format!("Duplicate variable '{}' ({}:{})\n{}", ident, pos.line, pos.col, cursor_line);
 
                 let pos = orig_ident.get_position();
@@ -115,20 +109,14 @@ impl DisplayError for TypecheckerError {
                 format!("{}\n{}", first_msg, second_msg)
             }
             TypecheckerError::UnknownIdentifier { ident } => {
-                let ident = match ident {
-                    Token::Ident(_, ident) => ident,
-                    _ => unreachable!()
-                };
+                let ident = Token::get_ident_name(&ident);
                 format!(
                     "Unknown identifier '{}' ({}:{})\n{}\nNo binding with that name visible in current scope",
                     ident, pos.line, pos.col, cursor_line
                 )
             }
             TypecheckerError::UnknownIdentifierType { ident } => {
-                let ident = match ident {
-                    Token::Ident(_, ident) => ident,
-                    _ => unreachable!()
-                };
+                let ident = Token::get_ident_name(&ident);
                 let msg = "It's possible that it hasn't been initialized";
 
                 format!(
@@ -144,10 +132,7 @@ impl DisplayError for TypecheckerError {
                 )
             }
             TypecheckerError::AssignmentToImmutable { orig_ident, token: _ } => {
-                let ident = match orig_ident {
-                    Token::Ident(_, ident) => ident,
-                    _ => unreachable!()
-                };
+                let ident = Token::get_ident_name(&orig_ident);
                 let first_msg = format!("Cannot assign to variable '{}' ({}:{})\n{}", ident, pos.line, pos.col, cursor_line);
 
                 let pos = orig_ident.get_position();

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -139,13 +139,10 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
         let line = token.get_position().line;
 
         let TypedBindingDeclNode { ident, expr, .. } = node;
-        let ident = match ident {
-            Token::Ident(_, ident) => ident,
-            _ => unreachable!() // We can assume it's an Ident; typechecking would have failed otherwise
-        };
+        let ident = Token::get_ident_name(&ident);
 
         let binding_idx = self.chunk.bindings.len();
-        self.chunk.bindings.insert(ident, binding_idx);
+        self.chunk.bindings.insert(ident.clone(), binding_idx);
 
         if let Some(node) = expr {
             self.visit(*node)?;
@@ -163,12 +160,9 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
     fn visit_identifier(&mut self, token: Token, _typ: Type, _is_mutable: bool) -> Result<(), ()> {
         let line = token.get_position().line;
 
-        let ident = match token {
-            Token::Ident(_, ident) => ident,
-            _ => unreachable!() // We can assume it's an Ident; typechecking would have failed otherwise
-        };
+        let ident = Token::get_ident_name(&token);
 
-        if let Some(binding_idx) = self.chunk.bindings.get(&ident) {
+        if let Some(binding_idx) = self.chunk.bindings.get(ident) {
             let const_idx = self.chunk.add_constant(Value::Int(*binding_idx as i64));
             self.chunk.write(Opcode::Constant as u8, line);
             self.chunk.write(const_idx, line);
@@ -184,10 +178,7 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
 
         let TypedAssignmentNode { target, expr, .. } = node;
         let ident = match *target {
-            TypedAstNode::Identifier(ident, _, _) => match ident {
-                Token::Ident(_, ident) => ident,
-                _ => unreachable!() // We can assume it's an Ident; typechecking would have failed otherwise
-            },
+            TypedAstNode::Identifier(ident, _, _) => Token::get_ident_name(&ident).clone(),
             _ => unreachable!() // We can assume it's an Identifier; typechecking would have failed otherwise
         };
 

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -177,12 +177,18 @@ impl<'a> VM<'a> {
                                 a || b
                             };
                             self.push(Value::Bool(res));
+                        } else {
+                            unreachable!()
                         }
+                    } else {
+                        unreachable!()
                     }
                 }
                 Opcode::Negate => {
                     if let Value::Bool(val) = self.pop_expect()? {
                         self.push(Value::Bool(!val));
+                    } else {
+                        unreachable!()
                     }
                 }
                 Opcode::LT => self.comp_values(Opcode::LT)?,
@@ -200,6 +206,8 @@ impl<'a> VM<'a> {
                             arr_items.push_front(Box::new(self.pop_expect()?));
                         }
                         self.push(Value::Obj(Obj::ArrayObj { value: arr_items.into() }));
+                    } else {
+                        unreachable!()
                     }
                 }
                 Opcode::Store => {
@@ -207,6 +215,8 @@ impl<'a> VM<'a> {
                         let var_idx = var_idx as usize;
                         let val = self.pop_expect()?;
                         self.vars.insert(var_idx, val);
+                    } else {
+                        unreachable!()
                     }
                 }
                 Opcode::Load => {
@@ -214,7 +224,11 @@ impl<'a> VM<'a> {
                         let var_idx = var_idx as usize;
                         if let Some(val) = self.vars.get(var_idx) {
                             self.push(val.clone());
+                        } else {
+                            unreachable!()
                         }
+                    } else {
+                        unreachable!()
                     }
                 }
                 Opcode::Return => break Ok(self.pop()),


### PR DESCRIPTION
  - Rather than matching on Token::Ident whenever we "know" it's an identifier, pull that out into the Token::get_ident_name function