### PR TITLE
Two pass typechecker for type decls

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,6 +1,8 @@
 type Node {
   value: String
-  next: Node? = None
+  next: Node? = Node.empty()
+
+  func empty(): Node? = None
 
   func toString(self): String {
     var str = self.value + ", "

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,4 +1,44 @@
-type Name { value: String? = None }
-type Person { name: Name? = None }
-val ken = Person(name: Name(value: "Ken"))
-ken.name?.value?.length
+// type Person {
+//   name: String = "Who?"
+//
+//   func getName(self): String = self.name
+//
+//   func ken(): Person = Person(name: "Ken")
+//   func who(): Person = Person()
+// }
+//
+// val ken = Person.ken()
+// ken.name + Person.who().getName()
+
+val a = 123
+1 + if (true) {
+  val b = 456
+  a
+} else { 3 }
+
+
+//type Node {
+//  value: String
+//  next: Node? = None
+//
+//  func toString(self): String {
+//    var str = self.value + ", "
+//    //var next = self.next
+//
+//    str = str + self.next?.value
+//
+//    //while (next != None) {
+//    //  //val v = (next?.value ?: "")
+//    //  //str = str + v + ", "
+//
+//    //  str = str + (next?.value ?: "")
+//
+//    //  next = next?.next
+//    //}
+//
+//    str
+//  }
+//}
+//
+//val node = Node(value: "a", next: Node(value: "b"))
+//node.toString()

--- a/abra_core/src/builtins/native_fns.rs
+++ b/abra_core/src/builtins/native_fns.rs
@@ -58,7 +58,7 @@ impl NativeFnDesc<'_> {
             .map(|(name, typ)| (name.to_string(), typ.clone().clone(), true));
         let args = req_args.chain(opt_args).collect();
 
-        Type::Fn(None, args, Box::new(self.return_type.clone()))
+        Type::Fn(args, Box::new(self.return_type.clone()))
     }
 }
 

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -1,6 +1,6 @@
 use crate::lexer::tokens::Token;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum AstNode {
     Literal(Token, AstLiteralNode),
     Unary(Token, UnaryNode),
@@ -23,7 +23,7 @@ pub enum AstNode {
     Accessor(Token, AccessorNode),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum AstLiteralNode {
     IntLiteral(i64),
     FloatLiteral(f64),
@@ -37,7 +37,7 @@ pub enum UnaryOp {
     Negate,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct UnaryNode {
     pub op: UnaryOp,
     pub expr: Box<AstNode>,
@@ -61,29 +61,29 @@ pub enum BinaryOp {
     Eq,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BinaryNode {
     pub right: Box<AstNode>,
     pub op: BinaryOp,
     pub left: Box<AstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GroupedNode {
     pub expr: Box<AstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ArrayNode {
     pub items: Vec<Box<AstNode>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MapNode {
     pub items: Vec<(Token, AstNode)>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BindingDeclNode {
     // Must be a Token::Ident
     pub ident: Token,
@@ -92,7 +92,7 @@ pub struct BindingDeclNode {
     pub is_mutable: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FunctionDeclNode {
     // Must be a Token::Ident
     pub name: Token,
@@ -102,7 +102,7 @@ pub struct FunctionDeclNode {
     pub body: Vec<AstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypeDeclNode {
     // Must be a Token::Ident
     pub name: Token,
@@ -111,7 +111,7 @@ pub struct TypeDeclNode {
     pub methods: Vec<AstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AssignmentNode {
     pub target: Box<AstNode>,
     pub expr: Box<AstNode>,
@@ -123,26 +123,26 @@ pub enum IndexingMode<T> {
     Range(Option<Box<T>>, Option<Box<T>>),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct IndexingNode {
     pub target: Box<AstNode>,
     pub index: IndexingMode<AstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct IfNode {
     pub condition: Box<AstNode>,
     pub if_block: Vec<AstNode>,
     pub else_block: Option<Vec<AstNode>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct InvocationNode {
     pub target: Box<AstNode>,
     pub args: Vec<(Option<Token>, AstNode)>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ForLoopNode {
     pub iteratee: Token,
     pub index_ident: Option<Token>,
@@ -150,20 +150,20 @@ pub struct ForLoopNode {
     pub body: Vec<AstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct WhileLoopNode {
     pub condition: Box<AstNode>,
     pub body: Vec<AstNode>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AccessorNode {
     pub target: Box<AstNode>,
     pub field: Token,
     pub is_opt_safe: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TypeIdentifier {
     Normal { ident: Token },
     Array { inner: Box<TypeIdentifier> },

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -40,6 +40,7 @@ pub enum TypecheckerError {
     InvalidSelfParamPosition { token: Token },
     InvalidSelfParam { token: Token },
     MissingRequiredTypeAnnotation { token: Token },
+    InvalidTypeDeclDepth { token: Token },
 }
 
 // TODO: Replace this when I do more work on Type representations
@@ -132,6 +133,7 @@ impl DisplayError for TypecheckerError {
             TypecheckerError::InvalidSelfParamPosition { token } => token.get_position(),
             TypecheckerError::InvalidSelfParam { token } => token.get_position(),
             TypecheckerError::MissingRequiredTypeAnnotation { token } => token.get_position(),
+            TypecheckerError::InvalidTypeDeclDepth { token } => token.get_position(),
         };
         let line = lines.get(pos.line - 1).expect("There should be a line");
 
@@ -389,6 +391,9 @@ impl DisplayError for TypecheckerError {
                 unimplemented!()
             }
             TypecheckerError::MissingRequiredTypeAnnotation { .. } => {
+                unimplemented!()
+            }
+            TypecheckerError::InvalidTypeDeclDepth { .. } => {
                 unimplemented!()
             }
         }

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -39,6 +39,7 @@ pub enum TypecheckerError {
     InvalidTypeFuncInvocation { token: Token },
     InvalidSelfParamPosition { token: Token },
     InvalidSelfParam { token: Token },
+    MissingRequiredTypeAnnotation { token: Token },
 }
 
 // TODO: Replace this when I do more work on Type representations
@@ -68,7 +69,7 @@ fn type_repr(t: &Type) -> String {
             }
         }
         Type::Option(typ) => format!("{}?", type_repr(typ)),
-        Type::Fn(_self_type, args, ret_type) => {
+        Type::Fn(args, ret_type) => {
             let args = args.iter().map(|(_, arg_type, _)| type_repr(arg_type)).collect::<Vec<String>>().join(", ");
             format!("({}) => {}", args, type_repr(ret_type))
         }
@@ -130,6 +131,7 @@ impl DisplayError for TypecheckerError {
             TypecheckerError::InvalidTypeFuncInvocation { token } => token.get_position(),
             TypecheckerError::InvalidSelfParamPosition { token } => token.get_position(),
             TypecheckerError::InvalidSelfParam { token } => token.get_position(),
+            TypecheckerError::MissingRequiredTypeAnnotation { token } => token.get_position(),
         };
         let line = lines.get(pos.line - 1).expect("There should be a line");
 
@@ -384,6 +386,9 @@ impl DisplayError for TypecheckerError {
                 unimplemented!()
             }
             TypecheckerError::InvalidSelfParam { .. } => {
+                unimplemented!()
+            }
+            TypecheckerError::MissingRequiredTypeAnnotation { .. } => {
                 unimplemented!()
             }
         }

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -15,11 +15,11 @@ pub enum Type {
     Array(Box<Type>),
     Map(/* fields: */ Vec<(String, Type)>, /* homogeneous_type: */ Option<Box<Type>>),
     Option(Box<Type>),
-    Fn(/* self_type:  Option<Box<Type>>, */Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, Box<Type>),
+    Fn(/* arg_types: */ Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, /* ret_type: */ Box<Type>),
     Type(/* type_name: */ String, /* underlying_type: */ Box<Type>),
     Struct(StructType),
-    Unknown,
     // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
+    Unknown,
     Placeholder,
 }
 

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -15,7 +15,7 @@ pub enum Type {
     Array(Box<Type>),
     Map(/* fields: */ Vec<(String, Type)>, /* homogeneous_type: */ Option<Box<Type>>),
     Option(Box<Type>),
-    Fn(/* self_type: */ Option<Box<Type>>, Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, Box<Type>),
+    Fn(/* self_type:  Option<Box<Type>>, */Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, Box<Type>),
     Type(/* type_name: */ String, /* underlying_type: */ Box<Type>),
     Struct(StructType),
     Unknown, // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
@@ -43,6 +43,7 @@ impl Type {
             (Array(t1), Array(t2)) |
             (Option(t1), Option(t2)) => self::Type::is_equivalent_to(t1, t2),
             (t1, Option(t2)) => self::Type::is_equivalent_to(t1, t2),
+            (Option(t1), t2) => self::Type::is_equivalent_to(t1, t2),
             (Or(t1s), Or(t2s)) => {
                 let t1s = HashSet::<self::Type>::from_iter(t1s.clone().into_iter());
                 let t2s = HashSet::<self::Type>::from_iter(t2s.clone().into_iter());
@@ -54,7 +55,7 @@ impl Type {
                 true
             }
             // For Fn types compare arities, param types, and return type
-            (Fn(_self_type1, args1, ret1), Fn(_self_type2, args2, ret2)) => {
+            (Fn(args1, ret1), Fn(args2, ret2)) => {
                 if args1.len() != args2.len() {
                     return false;
                 }

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -736,8 +736,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
             self.write_constant(Value::Str(type_name.clone()), line);
             self.write_opcode(Opcode::GStore, line);
         } else { // ...otherwise, it's a local
-            self.write_int_constant(0, line);
-            self.push_local(type_name.clone());
+            unreachable!("Type declarations are only allowed at the root scope");
         }
 
         let mut compiled_methods = Vec::with_capacity(methods.len());
@@ -774,14 +773,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
             self.write_constant(Value::Str(type_name.clone()), line);
             self.write_opcode(Opcode::GStore, line);
         } else { // ...otherwise, it's a local
-            // self.push_local(type_name);
-            let scope_depth = self.get_fn_depth();
-            let (local, type_local_idx) = self.resolve_local(&type_name, scope_depth)
-                .expect("There should have been a type pre-defined with this name");
-            local.is_closed = true;
-            self.write_store_local_instr(type_local_idx, line);
-            self.metadata.stores.push(type_name);
-            self.write_opcode(Opcode::CloseUpvalue, line);
+            unreachable!("Type declarations are only allowed at the root scope");
         }
 
         Ok(())

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -78,6 +78,7 @@ pub enum Opcode {
     Pop,
     PopN,
     Dup,
+    Swap,
     Return,
 }
 
@@ -161,7 +162,8 @@ impl From<&u8> for Opcode {
             74 => Opcode::Pop,
             75 => Opcode::PopN,
             76 => Opcode::Dup,
-            77 => Opcode::Return,
+            77 => Opcode::Swap,
+            78 => Opcode::Return,
             _ => unreachable!()
         }
     }

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -254,6 +254,7 @@ impl VM {
         let CallFrame { stack_offset, .. } = current_frame!(self);
         let stack_slot = stack_slot + *stack_offset;
         let value = self.pop_expect()?;
+        println!("slot: {}; store: {}", stack_slot, value.to_string());
         self.stack_insert_at(stack_slot, value); // TODO: Raise InterpretError when OOB stack_slot
         Ok(())
     }
@@ -276,6 +277,12 @@ impl VM {
         let CallFrame { stack_offset, .. } = current_frame!(self);
         let stack_slot = stack_slot + *stack_offset;
         let value = self.stack_get(stack_slot);
+        println!("slot: {}; load: {}", stack_slot, value.to_string());
+        if stack_slot == 3 {
+            for v in &self.stack {
+                println!("{}", v.to_string());
+            }
+        }
         Ok(self.push(value))
     }
 
@@ -478,6 +485,7 @@ impl VM {
                         }
                         _ => unreachable!()
                     };
+                    println!("GetField {}: {}", field_idx, &value);
                     self.push(value);
                 }
                 Opcode::SetField => {
@@ -746,6 +754,13 @@ impl VM {
                 Opcode::Dup => {
                     let value = self.stack.last().unwrap().clone();
                     self.stack.push(value);
+                }
+                Opcode::Swap => {
+                    let v1 = self.pop_expect()?;
+                    let v2 = self.pop_expect()?;
+                    println!("top: {}, second-from-top: {}", v1.to_string(), v2.to_string());
+                    self.stack.push(v1);
+                    self.stack.push(v2);
                 }
                 Opcode::Return => {
                     let is_main_frame = self.call_stack.len() == 1;

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1242,4 +1242,36 @@ mod tests {
         let expected = new_string_obj("I am Ken");
         assert_eq!(expected, result);
     }
+
+    #[test]
+    fn interpret_linked_list_kinda() {
+        // Verify self-referential types, as well as the usage of static methods in default field values
+        let input = "\
+          type Node {\n\
+            value: String\n\
+            next: Node? = Node.empty()\n\
+
+            func empty(): Node? = None\n\
+
+            func toString(self): String {\n\
+              var str = self.value + \", \"\n\
+              var next = self.next\n\
+
+              while (next != None) {\n\
+                str = str + (next?.value ?: \"\") + \", \"\n\
+
+                next = next?.next\n\
+              }\n\
+
+              str[:-2]\n\
+            }\n\
+          }\n\
+
+          val node = Node(value: \"a\", next: Node(value: \"b\", next: Node(value: \"c\")))\n\
+          node.toString()\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = new_string_obj("a, b, c");
+        assert_eq!(expected, result);
+    }
 }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1140,7 +1140,7 @@ mod tests {
         let input = "\
           type Person {\n\
             name: String\n\
-            func introduce(self) = \"I am \" + self.name\n\
+            func introduce(self): String = \"I am \" + self.name\n\
           }\n\
           val ken = Person(name: \"Ken\")\n\
           val brian = Person(name: \"Brian\")\n\
@@ -1156,7 +1156,7 @@ mod tests {
         let input = "\
           type Person {\n\
             name: String\n\
-            func introduce(self) = \"I am \" + self.name\n\
+            func introduce(self): String = \"I am \" + self.name\n\
           }\n\
           val ken = Person(name: \"Ken\")\n\
           val introduceFn = ken.introduce\n\
@@ -1172,7 +1172,7 @@ mod tests {
         let input = "\
           type Person {\n\
             name: String\n\
-            func introduce(name: String) = \"I am \" + name\n\
+            func introduce(name: String): String = \"I am \" + name\n\
           }\n\
           val ken = Person(name: \"Ken\")\n\
           Person.introduce(ken.name)\

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -69,7 +69,7 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("innerType", &JsType(inner_type))?;
                 obj.end()
             }
-            Type::Fn(_self_type, args, return_type) => {
+            Type::Fn(args, return_type) => {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "Fn")?;
                 let args: Vec<(String, JsType)> = args.iter()

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -303,6 +303,13 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.end()
                 }
+                TypecheckerError::InvalidTypeDeclDepth { token } => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidTypeDeclDepth")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -296,6 +296,13 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.end()
                 }
+                TypecheckerError::MissingRequiredTypeAnnotation { token } => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "missingRequiredTypeAnnotation")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {


### PR DESCRIPTION
- Previously, the typechecking of structs would be done in one pass,
progressively mutating and building up the type as new
fields/methods/static-fields were discovered. This meant that
forward-declarations were not possible, since it would fail
typechecking.