### PR TITLE
HUGE cleanup for Value::Obj

### DIFF
--- a/abra_core/src/builtins/native_types.rs
+++ b/abra_core/src/builtins/native_types.rs
@@ -1,10 +1,12 @@
 use crate::typechecker::types::Type;
 use crate::vm::value::{Value, Obj, StringObj};
+use std::sync::Arc;
+use std::cell::RefCell;
 
 pub trait NativeType {
     const FIELDS: &'static [(&'static str, Type)];
 
-    fn get_field_value(value: &Value, field_idx: usize) -> Value;
+    fn get_field_value(obj: &Arc<RefCell<Obj>>, field_idx: usize) -> Value;
 
     fn get_field_idx(field_name: &str) -> usize {
         match Self::get_field(field_name) {
@@ -34,14 +36,15 @@ impl NativeType for NativeArray {
         ("length", Type::Int)
     ];
 
-    fn get_field_value(value: &Value, field_idx: usize) -> Value {
-        if let Value::Obj(Obj::ArrayObj { value }) = value {
-            match field_idx {
-                0 => Value::Int(value.len() as i64),
-                _ => unreachable!()
+    fn get_field_value(obj: &Arc<RefCell<Obj>>, field_idx: usize) -> Value {
+        match &*obj.borrow() {
+            Obj::ArrayObj { value } => {
+                match field_idx {
+                    0 => Value::Int(value.len() as i64),
+                    _ => unreachable!()
+                }
             }
-        } else {
-            unreachable!()
+            _ => unreachable!()
         }
     }
 }
@@ -53,14 +56,15 @@ impl NativeType for NativeString {
         ("length", Type::Int)
     ];
 
-    fn get_field_value(value: &Value, field_idx: usize) -> Value {
-        if let Value::Obj(Obj::StringObj(StringObj { value, .. })) = value {
-            match field_idx {
-                0 => Value::Int(value.len() as i64),
-                _ => unreachable!()
+    fn get_field_value(obj: &Arc<RefCell<Obj>>, field_idx: usize) -> Value {
+        match &*obj.borrow() {
+            Obj::StringObj(StringObj { value, .. }) => {
+                match field_idx {
+                    0 => Value::Int(value.len() as i64),
+                    _ => unreachable!()
+                }
             }
-        } else {
-            unreachable!()
+            _ => unreachable!()
         }
     }
 }

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -4,7 +4,7 @@ use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode};
 use crate::vm::opcode::Opcode;
 use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedUnaryNode, TypedBinaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode};
 use crate::typechecker::types::Type;
-use crate::vm::value::{Value, Obj, FnValue, TypeValue};
+use crate::vm::value::{Value, FnValue, TypeValue};
 use crate::vm::prelude::Prelude;
 use crate::builtins::native_types::{NativeArray, NativeType};
 
@@ -510,7 +510,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
 
         let value = match node {
             TypedLiteralNode::FloatLiteral(val) => Value::Float(val),
-            TypedLiteralNode::StringLiteral(val) => Value::Obj(Obj::new_string_obj(val)),
+            TypedLiteralNode::StringLiteral(val) => Value::new_string_obj(val),
             TypedLiteralNode::IntLiteral(_) | TypedLiteralNode::BoolLiteral(_) => unreachable!() // Handled in if-let above
         };
         let const_idx = self.add_constant(value);
@@ -1160,8 +1160,8 @@ mod tests {
         native_fns().into_iter().find(|f| &f.name == name).unwrap()
     }
 
-    fn new_string_obj(string: &str) -> Obj {
-        Obj::new_string_obj(string.to_string())
+    fn new_string_obj(string: &str) -> Value {
+        Value::new_string_obj(string.to_string())
     }
 
     fn compile(input: &str) -> Module {
@@ -1207,7 +1207,7 @@ mod tests {
             constants: vec![
                 Value::Float(2.3),
                 Value::Float(5.6),
-                Value::Obj(new_string_obj("hello"))
+                new_string_obj("hello")
             ],
         };
         assert_eq!(expected, chunk);
@@ -1329,8 +1329,8 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("abc")),
-                Value::Obj(new_string_obj("def")),
+                new_string_obj("abc"),
+                new_string_obj("def"),
             ],
         };
         assert_eq!(expected, chunk);
@@ -1346,7 +1346,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("a")),
+                new_string_obj("a"),
                 Value::Float(3.4)
             ],
         };
