### PR TITLE
Rewrite Coalesce and Opt-safe Accessors

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,44 +1,11 @@
-type Node {
-  value: String
-  next: Node? = None
+//type Name { value: String? = None }
+//type Person { name: Name? = None }
+//val ken = Person(name: Name(value: "Ken"))
+////val ken = Person()
+//println(ken.name?.value?.length)
+
+func abc() {
+  val arr = ["a", "bc"]
+  7 + (arr[3]?.length ?: 14)
 }
-
-type LinkedList {
-  count: Int = 0
-  head: Node? = None
-
-  func push(self, item: String): Int {
-    if self.head |head| {
-      var node = head
-      while node.next |n| node = n
-      node.next = Node(value: item)
-    } else {
-      self.head = Node(value: item)
-    }
-
-    self.count = self.count + 1
-  }
-
-  func toString(self): String {
-    if self.head |head| {
-      var str = ""
-      var node = head
-
-      while node.next |n| {
-        str = str + node.value + ", "
-        node = n
-      }
-
-      str + node.value
-    } else {
-      "[]"
-    }
-  }
-}
-
-val list = LinkedList()
-list.push("a")
-list.push("b")
-list.push("c")
-list.push("d")
-list.toString()
+abc()

--- a/abra_core/src/common/mod.rs
+++ b/abra_core/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod ast_visitor;
 pub mod display_error;
 pub mod typed_ast_visitor;
+pub mod typed_ast_util;
 pub mod util;

--- a/abra_core/src/common/typed_ast_util.rs
+++ b/abra_core/src/common/typed_ast_util.rs
@@ -1,0 +1,46 @@
+use crate::typechecker::typed_ast::{TypedAstNode, TypedInvocationNode, TypedFunctionDeclNode};
+use crate::lexer::tokens::Token;
+use crate::typechecker::types::Type;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub static ANON_IDX: AtomicUsize = AtomicUsize::new(0);
+
+// An IIFE (immediately-invoked function expression) denotes a block of code which is meant to run
+// in its own isolated scope, without polluting the outer scope. This is especially useful/needed
+// for if-expressions and expressions which compile down to if-expressions (opt-safe accessors and
+// coalesce operations).
+// This version of the `wrap_in_iife` is meant to be called from the compiler, and passes bogus
+// values for `typ` and `scope_depth` (since post-typechecker stages don't care about those values).
+pub fn wrap_in_iife(token: &Token, expr_node: TypedAstNode) -> TypedAstNode {
+    wrap_in_proper_iife(token, expr_node, &Type::Placeholder, 0)
+}
+
+// Unlike `wrap_in_iife`, `wrap_in_proper_iife` allows to specify `typ` and `scope_depth`, and is
+// meant to be called from the typechecker, where those fields are used.
+pub fn wrap_in_proper_iife(
+    token: &Token,
+    expr_node: TypedAstNode,
+    typ: &Type,
+    scope_depth: usize,
+) -> TypedAstNode {
+    let anon_fn_name = format!("$anon_{}", ANON_IDX.fetch_add(1, Ordering::Relaxed));
+    TypedAstNode::Invocation(
+        Token::LParen(token.get_position(), false),
+        TypedInvocationNode {
+            typ: typ.clone(),
+            target: Box::new(TypedAstNode::FunctionDecl(
+                Token::Func(token.get_position()),
+                TypedFunctionDeclNode {
+                    name: Token::Ident(token.get_position(), anon_fn_name),
+                    args: vec![],
+                    ret_type: typ.clone(),
+                    body: vec![expr_node],
+                    scope_depth,
+                    is_recursive: false,
+                    is_anon: true,
+                },
+            )),
+            args: vec![],
+        },
+    )
+}

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1198,6 +1198,15 @@ mod tests {
         assert_eq!(expected, result);
 
         let input = "\
+          type Name { value: String? = None }\n\
+          type Person { name: Name? = None }\n\
+          \"1\" + Person().name?.value?.length\n\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = new_string_obj("1None");
+        assert_eq!(expected, result);
+
+        let input = "\
           type Person { name: String? = None }\n\
           val people = [Person(name: \"a\")]\n\
           [\n\


### PR DESCRIPTION
Addresses #153 

- Operations involving the Coalesce operator (`?:`) and Option-safe
Accessors (`?.`) are now rewritten to use if-expressions and condition
bindings. This also wraps those expressions (as well as if-expressions
themselves) in IIFEs (Immediately-Invoked Function Expressions) in order
to prevent pollution of the calling scope.
- Note that "function expressions" do not yet exist as a language
feature, they're mostly a hack at the moment (`is_anon` on `TypedFunctionDeclNode`).
But that'll change in a coming PR.