### PR TITLE
Compiling methods

### DIFF
--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -390,6 +390,114 @@ impl Compiler {
         }
         Ok(last_line)
     }
+
+    fn compile_function_decl(&mut self, token: Token, node: TypedFunctionDeclNode) -> Result<FnValue, ()> {
+        let TypedFunctionDeclNode { name, args, body, ret_type, scope_depth, .. } = node;
+        let func_name = Token::get_ident_name(&name);
+
+        let line = token.get_position().line;
+
+        let prev_code = self.code.clone();
+        self.code = Vec::new();
+        // TODO: std::mem::swap?
+
+        self.push_scope(ScopeKind::Func);
+
+        // Push return slot as local idx 0, if return value exists
+        if ret_type != Type::Unit {
+            self.push_local("<ret>");
+        }
+
+        // Track function arguments in local bindings, also track # optional args.
+        // Argument values will already be on the stack.
+        for (arg_token, _, default_value) in args.iter() {
+            let ident = Token::get_ident_name(arg_token);
+            self.push_local(&ident);
+
+            // This basically adds, for each default-valued parameter `p`:
+            // if (p == nil) { p = defaultValueForP }
+            match default_value {
+                None => continue,
+                Some(default_value_node) => {
+                    let pos = default_value_node.get_token().get_position();
+                    let typ = default_value_node.get_type();
+
+                    let ident_node = TypedAstNode::Identifier(
+                        arg_token.clone(),
+                        TypedIdentifierNode { typ: typ.clone(), name: ident.clone(), is_mutable: true, scope_depth },
+                    );
+                    let nil_expr = TypedAstNode::_Nil(Token::Ident(pos.clone(), "nil".to_string()));
+                    let default_param_value_node = TypedAstNode::IfStatement(
+                        Token::If(pos.clone()),
+                        TypedIfNode {
+                            typ: Type::Unit,
+                            condition: Box::new(
+                                TypedAstNode::Binary(
+                                    Token::Eq(pos.clone()),
+                                    TypedBinaryNode {
+                                        typ: Type::Bool,
+                                        right: Box::new(ident_node.clone()),
+                                        op: BinaryOp::Eq,
+                                        left: Box::new(nil_expr),
+                                    },
+                                )
+                            ),
+                            if_block: vec![
+                                TypedAstNode::Assignment(
+                                    Token::Assign(pos.clone()),
+                                    TypedAssignmentNode {
+                                        typ: typ.clone(),
+                                        target: Box::new(ident_node),
+                                        expr: Box::new(default_value_node.clone()),
+                                    },
+                                )
+                            ],
+                            else_block: None,
+                        },
+                    );
+                    self.visit(default_param_value_node)?;
+                }
+            }
+        }
+
+        let body_len = body.len();
+        let mut last_line = 0;
+        for (idx, node) in body.into_iter().enumerate() {
+            last_line = node.get_token().get_position().line;
+            let is_last_line = idx == body_len - 1;
+            let should_pop = should_pop_after_node(&node);
+            self.visit(node)?;
+
+            // Handle bare expressions
+            if !is_last_line && should_pop {
+                self.write_opcode(Opcode::Pop, line);
+            }
+            if is_last_line {
+                let popped_locals = self.pop_scope_locals();
+
+                let should_handle_return = ret_type != Type::Unit;
+                if should_handle_return {
+                    self.write_store_local_instr(0, line);
+                    self.metadata.stores.push("<ret>".to_string());
+                }
+                self.write_pops_for_closure(popped_locals, line);
+            }
+        }
+        self.write_opcode(Opcode::Return, last_line);
+        self.pop_scope();
+
+        let code = self.code.clone();
+        self.code = prev_code;
+        // TODO: std::mem::swap?
+
+        let fn_upvalues = self.upvalues.iter().rev()
+            .take_while(|uv| uv.depth == self.get_fn_depth())
+            .map(|uv| uv.clone())
+            .collect::<Vec<Upvalue>>();
+        self.upvalues.truncate(self.upvalues.len() - fn_upvalues.len());
+
+        Ok(FnValue { name: func_name.clone(), code, upvalues: fn_upvalues.clone(), receiver: None })
+    }
 }
 
 impl TypedAstVisitor<(), ()> for Compiler {
@@ -573,8 +681,8 @@ impl TypedAstVisitor<(), ()> for Compiler {
     }
 
     fn visit_function_decl(&mut self, token: Token, node: TypedFunctionDeclNode) -> Result<(), ()> {
-        let TypedFunctionDeclNode { name, args, body, ret_type, scope_depth, is_recursive } = node;
-        let func_name = Token::get_ident_name(&name);
+        let func_name = Token::get_ident_name(&node.name);
+        let is_recursive = node.is_recursive;
 
         let line = token.get_position().line;
 
@@ -587,114 +695,14 @@ impl TypedAstVisitor<(), ()> for Compiler {
             self.push_local(&func_name);
         }
 
-        let prev_code = self.code.clone();
-        self.code = Vec::new();
-        // TODO: std::mem::swap?
+        let fn_value = self.compile_function_decl(token, node)?;
 
-        self.push_scope(ScopeKind::Func);
-
-        // Push return slot as local idx 0, if return value exists
-        if ret_type != Type::Unit {
-            self.push_local("<ret>");
-        }
-
-        // Track function arguments in local bindings, also track # optional args.
-        // Argument values will already be on the stack.
-        for (arg_token, _, default_value) in args.iter() {
-            let ident = Token::get_ident_name(arg_token);
-            self.push_local(&ident);
-
-            // This basically adds, for each default-valued parameter `p`:
-            // if (p == nil) { p = defaultValueForP }
-            match default_value {
-                None => continue,
-                Some(default_value_node) => {
-                    let pos = default_value_node.get_token().get_position();
-                    let typ = default_value_node.get_type();
-
-                    let ident_node = TypedAstNode::Identifier(
-                        arg_token.clone(),
-                        TypedIdentifierNode { typ: typ.clone(), name: ident.clone(), is_mutable: true, scope_depth },
-                    );
-                    let nil_expr = TypedAstNode::_Nil(Token::Ident(pos.clone(), "nil".to_string()));
-                    let default_param_value_node = TypedAstNode::IfStatement(
-                        Token::If(pos.clone()),
-                        TypedIfNode {
-                            typ: Type::Unit,
-                            condition: Box::new(
-                                TypedAstNode::Binary(
-                                    Token::Eq(pos.clone()),
-                                    TypedBinaryNode {
-                                        typ: Type::Bool,
-                                        right: Box::new(ident_node.clone()),
-                                        op: BinaryOp::Eq,
-                                        left: Box::new(nil_expr),
-                                    },
-                                )
-                            ),
-                            if_block: vec![
-                                TypedAstNode::Assignment(
-                                    Token::Assign(pos.clone()),
-                                    TypedAssignmentNode {
-                                        typ: typ.clone(),
-                                        target: Box::new(ident_node),
-                                        expr: Box::new(default_value_node.clone()),
-                                    },
-                                )
-                            ],
-                            else_block: None,
-                        },
-                    );
-                    self.visit(default_param_value_node)?;
-                }
-            }
-        }
-
-        let body_len = body.len();
-        let mut last_line = 0;
-        for (idx, node) in body.into_iter().enumerate() {
-            last_line = node.get_token().get_position().line;
-            let is_last_line = idx == body_len - 1;
-            let should_pop = should_pop_after_node(&node);
-            self.visit(node)?;
-
-            // Handle bare expressions
-            if !is_last_line && should_pop {
-                self.write_opcode(Opcode::Pop, line);
-            }
-            if is_last_line {
-                let popped_locals = self.pop_scope_locals();
-
-                let should_handle_return = ret_type != Type::Unit;
-                if should_handle_return {
-                    self.write_store_local_instr(0, line);
-                    self.metadata.stores.push("<ret>".to_string());
-                }
-                self.write_pops_for_closure(popped_locals, line);
-            }
-        }
-        self.write_opcode(Opcode::Return, last_line);
-        self.pop_scope();
-
-        let code = self.code.clone();
-        self.code = prev_code;
-        // TODO: std::mem::swap?
-
-        let fn_upvalues = self.upvalues.iter().rev()
-            .take_while(|uv| uv.depth == self.get_fn_depth())
-            .map(|uv| uv.clone())
-            .collect::<Vec<Upvalue>>();
-        self.upvalues.truncate(self.upvalues.len() - fn_upvalues.len());
-
-        let const_idx = self.add_constant(Value::Fn(FnValue {
-            name: func_name.clone(),
-            code,
-            upvalues: fn_upvalues.clone(),
-        }));
+        let has_upvalues = !&fn_value.upvalues.is_empty();
+        let const_idx = self.add_constant(Value::Fn(fn_value));
 
         self.write_opcode(Opcode::Constant, line);
         self.write_byte(const_idx, line);
-        if !fn_upvalues.is_empty() {
+        if has_upvalues {
             self.write_opcode(Opcode::ClosureMk, line);
         }
 
@@ -718,10 +726,26 @@ impl TypedAstVisitor<(), ()> for Compiler {
 
     fn visit_type_decl(&mut self, token: Token, node: TypedTypeDeclNode) -> Result<(), ()> {
         let line = token.get_position().line;
-        let TypedTypeDeclNode { name, .. } = node;
+        let TypedTypeDeclNode { name, methods, .. } = node;
 
         let type_name = Token::get_ident_name(&name);
-        let const_idx = self.add_constant(Value::Type(TypeValue { name: type_name.clone() }));
+
+        let mut compiled_methods = Vec::with_capacity(methods.len());
+        for (method_name, method_node) in methods {
+            let (method_tok, method_node) = match method_node {
+                TypedAstNode::FunctionDecl(tok, node) => (tok, node),
+                _ => unreachable!()
+            };
+
+            let method = self.compile_function_decl(method_tok, method_node)?;
+            compiled_methods.push((method_name, method));
+        }
+
+        let type_value = Value::Type(TypeValue {
+            name: type_name.clone(),
+            methods: compiled_methods,
+        });
+        let const_idx = self.add_constant(type_value);
         self.write_opcode(Opcode::Constant, line);
         self.write_byte(const_idx, line);
 
@@ -1554,7 +1578,10 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Type(TypeValue { name: "Person".to_string() }),
+                Value::Type(TypeValue {
+                    name: "Person".to_string(),
+                    methods: vec![],
+                }),
                 Value::Obj(Obj::StringObj { value: Box::new("Person".to_string()) }),
                 Value::Obj(Obj::StringObj { value: Box::new("Meg".to_string()) }),
                 Value::Obj(Obj::StringObj { value: Box::new("meg".to_string()) }),
@@ -1590,7 +1617,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Type(TypeValue { name: "Person".to_string() }),
+                Value::Type(TypeValue { name: "Person".to_string(), methods: vec![] }),
                 Value::Obj(Obj::StringObj { value: Box::new("Person".to_string()) }),
                 Value::Obj(Obj::StringObj { value: Box::new("Unnamed".to_string()) }),
                 Value::Obj(Obj::StringObj { value: Box::new("someBaby".to_string()) }),
@@ -1649,6 +1676,7 @@ mod tests {
                             depth: 1,
                         }
                     ],
+                    receiver: None,
                 }),
                 Value::Fn(FnValue {
                     name: "a".to_string(),
@@ -1662,6 +1690,7 @@ mod tests {
                         Opcode::Return as u8,
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 }),
             ],
         };
@@ -1698,6 +1727,7 @@ mod tests {
                             depth: 2,
                         }
                     ],
