### PR TITLE
Bugfix: Using unclosed upvalues

### DIFF
--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -283,10 +283,11 @@ impl Compiler {
         self.scopes.iter().filter(|s| s.kind == ScopeKind::Func).count()
     }
 
-    fn push_local<S: AsRef<str>>(&mut self, name: S) -> usize {
+    fn push_local<S: AsRef<str>>(&mut self, name: S) {
+        let depth = self.get_fn_depth();
         self.locals.push(Local {
             name: name.as_ref().to_string(),
-            depth: self.get_fn_depth(),
+            depth,
             is_captured: false,
             is_closed: false,
         });
@@ -294,10 +295,9 @@ impl Compiler {
         let mut scope = self.scopes.last_mut().unwrap();
         scope.num_locals += 1;
         if scope.first_local_idx == None {
-            scope.first_local_idx = Some(self.locals.len() - 1);
+            let first_local_idx = self.locals.iter().filter(|l| l.depth == depth).count();
+            scope.first_local_idx = Some(first_local_idx - 1);
         }
-
-        self.locals.len() - 1
     }
 
     fn push_scope(&mut self, kind: ScopeKind) {

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -267,7 +267,8 @@ impl VM {
             let value = self.pop_expect()?;
             uv.val = Some(value);
         } else {
-            self.store_local(uv.slot_idx)?;
+            let value = self.pop_expect()?;
+            self.stack_insert_at(uv.slot_idx, value);
         }
         Ok(())
     }
@@ -291,7 +292,8 @@ impl VM {
                 .clone();
             self.push(val);
         } else {
-            self.load_local(uv.slot_idx)?;
+            let value = self.stack_get(uv.slot_idx);
+            self.push(value);
         }
         Ok(())
     }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -742,6 +742,47 @@ mod tests {
     }
 
     #[test]
+    fn interpret_func_invocation_closures_upvalues_not_yet_closed() {
+        let input = "\
+          func abc() {\n\
+            val a = 20\n\
+            func def() { a }\n\
+            4 + def()\n\
+          }\n\
+          abc()\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = "\
+          func abc() {\n\
+            var a = 20\n\
+            func wrapper() {\n\
+              val b = 123\n\
+              func wrapper2() {\n\
+                val c = 456\n\
+                if (true) {\n\
+                  val b = 456\n\
+                  a = 24\n\
+                  a\n\
+                } else {\n\
+                  0\n\
+                }\n\
+              }\n\
+              wrapper2()\n\
+            }\n\
+            wrapper()\n\
+          }\n\
+          abc()\
+        ";
+
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn interpret_func_invocation_callstack() {
         let input = "\
           val greeting = \"Hello\"\n\


### PR DESCRIPTION
- There was a bug where accessing upvalues in a function that have not
yet been closed over breaks. Normally, when we close over a local in a
function by another function, then return that function we're okay since
that closed-over value is moved onto the heap by the time the returned
closure executes. But if we call the closure before the enclosing
function returns, we never close over that captured local.
- In the code to load and store upvalues within the VM, there was a bug.
If the upvalue was not yet closed over (as is the case here), we were
using the upvalue's `slot_idx` and loading/storing a local, _but we were
doing it with respect to the current frame_. Instead, we want to do it
against the base of the stack in general, since this value is being
evaluated with respect to the caller's frame, and not the callee's
frame. What a sneaky nefarious little bug