### PR TITLE
Reference-type indirection layer

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,11 +1,10 @@
-//type Name { value: String? = None }
-//type Person { name: Name? = None }
-//val ken = Person(name: Name(value: "Ken"))
-////val ken = Person()
-//println(ken.name?.value?.length)
+type Counter {
+  value: Int = 0
 
-func abc() {
-  val arr = ["a", "bc"]
-  7 + (arr[3]?.length ?: 14)
+  func tickUp(self): Counter {
+    self.value = self.value + 1
+    self
+  }
 }
-abc()
+
+Counter().tickUp().tickUp().value

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -79,6 +79,7 @@ fn type_repr(t: &Type) -> String {
         Type::Unknown => "Unknown".to_string(),
         Type::Struct(StructType { name, .. }) => name.to_string(),
         Type::Placeholder => "_".to_string(),
+        Type::Reference(name) => name.clone(),
     }
 }
 

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1305,52 +1305,52 @@ mod tests {
     fn interpret_linked_list_even_closer() {
         // Verify self-referential types, as well as the usage of condition bindings for while-loops
         // and if-stmts/exprs.
-        let input = "\
-          type Node {\n\
-            value: String\n\
-            next: Node? = None\n\
-          }\n\
+        let input = r#"
+          type Node {
+            value: String
+            next: Node? = None
+          }
 
-          type LinkedList {\n\
-            count: Int = 0\n\
-            head: Node? = None\n\
+          type LinkedList {
+            count: Int = 0
+            head: Node? = None
 
-            func push(self, item: String): Int {\n\
-              if self.head |head| {\n\
-                var node = head\n\
-                while node.next |n| { node = n }\n\
-                node.next = Node(value: item)\n\
-              } else {\n\
-                self.head = Node(value: item)\n\
-              }\n\
+            func push(self, item: String): LinkedList { // <- Verify that methods can return instances of Self
+              if self.head |head| {
+                var node = head
+                while node.next |n| { node = n }
+                node.next = Node(value: item)
+              } else {
+                self.head = Node(value: item)
+              }
 
-              self.count = self.count + 1\n\
-            }\n\
+              self
+            }
 
-            func toString(self): String {\n\
-              if self.head |head| {\n\
-                var str = \"\"\n\
-                var node = head\n\
+            func toString(self): String {
+              if self.head |head| {
+                var str = ""
+                var node = head
 
-                while node.next |n| {\n\
-                  str = str + node.value + \", \"\n\
-                  node = n\n\
-                }\n\
+                while node.next |n| {
+                  str = str + node.value + ", "
+                  node = n
+                }
 
-                str + node.value\n\
-              } else {\n\
-                \"[]\"\n\
-              }\n\
-            }\n\
-          }\n\
+                str + node.value
+              } else {
+                "[]"
+              }
+            }
+          }
 
-          val list = LinkedList()\n\
-          list.push(\"a\")\n\
-          list.push(\"b\")\n\
-          list.push(\"c\")\n\
-          list.push(\"d\")\n\
-          list.toString()\
-        ";
+          val list = LinkedList()
+          list.push("a")
+            .push("b")
+            .push("c")
+            .push("d")
+            .toString()
+        "#;
         let result = interpret(input).unwrap();
         let expected = new_string_obj("a, b, c, d");
         assert_eq!(expected, result);

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -113,6 +113,12 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("kind", "Placeholder")?;
                 obj.end()
             }
+            Type::Reference(name) => {
+                let mut obj = serializer.serialize_map(Some(1))?;
+                obj.serialize_entry("kind", "Reference")?;
+                obj.serialize_entry("name", name)?;
+                obj.end()
+            }
         }
     }
 }


### PR DESCRIPTION
- When building up complex types (ie. struct type declarations), it
becomes increasingly important to handle cycles in type data. Meaning,
if a type `Foo` had a method `foo` which returned `Foo`, we have a "cycle",
and the representation of that Type as a data structure becomes
difficult to work with. For example, at typecheck-time, the methods of
the return value of `Foo#foo()` will be unknown, and saying
```
val f = Foo()
f.foo().foo()
```
will not properly typecheck.
- Add an indirection layer of `Type::Reference`, which wraps a `String`
which serves as a key into a hashmap stored within the typechecker. That
hashmap's value for a given type name will be the real structure of the
type, which is subject to change and grow outside of its References.
  - Note that this is not a memory-enforced reference (like a pointer or
memory-reference); this is a loose agreement that any `Type::Reference`
value will have a value present in the typechecker's
`referencable_types` hashmap. Kind of a loose abstraction, but not
leaky.