### PR TITLE
Closures/compilation of upvalues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,13 +22,13 @@ name = "abra_wasm"
 version = "0.4.0"
 dependencies = [
  "abra_core 0.3.0",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -61,12 +61,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bumpalo"
-version = "2.3.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -128,15 +128,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.25"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -151,10 +151,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -225,32 +225,32 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "0.2.7"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.90"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.90"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.39"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -339,63 +339,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.48"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.48"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bumpalo 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.48"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.48"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.48"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "web-sys"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -421,19 +433,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum bumpalo 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6a6bc2ba935b1e2f810787ceba8dfe86cbc164cee55925cae715541186673c4"
-"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+"checksum bumpalo 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap)" = "<none>"
 "checksum clap_derive 0.3.0 (git+https://github.com/clap-rs/clap_derive)" = "<none>"
-"checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
+"checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
-"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "da3ea71161651a4cd97d999b2da139109c537b15ab33abc8ae4ead38deac8a03"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum proc-macro-error 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "53c98547ceaea14eeb26fcadf51dc70d01a2479a7839170eae133721105e4428"
 "checksum proc-macro-error-attr 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c2bf5d493cf5d3e296beccfd61794e445e830dfc8070a9c248ad3ee071392c6c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
@@ -441,10 +453,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a0538bd897e17257b0128d2fd95c2ed6df939374073a36166051a79e2eb7986"
-"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
-"checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
-"checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+"checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+"checksum serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
+"checksum serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
+"checksum serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
 "checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
