### PR TITLE
Proper if-exprs

### DIFF
--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -67,8 +67,17 @@ impl TypedAstNode {
             TypedAstNode::Grouped(_, node) => node.typ.clone(),
             TypedAstNode::Array(_, node) => node.typ.clone(),
             TypedAstNode::Map(_, node) => node.typ.clone(),
+            TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { is_anon, args, ret_type, .. }) => {
+                if !is_anon { return Type::Unit; }
+
+                let args = args.iter().map(|(ident, typ, default_value)| {
+                    let name = Token::get_ident_name(ident);
+                    (name, typ.clone(), default_value.is_some())
+                }).collect();
+
+                Type::Fn(None, args, Box::new(ret_type.clone()))
+            }
             TypedAstNode::BindingDecl(_, _) |
-            TypedAstNode::FunctionDecl(_, _) |
             TypedAstNode::TypeDecl(_, _) |
             TypedAstNode::WhileLoop(_, _) |
             TypedAstNode::Break(_) |
@@ -146,6 +155,7 @@ pub struct TypedFunctionDeclNode {
     pub body: Vec<TypedAstNode>,
     pub scope_depth: usize,
     pub is_recursive: bool,
+    pub is_anon: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -679,16 +679,18 @@ impl TypedAstVisitor<(), ()> for Compiler {
     fn visit_function_decl(&mut self, token: Token, node: TypedFunctionDeclNode) -> Result<(), ()> {
         let func_name = Token::get_ident_name(&node.name);
         let is_recursive = node.is_recursive;
-
+        let is_anon = node.is_anon;
         let line = token.get_position().line;
 
-        if self.current_scope().kind == ScopeKind::Root { // If it's a global...
-            self.write_int_constant(0, line);
-            self.write_constant(Value::Str(func_name.clone()), line);
-            self.write_opcode(Opcode::GStore, line);
-        } else if is_recursive {
-            self.write_int_constant(0, line);
-            self.push_local(&func_name);
+        if !is_anon {
+            if self.current_scope().kind == ScopeKind::Root { // If it's a global...
+                self.write_int_constant(0, line);
+                self.write_constant(Value::Str(func_name.clone()), line);
+                self.write_opcode(Opcode::GStore, line);
+            } else if is_recursive {
+                self.write_int_constant(0, line);
+                self.push_local(&func_name);
+            }
         }
 
         let fn_value = self.compile_function_decl(token, node)?;
@@ -702,19 +704,21 @@ impl TypedAstVisitor<(), ()> for Compiler {
             self.write_opcode(Opcode::ClosureMk, line);
         }
 
-        if self.current_scope().kind == ScopeKind::Root { // If it's a global...
-            self.write_constant(Value::Str(func_name.clone()), line);
-            self.write_opcode(Opcode::GStore, line);
-        } else if is_recursive {
-            let scope_depth = self.get_fn_depth();
-            let (local, fn_local_idx) = self.resolve_local(&func_name, scope_depth)
-                .expect("There should have been a function pre-defined with this name");
-            local.is_closed = true;
-            self.write_store_local_instr(fn_local_idx, line);
-            self.metadata.stores.push(func_name.clone());
-            self.write_opcode(Opcode::CloseUpvalue, line);
-        } else {
-            self.push_local(func_name);
+        if !is_anon {
+            if self.current_scope().kind == ScopeKind::Root { // If it's a global...
+                self.write_constant(Value::Str(func_name.clone()), line);
+                self.write_opcode(Opcode::GStore, line);
+            } else if is_recursive {
+                let scope_depth = self.get_fn_depth();
+                let (local, fn_local_idx) = self.resolve_local(&func_name, scope_depth)
+                    .expect("There should have been a function pre-defined with this name");
+                local.is_closed = true;
+                self.write_store_local_instr(fn_local_idx, line);
+                self.metadata.stores.push(func_name.clone());
+                self.write_opcode(Opcode::CloseUpvalue, line);
+            } else {
+                self.push_local(func_name);
+            }
         }
 
         Ok(())
@@ -1155,10 +1159,30 @@ impl TypedAstVisitor<(), ()> for Compiler {
             }
 
             let pos = token.get_position().clone();
-            let nodes = compile_if_block(self, pos, &mut unwound_path, None)?;
-            for node in nodes {
-                self.visit(node)?;
-            }
+            let nodes = compile_if_block(self, pos.clone(), &mut unwound_path, None)?;
+            let scope_depth = self.get_fn_depth();
+            let anon_fn_name = format!("$anon_{}", random_string(4));
+            let wrapper_fn_node = TypedAstNode::Invocation(
+                Token::LParen(pos.clone(), false),
+                TypedInvocationNode {
+                    typ: Type::Placeholder, // The type does not matter
+                    target: Box::new(TypedAstNode::FunctionDecl(
+                        Token::Func(pos.clone()),
+                        TypedFunctionDeclNode {
+                            name: Token::Ident(pos.clone(), anon_fn_name),
+                            args: vec![],
+                            ret_type: Type::Placeholder, // The type does not matter
+                            body: nodes,
+                            scope_depth,
+                            is_recursive: false,
+                            is_anon: true,
+                        },
+                    )),
+                    args: vec![],
+                },
+            );
+
+            self.visit(wrapper_fn_node)?;
         } else {
             let TypedAccessorNode { target, field_name, field_idx, .. } = node;
             self.metadata.field_gets.push(field_name);

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -611,6 +611,25 @@ mod tests {
         let result = interpret(input).unwrap();
         let expected = Value::Int(123);
         assert_eq!(expected, result);
+
+        let input = "4 + if (true) { 20 } else { 0 }";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = "\
+          func abc() {\n\
+            val a = 20\n\
+            4 + if (true) {\n\
+              val b = 123\n\
+              a\n\
+            } else { 0 }\n\
+          }\n\
+          abc()\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -1150,14 +1169,15 @@ mod tests {
         let expected = Value::Nil;
         assert_eq!(expected, result);
 
+        // Verify that resolution of optional-safe accessors doesn't pollute the stack mid-expr
         let input = "\
           type Name { value: String? = None }\n\
           type Person { name: Name? = None }\n\
           val ken = Person(name: Name(value: \"Ken\"))\n\
-          ken.name?.value?.length\n\
+          1 + (ken.name?.value?.length ?: 0)\n\
         ";
         let result = interpret(input).unwrap();
-        let expected = Value::Int(3);
+        let expected = Value::Int(4);
         assert_eq!(expected, result);
 
         let input = "\


### PR DESCRIPTION
- I realized that if-expressions don't actually work properly... They're
fine if there's nothing else on the stack, but if there is, then any
variables created in the meantime mess things up. For example
```
var a = 1
1 + if (true) {
  val b = 2
  a
} else { 0 }
```
The variable `b` means that the binding `a` will not be properly
resolved, since the `1` will pollute the stack in the meantime.
- The "solution" to this (still not sure how I feel about it) is to have
if-expressions compile down to invocations of anonymous functions, the
bodies of which consist solely of the if-expression. This properly
resolves any stack issues (since variables referenced from outside of
the if-expr will be via upvalues). What I haven't yet decided though is
whether this convenience is _always_ worth allocating an anonymous
function for. For example, if there is nothing on the stack (which we
should be able to know at compile-time) we should be smart enough to not
incur this cost:
```
val a = if (true) { 1 } else { 2 }
```
This should ideally not create and immediately invoke an anonymous
function. But that sounds like a future enhancement, right?
- Also of note, since optional-safe accessors compile to if-expressions
under the hood, that code also needed to be wrapped in an
immediately-invoked function expression. Now, expressions like
```
1 + (maybeString?.length ?: 0)
```
will work, when previously it caused all bunch of stack-related issues.