### PR TITLE
Changing default-valued param funcs

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,24 +1,16 @@
-func getCounter() {
-  var count = 100
+func getOne() {
+  println("called!")
 
-  func unnecessaryLayer1() {
-    func unnecessaryLayer2() {
-      func tick() {
-        count = count + 1
-      }
-
-      tick
-    }
-
-    unnecessaryLayer2
-  }
-
-  count = 0
-  val l2 = unnecessaryLayer1()
-  l2()
+  1
 }
 
-val tick = getCounter()
-println(tick())
-println(tick())
-println(tick())
+func outer() {
+  func abc(def = getOne(), ghi = def, jkl = def + ghi) {
+    def + ghi + jkl
+  }
+
+  abc
+}
+
+val fn = outer()
+fn()

--- a/abra_core/src/builtins/native_fns.rs
+++ b/abra_core/src/builtins/native_fns.rs
@@ -1,5 +1,5 @@
 use crate::typechecker::types::Type;
-use crate::vm::compiler::fn_name_for_arity;
+// use crate::vm::compiler::fn_name_for_arity;
 use crate::vm::value::{Value, Obj};
 use crate::vm::vm::VMContext;
 use std::collections::HashMap;
@@ -36,15 +36,6 @@ fn native_fns_map() -> HashMap<String, &'static NativeFn> {
     for native_fn in native_fns {
         let name = native_fn.name.clone();
         map.insert(name.clone(), native_fn);
-
-        // Insert all of the pseudo-fns for each native function with default args
-        let num_required_args = native_fn.args.len();
-        let num_optional_args = native_fn.opt_args.len();
-        for num_opt in 0..num_optional_args {
-            let arity = num_required_args + num_opt;
-            let name = fn_name_for_arity(name.clone(), arity);
-            map.insert(name, native_fn);
-        }
     }
 
     map
@@ -95,7 +86,7 @@ fn range(_ctx: VMContext, args: Vec<Value>) -> Option<Value> {
         panic!("range requires an Int as second argument")
     };
     let incr = match args.get(2) {
-        None => 1,
+        None | Some(Value::Nil) => 1,
         Some(Value::Int(i)) => *i,
         Some(_) => panic!("range requires an Int as third argument")
     };

--- a/abra_core/src/common/typed_ast_visitor.rs
+++ b/abra_core/src/common/typed_ast_visitor.rs
@@ -25,6 +25,7 @@ pub trait TypedAstVisitor<V, E> {
             ForLoop(tok, node) => self.visit_for_loop(tok, node),
             WhileLoop(tok, node) => self.visit_while_loop(tok, node),
             Break(tok) => self.visit_break(tok),
+            _Nil(tok) => self.visit_nil(tok),
         }
     }
 
@@ -48,4 +49,5 @@ pub trait TypedAstVisitor<V, E> {
     fn visit_for_loop(&mut self, token: Token, node: TypedForLoopNode) -> Result<V, E>;
     fn visit_while_loop(&mut self, token: Token, node: TypedWhileLoopNode) -> Result<V, E>;
     fn visit_break(&mut self, token: Token) -> Result<V, E>;
+    fn visit_nil(&mut self, token: Token) -> Result<V, E>;
 }

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -24,6 +24,7 @@ pub enum TypedAstNode {
     WhileLoop(Token, TypedWhileLoopNode),
     Break(Token),
     Accessor(Token, TypedAccessorNode),
+    _Nil(Token),
 }
 
 impl TypedAstNode {
@@ -49,6 +50,7 @@ impl TypedAstNode {
             TypedAstNode::WhileLoop(token, _) => token,
             TypedAstNode::Break(token) => token,
             TypedAstNode::Accessor(token, _) => token,
+            TypedAstNode::_Nil(token) => token,
         }
     }
 
@@ -79,6 +81,7 @@ impl TypedAstNode {
             TypedAstNode::Invocation(_, node) => node.typ.clone(),
             TypedAstNode::Instantiation(_, node) => node.typ.clone(),
             TypedAstNode::Accessor(_, node) => node.typ.clone(),
+            TypedAstNode::_Nil(_) => Type::Any,
         }
     }
 }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -802,6 +802,55 @@ mod tests {
     }
 
     #[test]
+    fn interpret_func_invocation_default_args_closure() {
+        let input = "
+          var called = false
+          func getOne() {
+            called = true
+            1
+          }
+          func abc(def = getOne()) = def
+          abc(1)
+          called
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Bool(false);
+        assert_eq!(expected, result);
+
+        let input = "
+          var called = false
+          func getOne() {
+            called = true
+            1
+          }
+          func abc(def = getOne()) = def
+          abc()
+          called
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Bool(true);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn interpret_func_invocation_default_args_laziness() {
+        let input = "
+          func getOne() = 1
+          func outer() {
+            func abc(def = getOne(), ghi = def, jkl = def + ghi) {
+              def + ghi + jkl
+            }
+            abc
+          }
+          val fn = outer()
+          fn()
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(4);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn interpret_while_loop() {
         let input = "\
           var a = 0\n\


### PR DESCRIPTION
Addresses #94 

- Adding TypedAstNode::_Nil, which should never be directly parsed, but
is used when dynamically generating the AST for default param value
evaluation bytecode.
- Remove the old (and admittedly pretty janky) way of handling functions
with default param values. Now, all functions are invoked with the same
number of args as its arity, with `Nil` values being placed on the stack
when no value was passed for that argument. Within the function body,
bytecode is inserted to reassign to the param's local if `Nil` was
passed to it.