### PR TITLE
Creating prelude

### DIFF
--- a/abra_core/src/vm/mod.rs
+++ b/abra_core/src/vm/mod.rs
@@ -1,6 +1,7 @@
 pub mod compiler;
 pub mod disassembler;
 pub mod opcode;
+pub mod prelude;
 pub mod value;
 pub mod vm;
 mod vm_test;

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -1,0 +1,76 @@
+use crate::vm::value::Value;
+use crate::typechecker::types::Type;
+use crate::builtins::native_fns::{NATIVE_FNS, NativeFn};
+use std::collections::HashMap;
+use std::slice::Iter;
+
+#[derive(Clone)]
+struct PreludeBinding {
+    typ: Type,
+    value: Value,
+}
+
+pub struct Prelude {
+    bindings: HashMap<String, PreludeBinding>,
+    typedefs: HashMap<String, Type>,
+}
+
+impl Prelude {
+    pub fn new() -> Self {
+        let mut bindings = HashMap::new();
+        let mut typedefs = HashMap::new();
+
+        let native_fns: Iter<NativeFn> = NATIVE_FNS.iter();
+        for native_fn in native_fns {
+            let native_fn = native_fn.clone();
+            let name = native_fn.name.clone();
+            let value = Value::NativeFn(native_fn.clone());
+
+            let req_args = native_fn.args.iter().enumerate()
+                .map(|(idx, arg)| (format!("_{}", idx), arg.clone(), false));
+            let opt_args = native_fn.opt_args.iter().enumerate()
+                .map(|(idx, arg)| (format!("_{}", idx + native_fn.args.len()), arg.clone(), true));
+            let args = req_args.chain(opt_args).collect();
+            let typ = Type::Fn(args, Box::new(native_fn.return_type));
+
+            bindings.insert(name, PreludeBinding { typ, value });
+        }
+
+        let prelude_types = vec![
+            ("Int", Type::Int),
+            ("Float", Type::Float),
+            ("Bool", Type::Bool),
+            ("String", Type::String),
+        ];
+        for (type_name, typ) in prelude_types {
+            let binding = PreludeBinding {
+                typ: Type::Type(type_name.to_string(), Box::new(typ.clone())),
+                value: Value::Type(type_name.to_string()),
+            };
+            bindings.insert(type_name.to_string(), binding);
+
+            typedefs.insert(type_name.to_string(), typ);
+        }
+
+        Self { bindings, typedefs }
+    }
+
+    pub fn get_binding_types(&self) -> HashMap<String, Type> {
+        self.bindings.iter()
+            .map(|(name, binding)| (name.clone(), binding.typ.clone()))
+            .collect()
+    }
+
+    pub fn get_typedefs(&self) -> HashMap<String, Type> {
+        self.typedefs.iter()
+            .map(|(name, typ)| (name.clone(), typ.clone()))
+            .collect()
+    }
+
+    pub fn resolve_ident<S: AsRef<str>>(&self, ident: S) -> Option<Value> {
+        match self.bindings.get(ident.as_ref()) {
+            None => None,
+            Some(PreludeBinding { value, .. }) => Some(value.clone()),
+        }
+    }
+}

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::cell::RefCell;
 use std::sync::Arc;
+use crate::builtins::native_fns::NativeFn;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub enum Value {
@@ -14,6 +15,7 @@ pub enum Value {
     Obj(Obj),
     Fn { name: String, code: Vec<u8>, upvalues: Vec<Upvalue> },
     Closure { name: String, code: Vec<u8>, captures: Vec<Arc<RefCell<vm::Upvalue>>> },
+    NativeFn(NativeFn),
     Type(String),
     Nil,
 }
@@ -26,7 +28,8 @@ impl Value {
             Value::Bool(val) => format!("{}", val),
             Value::Obj(o) => o.to_string(),
             Value::Fn { name, .. } |
-            Value::Closure { name, .. } => format!("<func {}>", name),
+            Value::Closure { name, .. } |
+            Value::NativeFn(NativeFn { name, .. }) => format!("<func {}>", name),
             Value::Type(name) => format!("<type {}>", name),
             Value::Nil => format!("nil"),
         }
@@ -44,7 +47,8 @@ impl Display for Value {
                 o @ _ => write!(f, "{}", o.to_string()),
             }
             Value::Fn { name, .. } |
-            Value::Closure { name, .. } => write!(f, "<func {}>", name),
+            Value::Closure { name, .. } |
+            Value::NativeFn(NativeFn { name, .. }) => write!(f, "<func {}>", name),
             Value::Type(name) => write!(f, "<type {}>", name),
             Value::Nil => write!(f, "nil"),
         }

--- a/abra_wasm/src/js_value/value.rs
+++ b/abra_wasm/src/js_value/value.rs
@@ -1,3 +1,4 @@
+use abra_core::builtins::native_fns::NativeFn;
 use abra_core::vm::value::{Value, Obj};
 use serde::{Serializer, Serialize};
 
@@ -35,7 +36,8 @@ impl<'a> Serialize for JsWrappedValue<'a> {
                 obj.end()
             }
             Value::Fn { name: fn_name, .. } |
-            Value::Closure { name: fn_name, .. } => {
+            Value::Closure { name: fn_name, .. } |
+            Value::NativeFn(NativeFn { name: fn_name, .. }) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "fn")?;
                 obj.serialize_entry("name", &fn_name)?;

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
+use abra_core::builtins::native_fns::NativeFn;
 use abra_core::{Error, compile, compile_and_run, compile_and_disassemble};
 use abra_core::vm::value::{Obj, Value};
 use abra_core::vm::vm::VMContext;
@@ -55,8 +56,9 @@ impl Serialize for RunResult {
                     obj.end()
                 }
             }
-            RunResult(Value::Fn { name: fn_name, .. }) => serializer.serialize_str(fn_name),
-            RunResult(Value::Closure { name: fn_name, .. }) => serializer.serialize_str(fn_name),
+            RunResult(Value::Fn { name, .. }) => serializer.serialize_str(name),
+            RunResult(Value::Closure { name, .. }) => serializer.serialize_str(name),
+            RunResult(Value::NativeFn(NativeFn { name, .. })) => serializer.serialize_str(name),
             RunResult(Value::Type(type_name)) => serializer.serialize_str(type_name)
         }
     }


### PR DESCRIPTION
- Create the `Prelude` struct to manage all of the predefined values.
This includes native functions, and predefined types. This is helpful
for organization purposes, and also facilitates some functionality that
had been missing.
- Previously, the invocation of a native function was essentially the
invocation of a String... not great. Now there's a `Value::NativeFn`
value, which references a `NativeFn`. This also means that there's no
hashmap lookups happening at runtime.
- The other functionality that had been missing was the ability to
resolve type literals by name (ie. typing `Int` should produce the
underlying `Int` type).