### PR TITLE
Lambdas: Type Idents

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -24,11 +24,14 @@
 // var f = (a: ((String) => String) => String, b: String) => a(b)
 // f(f2 => f2("x"), "a")
 
-var f = (a: String) => a
+//var f = (a: String) => a
 //f = f = (a, b = "hello") => a + b
 //f = 123
 
-type Foo {
-  func greet(self, greeting: String): String = greeting
-}
-f = Foo().greet
+//type Foo {
+//  func greet(self, greeting: String): String = greeting
+//}
+//f = Foo().greet
+
+func call(fn: (String) => String, value: String) = fn(value)
+call((x, b = "hello") => b, "hello")

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -177,6 +177,10 @@ pub enum TypeIdentifier {
     Normal { ident: Token },
     Array { inner: Box<TypeIdentifier> },
     Option { inner: Box<TypeIdentifier> },
+    Func {
+        args: Vec<TypeIdentifier>,
+        ret: Box<TypeIdentifier>
+    },
 }
 
 impl TypeIdentifier {
@@ -184,7 +188,8 @@ impl TypeIdentifier {
         match self {
             TypeIdentifier::Normal { ident } => ident.clone(),
             TypeIdentifier::Array { inner } => inner.get_ident(),
-            TypeIdentifier::Option { inner } => inner.get_ident()
+            TypeIdentifier::Option { inner } => inner.get_ident(),
+            TypeIdentifier::Func { ret, .. } => ret.get_ident()
         }
     }
 }


### PR DESCRIPTION
- This adds type identifier parsing logic for function types; function
types are of the form `(A, B, C) => D`.