### PR TITLE
Adding `None` builtin value

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,16 +1,3 @@
-type A {
-  a: String
-}
-
-type Person {
-  name: A
-
-  func getName(self) = self.name
-}
-
-val ken = Person(name: A(a: "ken"))
-val a = ken.name = A(a: "Ken")
-println(ken.name.a)
-println(a.a)
-a.a = "asdf"
-println(ken.name.a)
+val arr = [1]
+arr[3] = 3
+(arr[2] ?: 17)

--- a/abra_core/src/lexer/lexer.rs
+++ b/abra_core/src/lexer/lexer.rs
@@ -173,6 +173,7 @@ impl<'a> Lexer<'a> {
                 "for" => Token::For(pos),
                 "in" => Token::In(pos),
                 "type" => Token::Type(pos),
+                "None" => Token::None(pos),
                 s @ _ => Token::Ident(pos, s.to_string())
             };
             return Ok(Some(token));

--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -30,6 +30,7 @@ pub enum Token {
 
     #[strum(to_string = "identifier", serialize = "Ident")] Ident(Position, String),
     #[strum(to_string = "self", serialize = "Self")] Self_(Position),
+    #[strum(to_string = "none", serialize = "None")] None(Position),
 
     #[strum(to_string = "=", serialize = "Assign")] Assign(Position),
     #[strum(to_string = "+", serialize = "Plus")] Plus(Position),
@@ -81,6 +82,7 @@ impl Token {
 
             Token::Ident(pos, _) |
             Token::Self_(pos) |
+            Token::None(pos) |
 
             Token::Assign(pos) |
             Token::Plus(pos) |
@@ -117,6 +119,7 @@ impl Token {
         match token {
             Token::Ident(_, ident) => ident.clone(),
             Token::Self_(_) => "self".to_string(),
+            Token::None(_) => "None".to_string(),
             _ => unreachable!()
         }
     }

--- a/abra_core/src/parser/parser.rs
+++ b/abra_core/src/parser/parser.rs
@@ -129,7 +129,8 @@ impl Parser {
             Token::LBrack(_, _) => Some(Box::new(Parser::parse_array)),
             Token::LBrace(_) => Some(Box::new(Parser::parse_map_literal)),
             Token::Ident(_, _) |
-            Token::Self_(_) => Some(Box::new(Parser::parse_ident)),
+            Token::Self_(_) |
+            Token::None(_) => Some(Box::new(Parser::parse_ident)),
             Token::If(_) => Some(Box::new(Parser::parse_if_expr)),
             _ => None,
         }
@@ -745,7 +746,7 @@ impl Parser {
 
     fn parse_ident(&mut self, token: Token) -> Result<AstNode, ParseError> {
         match &token {
-            Token::Ident(_, _) | Token::Self_(_) => Ok(AstNode::Identifier(token)),
+            Token::Ident(_, _) | Token::Self_(_) | Token::None(_) => Ok(AstNode::Identifier(token)),
             _ => Err(ParseError::UnexpectedToken(token)) // This should be unreachable, but just in case...
         }
     }
@@ -1771,6 +1772,10 @@ mod tests {
 
         let ast = parse("self")?;
         let expected = AstNode::Identifier(Token::Self_(Position::new(1, 1)));
+        assert_eq!(expected, ast[0]);
+
+        let ast = parse("None")?;
+        let expected = AstNode::Identifier(Token::None(Position::new(1, 1)));
         Ok(assert_eq!(expected, ast[0]))
     }
 

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -263,11 +263,11 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                 BinaryOp::Coalesce => {
                     match (&ltype, &rtype) {
                         (Type::Option(ltype), rtype @ _) => {
-                            if !ltype.is_equivalent_to(rtype) {
+                            if !rtype.is_equivalent_to(ltype) {
                                 let token = typed_right.get_token().clone();
                                 Err(TypecheckerError::Mismatch { token, expected: (**ltype).clone(), actual: rtype.clone() })
                             } else {
-                                Ok((**ltype).clone())
+                                Ok(rtype.clone())
                             }
                         }
                         (_, _) => Err(TypecheckerError::InvalidOperator { token: token.clone(), op: op.clone(), ltype, rtype })
@@ -1770,6 +1770,8 @@ mod tests {
             ("[1][0] ?: 2", Type::Int),
             ("[[0, 1]][0] ?: [1, 2]", Type::Array(Box::new(Type::Int))),
             ("[[0, 1][0]][0] ?: [1, 2][1]", Type::Option(Box::new(Type::Int))),
+            ("[][0] ?: 0", Type::Int),
+            ("None ?: 0", Type::Int),
         ];
 
         for (input, expected_type) in cases {
@@ -2768,7 +2770,7 @@ mod tests {
                             },
                         )),
                         field_idx: 0,
-                        field_name: "name".to_string()
+                        field_name: "name".to_string(),
                     },
                 )),
                 expr: Box::new(string_literal!((3, 10), "qwer")),

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -28,6 +28,9 @@ impl Prelude {
             bindings.insert(name, PreludeBinding { typ, value });
         }
 
+        // Insert None
+        bindings.insert("None".to_string(), PreludeBinding { typ: Type::Option(Box::new(Type::Any)), value: Value::Nil });
+
         let prelude_types = vec![
             ("Int", Type::Int),
             ("Float", Type::Float),

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -59,7 +59,7 @@ impl Value {
             Value::Closure(ClosureValue { name, .. }) => format!("<func {}>", name),
             Value::NativeFn(NativeFn { name, .. }) => format!("<func {}>", name),
             Value::Type(TypeValue { name, .. }) => format!("<type {}>", name),
-            Value::Nil => format!("nil"),
+            Value::Nil => format!("None"),
         }
     }
 
@@ -99,7 +99,7 @@ impl Display for Value {
             Value::Closure(ClosureValue { name, .. }) => write!(f, "<func {}>", name),
             Value::NativeFn(NativeFn { name, .. }) => write!(f, "<func {}>", name),
             Value::Type(TypeValue { name, .. }) => write!(f, "<type {}>", name),
-            Value::Nil => write!(f, "nil"),
+            Value::Nil => write!(f, "None"),
         }
     }
 }

--- a/abra_wasm/src/js_value/token.rs
+++ b/abra_wasm/src/js_value/token.rs
@@ -112,6 +112,12 @@ impl<'a> Serialize for JsToken<'a> {
                 obj.serialize_entry("pos", &JsPosition(pos))?;
                 obj.end()
             }
+            Token::None(pos) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "none")?;
+                obj.serialize_entry("pos", &JsPosition(pos))?;
+                obj.end()
+            }
             Token::Assign(pos) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "assign")?;


### PR DESCRIPTION
Addresses #127 

- The `None` value is of type `Optional<Any>`.
- The `Value::Nil` variant of `Value` should be displayed as `"None"`.
This makes sense because in the following code:
```
val arr = [0]
arr[4] = 4
arr  // Prints "0,None,None,None,4
```
so it makes sense, since saying `arr[1]` would effectively result in a
`None` value.