### PR TITLE
Compiling all invocations

### DIFF
--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -654,8 +654,7 @@ mod tests {
               unnecessaryLayer2\n\
             }\n\
             count = 0\n\
-            val l1 = unnecessaryLayer1()\n\
-            l1()
+            unnecessaryLayer1()()\n\
           }\n\
           val tick = getCounter()\n\
           val results = [tick(), tick(), tick(), tick(), tick()]\n\


### PR DESCRIPTION
Addresses #92 

- Previously, compilation of invocations was limited to only Identifiers
(since it was baked into the builtin-function logic). Since that logic
now lives in the logic for resolving prelude items, we can greatly
simplify the code used to compile invocations. This enabled compilation
of expressions like `getFunc()()`.