### PR TITLE
Fixing newline parsing issues

### DIFF
--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -28,6 +28,8 @@ pub enum Keyword {
 #[derive(Debug, Display, Clone, PartialEq, EnumString, EnumDiscriminants)]
 #[strum_discriminants(name(TokenType), derive(Display))]
 pub enum Token {
+    #[strum(to_string = "newline", serialize = "Newline")] Newline(Position),
+
     #[strum(to_string = "int", serialize = "Int")] Int(Position, i64),
     #[strum(to_string = "float", serialize = "Float")] Float(Position, f64),
     #[strum(to_string = "string", serialize = "String")] String(Position, String),
@@ -78,6 +80,7 @@ pub enum Token {
 impl Token {
     pub fn get_position(&self) -> Position {
         let pos = match self {
+            Token::Newline(pos) |
             Token::Int(pos, _) |
             Token::Float(pos, _) |
             Token::String(pos, _) |
@@ -94,7 +97,7 @@ impl Token {
             Token::In(pos) |
             Token::Type(pos) |
 
-            Token::Ident(pos, _) => pos,
+            Token::Ident(pos, _) |
 
             Token::Assign(pos) |
             Token::Plus(pos) |

--- a/abra_wasm/src/js_value/token.rs
+++ b/abra_wasm/src/js_value/token.rs
@@ -11,6 +11,12 @@ impl<'a> Serialize for JsToken<'a> {
         use serde::ser::SerializeMap;
 
         match &self.0 {
+            Token::Newline(pos) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "newline")?;
+                obj.serialize_entry("pos", &JsPosition(pos))?;
+                obj.end()
+            }
             Token::Int(pos, val) => {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "int")?;


### PR DESCRIPTION
Addresses #90

- There had been an issue where newlines were being ignored in the
middle of any binary expression. This resulted in code such as
`println("hello")\n[1]` to be treated as an array index operation,
rather than a top-level statement and a top-level expression. Correctly
recognizing newlines within `parse_precedence` fixes this issue.
However, it's important that we only break when the _next_ expression to
be parsed is of `Precendence::Call` and we had just seen a `Newline`; if
we don't do this, then expressions such as `1\n+\n1` would be
impossible, which doesn't really make sense.
- This required a change to the lexer, which now can emit a `Newline`
token. This token will represent any block of newlines; there should
never be more than 1 consecutive `Newline` token in a token stream.