### PR TITLE
Instance methods on Types: Typechecking

### DIFF
--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -133,6 +133,7 @@ impl Token {
     pub fn get_ident_name(token: &Token) -> String {
         match token {
             Token::Ident(_, ident) => ident.clone(),
+            Token::Self_(_) => "self".to_string(),
             _ => unreachable!()
         }
     }

--- a/abra_core/src/parser/parser.rs
+++ b/abra_core/src/parser/parser.rs
@@ -238,8 +238,13 @@ impl Parser {
                 }
                 Token::Self_(_) => {
                     let self_tok = self.expect_next()?;
-
                     args.push((self_tok, None, None));
+
+                    match self.peek().ok_or(ParseError::UnexpectedEof)? {
+                        Token::Comma(_) => self.expect_next(),
+                        Token::RParen(_) => continue,
+                        tok @ _ => return Err(ParseError::UnexpectedToken(tok.clone())),
+                    }?;
                 }
                 Token::Ident(_, _) => {
                     let arg_ident = self.expect_next()?;

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -62,7 +62,7 @@ fn type_repr(t: &Type) -> String {
             }
         }
         Type::Option(typ) => format!("{}?", type_repr(typ)),
-        Type::Fn(args, ret_type) => {
+        Type::Fn(_self_type, args, ret_type) => {
             let args = args.iter().map(|(_, arg_type, _)| type_repr(arg_type)).collect::<Vec<String>>().join(", ");
             format!("({}) => {}", args, type_repr(ret_type))
         }

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -154,6 +154,7 @@ pub struct TypedTypeDeclNode {
     pub name: Token,
     // Tokens represent arg idents, and must be Token::Ident
     pub fields: Vec<(Token, Type, Option<TypedAstNode>)>,
+    pub methods: Vec<(String, TypedAstNode)>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -15,7 +15,7 @@ pub enum Type {
     Array(Box<Type>),
     Map(/* fields: */ Vec<(String, Type)>, /* homogeneous_type: */ Option<Box<Type>>),
     Option(Box<Type>),
-    Fn(Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, Box<Type>),
+    Fn(/* self_type: */ Option<Box<Type>>, Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, Box<Type>),
     Type(/* type_name: */ String, /* underlying_type: */ Box<Type>),
     Struct(StructType),
     Unknown, // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
@@ -51,7 +51,7 @@ impl Type {
                 true
             }
             // For Fn types compare arities, param types, and return type
-            (Fn(args1, ret1), Fn(args2, ret2)) => {
+            (Fn(_self_type1, args1, ret1), Fn(_self_type2, args2, ret2)) => {
                 if args1.len() != args2.len() {
                     return false;
                 }

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -954,7 +954,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
 
         let typ = target.get_type();
         let (arity, has_return) = match typ {
-            Type::Fn(args, ret) => (args.len(), *ret != Type::Unit),
+            Type::Fn(_self_type, args, ret) => (args.len(), *ret != Type::Unit),
             _ => unreachable!() // This should have been caught during typechecking
         };
 

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -31,7 +31,7 @@ impl Prelude {
             let opt_args = native_fn.opt_args.iter().enumerate()
                 .map(|(idx, arg)| (format!("_{}", idx + native_fn.args.len()), arg.clone(), true));
             let args = req_args.chain(opt_args).collect();
-            let typ = Type::Fn(args, Box::new(native_fn.return_type));
+            let typ = Type::Fn(None, args, Box::new(native_fn.return_type));
 
             bindings.insert(name, PreludeBinding { typ, value });
         }

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -1,4 +1,4 @@
-use abra_core::typechecker::types::Type;
+use abra_core::typechecker::types::{Type, StructType};
 use serde::{Serialize, Serializer};
 
 pub struct JsType<'a>(pub &'a Type);
@@ -90,7 +90,7 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("kind", "Unknown")?;
                 obj.end()
             }
-            Type::Struct { name, fields } => {
+            Type::Struct(StructType { name, fields, methods }) => {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "Struct")?;
                 obj.serialize_entry("name", name)?;
@@ -98,6 +98,10 @@ impl<'a> Serialize for JsType<'a> {
                     .map(|(name, typ, _)| (name.clone(), JsType(typ)))
                     .collect();
                 obj.serialize_entry("fields", &fields)?;
+                let methods: Vec<(String, JsType)> = methods.iter()
+                    .map(|(name, typ)| (name.clone(), JsType(typ)))
+                    .collect();
+                obj.serialize_entry("methods", &methods)?;
                 obj.end()
             }
         }

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -69,7 +69,7 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("innerType", &JsType(inner_type))?;
                 obj.end()
             }
-            Type::Fn(args, return_type) => {
+            Type::Fn(_self_type, args, return_type) => {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "Fn")?;
                 let args: Vec<(String, JsType)> = args.iter()

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -108,6 +108,15 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("origIdent", &JsToken(orig_ident))?;
                     obj.end()
                 }
+                TypecheckerError::DuplicateField { ident, orig_ident, orig_is_field } => {
+                    let mut obj = serializer.serialize_map(Some(4))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "duplicateField")?;
+                    obj.serialize_entry("ident", &JsToken(ident))?;
+                    obj.serialize_entry("origIdent", &JsToken(orig_ident))?;
+                    obj.serialize_entry("origType", if *orig_is_field { "field" } else { "method" })?;
+                    obj.end()
+                }
                 TypecheckerError::DuplicateType { ident, orig_ident } => {
                     let mut obj = serializer.serialize_map(Some(4))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
@@ -270,6 +279,20 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     let mut obj = serializer.serialize_map(Some(3))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "invalidTypeFuncInvocation")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.end()
+                }
+                TypecheckerError::InvalidSelfParamPosition { token } => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidSelfParamPosition")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.end()
+                }
+                TypecheckerError::InvalidSelfParam { token } => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidSelfParam")?;
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.end()
                 }


### PR DESCRIPTION
- Modifying parser to properly parse `self` params (it had been failing
if `self` was not the _only_ parameter...)
- When typechecking a type declaration, persist that to
`self.cur_typedef` so that the type of `self` can be looked up within
function body of methods.