### PR TITLE
Cleanup: cleaning up TypedAstNode::Break

### DIFF
--- a/abra_core/src/common/typed_ast_visitor.rs
+++ b/abra_core/src/common/typed_ast_visitor.rs
@@ -24,7 +24,7 @@ pub trait TypedAstVisitor<V, E> {
             Accessor(tok, node) => self.visit_accessor(tok, node),
             ForLoop(tok, node) => self.visit_for_loop(tok, node),
             WhileLoop(tok, node) => self.visit_while_loop(tok, node),
-            Break(tok, loop_depth) => self.visit_break(tok, loop_depth),
+            Break(tok) => self.visit_break(tok),
         }
     }
 
@@ -47,5 +47,5 @@ pub trait TypedAstVisitor<V, E> {
     fn visit_accessor(&mut self, token: Token, node: TypedAccessorNode) -> Result<V, E>;
     fn visit_for_loop(&mut self, token: Token, node: TypedForLoopNode) -> Result<V, E>;
     fn visit_while_loop(&mut self, token: Token, node: TypedWhileLoopNode) -> Result<V, E>;
-    fn visit_break(&mut self, token: Token, loop_depth: usize) -> Result<V, E>;
+    fn visit_break(&mut self, token: Token) -> Result<V, E>;
 }

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -22,7 +22,7 @@ pub enum TypedAstNode {
     Instantiation(Token, TypedInstantiationNode),
     ForLoop(Token, TypedForLoopNode),
     WhileLoop(Token, TypedWhileLoopNode),
-    Break(Token, /* loop_depth: */ usize),
+    Break(Token),
     Accessor(Token, TypedAccessorNode),
 }
 
@@ -47,7 +47,7 @@ impl TypedAstNode {
             TypedAstNode::Instantiation(token, _) => token,
             TypedAstNode::ForLoop(token, _) => token,
             TypedAstNode::WhileLoop(token, _) => token,
-            TypedAstNode::Break(token, _) => token,
+            TypedAstNode::Break(token) => token,
             TypedAstNode::Accessor(token, _) => token,
         }
     }
@@ -69,7 +69,7 @@ impl TypedAstNode {
             TypedAstNode::FunctionDecl(_, _) |
             TypedAstNode::TypeDecl(_, _) |
             TypedAstNode::WhileLoop(_, _) |
-            TypedAstNode::Break(_, _) |
+            TypedAstNode::Break(_) |
             TypedAstNode::ForLoop(_, _) => Type::Unit,
             TypedAstNode::Identifier(_, node) => node.typ.clone(),
             TypedAstNode::Assignment(_, node) => node.typ.clone(),
@@ -192,7 +192,7 @@ pub struct TypedInvocationNode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct TypedInstantiationNode {
     pub typ: Type,
-    pub fields: Vec<(String, TypedAstNode)>
+    pub fields: Vec<(String, TypedAstNode)>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -213,6 +213,6 @@ pub struct TypedForLoopNode {
 pub struct TypedAccessorNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
-    pub field: Token
+    pub field: Token,
 }
 

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -80,7 +80,7 @@ fn should_pop_after_node(node: &TypedAstNode) -> bool {
         TypedAstNode::FunctionDecl(_, _) |
         TypedAstNode::TypeDecl(_, _) |
         TypedAstNode::IfStatement(_, _) |
-        TypedAstNode::Break(_, _) | // This is here for completeness; the return type for this node should never matter
+        TypedAstNode::Break(_) | // This is here for completeness; the return type for this node should never matter
         TypedAstNode::ForLoop(_, _) |
         TypedAstNode::WhileLoop(_, _) => false,
         TypedAstNode::Invocation(_, TypedInvocationNode { typ, .. }) => typ != &Type::Unit,
@@ -256,7 +256,7 @@ impl Compiler {
 
             let should_pop = should_pop_after_node(&node);
             let is_interrupt = match &node {
-                TypedAstNode::Break(_, _) => true,
+                TypedAstNode::Break(_) => true,
                 _ => false
             };
             self.visit(node)?;
@@ -744,7 +744,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
 
                 let should_pop = should_pop_after_node(&node);
                 let is_interrupt = match &node {
-                    TypedAstNode::Break(_, _) => true,
+                    TypedAstNode::Break(_) => true,
                     _ => false
                 };
                 compiler.visit(node)?;
@@ -1000,7 +1000,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
         Ok(())
     }
 
-    fn visit_break(&mut self, token: Token, loop_depth: usize) -> Result<(), ()> {
+    fn visit_break(&mut self, token: Token) -> Result<(), ()> {
         let line = token.get_position().line;
 
         // Emit bytecode to pop locals from stack. The scope in which the break statement lives


### PR DESCRIPTION
- Since the `loop_depth` field was no longer being used in the compiler
(we have a separate mechanism for tracking this type of thing now, as
of #85), it can be removed from the ast node.
- Also add logic (and tests) to verify that a break placed anywhere
other than within a Loop scope is invalid (a loop placed in a Block
scope will be okay, as long as it eventually is contained by a Loop).