### PR TITLE
Lambda Expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
 name = "abra_core"
 version = "0.3.0"
 dependencies = [
+ "peekmore 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -168,6 +169,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "peekmore"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +313,11 @@ dependencies = [
  "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -504,6 +518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum peekmore 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7963b024d9df0af1eb5f426a21684ee1d292b7bbeabbdbe24dfc59012b9cba"
 "checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 "checksum proc-macro-error 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "53c98547ceaea14eeb26fcadf51dc70d01a2479a7839170eae133721105e4428"
 "checksum proc-macro-error-attr 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c2bf5d493cf5d3e296beccfd61794e445e830dfc8070a9c248ad3ee071392c6c"
@@ -520,6 +535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 "checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 "checksum serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+"checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 "checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,10 +1,28 @@
-type Counter {
-  value: Int = 0
+//type Counter {
+//  value: Int = 0
+//  listener: ((Int) => Int)? = None
+//
+//  func tickUp(self): Counter {
+//    self.value = self.value + 1
+//
+//    if self.listener |fn| fn(self.value)
+//
+//    self
+//  }
+//
+//  func addListener(self, fn: Int => Int): Void {
+//    self.listener = fn
+//  }
+//}
+//
+//let counter = Counter()
+//
+//counter.addListener(v => println("Value: " + v))
+//
+//counter.tickUp().tickUp().tickUp()
 
-  func tickUp(self): Counter {
-    self.value = self.value + 1
-    self
-  }
-}
+//val f = () => "Hello"
+//println(f())
 
-Counter().tickUp().tickUp().value
+//(u = "", v: Int,) => (u = "", v: Int,) => "Hello"
+u => v => u + v

--- a/abra_core/Cargo.toml
+++ b/abra_core/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ken Gorab <ken.gorab@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+peekmore = "0.5.2"
 strum = "0.15.0"
 strum_macros = "0.15.0"
 rand = "0.7.3"

--- a/abra_core/src/common/ast_visitor.rs
+++ b/abra_core/src/common/ast_visitor.rs
@@ -1,4 +1,4 @@
-use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode};
+use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode, LambdaNode};
 use crate::parser::ast::AstNode::*;
 use crate::lexer::tokens::Token;
 
@@ -24,6 +24,7 @@ pub trait AstVisitor<V, E> {
             Break(tok) => self.visit_break(tok),
             ForLoop(tok, node) => self.visit_for_loop(tok, node),
             Accessor(tok, node) => self.visit_accessor(tok, node),
+            Lambda(tok, node) => self.visit_lambda(tok, node),
         }
     }
 
@@ -46,4 +47,5 @@ pub trait AstVisitor<V, E> {
     fn visit_while_loop(&mut self, token: Token, node: WhileLoopNode) -> Result<V, E>;
     fn visit_break(&mut self, token: Token) -> Result<V, E>;
     fn visit_accessor(&mut self, token: Token, node: AccessorNode) -> Result<V, E>;
+    fn visit_lambda(&mut self, token: Token, node: LambdaNode) -> Result<V, E>;
 }

--- a/abra_core/src/lexer/lexer.rs
+++ b/abra_core/src/lexer/lexer.rs
@@ -271,6 +271,9 @@ impl<'a> Lexer<'a> {
                 if let Some('=') = self.peek() {
                     self.expect_next()?; // Consume '=' token
                     Ok(Some(Token::Eq(pos)))
+                } else if let Some('>') = self.peek() {
+                    self.expect_next()?; // Consume '>' token
+                    Ok(Some(Token::Arrow(pos)))
                 } else {
                     Ok(Some(Token::Assign(pos)))
                 }
@@ -344,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_tokenize_multi_char_operators() {
-        let input = "&& || <= >= != == ?: ?.";
+        let input = "&& || <= >= != == ?: ?. =>";
         let tokens = tokenize(&input.to_string()).unwrap();
         let expected = vec![
             Token::And(Position::new(1, 1)),
@@ -355,6 +358,7 @@ mod tests {
             Token::Eq(Position::new(1, 16)),
             Token::Elvis(Position::new(1, 19)),
             Token::QuestionDot(Position::new(1, 22)),
+            Token::Arrow(Position::new(1, 25)),
         ];
         assert_eq!(expected, tokens);
     }

--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -66,6 +66,7 @@ pub enum Token {
     #[strum(to_string = "?", serialize = "Question")] Question(Position),
     #[strum(to_string = ".", serialize = "Dot")] Dot(Position),
     #[strum(to_string = "?.", serialize = "QuestionDot")] QuestionDot(Position),
+    #[strum(to_string = "=>", serialize = "Arrow")] Arrow(Position),
 }
 
 impl Token {
@@ -119,7 +120,8 @@ impl Token {
             Token::Comma(pos) |
             Token::Question(pos) |
             Token::Dot(pos) |
-            Token::QuestionDot(pos) => pos
+            Token::QuestionDot(pos) |
+            Token::Arrow(pos) => pos
         };
         pos.clone()
     }

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -21,6 +21,7 @@ pub enum AstNode {
     WhileLoop(Token, WhileLoopNode),
     Break(Token),
     Accessor(Token, AccessorNode),
+    Lambda(Token, LambdaNode),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -99,6 +100,12 @@ pub struct FunctionDeclNode {
     // Tokens represent arg idents, and must be Token::Ident
     pub args: Vec<(Token, Option<TypeIdentifier>, Option<AstNode>)>,
     pub ret_type: Option<TypeIdentifier>,
+    pub body: Vec<AstNode>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LambdaNode {
+    pub args: Vec<(Token, Option<TypeIdentifier>, Option<AstNode>)>,
     pub body: Vec<AstNode>,
 }
 

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -2,7 +2,7 @@ use crate::builtins::native_types::field_for_type;
 use crate::common::ast_visitor::AstVisitor;
 use crate::common::typed_ast_util::wrap_in_proper_iife;
 use crate::lexer::tokens::{Token, Position};
-use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, BinaryOp, UnaryOp, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, IndexingMode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode};
+use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, BinaryOp, UnaryOp, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, IndexingMode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode, LambdaNode};
 use crate::vm::prelude::Prelude;
 use crate::typechecker::types::{Type, StructType};
 use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedUnaryNode, TypedBinaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode, AssignmentTargetKind};
@@ -1468,6 +1468,11 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         } else { (token, is_opt_safe) };
 
         Ok(TypedAstNode::Accessor(token, TypedAccessorNode { typ, target: Box::new(target), field_name, field_idx, is_opt_safe }))
+    }
+
+    fn visit_lambda(&mut self, _token: Token, node: LambdaNode) -> Result<TypedAstNode, TypecheckerError> {
+        dbg!(node);
+        unimplemented!()
     }
 }
 

--- a/abra_wasm/src/js_value/token.rs
+++ b/abra_wasm/src/js_value/token.rs
@@ -288,6 +288,12 @@ impl<'a> Serialize for JsToken<'a> {
                 obj.serialize_entry("pos", &JsPosition(pos))?;
                 obj.end()
             }
+            Token::Arrow(pos) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "arrow")?;
+                obj.serialize_entry("pos", &JsPosition(pos))?;
+                obj.end()
+            }
         }
     }
 }


### PR DESCRIPTION
- Add parsing of lambda expressions. This supports no-arguments,
single-arguments (with and without parens), and multi-argument lambdas.
- This also refactors the funcdecl parsing, since it pulls out the
argument parameter parsing.
- Note: This pulls in the `peekmore` crate to peek additional tokens
ahead in the stream. The stdlib Peekable trait only allows for one
lookahead item.