### PR TITLE
Change function return value approach

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,6 +1,10 @@
-func add(a: Int, b = 2) =
-  if (b == 2) a + b
-  else a + b
-
-println(add(1))
-println(add(1, 2))
+val greeting = "Hello"
+func exclaim(word: String) {
+  val abc = 123
+  word + "!"
+}
+func greet(recipient: String) {
+  greeting + ", " + exclaim(recipient)
+}
+val languageName = "Abra"
+greet(languageName) + " " + greet(languageName)

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -130,7 +130,7 @@ impl From<&u8> for Opcode {
 }
 
 impl Opcode {
-    pub fn expects_imm(&self) -> bool {
+    pub fn num_expected_imms(&self) -> u8 {
         match self {
             Opcode::Constant |
             Opcode::Jump |
@@ -139,9 +139,9 @@ impl Opcode {
             Opcode::ArrMk |
             Opcode::MapMk |
             Opcode::LStore |
-            Opcode::LLoad |
-            Opcode::Invoke => true,
-            _ => false
+            Opcode::LLoad => 1,
+            Opcode::Invoke => 2,
+            _ => 0
         }
     }
 }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -556,6 +556,7 @@ mod tests {
             code: vec![
                 Opcode::Constant as u8, 3,
                 Opcode::LStore0 as u8,
+                Opcode::Pop as u8,
                 Opcode::Return as u8
             ],
         };
@@ -577,6 +578,11 @@ mod tests {
         let result = interpret(input).unwrap();
         let expected = Value::Int(6);
         assert_eq!(expected, result);
+
+        // There should be nothing leftover on the stack after a non-returning function executes
+        let input = "println(\"hello\")";
+        let result = interpret(input);
+        assert_eq!(None, result);
     }
 
     #[test]

--- a/abra_wasm/Cargo.toml
+++ b/abra_wasm/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.4.0"
 authors = ["Ken Gorab <ken.gorab@gmail.com>"]
 edition = "2018"
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/abra_wasm/ts/types/module.ts
+++ b/abra_wasm/ts/types/module.ts
@@ -1,6 +1,6 @@
 import { Value } from './value'
 
 export interface Module {
-    code: [string, number | null][],
+    code: [string, number[] | null][],
     constants: Value[],
 }


### PR DESCRIPTION
  - Instead of storing into their first available local (which is confusing for a function which has no locals to begin with), always assume local slot 0 is available, and LStore0 into that when returning.
  - This means that we don't need to determine the "earliest local at depth" anymore (for functions, it's still a thing for conditional stmts/exprs); it also means that we need to push a Nil onto the stack prior to an Invoke, for functions with a return value