@@ -1403,8 +1403,8 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("a")),
-                Value::Obj(new_string_obj("b"))
+                new_string_obj("a"),
+                new_string_obj("b")
             ],
         };
         assert_eq!(expected, chunk);
@@ -1429,9 +1429,9 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("a")),
-                Value::Obj(new_string_obj("b")),
-                Value::Obj(new_string_obj("c")),
+                new_string_obj("a"),
+                new_string_obj("b"),
+                new_string_obj("c"),
             ],
         };
         assert_eq!(expected, chunk);
@@ -1461,9 +1461,9 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("a")),
-                Value::Obj(new_string_obj("b")),
-                Value::Obj(new_string_obj("c")),
+                new_string_obj("a"),
+                new_string_obj("b"),
+                new_string_obj("c"),
             ],
         };
         assert_eq!(expected, chunk);
@@ -1506,7 +1506,7 @@ mod tests {
             constants: vec![
                 Value::Str("a".to_string()),
                 Value::Str("b".to_string()),
-                Value::Obj(new_string_obj("c")),
+                new_string_obj("c"),
                 Value::Str("d".to_string()),
             ],
         };
@@ -1559,8 +1559,8 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("a")),
-                Value::Obj(new_string_obj("b")),
+                new_string_obj("a"),
+                new_string_obj("b"),
                 Value::Str("abc".to_string()),
                 Value::Int(5),
                 Value::Str("def".to_string()),
@@ -1597,7 +1597,7 @@ mod tests {
                     static_fields: vec![],
                 }),
                 Value::Str("Person".to_string()),
-                Value::Obj(new_string_obj("Meg")),
+                new_string_obj("Meg"),
                 Value::Str("meg".to_string()),
             ],
         };
@@ -1637,10 +1637,10 @@ mod tests {
             constants: vec![
                 Value::Type(TypeValue { name: "Person".to_string(), methods: vec![], static_fields: vec![] }),
                 Value::Str("Person".to_string()),
-                Value::Obj(new_string_obj("Unnamed")),
+                new_string_obj("Unnamed"),
                 Value::Str("someBaby".to_string()),
                 Value::Int(29),
-                Value::Obj(new_string_obj("Some Name")),
+                new_string_obj("Some Name"),
                 Value::Str("anAdult".to_string()),
             ],
         };
@@ -1970,7 +1970,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("some string")),
+                new_string_obj("some string"),
             ],
         };
         assert_eq!(expected, chunk);
@@ -1986,7 +1986,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("some string")),
+                new_string_obj("some string"),
             ],
         };
         assert_eq!(expected, chunk);
@@ -2003,7 +2003,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("some string")),
+                new_string_obj("some string"),
             ],
         };
         assert_eq!(expected, chunk);
@@ -2023,7 +2023,7 @@ mod tests {
             constants: vec![
                 Value::Str("a".to_string()),
                 Value::Str("b".to_string()),
-                Value::Obj(new_string_obj("a")),
+                new_string_obj("a"),
             ],
         };
         assert_eq!(expected, chunk);