@@ -457,12 +469,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "4de97fa1806bb1a99904216f6ac5e0c050dc4f8c676dc98775047c38e5c01b55"
-"checksum wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "5d82c170ef9f5b2c63ad4460dfcee93f3ec04a9a36a4cc20bc973c39e59ab8e3"
-"checksum wasm-bindgen-futures 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "73c25810ee684c909488c214f55abcbc560beb62146d352b9588519e73c2fed9"
-"checksum wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f07d50f74bf7a738304f6b8157f4a581e1512cd9e9cdb5baad8c31bbe8ffd81d"
-"checksum wasm-bindgen-macro-support 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "95cf8fe77e45ba5f91bc8f3da0c3aa5d464b3d8ed85d84f4d4c7cc106436b1d7"
-"checksum wasm-bindgen-shared 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c2d4d4756b2e46d3a5422e06277d02e4d3e1d62d138b76a4c681e925743623"
+"checksum wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+"checksum wasm-bindgen-backend 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+"checksum wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
+"checksum wasm-bindgen-macro 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+"checksum wasm-bindgen-macro-support 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+"checksum wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+"checksum web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,11 +1,24 @@
-func getSum(): Int {
-  val one = 1
+func getCounter() {
+  var count = 100
 
-  func add1(n: Int): Int {
-    n + one
+  func unnecessaryLayer1() {
+    func unnecessaryLayer2() {
+      func tick() {
+        count = count + 1
+      }
+
+      tick
+    }
+
+    unnecessaryLayer2
   }
 
-  add1(2)
+  count = 0
+  val l2 = unnecessaryLayer1()
+  l2()
 }
 
-getSum()
+val tick = getCounter()
+println(tick())
+println(tick())
+println(tick())

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,8 +1,11 @@
 func getSum(): Int {
-  func ret1(): Int { 1 }
-  func add1(n: Int): Int { n + 1 }
+  val one = 1
 
-  ret1() + add1(ret1())
+  func add1(n: Int): Int {
+    n + one
+  }
+
+  add1(2)
 }
 
 getSum()

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -142,6 +142,7 @@ pub struct TypedFunctionDeclNode {
     pub ret_type: Type,
     pub body: Vec<TypedAstNode>,
     pub scope_depth: usize,
+    pub is_recursive: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -1,4 +1,4 @@
-#[derive(Display, Debug, PartialEq)]
+#[derive(Clone, Display, Debug, PartialEq)]
 #[repr(u8)]
 pub enum Opcode {
     Constant = 0,
@@ -47,6 +47,12 @@ pub enum Opcode {
     LStore3,
     LStore4,
     LStore,
+    UStore0,
+    UStore1,
+    UStore2,
+    UStore3,
+    UStore4,
+    UStore,
     GLoad,
     LLoad0,
     LLoad1,
@@ -54,10 +60,18 @@ pub enum Opcode {
     LLoad3,
     LLoad4,
     LLoad,
+    ULoad0,
+    ULoad1,
+    ULoad2,
+    ULoad3,
+    ULoad4,
+    ULoad,
     Jump,
     JumpIfF,
     JumpB,
     Invoke,
+    ClosureMk,
+    CloseUpvalue,
     Pop,
     PopN,
     Return,
@@ -112,20 +126,34 @@ impl From<&u8> for Opcode {
             43 => Opcode::LStore3,
             44 => Opcode::LStore4,
             45 => Opcode::LStore,
-            46 => Opcode::GLoad,
-            47 => Opcode::LLoad0,
-            48 => Opcode::LLoad1,
-            49 => Opcode::LLoad2,
-            50 => Opcode::LLoad3,
-            51 => Opcode::LLoad4,
-            52 => Opcode::LLoad,
-            53 => Opcode::Jump,
-            54 => Opcode::JumpIfF,
-            55 => Opcode::JumpB,
-            56 => Opcode::Invoke,
-            57 => Opcode::Pop,
-            58 => Opcode::PopN,
-            59 => Opcode::Return,
+            46 => Opcode::UStore0,
+            47 => Opcode::UStore1,
+            48 => Opcode::UStore2,
+            49 => Opcode::UStore3,
+            50 => Opcode::UStore4,
+            51 => Opcode::UStore,
+            52 => Opcode::GLoad,
+            53 => Opcode::LLoad0,
+            54 => Opcode::LLoad1,
+            55 => Opcode::LLoad2,
+            56 => Opcode::LLoad3,
+            57 => Opcode::LLoad4,
+            58 => Opcode::LLoad,
+            59 => Opcode::ULoad0,
+            60 => Opcode::ULoad1,
+            61 => Opcode::ULoad2,
+            62 => Opcode::ULoad3,
+            63 => Opcode::ULoad4,
+            64 => Opcode::ULoad,
+            65 => Opcode::Jump,
+            66 => Opcode::JumpIfF,
+            67 => Opcode::JumpB,
+            68 => Opcode::Invoke,
+            69 => Opcode::ClosureMk,
+            70 => Opcode::CloseUpvalue,
+            71 => Opcode::Pop,
+            72 => Opcode::PopN,
+            73 => Opcode::Return,
             _ => unreachable!()
         }
     }
@@ -141,8 +169,10 @@ impl Opcode {
             Opcode::ArrMk |
             Opcode::MapMk |
             Opcode::LStore |
+            Opcode::UStore |
             Opcode::PopN |
-            Opcode::LLoad => 1,
+            Opcode::LLoad |
+            Opcode::ULoad => 1,
             Opcode::Invoke => 2,
             _ => 0
         }

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -72,6 +72,7 @@ pub enum Opcode {
     Invoke,
     ClosureMk,
     CloseUpvalue,
+    CloseUpvalueAndPop,
     Pop,
     PopN,
     Return,
@@ -151,9 +152,10 @@ impl From<&u8> for Opcode {
             68 => Opcode::Invoke,
             69 => Opcode::ClosureMk,
             70 => Opcode::CloseUpvalue,
-            71 => Opcode::Pop,
-            72 => Opcode::PopN,
-            73 => Opcode::Return,
+            71 => Opcode::CloseUpvalueAndPop,
+            72 => Opcode::Pop,
+            73 => Opcode::PopN,
+            74 => Opcode::Return,
             _ => unreachable!()
         }
     }

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter, Error};
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use crate::vm::compiler::Upvalue;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub enum Value {
@@ -8,7 +9,7 @@ pub enum Value {
     Float(f64),
     Bool(bool),
     Obj(Obj),
-    Fn { name: String, code: Vec<u8> },
+    Fn { name: String, code: Vec<u8>, upvalues: Vec<Upvalue> },
     Type(String),
     Nil,
 }

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -1,7 +1,10 @@
+use crate::vm::vm;
+use crate::vm::compiler::Upvalue;
 use std::fmt::{Display, Formatter, Error};
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use crate::vm::compiler::Upvalue;
+use std::cell::RefCell;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub enum Value {
@@ -10,6 +13,7 @@ pub enum Value {
     Bool(bool),
     Obj(Obj),
     Fn { name: String, code: Vec<u8>, upvalues: Vec<Upvalue> },
+    Closure { name: String, code: Vec<u8>, captures: Vec<Arc<RefCell<vm::Upvalue>>> },
     Type(String),
     Nil,
 }
@@ -21,7 +25,8 @@ impl Value {
             Value::Float(val) => format!("{}", val),
             Value::Bool(val) => format!("{}", val),
             Value::Obj(o) => o.to_string(),
-            Value::Fn { name, .. } => format!("<func {}>", name),
+            Value::Fn { name, .. } |
+            Value::Closure { name, .. } => format!("<func {}>", name),
             Value::Type(name) => format!("<type {}>", name),
             Value::Nil => format!("nil"),
         }
@@ -38,7 +43,8 @@ impl Display for Value {
                 Obj::StringObj { value } => write!(f, "\"{}\"", *value),
                 o @ _ => write!(f, "{}", o.to_string()),
             }
-            Value::Fn { name, .. } => write!(f, "<func {}>", name),
+            Value::Fn { name, .. } |
+            Value::Closure { name, .. } => write!(f, "<func {}>", name),
             Value::Type(name) => write!(f, "<type {}>", name),
             Value::Nil => write!(f, "nil"),
         }

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -1,11 +1,13 @@
 use crate::builtins::native_fns::{NATIVE_FNS_MAP, NativeFn};
+use crate::builtins::native_types::{NativeString, NativeType, NativeArray};
+use crate::vm::compiler::{Module, UpvalueCaptureKind};
 use crate::vm::opcode::Opcode;
 use crate::vm::value::{Value, Obj};
-use crate::vm::compiler::Module;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::vec_deque::VecDeque;
-use crate::builtins::native_types::{NativeString, NativeType, NativeArray};
+use std::cell::RefCell;
+use std::sync::Arc;
 
 // Helper macros
 macro_rules! pop_expect_string {
@@ -62,7 +64,7 @@ pub enum InterpretError {
 pub struct Upvalue {
     pub slot_idx: usize,
     pub is_closed: bool,
-    pub value: Option<Value>,
+    pub val: Option<Value>,
 }
 
 struct CallFrame {
@@ -70,7 +72,7 @@ struct CallFrame {
     code: Vec<u8>,
     stack_offset: usize,
     name: String,
-    _upvalues: Vec<Upvalue>,
+    upvalues: Vec<Arc<RefCell<Upvalue>>>,
 }
 
 #[derive(Clone)]
@@ -96,7 +98,7 @@ pub struct VM {
     call_stack: Vec<CallFrame>,
     stack: Vec<Value>,
     globals: HashMap<String, Value>,
-    _open_upvalues: HashMap<usize, Upvalue>,
+    open_upvalues: HashMap<usize, Arc<RefCell<Upvalue>>>,
 }
 
 const STACK_LIMIT: usize = 64;
@@ -105,14 +107,15 @@ impl VM {
     pub fn new(module: Module, ctx: VMContext) -> Self {
         let name = "$main".to_string();
         let Module { code, constants } = module;
-        let root_frame = CallFrame { ip: 0, code, stack_offset: 0, name, _upvalues: vec![] };
+        let root_frame = CallFrame { ip: 0, code, stack_offset: 0, name, upvalues: vec![] };
+
         VM {
             ctx,
             constants,
             call_stack: vec![root_frame],
             stack: Vec::new(),
             globals: HashMap::new(),
-            _open_upvalues: HashMap::new(),
+            open_upvalues: HashMap::new(),
         }
     }
 
@@ -239,7 +242,7 @@ impl VM {
         Ok(())
     }
 
-    fn store(&mut self, stack_slot: usize) -> Result<(), InterpretError> {
+    fn store_local(&mut self, stack_slot: usize) -> Result<(), InterpretError> {
         let CallFrame { stack_offset, .. } = current_frame!(self);
         let stack_slot = stack_slot + *stack_offset;
         let value = self.pop_expect()?;
@@ -247,11 +250,125 @@ impl VM {
         Ok(())
     }
 
-    fn load(&mut self, stack_slot: usize) -> Result<(), InterpretError> {
+    fn store_upvalue(&mut self, upvalue_idx: usize) -> Result<(), InterpretError> {
+        let frame = current_frame!(self);
+        let uv = frame.upvalues[upvalue_idx].clone();
+        let mut uv = (*uv).borrow_mut();
+
+        if uv.is_closed {
+            let value = self.pop_expect()?;
+            uv.val = Some(value);
+        } else {
+            self.store_local(uv.slot_idx)?;
+        }
+        Ok(())
+    }
+
+    fn load_local(&mut self, stack_slot: usize) -> Result<(), InterpretError> {
         let CallFrame { stack_offset, .. } = current_frame!(self);
         let stack_slot = stack_slot + *stack_offset;
         let value = self.stack_get(stack_slot);
         Ok(self.push(value))
+    }
+
+    fn load_upvalue(&mut self, upvalue_idx: usize) -> Result<(), InterpretError> {
+        let frame = current_frame!(self);
+        let uv = frame.upvalues[upvalue_idx].clone();
+        let uv = uv.borrow();
+
+        if uv.is_closed {
+            // TODO: Note, this won't work for mutable upvalues, ie. `myArray.push(1)`
+            let val = uv.val.as_ref()
+                .expect("A closed upvalue should have a val")
+                .clone();
+            self.push(val);
+        } else {
+            self.load_local(uv.slot_idx)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn invoke(&mut self, arity: usize, name: String, code: Vec<u8>, upvalues: Vec<Arc<RefCell<Upvalue>>>) -> Result<(), InterpretError> {
+        let frame = CallFrame {
+            ip: 0,
+            code,
+            stack_offset: self.stack.len() - arity,
+            name,
+            upvalues,
+        };
+        if self.call_stack.len() + 1 >= STACK_LIMIT {
+            Err(InterpretError::StackOverflow)
+        } else {
+            Ok(self.call_stack.push(frame))
+        }
+    }
+
+    fn close_upvalues_from_idx(&mut self, stack_slot: usize) -> Result<(), InterpretError> {
+        let max_slot_idx = self.open_upvalues.keys().max();
+        if max_slot_idx.is_none() { return Ok(()) }
+
+        for idx in stack_slot..=*max_slot_idx.unwrap() {
+            match self.open_upvalues.remove(&idx) {
+                None => continue,
+                Some(uv) => {
+                    let mut uv = (*uv).borrow_mut();
+                    uv.is_closed = true;
+                    let value = self.stack_get(uv.slot_idx);
+                    uv.val = Some(value);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn close_upvalues_for_frame(&mut self) -> Result<(), InterpretError> {
+        let stack_offset = current_frame!(self).stack_offset.clone();
+        self.close_upvalues_from_idx(stack_offset)
+    }
+
+    fn close_upvalue(&mut self) -> Result<(), InterpretError> {
+        let cur_stack_slot = self.stack.len() - 1;
+        self.close_upvalues_from_idx(cur_stack_slot)
+    }
+
+    #[inline]
+    fn make_closure(&mut self) -> Result<(), InterpretError> {
+        let function = self.pop_expect()?;
+        let (name, code, upvalues) = match function {
+            Value::Fn { name, code, upvalues } => Ok((name, code, upvalues)),
+            v @ _ => Err(InterpretError::TypeError("Function".to_string(), v.to_string())),
+        }?;
+
+        let captures = upvalues.iter().map(|uv| {
+            match uv.capture_kind {
+                UpvalueCaptureKind::Local { local_idx } => {
+                    let frame = current_frame!(self);
+                    let idx = frame.stack_offset + local_idx;
+
+                    match self.open_upvalues.get(&idx) {
+                        None => {
+                            let uv = Upvalue { slot_idx: idx, is_closed: false, val: None };
+                            let uv = Arc::new(RefCell::new(uv));
+                            self.open_upvalues.insert(idx, uv.clone());
+                            uv
+                        }
+                        Some(uv) => uv.clone(),
+                    }
+                }
+                UpvalueCaptureKind::Upvalue { upvalue_idx } => {
+                    let frame = current_frame!(self);
+                    frame.upvalues[upvalue_idx].clone()
+                }
+            }
+        });
+        // Because upvalues are discovered in static order (the order in which they're encountered
+        // in the code), but closed in _stack-pop_ order (aka, reversed), this needs to be reversed
+        // in order for the upvalue_idx's to line up properly.
+        let captures = captures.rev().collect::<Vec<_>>();
+
+        self.push(Value::Closure { name, code, captures });
+        Ok(())
     }
 
     pub fn run(&mut self) -> Result<Option<Value>, InterpretError> {
@@ -452,21 +569,24 @@ impl VM {
                     let value = self.pop_expect()?;
                     self.globals.insert(global_name, value);
                 }
-                Opcode::LStore0 => self.store(0)?,
-                Opcode::LStore1 => self.store(1)?,
-                Opcode::LStore2 => self.store(2)?,
-                Opcode::LStore3 => self.store(3)?,
-                Opcode::LStore4 => self.store(4)?,
+                Opcode::LStore0 => self.store_local(0)?,
+                Opcode::LStore1 => self.store_local(1)?,
+                Opcode::LStore2 => self.store_local(2)?,
+                Opcode::LStore3 => self.store_local(3)?,
+                Opcode::LStore4 => self.store_local(4)?,
                 Opcode::LStore => {
                     let stack_slot = self.read_byte_expect()?;
-                    self.store(stack_slot)?
+                    self.store_local(stack_slot)?
                 }
-                Opcode::UStore0 |
-                Opcode::UStore1 |
-                Opcode::UStore2 |
-                Opcode::UStore3 |
-                Opcode::UStore4 |
-                Opcode::UStore => unimplemented!(),
+                Opcode::UStore0 => self.store_upvalue(0)?,
+                Opcode::UStore1 => self.store_upvalue(1)?,
+                Opcode::UStore2 => self.store_upvalue(2)?,
+                Opcode::UStore3 => self.store_upvalue(3)?,
+                Opcode::UStore4 => self.store_upvalue(4)?,
+                Opcode::UStore => {
+                    let upvalue_idx = self.read_byte_expect()?;
+                    self.store_upvalue(upvalue_idx)?;
+                }
                 Opcode::GLoad => {
                     let global_name: String = pop_expect_string!(self)?;
                     let value = self.globals.get(&global_name)
@@ -474,21 +594,24 @@ impl VM {
                         .clone();
                     self.push(value);
                 }
-                Opcode::LLoad0 => self.load(0)?,
-                Opcode::LLoad1 => self.load(1)?,
-                Opcode::LLoad2 => self.load(2)?,
-                Opcode::LLoad3 => self.load(3)?,
-                Opcode::LLoad4 => self.load(4)?,
+                Opcode::LLoad0 => self.load_local(0)?,
+                Opcode::LLoad1 => self.load_local(1)?,
+                Opcode::LLoad2 => self.load_local(2)?,
+                Opcode::LLoad3 => self.load_local(3)?,
+                Opcode::LLoad4 => self.load_local(4)?,
                 Opcode::LLoad => {
                     let stack_slot = self.read_byte_expect()?;
-                    self.load(stack_slot)?
+                    self.load_local(stack_slot)?
                 }
-                Opcode::ULoad0 |
-                Opcode::ULoad1 |
-                Opcode::ULoad2 |
-                Opcode::ULoad3 |
-                Opcode::ULoad4 |
-                Opcode::ULoad => unimplemented!(),
+                Opcode::ULoad0 => self.load_upvalue(0)?,
+                Opcode::ULoad1 => self.load_upvalue(1)?,
+                Opcode::ULoad2 => self.load_upvalue(2)?,
+                Opcode::ULoad3 => self.load_upvalue(3)?,
+                Opcode::ULoad4 => self.load_upvalue(4)?,
+                Opcode::ULoad => {
+                    let upvalue_idx = self.read_byte_expect()?;
+                    self.load_upvalue(upvalue_idx)?;
+                }
                 Opcode::Jump => {
                     let jump_offset = self.read_byte_expect()?;
 
@@ -534,28 +657,27 @@ impl VM {
                                 unreachable!() // A native fn that exists in bytecode but not at runtime is "impossible"
                             }
                         }
-                        Value::Fn { name, code, upvalues: _upvalues } => {
+                        Value::Fn { name, code, .. } => {
                             if has_return { arity += 1 }
-                            let frame = CallFrame {
-                                ip: 0,
-                                code,
-                                stack_offset: self.stack.len() - arity,
-                                name,
-                                _upvalues: vec![]
-                            };
-                            if self.call_stack.len() + 1 >= STACK_LIMIT {
-                                break Err(InterpretError::StackOverflow);
-                            } else {
-                                self.call_stack.push(frame);
-                            }
+                            let res = self.invoke(arity, name, code, vec![]);
+                            if res.is_err() { break Err(res.unwrap_err()) } else { continue }
+                        }
+                        Value::Closure { name, code, captures } => {
+                            if has_return { arity += 1 }
+                            let res = self.invoke(arity, name, code, captures);
+                            if res.is_err() { break Err(res.unwrap_err()) } else { continue }
                         }
                         v @ _ => {
                             return Err(InterpretError::TypeError("Function".to_string(), v.to_string()));
                         }
                     }
                 }
-                Opcode::CloseUpvalue => unimplemented!(),
-                Opcode::ClosureMk => unimplemented!(),
+                Opcode::ClosureMk => self.make_closure()?,
+                Opcode::CloseUpvalue => self.close_upvalue()?,
+                Opcode::CloseUpvalueAndPop => {
+                    self.close_upvalue()?;
+                    self.pop_expect()?;
+                }
                 Opcode::Pop => {
                     self.pop_expect()?;
                 }
@@ -570,6 +692,9 @@ impl VM {
                         let top = self.pop();
                         break Ok(top.clone());
                     } else {
+                        // Ensure that any upvalues that are created in the current frame are closed
+                        self.close_upvalues_for_frame()?;
+
                         // Pop off current frame, so the next loop will resume with the previous frame
                         self.call_stack.pop();
                     }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -559,6 +559,7 @@ mod tests {
                 Opcode::Pop as u8,
                 Opcode::Return as u8
             ],
+            upvalues: vec![],
         };
         assert_eq!(expected, result);
     }

--- a/abra_wasm/src/js_value/value.rs
+++ b/abra_wasm/src/js_value/value.rs
@@ -34,7 +34,8 @@ impl<'a> Serialize for JsWrappedValue<'a> {
                 obj.serialize_entry("value", &JsWrappedObjValue(o))?;
                 obj.end()
             }
-            Value::Fn { name: fn_name, .. } => {
+            Value::Fn { name: fn_name, .. } |
+            Value::Closure { name: fn_name, .. } => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "fn")?;
                 obj.serialize_entry("name", &fn_name)?;

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -56,6 +56,7 @@ impl Serialize for RunResult {
                 }
             }
             RunResult(Value::Fn { name: fn_name, .. }) => serializer.serialize_str(fn_name),
+            RunResult(Value::Closure { name: fn_name, .. }) => serializer.serialize_str(fn_name),
             RunResult(Value::Type(type_name)) => serializer.serialize_str(type_name)
         }
     }


### PR DESCRIPTION
There are a _ton_ of changes here, so I'll try and summarize by area of
concern.
- Typechecker:
  - The `TypedFunctionDeclNode` node now has an `is_recursive` field.
This is necessary in order to facilitate certain compilation strategies
for nested recursive functions.
  - There's also a bit of a cleanup with how `NativeFn`s are
typechecked; see the NativeFns summary for more details

- Compiler:
  - Fix issue where Upvalues which reference an upvalue_idx could not
themselves reference another such Upvalue. Previously, all that had
worked was Upvalues which reference an upvalue_idx could only point to
an Upvalue which referenced a local_idx.
  - Use the `is_recursive` field when compiling nested functions to save
an initial dummy value (the value 0) to a local slot, and then
overwriting it with the actual function value once its compilation is
complete. This allows for functions to be captured within themselves as
upvalues, thus facilitating recursive nested functions.

- VM:
  - Adding runtime support for capturing and closing local variables
into upvalues, as well as upgrading functions into closures if they
close over any variables.
  - Also added the `Value::Closure` type. This could stand to be
refactored a bit since it's so similar to `Value::Fn`, but that's for
another day.

- NativeFns
  - This was a bit of an unexpected change, but it _was_ necessary.
Because of the implementation of `Value::Closure` and how it needed
to have shared, mutable, heap-allocated data to represent its upvalues,
there were issues initializing the `NATIVE_FNS` and `NATIVE_FNS_MAP`
using `lazy_static!`. I changed the signature of `NativeFn` a bit to
still achieve the notion of optional values though, and I actually think
this design is much nicer. But man, did it take a while to figure out
what was the underlying issue there. I still have a lot to learn about
how rust deals with shared, mutable, heap-allocated memory.