### PR TITLE
Fixing newline parsing issues

### DIFF
--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -65,7 +65,7 @@ pub enum Token {
 
     #[strum(to_string = "(", serialize = "LParen")] LParen(Position),
     #[strum(to_string = ")", serialize = "RParen")] RParen(Position),
-    #[strum(to_string = "[", serialize = "LBrack")] LBrack(Position),
+    #[strum(to_string = "[", serialize = "LBrack")] LBrack(Position, /* is_preceded_by_newline: */ bool),
     #[strum(to_string = "]", serialize = "RBrack")] RBrack(Position),
     #[strum(to_string = "{", serialize = "LBrace")] LBrace(Position),
     #[strum(to_string = "}", serialize = "RBrace")] RBrace(Position),
@@ -94,7 +94,7 @@ impl Token {
             Token::In(pos) |
             Token::Type(pos) |
 
-            Token::Ident(pos, _) => pos,
+            Token::Ident(pos, _) |
 
             Token::Assign(pos) |
             Token::Plus(pos) |
@@ -115,7 +115,7 @@ impl Token {
 
             Token::LParen(pos) |
             Token::RParen(pos) |
-            Token::LBrack(pos) |
+            Token::LBrack(pos, _) |
             Token::RBrack(pos) |
             Token::LBrace(pos) |
             Token::RBrace(pos) |

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -1660,7 +1660,7 @@ mod tests {
     fn typecheck_array_empty() -> TestResult {
         let typed_ast = typecheck("[]")?;
         let expected = TypedAstNode::Array(
-            Token::LBrack(Position::new(1, 1)),
+            Token::LBrack(Position::new(1, 1), false),
             TypedArrayNode { typ: Type::Array(Box::new(Type::Any)), items: vec![] },
         );
         assert_eq!(expected, typed_ast[0]);
@@ -1672,7 +1672,7 @@ mod tests {
     fn typecheck_array_homogeneous() -> TestResult {
         let typed_ast = typecheck("[1, 2, 3]")?;
         let expected = TypedAstNode::Array(
-            Token::LBrack(Position::new(1, 1)),
+            Token::LBrack(Position::new(1, 1), false),
             TypedArrayNode {
                 typ: Type::Array(Box::new(Type::Int)),
                 items: vec![
@@ -1686,7 +1686,7 @@ mod tests {
 
         let typed_ast = typecheck("[\"a\", \"b\"]")?;
         let expected = TypedAstNode::Array(
-            Token::LBrack(Position::new(1, 1)),
+            Token::LBrack(Position::new(1, 1), false),
             TypedArrayNode {
                 typ: Type::Array(Box::new(Type::String)),
                 items: vec![
@@ -1699,7 +1699,7 @@ mod tests {
 
         let typed_ast = typecheck("[true, false]")?;
         let expected = TypedAstNode::Array(
-            Token::LBrack(Position::new(1, 1)),
+            Token::LBrack(Position::new(1, 1), false),
             TypedArrayNode {
                 typ: Type::Array(Box::new(Type::Bool)),
                 items: vec![
@@ -1962,7 +1962,7 @@ mod tests {
                             is_mutable: false,
                             expr: Some(Box::new(
                                 TypedAstNode::Array(
-                                    Token::LBrack(Position::new(1, 22)),
+                                    Token::LBrack(Position::new(1, 22), false),
                                     TypedArrayNode {
                                         typ: Type::Array(Box::new(Type::Int)),
                                         items: vec![
@@ -2044,7 +2044,7 @@ mod tests {
             (ident_token!((1, 10), "a"), Type::Int, Some(int_literal!((1, 19), 1))),
             (ident_token!((1, 22), "b"), Type::Array(Box::new(Type::Int)), Some(
                 TypedAstNode::Array(
-                    Token::LBrack(Position::new(1, 26)),
+                    Token::LBrack(Position::new(1, 26), false),
                     TypedArrayNode {
                         typ: Type::Array(Box::new(Type::Int)),
                         items: vec![
@@ -2322,7 +2322,7 @@ mod tests {
     fn typecheck_indexing() -> TestResult {
         let typed_ast = typecheck("val abc = [1, 2, 3]\nabc[1]")?;
         let expected = TypedAstNode::Indexing(
-            Token::LBrack(Position::new(2, 4)),
+            Token::LBrack(Position::new(2, 4), false),
             TypedIndexingNode {
                 typ: Type::Option(Box::new(Type::Int)),
                 target: Box::new(
@@ -2343,7 +2343,7 @@ mod tests {
 
         let typed_ast = typecheck("val idx = 1\nval abc = [1, 2, 3]\nabc[idx:]")?;
         let expected = TypedAstNode::Indexing(
-            Token::LBrack(Position::new(3, 4)),
+            Token::LBrack(Position::new(3, 4), false),
             TypedIndexingNode {
                 typ: Type::Array(Box::new(Type::Int)),
                 target: Box::new(
@@ -2377,7 +2377,7 @@ mod tests {
 
         let typed_ast = typecheck("val idx = 1\n\"abc\"[:idx * 2]")?;
         let expected = TypedAstNode::Indexing(
-            Token::LBrack(Position::new(2, 6)),
+            Token::LBrack(Position::new(2, 6), false),
             TypedIndexingNode {
                 typ: Type::String,
                 target: Box::new(string_literal!((2, 1), "abc")),
@@ -2411,7 +2411,7 @@ mod tests {
 
         let typed_ast = typecheck("val map = { a: 1, b: 2 }\nmap[\"a\"]")?;
         let expected = TypedAstNode::Indexing(
-            Token::LBrack(Position::new(2, 4)),
+            Token::LBrack(Position::new(2, 4), false),
             TypedIndexingNode {
                 typ: Type::Option(Box::new(Type::Int)),
                 target: Box::new(TypedAstNode::Identifier(
@@ -2446,7 +2446,7 @@ mod tests {
 
         let err = typecheck("\"abcd\"[[1, 2]]").unwrap_err();
         let expected = TypecheckerError::InvalidIndexingSelector {
-            token: Token::LBrack(Position::new(1, 8)),
+            token: Token::LBrack(Position::new(1, 8), false),
             target_type: Type::String,
             selector_type: Type::Array(Box::new(Type::Int)),
         };
@@ -2470,14 +2470,14 @@ mod tests {
 
         let err = typecheck("123[0]").unwrap_err();
         let expected = TypecheckerError::InvalidIndexingTarget {
-            token: Token::LBrack(Position::new(1, 4)),
+            token: Token::LBrack(Position::new(1, 4), false),
             target_type: Type::Int,
         };
         assert_eq!(expected, err);
 
         let err = typecheck("val a: Int = [1, 2, 3][0]").unwrap_err();
         let expected = TypecheckerError::Mismatch {
-            token: Token::LBrack(Position::new(1, 23)),
+            token: Token::LBrack(Position::new(1, 23), false),
             expected: Type::Int,
             actual: Type::Option(Box::new(Type::Int)),
         };
@@ -2496,7 +2496,7 @@ mod tests {
 
         let err = typecheck("{ a: true, b: 2 }[\"a\"]").unwrap_err();
         let expected = TypecheckerError::InvalidIndexingTarget {
-            token: Token::LBrack(Position::new(1, 18)),
+            token: Token::LBrack(Position::new(1, 18), false),
             target_type: Type::Map(
                 vec![("a".to_string(), Type::Bool), ("b".to_string(), Type::Int)],
                 None,
@@ -3288,7 +3288,7 @@ mod tests {
             TypedAccessorNode {
                 typ: Type::Int,
                 target: Box::new(TypedAstNode::Array(
-                    Token::LBrack(Position::new(1, 1)),
+                    Token::LBrack(Position::new(1, 1), false),
                     TypedArrayNode {
                         typ: Type::Array(Box::new(Type::Int)),
                         items: vec![

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -719,7 +719,7 @@ Required parameters must all be listed before any optional parameters"
         // Testing non-homogeneous maps
         let src = "val m = { a: \"hello\", b: 3 }\nm[\"a\"]".to_string();
         let err = TypecheckerError::InvalidIndexingTarget {
-            token: Token::LBrack(Position::new(2, 2)),
+            token: Token::LBrack(Position::new(2, 2), false),
             target_type: Type::Map(
                 vec![("a".to_string(), Type::String), ("b".to_string(), Type::Int)],
                 None,
@@ -737,7 +737,7 @@ Cannot index into maps whose values are not all the same type"
         // Testing other types
         let src = "123[1]".to_string();
         let err = TypecheckerError::InvalidIndexingTarget {
-            token: Token::LBrack(Position::new(1, 4)),
+            token: Token::LBrack(Position::new(1, 4), false),
             target_type: Type::Int,
         };
 
@@ -754,7 +754,7 @@ Type Int is not indexable"
     fn test_invalid_indexing_selector() {
         let src = "\"abc\"[\"d\"]".to_string();
         let err = TypecheckerError::InvalidIndexingSelector {
-            token: Token::LBrack(Position::new(1, 6)),
+            token: Token::LBrack(Position::new(1, 6), false),
             target_type: Type::String,
             selector_type: Type::String,
         };

--- a/abra_wasm/src/js_value/token.rs
+++ b/abra_wasm/src/js_value/token.rs
@@ -214,10 +214,11 @@ impl<'a> Serialize for JsToken<'a> {
                 obj.serialize_entry("pos", &JsPosition(pos))?;
                 obj.end()
             }
-            Token::LBrack(pos) => {
-                let mut obj = serializer.serialize_map(Some(2))?;
+            Token::LBrack(pos, is_preceded_by_newline) => {
+                let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "lBrack")?;
                 obj.serialize_entry("pos", &JsPosition(pos))?;
+                obj.serialize_entry("isPrecededByNewline", is_preceded_by_newline)?;
                 obj.end()
             }
             Token::RBrack(pos) => {


### PR DESCRIPTION
Addresses #90

- There had been an issue where newlines were being ignored in the
middle of any binary expression. This resulted in code such as
`println("hello")\n[1]` to be treated as an array index operation,
rather than a top-level statement and a top-level expression.
- To fix this, first I had tried a more complex approach where I tracked
`Token::Newline`s, a new type of Token, and tried to make decisions at
parse-time. This proved to be difficult to do, due to the way that the
Pratt parsing technique attempts to aggregate expressions (see #107 for
the failed attempt). The better way to fix this was to modify the
`Token::LBrack` token to know whether it was preceded by a newline
character, and if so, treat it as `Precedence::None` in the parser (so
it would be treated as an array literal); otherwise, it'd retain its
normal `Precedence::Call` (so it'd be treated as an index operator).
- This is the only place where this needs to happen (at the moment),
since the `[` token is the only token that can be both an infix operator
and the start of a more complex expression. I expect that if tuples were
to exist (something like `(1, 2)`), a similar approach would need to be
taken in order to avoid errant `Precedence::Call` parses.