### PR TITLE
Support having Options as conditions

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -8,7 +8,7 @@ type Node {
     var str = self.value + ", "
     var next = self.next
 
-    while (next != None) {
+    while (next) {
       str = str + (next?.value ?: "") + ", "
 
       next = next?.next

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -12,6 +12,7 @@ pub enum InvalidAssignmentTargetReason {
 #[derive(Debug, PartialEq)]
 pub enum TypecheckerError {
     Mismatch { token: Token, expected: Type, actual: Type },
+    InvalidIfConditionType { token: Token, actual: Type },
     InvalidOperator { token: Token, op: BinaryOp, ltype: Type, rtype: Type },
     MissingRequiredAssignment { ident: Token },
     DuplicateBinding { ident: Token, orig_ident: Token },
@@ -105,6 +106,7 @@ impl DisplayError for TypecheckerError {
     fn message_for_error(&self, lines: &Vec<&str>) -> String {
         let pos = match self {
             TypecheckerError::Mismatch { token, .. } => token.get_position(),
+            TypecheckerError::InvalidIfConditionType { token, .. } => token.get_position(),
             TypecheckerError::InvalidOperator { token, .. } => token.get_position(),
             TypecheckerError::MissingRequiredAssignment { ident } => ident.get_position(),
             TypecheckerError::DuplicateBinding { ident, .. } => ident.get_position(),
@@ -146,6 +148,9 @@ impl DisplayError for TypecheckerError {
                 let message = format!("{}Expected {}, got {}", indent, type_repr(expected), type_repr(actual));
 
                 format!("Type mismatch ({}:{})\n{}\n{}", pos.line, pos.col, cursor_line, message)
+            }
+            TypecheckerError::InvalidIfConditionType { .. } => {
+                unreachable!()
             }
             TypecheckerError::InvalidOperator { op, ltype, rtype, .. } => {
                 let message = format!(

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1257,7 +1257,7 @@ mod tests {
               var str = self.value + \", \"\n\
               var next = self.next\n\
 
-              while (next != None) {\n\
+              while next {\n\
                 str = str + (next?.value ?: \"\") + \", \"\n\
 
                 next = next?.next\n\

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -83,6 +83,14 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("actual", &JsType(actual))?;
                     obj.end()
                 }
+                TypecheckerError::InvalidIfConditionType { token, actual } => {
+                    let mut obj = serializer.serialize_map(Some(5))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "mismatch")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("actual", &JsType(actual))?;
+                    obj.end()
+                }
                 TypecheckerError::InvalidOperator { token, op, ltype, rtype } => {
                     let mut obj = serializer.serialize_map(Some(6))?;
                     obj.serialize_entry("kind", "typecheckerError")?;


### PR DESCRIPTION
Addresses #144 

- In if-statements/expressions and while-loops, the condition previously
had been limited to Booleans only. But it makes sense to allow Option
types as well, where a `None` value is equivalent to `false`, and any
other value is `true`.