### PR TITLE
Ensure top of stack is always pure

### DIFF
--- a/abra_core/src/common/typed_ast_visitor.rs
+++ b/abra_core/src/common/typed_ast_visitor.rs
@@ -15,7 +15,7 @@ pub trait TypedAstVisitor<V, E> {
             Identifier(tok, node) => self.visit_identifier(tok, node),
             Assignment(tok, node) => self.visit_assignment(tok, node),
             Indexing(tok, node) => self.visit_indexing(tok, node),
-            IfStatement(tok, node) => self.visit_if_statement(tok, node),
+            IfStatement(tok, node) => self.visit_if_statement(true, tok, node),
             IfExpression(tok, node) => self.visit_if_expression(tok, node),
             Invocation(tok, node) => self.visit_invocation(tok, node),
         }
@@ -31,7 +31,7 @@ pub trait TypedAstVisitor<V, E> {
     fn visit_identifier(&mut self, token: Token, node: TypedIdentifierNode) -> Result<V, E>;
     fn visit_assignment(&mut self, token: Token, node: TypedAssignmentNode) -> Result<V, E>;
     fn visit_indexing(&mut self, token: Token, node: TypedIndexingNode) -> Result<V, E>;
-    fn visit_if_statement(&mut self, token: Token, node: TypedIfNode) -> Result<V, E>;
+    fn visit_if_statement(&mut self, is_stmt: bool, token: Token, node: TypedIfNode) -> Result<V, E>;
     fn visit_if_expression(&mut self, token: Token, node: TypedIfNode) -> Result<V, E>;
     fn visit_invocation(&mut self, token: Token, node: TypedInvocationNode) -> Result<V, E>;
 }

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -50,6 +50,7 @@ pub enum Opcode {
     Jump,
     JumpIfF,
     Invoke,
+    Pop,
     Return,
 }
 
@@ -105,7 +106,8 @@ impl From<u8> for Opcode {
             46 => Opcode::Jump,
             47 => Opcode::JumpIfF,
             48 => Opcode::Invoke,
-            49 => Opcode::Return,
+            49 => Opcode::Pop,
+            50 => Opcode::Return,
             _ => unreachable!()
         }
     }

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -388,6 +388,9 @@ impl<'a> VM<'a> {
                     self.call_stack.push(frame);
                     self.ip = 0;
                 }
+                Opcode::Pop => {
+                    self.pop_expect()?;
+                },
                 Opcode::Return => {
                     let CallFrame { chunk_name, .. } = self.curr_chunk();
                     let chunk_name = chunk_name.clone();

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -389,54 +389,74 @@ mod tests {
     #[test]
     fn interpret_if_else_statements() {
         let input = "\
+          var res = 0\
           if (1 != 2) {\
             val a = 123\
-            a\
+            res = a\
           } else {\
-            456\
+            res = 456\
           }
+        ";
+        let result = interpret(input);
+        assert!(result.is_none());
+
+        let input = "\
+          var res = 0\
+          if (1 != 2) {\
+            val a = 123\
+            res = a\
+          } else {\
+            res = 456\
+          }\
+          res
         ";
         let result = interpret(input).unwrap();
         let expected = Value::Int(123);
         assert_eq!(expected, result);
 
         let input = "\
+          var res = 0\
           if (1 == 2) {\
-            123\
+            res = 123\
           } else {\
-            456\
-          }
+            res = 456\
+          }\
+          res
         ";
         let result = interpret(input).unwrap();
         let expected = Value::Int(456);
         assert_eq!(expected, result);
 
         let input = "\
+          var res = 0\
           if (1 == 2) {\
-            123\
+            res = 123\
           } else if (2 > 3) {\
-            456\
+            res = 456\
           } else if (4 < 6) {\
-            789\
+            res = 789\
           } else {\
-            1011\
-          }
+            res = 1011\
+          }\
+          res
         ";
         let result = interpret(input).unwrap();
         let expected = Value::Int(789);
         assert_eq!(expected, result);
 
         let input = "\
+          var res = 0\
           val a = 123\
           if (1 != 2) {\
             val b = 123\
             if (true) {\
               val c = a + b \
-              c
+              res = c
             }\
           } else {\
-            a + 456\
-          }
+            res = a + 456\
+          }\
+          res
         ";
         let result = interpret(input).unwrap();
         let expected = Value::Int(246);


### PR DESCRIPTION
  - After evaluating ast nodes which leave values on the top of the stack upon finishing execution, we need to make sure those values are popped off.
  - This sets us up to be able to utilize the stack to store locals, since the index into a maintained `locals` vector for a given local will always correspond to the index on the stack. The only thing left on a stack after a "synchronization point" should be a value that corresponds to a variable defined during that "synchronization point".
    - This also helps with that TODO related to cleaning up "unnecessary" locals after an if-block ends