### PR TITLE
Filled in unimplemented!() TypecheckerErrors

### DIFF
--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -6,7 +6,6 @@ use crate::vm::opcode::Opcode;
 use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode};
 use crate::typechecker::types::Type;
 use crate::vm::value::{Value, Obj};
-use std::collections::HashSet;
 
 #[derive(Debug, PartialEq)]
 pub struct Local(/* name: */ String, /* scope_depth: */ usize);
@@ -815,7 +814,7 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
 
     fn visit_instantiation(&mut self, token: Token, node: TypedInstantiationNode) -> Result<(), ()> {
         let line = token.get_position().line;
-        let TypedInstantiationNode { typ, fields } = node;
+        let TypedInstantiationNode { fields, .. } = node;
 
         let num_fields = fields.len();
         for (field_name, field_value) in fields {

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -172,11 +172,12 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("elseType", &JsType(else_type))?;
                     obj.end()
                 }
-                TypecheckerError::InvalidInvocationTarget { token } => {
-                    let mut obj = serializer.serialize_map(Some(3))?;
+                TypecheckerError::InvalidInvocationTarget { token, target_type } => {
+                    let mut obj = serializer.serialize_map(Some(4))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "invalidInvocationTarget")?;
                     obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("targetType", &JsType(target_type))?;
                     obj.end()
                 }
                 TypecheckerError::IncorrectArity { token, expected, actual } => {
@@ -245,11 +246,12 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("targetType", &JsType(target_type))?;
                     obj.end()
                 }
-                TypecheckerError::MissingRequiredField { token, field: (name, typ) } => {
-                    let mut obj = serializer.serialize_map(Some(5))?;
+                TypecheckerError::MissingRequiredField { token, target_type, field: (name, typ) } => {
+                    let mut obj = serializer.serialize_map(Some(6))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "missingRequiredField")?;
                     obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("targetType", &JsType(target_type))?;
                     obj.serialize_entry("fieldName", name)?;
                     obj.serialize_entry("fieldType", &JsType(typ))?;
                     obj.end()


### PR DESCRIPTION
Addresses #64 
Added implementation for all of the missing `TypecheckerError` types:
- TypecheckerError::DuplicateType
- TypecheckerError::InvalidInvocationTarget
- TypecheckerError::IncorrectArity
- TypecheckerError::ParamNameMismatch
- TypecheckerError::InvalidBreak
- TypecheckerError::InvalidRequiredArgPosition
- TypecheckerError::InvalidIndexingTarget
- TypecheckerError::InvalidIndexingSelector
- TypecheckerError::UnknownMember
- TypecheckerError::MissingRequiredField
- TypecheckerError::InvalidInstantiationParam