### PR TITLE
Condition convenience bindings: Typechecking

### DIFF
--- a/abra_core/src/parser/parser.rs
+++ b/abra_core/src/parser/parser.rs
@@ -467,7 +467,6 @@ impl Parser {
         let condition_binding = if let Some(Token::Pipe(_)) = self.peek() {
             self.expect_next()?; // Consume '|'
             let ident = self.expect_next_token(TokenType::Ident)?; // Expect binding ident
-            dbg!(&ident);
             self.expect_next_token(TokenType::Pipe)?; // Expect closing '|'
 
             Some(ident)

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -203,6 +203,7 @@ pub struct TypedIndexingNode {
 pub struct TypedIfNode {
     pub typ: Type,
     pub condition: Box<TypedAstNode>,
+    pub condition_binding: Option<Token>,
     pub if_block: Vec<TypedAstNode>,
     pub else_block: Option<Vec<TypedAstNode>>,
 }
@@ -224,6 +225,7 @@ pub struct TypedInstantiationNode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct TypedWhileLoopNode {
     pub condition: Box<TypedAstNode>,
+    pub condition_binding: Option<Token>,
     pub body: Vec<TypedAstNode>,
 }
 

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -438,6 +438,7 @@ impl Compiler {
                                     },
                                 )
                             ),
+                            condition_binding: None,
                             if_block: vec![
                                 TypedAstNode::Assignment(
                                     Token::Assign(pos.clone()),
@@ -1159,6 +1160,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
                                         },
                                     )
                                 ),
+                                condition_binding: None,
                                 if_block: if_block_stmts,
                                 else_block: Some(vec![nil_expr]),
                             },
@@ -1277,7 +1279,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
     fn visit_while_loop(&mut self, token: Token, node: TypedWhileLoopNode) -> Result<(), ()> {
         let line = token.get_position().line;
 
-        let TypedWhileLoopNode { condition, body } = node;
+        let TypedWhileLoopNode { condition, body, .. } = node;
         let cond_slot_idx = self.code.len();
 
         let is_opt = if let Type::Option(_) = condition.get_type() { true } else { false };


### PR DESCRIPTION
Contributes towards #146 

- Add typechecking for condition convenience bindings in if-stmts/exprs
and while-loops. This binding will either be a Boolean if the type of
the condition is Boolean (in fact, it will always be `true`); if the
condition is of type `T?`, the binding will be of type `T`. This will
also unwind Optionals, so if the condition is of type `T???`, the
binding will be of type `T`.