@@ -2215,7 +2215,7 @@ mod tests {
             ],
             constants: vec![
                 Value::Str("abc".to_string()),
-                Value::Obj(new_string_obj("hello")),
+                new_string_obj("hello"),
                 Value::NativeFn(get_native_fn("println")),
                 Value::Fn(FnValue {
                     name: "abc".to_string(),
@@ -2648,7 +2648,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("Row: ")),
+                new_string_obj("Row: "),
                 Value::Str("msg".to_string()),
                 Value::Str("arr".to_string()),
                 Value::NativeFn(get_native_fn("println")),
@@ -2686,7 +2686,7 @@ mod tests {
             constants: vec![
                 Value::Type(TypeValue { name: "Person".to_string(), methods: vec![], static_fields: vec![] }),
                 Value::Str("Person".to_string()),
-                Value::Obj(new_string_obj("Ken")),
+                new_string_obj("Ken"),
                 Value::Str("ken".to_string()),
             ],
         };
@@ -2701,7 +2701,7 @@ mod tests {
                 Opcode::Return as u8
             ],
             constants: vec![
-                Value::Obj(new_string_obj("hello")),
+                new_string_obj("hello"),
             ],
         };
         assert_eq!(expected, chunk);

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -130,19 +130,9 @@ impl Obj {
         match self {
             Obj::StringObj(StringObj { value, .. }) => value.clone(),
             Obj::ArrayObj { value } => {
-                let items = value.iter()
-                    .map(|v| v.to_string())
-                    .collect::<Vec<String>>()
-                    .join(", ");
-                format!("[{}]", items)
+                value.iter().map(|v| v.to_string()).collect::<Vec<String>>().join(",")
             }
-            Obj::MapObj { value } => {
-                let items = value.iter()
-                    .map(|(key, value)| format!("{}: {}", key.to_string(), value.to_string()))
-                    .collect::<Vec<String>>()
-                    .join(", ");
-                format!("{{ {} }}", items)
-            }
+            Obj::MapObj { .. } => "<map>".to_string(),
             Obj::InstanceObj(inst) => {
                 match &*inst.typ {
                     Value::Type(TypeValue { name, .. }) => format!("<instance {}>", name),

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -12,7 +12,7 @@ pub struct FnValue {
     pub name: String,
     pub code: Vec<u8>,
     pub upvalues: Vec<Upvalue>,
-    pub receiver: Option<Arc<RefCell<InstanceObj>>>,
+    pub receiver: Option<Arc<RefCell<Obj>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -20,7 +20,7 @@ pub struct ClosureValue {
     pub name: String,
     pub code: Vec<u8>,
     pub captures: Vec<Arc<RefCell<vm::Upvalue>>>,
-    pub receiver: Option<Arc<RefCell<InstanceObj>>>,
+    pub receiver: Option<Arc<RefCell<Obj>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -39,7 +39,7 @@ pub enum Value {
     /// These are only transient values and should not remain on the stack. Compare to an actual,
     /// heap-allocated, run-time Value::Obj(Obj::StringObj) value.
     Str(String),
-    Obj(Obj),
+    Obj(Arc<RefCell<Obj>>),
     Fn(FnValue),
     Closure(ClosureValue),
     NativeFn(NativeFn),
@@ -54,13 +54,33 @@ impl Value {
             Value::Float(val) => format!("{}", val),
             Value::Bool(val) => format!("{}", val),
             Value::Str(val) => val.clone(),
-            Value::Obj(o) => o.to_string(),
+            Value::Obj(obj) => format!("{}", &obj.borrow().to_string()),
             Value::Fn(FnValue { name, .. }) |
             Value::Closure(ClosureValue { name, .. }) |
             Value::NativeFn(NativeFn { name, .. }) => format!("<func {}>", name),
             Value::Type(TypeValue { name, .. }) => format!("<type {}>", name),
             Value::Nil => format!("nil"),
         }
+    }
+
+    pub fn new_string_obj(value: String) -> Value {
+        let str = Obj::StringObj(StringObj { value, fields: vec![] });
+        Value::Obj(Arc::new(RefCell::new(str)))
+    }
+
+    pub fn new_array_obj(values: Vec<Value>) -> Value {
+        let arr = Obj::ArrayObj { value: values };
+        Value::Obj(Arc::new(RefCell::new(arr)))
+    }
+
+    pub fn new_map_obj(items: HashMap<String, Value>) -> Value {
+        let map = Obj::MapObj { value: items };
+        Value::Obj(Arc::new(RefCell::new(map)))
+    }
+
+    pub fn new_instance_obj(typ: Value, fields: Vec<Value>) -> Value {
+        let inst = Obj::InstanceObj(InstanceObj { typ: Box::new(typ), fields });
+        Value::Obj(Arc::new(RefCell::new(inst)))
     }
 }
 
@@ -71,7 +91,7 @@ impl Display for Value {
             Value::Float(v) => write!(f, "{}", v),
             Value::Bool(v) => write!(f, "{}", v),
             Value::Str(val) => write!(f, "{}", val),
-            Value::Obj(o) => match o {
+            Value::Obj(o) => match &*o.borrow() {
                 Obj::StringObj(StringObj { value, .. }) => write!(f, "\"{}\"", *value),
                 o @ _ => write!(f, "{}", o.to_string()),
             }
@@ -99,16 +119,9 @@ pub struct InstanceObj {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Obj {
     StringObj(StringObj),
-    ArrayObj { value: Vec<Box<Value>> },
+    ArrayObj { value: Vec<Value> },
     MapObj { value: HashMap<String, Value> },
-    InstanceObj(Arc<RefCell<InstanceObj>>),
-}
-
-impl Obj {
-    pub fn new_string_obj(value: String) -> Obj {
-        let fields = vec![];
-        Obj::StringObj(StringObj { value, fields })
-    }
+    InstanceObj(InstanceObj),
 }
 
 impl Obj {
@@ -131,8 +144,7 @@ impl Obj {
                 format!("{{ {} }}", items)
             }
             Obj::InstanceObj(inst) => {
-                let typ = &inst.borrow().typ;
-                match &**typ {
+                match &*inst.typ {
                     Value::Type(TypeValue { name, .. }) => format!("<instance {}>", name),
                     _ => unreachable!("Shouldn't have instances of non-struct types")
                 }

--- a/abra_wasm/js-tests/__tests__/abra-unary-binary.test.ts
+++ b/abra_wasm/js-tests/__tests__/abra-unary-binary.test.ts
@@ -22,8 +22,8 @@ describe('unary & binary expressions', () => {
         expect(Abra.runSync('3.14 +"hello"')).toEqual('3.14hello');
         expect(Abra.runSync('"hello" + true')).toEqual('hellotrue');
         expect(Abra.runSync('false + "world"')).toEqual('falseworld');
-        expect(Abra.runSync('[1, 2, 3] + "world"')).toEqual('[1, 2, 3]world');
-        expect(Abra.runSync('"hello" + [" ", "world"]')).toEqual('hello[" ", "world"]');
+        expect(Abra.runSync('[1, 2, 3] + "world"')).toEqual('1,2,3world');
+        expect(Abra.runSync('"hello" + [" ", "world"]')).toEqual('hello ,world');
     });
 
     test('comparisons', () => {

--- a/abra_wasm/src/js_value/value.rs
+++ b/abra_wasm/src/js_value/value.rs
@@ -38,7 +38,7 @@ impl<'a> Serialize for JsWrappedValue<'a> {
             Value::Obj(o) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "obj")?;
-                obj.serialize_entry("value", &JsWrappedObjValue(o))?;
+                obj.serialize_entry("value", &JsWrappedObjValue(&*o.borrow()))?;
                 obj.end()
             }
             Value::Fn(FnValue { name: fn_name, .. }) |
@@ -96,13 +96,10 @@ impl<'a> Serialize for JsWrappedObjValue<'a> {
                 obj.end()
             }
             Obj::InstanceObj(inst) => {
-                let typ = &inst.borrow().typ;
-                let fields = &inst.borrow().fields;
-
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "instanceObj")?;
-                obj.serialize_entry("type", &JsWrappedValue(typ))?;
-                let value: Vec<JsWrappedValue> = fields.iter().map(|i| JsWrappedValue(i)).collect();
+                obj.serialize_entry("type", &JsWrappedValue(&inst.typ))?;
+                let value: Vec<JsWrappedValue> = inst.fields.iter().map(|i| JsWrappedValue(i)).collect();
                 obj.serialize_entry("value", &value)?;
                 obj.end()
             }

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -36,12 +36,12 @@ impl Serialize for RunResult {
             RunResult(Value::Float(val)) => serializer.serialize_f64(*val),
             RunResult(Value::Bool(val)) => serializer.serialize_bool(*val),
             RunResult(Value::Str(val)) => serializer.serialize_str(val),
-            RunResult(Value::Obj(obj)) => match obj {
+            RunResult(Value::Obj(obj)) => match &*obj.borrow() {
                 Obj::StringObj(StringObj { value, .. }) => serializer.serialize_str(&*value),
                 Obj::ArrayObj { value } => {
                     let mut arr = serializer.serialize_seq(Some((*value).len()))?;
                     value.into_iter().for_each(|val| {
-                        arr.serialize_element(&RunResult((**val).clone())).unwrap();
+                        arr.serialize_element(&RunResult((*val).clone())).unwrap();
                     });
                     arr.end()
                 }
@@ -53,7 +53,7 @@ impl Serialize for RunResult {
                     obj.end()
                 }
                 Obj::InstanceObj(inst) => {
-                    let fields = &inst.borrow().fields;
+                    let fields = &inst.fields;
                     let mut arr = serializer.serialize_seq(Some(fields.len()))?;
                     fields.into_iter().for_each(|val| {
                         arr.serialize_element(&RunResult((*val).clone())).unwrap();


### PR DESCRIPTION
- Lift the `Arc<RefCell<>>` up a layer, so all inner Values that are
`Value::Obj` are contained within an `Arc<RefCell<>>`. This means that
we get to treat all instances as locally-mutable cells (whether they're
Obj::Instance, or "primitives" like
Obj::StringObj/Obj::ArrayObj/Obj::MapObj).
- Removes the unused `arr_len` NativeFn, since its usages in the runtime
have been replaced with a `.length` call.