### PR TITLE
Condition convenience bindings

### DIFF
--- a/abra_core/src/lexer/lexer.rs
+++ b/abra_core/src/lexer/lexer.rs
@@ -227,8 +227,7 @@ impl<'a> Lexer<'a> {
             '|' => {
                 let ch = self.expect_next()?;
                 if ch != '|' {
-                    let pos = Position::new(self.line, self.col);
-                    Err(LexerError::UnexpectedChar(pos, ch.to_string()))
+                    Ok(Some(Token::Pipe(pos)))
                 } else {
                     Ok(Some(Token::Or(pos)))
                 }
@@ -362,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_tokenize_single_char_separators() {
-        let input = "( ) [ ] { } , : ?";
+        let input = "( ) [ ] { } | , : ?";
         let tokens = tokenize(&input.to_string()).unwrap();
         let expected = vec![
             Token::LParen(Position::new(1, 1), false),
@@ -371,9 +370,10 @@ mod tests {
             Token::RBrack(Position::new(1, 7)),
             Token::LBrace(Position::new(1, 9)),
             Token::RBrace(Position::new(1, 11)),
-            Token::Comma(Position::new(1, 13)),
-            Token::Colon(Position::new(1, 15)),
-            Token::Question(Position::new(1, 17)),
+            Token::Pipe(Position::new(1, 13)),
+            Token::Comma(Position::new(1, 15)),
+            Token::Colon(Position::new(1, 17)),
+            Token::Question(Position::new(1, 19)),
         ];
         assert_eq!(expected, tokens);
     }
@@ -391,21 +391,6 @@ mod tests {
         assert_eq!(expected, error);
 
         let input = "& &";
-        let error = tokenize(&input.to_string()).unwrap_err();
-        let expected = LexerError::UnexpectedChar(Position::new(1, 2), " ".to_string());
-        assert_eq!(expected, error);
-
-        let input = "|";
-        let error = tokenize(&input.to_string()).unwrap_err();
-        let expected = LexerError::UnexpectedEof(Position::new(1, 2));
-        assert_eq!(expected, error);
-
-        let input = "|-";
-        let error = tokenize(&input.to_string()).unwrap_err();
-        let expected = LexerError::UnexpectedChar(Position::new(1, 2), "-".to_string());
-        assert_eq!(expected, error);
-
-        let input = "| |";
         let error = tokenize(&input.to_string()).unwrap_err();
         let expected = LexerError::UnexpectedChar(Position::new(1, 2), " ".to_string());
         assert_eq!(expected, error);

--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -12,11 +12,13 @@ impl Default for Position {
 #[derive(Debug, Display, Clone, PartialEq, EnumString, EnumDiscriminants)]
 #[strum_discriminants(name(TokenType), derive(Display))]
 pub enum Token {
+    // Builtin types
     #[strum(to_string = "int", serialize = "Int")] Int(Position, i64),
     #[strum(to_string = "float", serialize = "Float")] Float(Position, f64),
     #[strum(to_string = "string", serialize = "String")] String(Position, String),
     #[strum(to_string = "boolean", serialize = "Bool")] Bool(Position, bool),
 
+    // Keywords
     #[strum(to_string = "func", serialize = "Func")] Func(Position),
     #[strum(to_string = "val", serialize = "Val")] Val(Position),
     #[strum(to_string = "var", serialize = "Var")] Var(Position),
@@ -28,10 +30,12 @@ pub enum Token {
     #[strum(to_string = "in", serialize = "In")] In(Position),
     #[strum(to_string = "type", serialize = "Type")] Type(Position),
 
+    // Identifiers
     #[strum(to_string = "identifier", serialize = "Ident")] Ident(Position, String),
     #[strum(to_string = "self", serialize = "Self")] Self_(Position),
     #[strum(to_string = "none", serialize = "None")] None(Position),
 
+    // Operators
     #[strum(to_string = "=", serialize = "Assign")] Assign(Position),
     #[strum(to_string = "+", serialize = "Plus")] Plus(Position),
     #[strum(to_string = "-", serialize = "Minus")] Minus(Position),
@@ -49,12 +53,14 @@ pub enum Token {
     #[strum(to_string = "!=", serialize = "Neq")] Neq(Position),
     #[strum(to_string = "!", serialize = "Bang")] Bang(Position),
 
+    // Delimiters
     #[strum(to_string = "(", serialize = "LParen")] LParen(Position, /* is_preceded_by_newline: */ bool),
     #[strum(to_string = ")", serialize = "RParen")] RParen(Position),
     #[strum(to_string = "[", serialize = "LBrack")] LBrack(Position, /* is_preceded_by_newline: */ bool),
     #[strum(to_string = "]", serialize = "RBrack")] RBrack(Position),
     #[strum(to_string = "{", serialize = "LBrace")] LBrace(Position),
     #[strum(to_string = "}", serialize = "RBrace")] RBrace(Position),
+    #[strum(to_string = "|", serialize = "Pipe")] Pipe(Position),
     #[strum(to_string = ":", serialize = "Colon")] Colon(Position),
     #[strum(to_string = ",", serialize = "Comma")] Comma(Position),
     #[strum(to_string = "?", serialize = "Question")] Question(Position),
@@ -108,6 +114,7 @@ impl Token {
             Token::RBrack(pos) |
             Token::LBrace(pos) |
             Token::RBrace(pos) |
+            Token::Pipe(pos) |
             Token::Colon(pos) |
             Token::Comma(pos) |
             Token::Question(pos) |

--- a/abra_wasm/src/js_value/token.rs
+++ b/abra_wasm/src/js_value/token.rs
@@ -252,6 +252,12 @@ impl<'a> Serialize for JsToken<'a> {
                 obj.serialize_entry("pos", &JsPosition(pos))?;
                 obj.end()
             }
+            Token::Pipe(pos) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "pipe")?;
+                obj.serialize_entry("pos", &JsPosition(pos))?;
+                obj.end()
+            }
             Token::Colon(pos) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "colon")?;


### PR DESCRIPTION
Contributes towards #146 

- Adding lexing for the pipe (`|`) token