+                    receiver: None,
                 }),
                 Value::Fn(FnValue {
                     name: "c".to_string(),
@@ -1713,6 +1743,7 @@ mod tests {
                             depth: 1,
                         }
                     ],
+                    receiver: None,
                 }),
                 Value::Fn(FnValue {
                     name: "a".to_string(),
@@ -1726,6 +1757,7 @@ mod tests {
                         Opcode::Return as u8,
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 }),
             ],
         };
@@ -1830,6 +1862,7 @@ mod tests {
                         Opcode::Return as u8
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 }),
             ],
         };
@@ -1866,6 +1899,7 @@ mod tests {
                             depth: 1,
                         }
                     ],
+                    receiver: None,
                 }),
                 Value::Fn(FnValue {
                     name: "outer".to_string(),
@@ -1878,6 +1912,7 @@ mod tests {
                         Opcode::Return as u8
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 }),
             ],
         };
@@ -2134,6 +2169,7 @@ mod tests {
                         Opcode::Return as u8,
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 })
             ],
         };
@@ -2173,6 +2209,7 @@ mod tests {
                         Opcode::Return as u8,
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 }),
             ],
         };
@@ -2227,6 +2264,7 @@ mod tests {
                         Opcode::Return as u8,
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 }),
             ],
         };
@@ -2265,6 +2303,7 @@ mod tests {
                         Opcode::Return as u8,
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 }),
                 Value::Fn(FnValue {
                     name: "abc".to_string(),
@@ -2284,7 +2323,62 @@ mod tests {
                         Opcode::Return as u8,
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 })
+            ],
+        };
+        assert_eq!(expected, chunk);
+    }
+
+    #[test]
+    fn compile_type_decl_struct_type_methods() {
+        let chunk = compile("\
+          type Person {\n\
+            name: String\n\
+            func getName(self) = self.name\n\
+            func getName2(self) = self.getName()\n\
+          }\
+        ");
+        let expected = Module {
+            code: vec![
+                Opcode::Constant as u8, 0,
+                Opcode::Constant as u8, 1,
+                Opcode::GStore as u8,
+                Opcode::Return as u8
+            ],
+            constants: vec![
+                Value::Type(TypeValue {
+                    name: "Person".to_string(),
+                    methods: vec![
+                        ("getName".to_string(), FnValue {
+                            name: "getName".to_string(),
+                            code: vec![
+                                Opcode::LLoad1 as u8,
+                                Opcode::GetField as u8, 0,
+                                Opcode::LStore0 as u8,
+                                Opcode::Pop as u8,
+                                Opcode::Return as u8
+                            ],
+                            upvalues: vec![],
+                            receiver: None,
+                        }),
+                        ("getName2".to_string(), FnValue {
+                            name: "getName2".to_string(),
+                            code: vec![
+                                Opcode::Nil as u8,
+                                Opcode::LLoad1 as u8,
+                                Opcode::GetField as u8, 1,
+                                Opcode::Invoke as u8, 0, 1,
+                                Opcode::LStore0 as u8,
+                                Opcode::Pop as u8,
+                                Opcode::Return as u8
+                            ],
+                            upvalues: vec![],
+                            receiver: None,
+                        }),
+                    ],
+                }),
+                Value::Obj(Obj::StringObj { value: Box::new("Person".to_string()) }),
             ],
         };
         assert_eq!(expected, chunk);
@@ -2334,6 +2428,7 @@ mod tests {
                         Opcode::Return as u8,
                     ],
                     upvalues: vec![],
+                    receiver: None,
                 }),
                 Value::Obj(Obj::StringObj { value: Box::new("two".to_string()) }),
             ],
