### PR TITLE
Conditional convenience bindings

### DIFF
--- a/abra_core/src/lexer/lexer.rs
+++ b/abra_core/src/lexer/lexer.rs
@@ -225,11 +225,11 @@ impl<'a> Lexer<'a> {
                 }
             }
             '|' => {
-                let ch = self.expect_next()?;
-                if ch != '|' {
-                    Ok(Some(Token::Pipe(pos)))
-                } else {
+                if let Some('|') = self.peek() {
+                    self.expect_next()?; // Consume '|' token
                     Ok(Some(Token::Or(pos)))
+                } else {
+                    Ok(Some(Token::Pipe(pos)))
                 }
             }
             '?' => {

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -132,6 +132,7 @@ pub struct IndexingNode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct IfNode {
     pub condition: Box<AstNode>,
+    pub condition_binding: Option<Token>,
     pub if_block: Vec<AstNode>,
     pub else_block: Option<Vec<AstNode>>,
 }
@@ -153,6 +154,7 @@ pub struct ForLoopNode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct WhileLoopNode {
     pub condition: Box<AstNode>,
+    pub condition_binding: Option<Token>,
     pub body: Vec<AstNode>,
 }
 

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -138,7 +138,7 @@ impl Typechecker {
     // Called from visit_if_expression and visit_if_statement, but it has to be up here since it's
     // not part of the AstVisitor trait.
     fn visit_if_node(&mut self, is_stmt: bool, node: IfNode) -> Result<TypedIfNode, TypecheckerError> {
-        let IfNode { condition, if_block, else_block } = node;
+        let IfNode { condition, if_block, else_block, .. } = node;
 
         let condition = self.visit(*condition)?;
         let is_valid_cond_type = match condition.get_type() {
@@ -1399,7 +1399,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
     }
 
     fn visit_while_loop(&mut self, token: Token, node: WhileLoopNode) -> Result<TypedAstNode, TypecheckerError> {
-        let WhileLoopNode { condition, body } = node;
+        let WhileLoopNode { condition, body, .. } = node;
 
         let condition = self.visit(*condition)?;
         let is_valid_cond_type = match condition.get_type() {
@@ -3984,11 +3984,11 @@ mod tests {
                                         items: vec![
                                             Box::new(int_literal!((1, 8), 1)),
                                             Box::new(int_literal!((1, 11), 2)),
-                                        ]
-                                    }
+                                        ],
+                                    },
                                 )
-                            )
-                        }
+                            ),
+                        },
                     )
                 ),
                 body: vec![


### PR DESCRIPTION
- Parsing of conditional bindings for if-stmts/exprs or while-loops.
This also fixes a lexing bug where the first character after the Pipe
token was skipped over.