### PR TITLE
Optional-safe accessor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
 name = "abra_core"
 version = "0.3.0"
 dependencies = [
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -102,6 +103,16 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +168,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro-error"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +226,43 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -337,6 +390,11 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap)" = "<none>"
 "checksum clap_derive 0.3.0 (git+https://github.com/clap-rs/clap_derive)" = "<none>"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
@@ -445,12 +504,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 "checksum proc-macro-error 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "53c98547ceaea14eeb26fcadf51dc70d01a2479a7839170eae133721105e4428"
 "checksum proc-macro-error-attr 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c2bf5d493cf5d3e296beccfd61794e445e830dfc8070a9c248ad3ee071392c6c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+"checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a0538bd897e17257b0128d2fd95c2ed6df939374073a36166051a79e2eb7986"
 "checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 "checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
@@ -468,6 +532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
 "checksum wasm-bindgen-backend 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
 "checksum wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,3 +1,4 @@
-val arr = [1]
-arr[3] = 3
-(arr[2] ?: 17)
+type Name { value: String? = None }
+type Person { name: Name? = None }
+val ken = Person(name: Name(value: "Ken"))
+ken.name?.value?.length

--- a/abra_core/Cargo.toml
+++ b/abra_core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 strum = "0.15.0"
 strum_macros = "0.15.0"
+rand = "0.7.3"
 
 [lib]
 name = "abra_core"

--- a/abra_core/src/common/mod.rs
+++ b/abra_core/src/common/mod.rs
@@ -1,3 +1,4 @@
 pub mod ast_visitor;
 pub mod display_error;
 pub mod typed_ast_visitor;
+pub mod util;

--- a/abra_core/src/common/util.rs
+++ b/abra_core/src/common/util.rs
@@ -1,0 +1,11 @@
+use rand::{thread_rng, distributions, Rng};
+use std::iter;
+
+pub fn random_string(length: usize) -> String {
+    let mut rng = thread_rng();
+    let chars: String = iter::repeat(())
+        .map(|()| rng.sample(distributions::Alphanumeric))
+        .take(length)
+        .collect();
+    return chars;
+}

--- a/abra_core/src/lexer/lexer.rs
+++ b/abra_core/src/lexer/lexer.rs
@@ -237,6 +237,9 @@ impl<'a> Lexer<'a> {
                 if let Some(':') = self.peek() {
                     self.expect_next()?; // Consume ':' token
                     Ok(Some(Token::Elvis(pos)))
+                } else if let Some('.') = self.peek() {
+                    self.expect_next()?; // Consume '.' token
+                    Ok(Some(Token::QuestionDot(pos)))
                 } else {
                     Ok(Some(Token::Question(pos)))
                 }
@@ -342,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_tokenize_multi_char_operators() {
-        let input = "&& || <= >= != == ?:";
+        let input = "&& || <= >= != == ?: ?.";
         let tokens = tokenize(&input.to_string()).unwrap();
         let expected = vec![
             Token::And(Position::new(1, 1)),
@@ -352,6 +355,7 @@ mod tests {
             Token::Neq(Position::new(1, 13)),
             Token::Eq(Position::new(1, 16)),
             Token::Elvis(Position::new(1, 19)),
+            Token::QuestionDot(Position::new(1, 22)),
         ];
         assert_eq!(expected, tokens);
     }

--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -59,6 +59,7 @@ pub enum Token {
     #[strum(to_string = ",", serialize = "Comma")] Comma(Position),
     #[strum(to_string = "?", serialize = "Question")] Question(Position),
     #[strum(to_string = ".", serialize = "Dot")] Dot(Position),
+    #[strum(to_string = "?.", serialize = "QuestionDot")] QuestionDot(Position),
 }
 
 impl Token {
@@ -110,7 +111,8 @@ impl Token {
             Token::Colon(pos) |
             Token::Comma(pos) |
             Token::Question(pos) |
-            Token::Dot(pos) => pos
+            Token::Dot(pos) |
+            Token::QuestionDot(pos) => pos
         };
         pos.clone()
     }

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -147,19 +147,20 @@ pub struct ForLoopNode {
     pub iteratee: Token,
     pub index_ident: Option<Token>,
     pub iterator: Box<AstNode>,
-    pub body: Vec<AstNode>
+    pub body: Vec<AstNode>,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct WhileLoopNode {
     pub condition: Box<AstNode>,
-    pub body: Vec<AstNode>
+    pub body: Vec<AstNode>,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct AccessorNode {
     pub target: Box<AstNode>,
-    pub field: Token
+    pub field: Token,
+    pub is_opt_safe: bool,
 }
 
 #[derive(Debug, PartialEq)]

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -1284,7 +1284,8 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         let mut target_type = target.get_type();
         let mut is_opt = false;
         if is_opt_safe {
-            if let Type::Option(inner_type) = target_type {
+            // Handle nested Option types (ie. String??? -> String?)
+            while let Type::Option(inner_type) = target_type {
                 target_type = *inner_type;
                 is_opt = true;
             }

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -75,6 +75,7 @@ fn type_repr(t: &Type) -> String {
         Type::Type(name, _) => name.to_string(),
         Type::Unknown => "Unknown".to_string(),
         Type::Struct(StructType { name, .. }) => name.to_string(),
+        Type::Placeholder => "_".to_string(),
     }
 }
 

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -231,5 +231,6 @@ pub struct TypedAccessorNode {
     pub target: Box<TypedAstNode>,
     pub field_name: String,
     pub field_idx: usize,
+    pub is_opt_safe: bool,
 }
 

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -42,6 +42,7 @@ impl Type {
             // For Array / Option types, compare inner type
             (Array(t1), Array(t2)) |
             (Option(t1), Option(t2)) => self::Type::is_equivalent_to(t1, t2),
+            (t1, Option(t2)) => self::Type::is_equivalent_to(t1, t2),
             (Or(t1s), Or(t2s)) => {
                 let t1s = HashSet::<self::Type>::from_iter(t1s.clone().into_iter());
                 let t2s = HashSet::<self::Type>::from_iter(t2s.clone().into_iter());

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -19,6 +19,7 @@ pub enum Type {
     Type(/* type_name: */ String, /* underlying_type: */ Box<Type>),
     Struct(StructType),
     Unknown, // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
+    Placeholder,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -107,6 +108,7 @@ impl Type {
                 true
             }
             (_, Any) => true,
+            (Placeholder, _) | (_, Placeholder) => true,
             (_, _) => false
         }
     }

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -29,7 +29,7 @@ impl Prelude {
         }
 
         // Insert None
-        bindings.insert("None".to_string(), PreludeBinding { typ: Type::Option(Box::new(Type::Any)), value: Value::Nil });
+        bindings.insert("None".to_string(), PreludeBinding { typ: Type::Option(Box::new(Type::Placeholder)), value: Value::Nil });
 
         let prelude_types = vec![
             ("Int", Type::Int),

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1098,6 +1098,44 @@ mod tests {
     }
 
     #[test]
+    fn interpret_accessor_opt_safe() {
+        let input = "\
+          type Name { value: String? = None }\n\
+          type Person { name: Name? = None }\n\
+          val ken = Person()\n\
+          ken.name?.value?.length\n\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Nil;
+        assert_eq!(expected, result);
+
+        let input = "\
+          type Name { value: String? = None }\n\
+          type Person { name: Name? = None }\n\
+          val ken = Person(name: Name(value: \"Ken\"))\n\
+          ken.name?.value?.length\n\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(3);
+        assert_eq!(expected, result);
+
+        let input = "\
+          type Person { name: String? = None }\n\
+          val people = [Person(name: \"a\")]\n\
+          [\n\
+            people[0]?.name?.length,\n\
+            people[1]?.name?.length,\n\
+          ]\n\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::new_array_obj(vec![
+            Value::Int(1),
+            Value::Nil
+        ]);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn interpret_method_invocation_struct() {
         let input = "\
           type Person {\n\

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -108,6 +108,11 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("methods", &methods)?;
                 obj.end()
             }
+            Type::Placeholder => {
+                let mut obj = serializer.serialize_map(Some(1))?;
+                obj.serialize_entry("kind", "Placeholder")?;
+                obj.end()
+            }
         }
     }
 }

--- a/abra_wasm/src/js_value/token.rs
+++ b/abra_wasm/src/js_value/token.rs
@@ -276,6 +276,12 @@ impl<'a> Serialize for JsToken<'a> {
                 obj.serialize_entry("pos", &JsPosition(pos))?;
                 obj.end()
             }
+            Token::QuestionDot(pos) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "questionDot")?;
+                obj.serialize_entry("pos", &JsPosition(pos))?;
+                obj.end()
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses #124

- Add lexing of `?.` operator
- Add parsing of `?.` expressions (it creates an `AstNode::Accessor`
whose `AccessorNode` has `is_opt_safe: true`).
- Add typechecking of `?.` expressions. `a?.b` will "unwrap" `a` if it's
an optional, and then typechecks the field `b` against it, then re-wraps
it as an optional; if `a` is _not_ optional, it's effectively the same
as `a.b`; a `Token::Dot` is actually emitted instead of
`Token::QuestionDot`, so downstream code will actually compile away the
unnecessary optional-safeness.