### PR TITLE
Add recursion support

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,1 +1,11 @@
-val greeting = "Hello"
+func fib(n: Int): Int {
+  if (n == 0) {
+    0
+  } else if (n == 1) {
+    1
+  } else {
+    fib(n - 2) + fib(n - 1)
+  }
+}
+
+[fib(0), fib(1), fib(2), fib(3), fib(4), fib(5), fib(6), fib(7), fib(8), fib(9), fib(10)]

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -15,6 +15,7 @@ pub enum Type {
     Array(Box<Type>),
     Option(Box<Type>),
     Fn(Vec<(String, Type)>, Box<Type>),
+    Unknown, // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
 }
 
 impl Type {

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -578,4 +578,36 @@ mod tests {
         let expected = Value::Obj(Obj::StringObj { value: Box::new("Save the Cheerleader, Save the World!".to_string()) });
         assert_eq!(expected, result);
     }
+
+    #[test]
+    fn interpret_func_invocation_recursion() {
+        let input = "\
+          func fib(n: Int): Int {\n\
+            if (n == 0) {\n\
+              0\n\
+            } else if (n == 1) {\n\
+              1\n\
+            } else {\n\
+              fib(n - 2) + fib(n - 1)\n\
+            }\n\
+          }\n\
+          \n\
+          [fib(0), fib(1), fib(2), fib(3), fib(4), fib(5), fib(6), fib(7), fib(8)]\n\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Obj(Obj::ArrayObj {
+            value: vec![
+                Box::new(Value::Int(0)),
+                Box::new(Value::Int(1)),
+                Box::new(Value::Int(1)),
+                Box::new(Value::Int(2)),
+                Box::new(Value::Int(3)),
+                Box::new(Value::Int(5)),
+                Box::new(Value::Int(8)),
+                Box::new(Value::Int(13)),
+                Box::new(Value::Int(21)),
+            ]
+        });
+        assert_eq!(expected, result);
+    }
 }

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -69,6 +69,11 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("returnType", &JsType(return_type))?;
                 obj.end()
             }
+            Type::Unknown => {
+                let mut obj = serializer.serialize_map(Some(1))?;
+                obj.serialize_entry("kind", "Unknown")?;
+                obj.end()
+            }
         }
     }
 }

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -187,6 +187,15 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("actual", actual)?;
                     obj.end()
                 }
+                TypecheckerError::RecursiveRefWithoutReturnType { orig_token, token } => {
+                    let mut obj = serializer.serialize_map(Some(5))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "recursiveRefWithoutReturnType")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("origToken", &JsToken(orig_token))?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {
@@ -208,11 +217,17 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.end()
                 }
                 InterpretError::TypeError(expected, actual) => {
-                    let mut obj = serializer.serialize_map(Some(2))?;
+                    let mut obj = serializer.serialize_map(Some(4))?;
                     obj.serialize_entry("kind", "interpretError")?;
                     obj.serialize_entry("subKind", "typeError")?;
                     obj.serialize_entry("expected", expected)?;
                     obj.serialize_entry("actual", actual)?;
+                    obj.end()
+                }
+                InterpretError::StackOverflow => {
+                    let mut obj = serializer.serialize_map(Some(2))?;
+                    obj.serialize_entry("kind", "interpretError")?;
+                    obj.serialize_entry("subKind", "stackOverflow")?;
                     obj.end()
                 }
             }


### PR DESCRIPTION
  - When typechecking a function, insert a preliminary type for the function which can be referenced within the function body
  - When the function's body is fully typed, replace the return type with the actual type