@@ -2570,7 +2665,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Type(TypeValue { name: "Person".to_string() }),
+                Value::Type(TypeValue { name: "Person".to_string(), methods: vec![] }),
                 Value::Obj(Obj::StringObj { value: Box::new("Person".to_string()) }),
                 Value::Obj(Obj::StringObj { value: Box::new("Ken".to_string()) }),
                 Value::Obj(Obj::StringObj { value: Box::new("ken".to_string()) }),

--- a/abra_core/src/vm/disassembler.rs
+++ b/abra_core/src/vm/disassembler.rs
@@ -1,6 +1,6 @@
 use crate::vm::compiler::{Metadata, Module};
 use crate::vm::opcode::Opcode;
-use crate::vm::value::Value;
+use crate::vm::value::{Value, FnValue};
 use std::collections::HashMap;
 
 pub fn disassemble(module: Module, metadata: Metadata) -> String {
@@ -141,7 +141,7 @@ impl Disassembler {
         let constants = self.module.constants.clone();
         let iter = constants.iter().filter_map(|val| {
             match val {
-                Value::Fn { name, code, .. } => Some((format!("fn {}", name.clone()), code.clone())),
+                Value::Fn(FnValue { name, code, .. }) => Some((format!("fn {}", name.clone()), code.clone())),
                 _ => None,
             }
         });

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -45,7 +45,10 @@ impl Prelude {
         for (type_name, typ) in prelude_types {
             let binding = PreludeBinding {
                 typ: Type::Type(type_name.to_string(), Box::new(typ.clone())),
-                value: Value::Type(TypeValue { name: type_name.to_string() }),
+                value: Value::Type(TypeValue {
+                    name: type_name.to_string(),
+                    methods: vec![],
+                }),
             };
             bindings.insert(type_name.to_string(), binding);
 

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -1,4 +1,4 @@
-use crate::vm::value::Value;
+use crate::vm::value::{Value, TypeValue};
 use crate::typechecker::types::Type;
 use crate::builtins::native_fns::{NATIVE_FNS, NativeFn};
 use std::collections::HashMap;
@@ -45,7 +45,7 @@ impl Prelude {
         for (type_name, typ) in prelude_types {
             let binding = PreludeBinding {
                 typ: Type::Type(type_name.to_string(), Box::new(typ.clone())),
-                value: Value::Type(type_name.to_string()),
+                value: Value::Type(TypeValue { name: type_name.to_string() }),
             };
             bindings.insert(type_name.to_string(), binding);
 

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -12,6 +12,7 @@ pub struct FnValue {
     pub name: String,
     pub code: Vec<u8>,
     pub upvalues: Vec<Upvalue>,
+    pub receiver: Option<Arc<RefCell<Value>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -19,11 +20,13 @@ pub struct ClosureValue {
     pub name: String,
     pub code: Vec<u8>,
     pub captures: Vec<Arc<RefCell<vm::Upvalue>>>,
+    pub receiver: Option<Arc<RefCell<Value>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct TypeValue {
     pub name: String,
+    pub methods: Vec<(String, FnValue)>,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -49,7 +52,7 @@ impl Value {
             Value::Fn(FnValue { name, .. }) |
             Value::Closure(ClosureValue { name, .. }) |
             Value::NativeFn(NativeFn { name, .. }) => format!("<func {}>", name),
-            Value::Type(TypeValue { name }) => format!("<type {}>", name),
+            Value::Type(TypeValue { name, .. }) => format!("<type {}>", name),
             Value::Nil => format!("nil"),
         }
     }
@@ -68,7 +71,7 @@ impl Display for Value {
             Value::Fn(FnValue { name, .. }) |
             Value::Closure(ClosureValue { name, .. }) |
             Value::NativeFn(NativeFn { name, .. }) => write!(f, "<func {}>", name),
-            Value::Type(TypeValue { name }) => write!(f, "<type {}>", name),
+            Value::Type(TypeValue { name, .. }) => write!(f, "<type {}>", name),
             Value::Nil => write!(f, "nil"),
         }
     }
@@ -103,7 +106,7 @@ impl Obj {
             }
             Obj::InstanceObj { typ, .. } => {
                 match &**typ {
-                    Value::Type(TypeValue { name }) => format!("<instance {}>", name),
+                    Value::Type(TypeValue { name, .. }) => format!("<instance {}>", name),
                     _ => unreachable!("Shouldn't have instances of non-struct types")
                 }
             }

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -334,8 +334,8 @@ impl VM {
     #[inline]
     fn make_closure(&mut self) -> Result<(), InterpretError> {
         let function = self.pop_expect()?;
-        let (name, code, upvalues) = match function {
-            Value::Fn(FnValue { name, code, upvalues }) => Ok((name, code, upvalues)),
+        let (name, code, upvalues, receiver) = match function {
+            Value::Fn(FnValue { name, code, upvalues, receiver }) => Ok((name, code, upvalues, receiver)),
             v @ _ => Err(InterpretError::TypeError("Function".to_string(), v.to_string())),
         }?;
 
@@ -366,7 +366,7 @@ impl VM {
         // in order for the upvalue_idx's to line up properly.
         let captures = captures.rev().collect::<Vec<_>>();
 
-        self.push(Value::Closure(ClosureValue { name, code, captures }));
+        self.push(Value::Closure(ClosureValue { name, code, captures, receiver }));
         Ok(())
     }
 
@@ -642,7 +642,7 @@ impl VM {
                             let res = self.invoke(arity, name, code, vec![]);
                             if res.is_err() { break Err(res.unwrap_err()); } else { continue; }
                         }
-                        Value::Closure(ClosureValue { name, code, captures }) => {
+                        Value::Closure(ClosureValue { name, code, captures, .. }) => {
                             if has_return { arity += 1 }
                             let res = self.invoke(arity, name, code, captures);
                             if res.is_err() { break Err(res.unwrap_err()); } else { continue; }

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -1,7 +1,7 @@
 use crate::builtins::native_types::{NativeString, NativeType, NativeArray};
 use crate::vm::compiler::{Module, UpvalueCaptureKind};
 use crate::vm::opcode::Opcode;
-use crate::vm::value::{Value, Obj};
+use crate::vm::value::{Value, Obj, FnValue, ClosureValue};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::vec_deque::VecDeque;
@@ -305,7 +305,7 @@ impl VM {
 
     fn close_upvalues_from_idx(&mut self, stack_slot: usize) -> Result<(), InterpretError> {
         let max_slot_idx = self.open_upvalues.keys().max();
-        if max_slot_idx.is_none() { return Ok(()) }
+        if max_slot_idx.is_none() { return Ok(()); }
 
         for idx in stack_slot..=*max_slot_idx.unwrap() {
             match self.open_upvalues.remove(&idx) {
@@ -335,7 +335,7 @@ impl VM {
     fn make_closure(&mut self) -> Result<(), InterpretError> {
         let function = self.pop_expect()?;
         let (name, code, upvalues) = match function {
-            Value::Fn { name, code, upvalues } => Ok((name, code, upvalues)),
+            Value::Fn(FnValue { name, code, upvalues }) => Ok((name, code, upvalues)),
             v @ _ => Err(InterpretError::TypeError("Function".to_string(), v.to_string())),
         }?;
 
@@ -366,7 +366,7 @@ impl VM {
         // in order for the upvalue_idx's to line up properly.
         let captures = captures.rev().collect::<Vec<_>>();
 
-        self.push(Value::Closure { name, code, captures });
+        self.push(Value::Closure(ClosureValue { name, code, captures }));
         Ok(())
     }
 
@@ -637,15 +637,15 @@ impl VM {
                             }
                             continue;
                         }
-                        Value::Fn { name, code, .. } => {
+                        Value::Fn(FnValue { name, code, .. }) => {
                             if has_return { arity += 1 }
                             let res = self.invoke(arity, name, code, vec![]);
-                            if res.is_err() { break Err(res.unwrap_err()) } else { continue }
+                            if res.is_err() { break Err(res.unwrap_err()); } else { continue; }
                         }
-                        Value::Closure { name, code, captures } => {
+                        Value::Closure(ClosureValue { name, code, captures }) => {
                             if has_return { arity += 1 }
                             let res = self.invoke(arity, name, code, captures);
-                            if res.is_err() { break Err(res.unwrap_err()) } else { continue }
+                            if res.is_err() { break Err(res.unwrap_err()); } else { continue; }
                         }
                         v @ _ => {
                             return Err(InterpretError::TypeError("Function".to_string(), v.to_string()));

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -577,6 +577,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             upvalues: vec![],
+            receiver: None,
         });
         assert_eq!(expected, result);
     }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -7,7 +7,7 @@ mod tests {
     use crate::parser::parser::parse;
     use crate::typechecker::typechecker::typecheck;
     use crate::vm::compiler::compile;
-    use crate::vm::value::{Value, Obj};
+    use crate::vm::value::{Value, Obj, FnValue};
     use crate::vm::vm::{VM, VMContext};
     use std::collections::HashMap;
     use crate::vm::opcode::Opcode;
@@ -568,7 +568,7 @@ mod tests {
           def
         ";
         let result = interpret(input).unwrap();
-        let expected = Value::Fn {
+        let expected = Value::Fn(FnValue {
             name: "abc".to_string(),
             code: vec![
                 Opcode::Constant as u8, 3,
@@ -577,7 +577,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             upvalues: vec![],
-        };
+        });
         assert_eq!(expected, result);
     }
 

--- a/abra_wasm/src/js_value/value.rs
+++ b/abra_wasm/src/js_value/value.rs
@@ -43,7 +43,7 @@ impl<'a> Serialize for JsWrappedValue<'a> {
                 obj.serialize_entry("name", &fn_name)?;
                 obj.end()
             }
-            Value::Type(TypeValue { name }) => {
+            Value::Type(TypeValue { name, .. }) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "type")?;
                 obj.serialize_entry("name", &name)?;

--- a/abra_wasm/src/js_value/value.rs
+++ b/abra_wasm/src/js_value/value.rs
@@ -1,5 +1,5 @@
 use abra_core::builtins::native_fns::NativeFn;
-use abra_core::vm::value::{Value, Obj};
+use abra_core::vm::value::{Value, Obj, FnValue, ClosureValue, TypeValue};
 use serde::{Serializer, Serialize};
 
 pub struct JsWrappedValue<'a>(pub &'a Value);
@@ -35,18 +35,18 @@ impl<'a> Serialize for JsWrappedValue<'a> {
                 obj.serialize_entry("value", &JsWrappedObjValue(o))?;
                 obj.end()
             }
-            Value::Fn { name: fn_name, .. } |
-            Value::Closure { name: fn_name, .. } |
+            Value::Fn(FnValue { name: fn_name, .. }) |
+            Value::Closure(ClosureValue { name: fn_name, .. }) |
             Value::NativeFn(NativeFn { name: fn_name, .. }) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "fn")?;
                 obj.serialize_entry("name", &fn_name)?;
                 obj.end()
             }
-            Value::Type(type_name) => {
+            Value::Type(TypeValue { name }) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "type")?;
-                obj.serialize_entry("name", &type_name)?;
+                obj.serialize_entry("name", &name)?;
                 obj.end()
             }
             Value::Nil => {

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -18,7 +18,7 @@ use wasm_bindgen_futures::future_to_promise;
 
 use abra_core::builtins::native_fns::NativeFn;
 use abra_core::{Error, compile, compile_and_run, compile_and_disassemble};
-use abra_core::vm::value::{Obj, Value};
+use abra_core::vm::value::{Obj, Value, FnValue, ClosureValue, TypeValue};
 use abra_core::vm::vm::VMContext;
 use abra_core::vm::compiler::Module;
 
@@ -59,10 +59,10 @@ impl Serialize for RunResult {
                     arr.end()
                 }
             }
-            RunResult(Value::Fn { name, .. }) => serializer.serialize_str(name),
-            RunResult(Value::Closure { name, .. }) => serializer.serialize_str(name),
+            RunResult(Value::Fn(FnValue { name, .. })) => serializer.serialize_str(name),
+            RunResult(Value::Closure(ClosureValue { name, .. })) => serializer.serialize_str(name),
             RunResult(Value::NativeFn(NativeFn { name, .. })) => serializer.serialize_str(name),
-            RunResult(Value::Type(type_name)) => serializer.serialize_str(type_name)
+            RunResult(Value::Type(TypeValue { name })) => serializer.serialize_str(name)
         }
     }
 }

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -62,7 +62,7 @@ impl Serialize for RunResult {
             RunResult(Value::Fn(FnValue { name, .. })) => serializer.serialize_str(name),
             RunResult(Value::Closure(ClosureValue { name, .. })) => serializer.serialize_str(name),
             RunResult(Value::NativeFn(NativeFn { name, .. })) => serializer.serialize_str(name),
-            RunResult(Value::Type(TypeValue { name })) => serializer.serialize_str(name)
+            RunResult(Value::Type(TypeValue { name, .. })) => serializer.serialize_str(name)
         }
     }
 }


### PR DESCRIPTION
- Use FnValue, ClosureValue, and TypeValue, rather than having
bare fields in Type enum variant.