### PR TITLE
Refactor Token::get_ident_name

### DIFF
--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -130,9 +130,9 @@ impl Token {
         pos.clone()
     }
 
-    pub fn get_ident_name(token: &Token) -> &String {
+    pub fn get_ident_name(token: &Token) -> String {
         match token {
-            Token::Ident(_, ident) => ident,
+            Token::Ident(_, ident) => ident.clone(),
             _ => unreachable!()
         }
     }

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -107,7 +107,7 @@ impl Type {
         match type_ident {
             TypeIdentifier::Normal { ident } => {
                 let type_name = Token::get_ident_name(ident);
-                types.get(type_name).map(|t| t.clone())
+                types.get(&type_name).map(|t| t.clone())
             }
             TypeIdentifier::Array { inner } => {
                 let typ = Type::from_type_ident(inner, types)?;

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -584,7 +584,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
             self.write_opcode(Opcode::GStore, line);
         } else if is_recursive {
             self.write_int_constant(0, line);
-            self.push_local(func_name);
+            self.push_local(&func_name);
         }
 
         let prev_code = self.code.clone();
@@ -602,7 +602,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
         // Argument values will already be on the stack.
         for (arg_token, _, default_value) in args.iter() {
             let ident = Token::get_ident_name(arg_token);
-            self.push_local(ident);
+            self.push_local(&ident);
 
             // This basically adds, for each default-valued parameter `p`:
             // if (p == nil) { p = defaultValueForP }
@@ -703,7 +703,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
             self.write_opcode(Opcode::GStore, line);
         } else if is_recursive {
             let scope_depth = self.get_fn_depth();
-            let (local, fn_local_idx) = self.resolve_local(func_name, scope_depth)
+            let (local, fn_local_idx) = self.resolve_local(&func_name, scope_depth)
                 .expect("There should have been a function pre-defined with this name");
             local.is_closed = true;
             self.write_store_local_instr(fn_local_idx, line);


### PR DESCRIPTION
- Right now, it returned the `Token::Ident`'s name, as a `&String`, but
this doesn't work right when we need to resolve `Token::Self_`'s name
(which is hard-coded to `"self"`). Also, this value just ended up
getting cloned in a bunch of places anyway.