### PR TITLE
Default fn arg values

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,15 +1,3 @@
-func innerLoop() {
-  for a2, i2 in range(0, 5) {
-    println("Inner " + a2)
-  }
-}
+func abc(a: Int = 2, b = 3, c = 5) { a * b * c }
 
-func runLoop() {
-  for a1, i1 in range(0, 5) {
-     println("Outer " + a1)
-
-     innerLoop()
-  }
-}
-
-runLoop()
+[abc(), abc(7), abc(7, 11), abc(7, 11, 13)]

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -89,7 +89,7 @@ pub struct FunctionDeclNode {
     // Must be a Token::Ident
     pub name: Token,
     // Tokens represent arg idents, and must be Token::Ident
-    pub args: Vec<(Token, TypeIdentifier)>,
+    pub args: Vec<(Token, Option<TypeIdentifier>, Option<AstNode>)>,
     pub ret_type: Option<TypeIdentifier>,
     pub body: Vec<AstNode>,
 }

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -28,7 +28,7 @@ pub enum AstLiteralNode {
     BoolLiteral(bool),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum UnaryOp {
     Minus,
     Negate,
@@ -40,7 +40,7 @@ pub struct UnaryNode {
     pub expr: Box<AstNode>,
 }
 
-#[derive(Display, Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq)]
 pub enum BinaryOp {
     Add,
     Sub,
@@ -100,7 +100,7 @@ pub struct AssignmentNode {
     pub expr: Box<AstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum IndexingMode<T> {
     Index(Box<T>),
     Range(Option<Box<T>>, Option<Box<T>>),

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -37,8 +37,8 @@ impl Scope {
         let native_fns: Iter<NativeFn> = NATIVE_FNS.iter();
         for NativeFn { name, args, return_type, .. } in native_fns {
             let token = Token::Ident(Position::new(0, 0), name.clone());
-            let args: Vec<(String, Type)> = (0..args.len()).zip(args.iter())
-                .map(|(idx, arg)| (format!("_{}", idx), arg.clone()))
+            let args: Vec<(String, Type, bool)> = (0..args.len()).zip(args.iter())
+                .map(|(idx, arg)| (format!("_{}", idx), arg.clone(), false))
                 .collect();
             let typ = Type::Fn(args, Box::new(return_type.clone()));
             scope.bindings.insert(name.to_string(), ScopeBinding(token, typ, false));
@@ -380,25 +380,58 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         }
 
         self.scopes.push(Scope::new(ScopeKind::Function(name.clone(), func_name.clone())));
-        let mut typed_args = Vec::<(Token, Type)>::with_capacity(args.len());
+        let mut typed_args = Vec::<(Token, Type, Option<TypedAstNode>)>::with_capacity(args.len());
         let mut arg_idents = HashMap::<String, Token>::new();
-        for (token, type_ident, _) in args {
+        let mut seen_optional_arg = false;
+        for (token, type_ident, default_value) in args {
             let arg_name = Token::get_ident_name(&token).clone();
             if let Some(arg_tok) = arg_idents.get(&arg_name) {
                 return Err(TypecheckerError::DuplicateBinding { orig_ident: arg_tok.clone(), ident: token.clone() });
             }
             arg_idents.insert(arg_name, token.clone());
 
-            // TODO: fix
-            let type_ident = type_ident.unwrap();
-
-            let arg_type = Type::from_type_ident(&type_ident, self.get_types_in_scope());
-            match arg_type {
-                None => return Err(TypecheckerError::UnknownType { type_ident: type_ident.get_ident() }),
-                Some(arg_type) => {
-                    let arg_name = Token::get_ident_name(&token);
-                    self.add_binding(arg_name, &token, &arg_type, false);
-                    typed_args.push((token, arg_type));
+            match type_ident {
+                Some(type_ident) => {
+                    let arg_type = Type::from_type_ident(&type_ident, self.get_types_in_scope());
+                    match arg_type {
+                        None => return Err(TypecheckerError::UnknownType { type_ident: type_ident.get_ident() }),
+                        Some(arg_type) => {
+                            match default_value {
+                                Some(default_value) => {
+                                    seen_optional_arg = true;
+                                    let default_value = self.visit(default_value)?;
+                                    if default_value.get_type().is_equivalent_to(&arg_type) {
+                                        let arg_name = Token::get_ident_name(&token);
+                                        self.add_binding(arg_name, &token, &arg_type, false);
+                                        typed_args.push((token, arg_type, Some(default_value)));
+                                    } else {
+                                        return Err(TypecheckerError::Mismatch { token: default_value.get_token().clone(), expected: arg_type, actual: default_value.get_type() });
+                                    }
+                                }
+                                None => {
+                                    if seen_optional_arg {
+                                        return Err(TypecheckerError::InvalidRequiredArgPosition(token))
+                                    }
+                                    let arg_name = Token::get_ident_name(&token);
+                                    self.add_binding(arg_name, &token, &arg_type, false);
+                                    typed_args.push((token, arg_type, None));
+                                }
+                            }
+                        }
+                    }
+                }
+                None => {
+                    match default_value {
+                        None => unreachable!(), // This should be caught during parsing
+                        Some(default_value) => {
+                            seen_optional_arg = true;
+                            let default_value = self.visit(default_value)?;
+                            let arg_type = default_value.get_type();
+                            let arg_name = Token::get_ident_name(&token);
+                            self.add_binding(arg_name, &token, &arg_type, false);
+                            typed_args.push((token, arg_type, Some(default_value)));
+                        }
+                    }
                 }
             }
         }
@@ -415,7 +448,9 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         // this pop/push.
         let scope = self.scopes.pop().unwrap();
         let arg_types = args.iter()
-            .map(|(ident, typ)| (Token::get_ident_name(ident).clone(), typ.clone()))
+            .map(|(ident, typ, default_value)| {
+                (Token::get_ident_name(ident).clone(), typ.clone(), default_value.is_some())
+            })
             .collect::<Vec<_>>();
         let initial_ret_type = match &ret_type {
             None => Type::Unknown,
@@ -689,7 +724,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
             let mut typed_args = Vec::<TypedAstNode>::new();
             for (arg, expected) in args.into_iter().zip(arg_types.iter()) {
                 let (arg_name, arg) = arg;
-                let (expected_name, expected_arg_type) = expected;
+                let (expected_name, expected_arg_type, _) = expected;
 
                 if let Some(arg_name) = arg_name {
                     let passed_name = Token::get_ident_name(&arg_name);
@@ -1495,7 +1530,7 @@ mod tests {
             Token::Func(Position::new(1, 1)),
             TypedFunctionDeclNode {
                 name: Token::Ident(Position::new(1, 6), "abc".to_string()),
-                args: vec![(ident_token!((1, 10), "a"), Type::Int)],
+                args: vec![(ident_token!((1, 10), "a"), Type::Int, None)],
                 ret_type: Type::Int,
                 body: vec![
                     TypedAstNode::Binary(
@@ -1572,7 +1607,7 @@ mod tests {
         // Test that bindings assigned to functions have the proper type
         let (typechecker, _) = typecheck_get_typechecker("func abc(a: Int): Bool = a == 1\nval def = abc");
         let (ScopeBinding(_, typ, _), _) = typechecker.get_binding("def").unwrap();
-        assert_eq!(&Type::Fn(vec![("a".to_string(), Type::Int)], Box::new(Type::Bool)), typ);
+        assert_eq!(&Type::Fn(vec![("a".to_string(), Type::Int, false)], Box::new(Type::Bool)), typ);
 
         Ok(())
     }
@@ -1585,7 +1620,7 @@ mod tests {
             _ => panic!("Node must be a FunctionDecl")
         };
         let expected = vec![
-            (ident_token!((1, 10), "a"), Type::Int)
+            (ident_token!((1, 10), "a"), Type::Int, None)
         ];
         assert_eq!(&expected, args);
 
@@ -1595,9 +1630,32 @@ mod tests {
             _ => panic!("Node must be a FunctionDecl")
         };
         let expected = vec![
-            (ident_token!((1, 10), "a"), Type::Int),
-            (ident_token!((1, 18), "b"), Type::Option(Box::new(Type::Bool))),
-            (ident_token!((1, 28), "c"), Type::Array(Box::new(Type::Int))),
+            (ident_token!((1, 10), "a"), Type::Int, None),
+            (ident_token!((1, 18), "b"), Type::Option(Box::new(Type::Bool)), None),
+            (ident_token!((1, 28), "c"), Type::Array(Box::new(Type::Int)), None),
+        ];
+        assert_eq!(&expected, args);
+
+        let typed_ast = typecheck("func abc(a: Int = 1, b = [1, 2, 3]) = 123")?;
+        let args = match typed_ast.first().unwrap() {
+            TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { args, .. }) => args,
+            _ => panic!("Node must be a FunctionDecl")
+        };
+        let expected = vec![
+            (ident_token!((1, 10), "a"), Type::Int, Some(int_literal!((1, 19), 1))),
+            (ident_token!((1, 22), "b"), Type::Array(Box::new(Type::Int)), Some(
+                TypedAstNode::Array(
+                    Token::LBrack(Position::new(1, 26)),
+                    TypedArrayNode {
+                        typ: Type::Array(Box::new(Type::Int)),
+                        items: vec![
+                            Box::new(int_literal!((1, 27), 1)),
+                            Box::new(int_literal!((1, 30), 2)),
+                            Box::new(int_literal!((1, 33), 3)),
+                        ],
+                    },
+                )
+            )),
         ];
         assert_eq!(&expected, args);
 
@@ -1611,6 +1669,18 @@ mod tests {
             orig_ident: ident_token!((1, 10), "a"),
             ident: ident_token!((1, 18), "a"),
         };
+        assert_eq!(expected, error);
+
+        let error = typecheck("func abc(a: Int, b: Bool = \"hello\") = 123").unwrap_err();
+        let expected = TypecheckerError::Mismatch {
+            token: Token::String(Position::new(1, 28), "hello".to_string()),
+            expected: Type::Bool,
+            actual: Type::String
+        };
+        assert_eq!(expected, error);
+
+        let error = typecheck("func abc(a: Int, b = 1, c: Int) = 123").unwrap_err();
+        let expected = TypecheckerError::InvalidRequiredArgPosition(ident_token!((1, 25), "c"));
         assert_eq!(expected, error);
     }
 
@@ -2203,7 +2273,7 @@ mod tests {
                     ident_token!((2, 1), "abc"),
                     TypedIdentifierNode {
                         typ: Type::Fn(
-                            vec![("a".to_string(), Type::Int), ("b".to_string(), Type::String)],
+                            vec![("a".to_string(), Type::Int, false), ("b".to_string(), Type::String, false)],
                             Box::new(Type::String),
                         ),
                         is_mutable: false,

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -382,12 +382,15 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         self.scopes.push(Scope::new(ScopeKind::Function(name.clone(), func_name.clone())));
         let mut typed_args = Vec::<(Token, Type)>::with_capacity(args.len());
         let mut arg_idents = HashMap::<String, Token>::new();
-        for (token, type_ident) in args {
+        for (token, type_ident, _) in args {
             let arg_name = Token::get_ident_name(&token).clone();
             if let Some(arg_tok) = arg_idents.get(&arg_name) {
                 return Err(TypecheckerError::DuplicateBinding { orig_ident: arg_tok.clone(), ident: token.clone() });
             }
             arg_idents.insert(arg_name, token.clone());
+
+            // TODO: fix
+            let type_ident = type_ident.unwrap();
 
             let arg_type = Type::from_type_ident(&type_ident, self.get_types_in_scope());
             match arg_type {

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -21,6 +21,7 @@ pub enum TypecheckerError {
     ParamNameMismatch { token: Token, expected: String, actual: String },
     RecursiveRefWithoutReturnType { orig_token: Token, token: Token },
     InvalidBreak(Token),
+    InvalidRequiredArgPosition(Token),
 }
 
 // TODO: Replace this when I do more work on Type representations
@@ -41,7 +42,7 @@ fn type_repr(t: &Type) -> String {
         Type::Array(typ) => format!("{}[]", type_repr(typ)),
         Type::Option(typ) => format!("{}?", type_repr(typ)),
         Type::Fn(args, ret_type) => {
-            let args = args.iter().map(|(_, arg_type)| type_repr(arg_type)).collect::<Vec<String>>().join(", ");
+            let args = args.iter().map(|(_, arg_type, _)| type_repr(arg_type)).collect::<Vec<String>>().join(", ");
             format!("({}) => {}", args, type_repr(ret_type))
         }
         Type::Unknown => "Unknown".to_string(),
@@ -87,6 +88,7 @@ impl DisplayError for TypecheckerError {
             TypecheckerError::ParamNameMismatch { token, .. } => token.get_position(),
             TypecheckerError::RecursiveRefWithoutReturnType { token, .. } => token.get_position(),
             TypecheckerError::InvalidBreak(token) => token.get_position(),
+            TypecheckerError::InvalidRequiredArgPosition(token) => token.get_position(),
         };
         let line = lines.get(pos.line - 1).expect("There should be a line");
 
@@ -218,6 +220,9 @@ impl DisplayError for TypecheckerError {
                 )
             }
             TypecheckerError::InvalidBreak(_token) => {
+                unimplemented!()
+            }
+            TypecheckerError::InvalidRequiredArgPosition(_token) => {
                 unimplemented!()
             }
         }

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -2,7 +2,7 @@ use crate::typechecker::types::Type;
 use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode};
 use crate::lexer::tokens::Token;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TypedAstNode {
     Literal(Token, TypedLiteralNode),
     Unary(Token, TypedUnaryNode),
@@ -71,7 +71,7 @@ impl TypedAstNode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TypedLiteralNode {
     IntLiteral(i64),
     FloatLiteral(f64),
@@ -79,14 +79,14 @@ pub enum TypedLiteralNode {
     BoolLiteral(bool),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedUnaryNode {
     pub typ: Type,
     pub op: UnaryOp,
     pub expr: Box<TypedAstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedBinaryNode {
     pub typ: Type,
     pub right: Box<TypedAstNode>,
@@ -94,19 +94,19 @@ pub struct TypedBinaryNode {
     pub left: Box<TypedAstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedGroupedNode {
     pub typ: Type,
     pub expr: Box<TypedAstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedArrayNode {
     pub typ: Type,
     pub items: Vec<Box<TypedAstNode>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedBindingDeclNode {
     // Must be a Token::Ident
     pub ident: Token,
@@ -115,7 +115,7 @@ pub struct TypedBindingDeclNode {
     pub scope_depth: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedFunctionDeclNode {
     // Must be a Token::Ident
     pub name: Token,
@@ -126,28 +126,28 @@ pub struct TypedFunctionDeclNode {
     pub scope_depth: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedIdentifierNode {
     pub typ: Type,
     pub is_mutable: bool,
     pub scope_depth: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedAssignmentNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
     pub expr: Box<TypedAstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedIndexingNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
     pub index: IndexingMode<TypedAstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedIfNode {
     pub typ: Type,
     pub condition: Box<TypedAstNode>,
@@ -155,20 +155,20 @@ pub struct TypedIfNode {
     pub else_block: Option<Vec<TypedAstNode>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedInvocationNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
     pub args: Vec<TypedAstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedWhileLoopNode {
     pub condition: Box<TypedAstNode>,
     pub body: Vec<TypedAstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedForLoopNode {
     pub iteratee: Token,
     pub index_ident: Option<Token>,

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -120,7 +120,7 @@ pub struct TypedFunctionDeclNode {
     // Must be a Token::Ident
     pub name: Token,
     // Tokens represent arg idents, and must be Token::Ident
-    pub args: Vec<(Token, Type)>,
+    pub args: Vec<(Token, Type, Option<TypedAstNode>)>,
     pub ret_type: Type,
     pub body: Vec<TypedAstNode>,
     pub scope_depth: usize,

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -14,7 +14,7 @@ pub enum Type {
     Bool,
     Array(Box<Type>),
     Option(Box<Type>),
-    Fn(Vec<(String, Type)>, Box<Type>),
+    Fn(Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, Box<Type>),
     Unknown, // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
 }
 
@@ -42,7 +42,13 @@ impl Type {
             }
             // For Fn types compare arities, param types, and return type
             (Fn(args1, ret1), Fn(args2, ret2)) => {
-                for ((_, t1), (_, t2)) in args1.iter().zip(args2.iter()) {
+                if args1.len() != args2.len() {
+                    return false;
+                }
+
+                // TODO: Factor in optional params here
+                // func abc(a: Int, b = 3) = a + b should satisfy a type of (Int, Int) => Int and also (Int) => Int
+                for ((_, t1, _), (_, t2, _)) in args1.iter().zip(args2.iter()) {
                     if !Type::is_equivalent_to(t1, t2) {
                         return false;
                     }

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -418,7 +418,7 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
         let func_depth = self.depth;
 
         // Pop function arguments off stack and store in local bindings
-        for (arg_token, _) in args {
+        for (arg_token, _, _) in args {
             let ident = Token::get_ident_name(&arg_token);
 
             let local = Local(ident.clone(), self.depth);

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -621,6 +621,24 @@ mod tests {
     }
 
     #[test]
+    fn interpret_func_invocation_default_args() {
+        let input = "\
+          func abc(a: Int = 2, b = 3, c = 5) { a * b * c }\n\
+          [abc(), abc(7), abc(7, 11), abc(7, 11, 13)]\n\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Obj(Obj::ArrayObj {
+            value: vec![
+                Box::new(Value::Int(30)),
+                Box::new(Value::Int(105)),
+                Box::new(Value::Int(385)),
+                Box::new(Value::Int(1001)),
+            ]
+        });
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn interpret_while_loop() {
         let input = "\
           var a = 0\n\

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -63,7 +63,7 @@ impl<'a> Serialize for JsType<'a> {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "Fn")?;
                 let args: Vec<(String, JsType)> = args.iter()
-                    .map(|(name, typ)| (name.clone(), JsType(typ)))
+                    .map(|(name, typ, _)| (name.clone(), JsType(typ)))
                     .collect();
                 obj.serialize_entry("args", &args)?;
                 obj.serialize_entry("returnType", &JsType(return_type))?;

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -203,6 +203,13 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.end()
                 }
+                TypecheckerError::InvalidRequiredArgPosition(token) => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidRequiredArgPosition")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {


### PR DESCRIPTION
Addresses #29 

Typechecker
  Handle arity errors in invocations involving functions with optional args (args with default values)
  Add `Clone` to the derived traits for all of the TypedAstNodes (and types referenced therein). This made it easier to write the code for generating the "pseudo-fns"

Compiler
  Generate "pseudo-fns" to handle the underlying logic for default-arg-valued functions