### PR TITLE
Lambdas: Adding Unit type

### DIFF
--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -1353,7 +1353,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                         }
                     }
                 }
-                _ => unreachable!("Anything else should be caught by an UnknownIdentifier")
+                typ @ _ => Err(TypecheckerError::InvalidInstantiation { token: target.get_token().clone(), typ }),
             }
             target_type @ _ => Err(TypecheckerError::InvalidInvocationTarget { token: target.get_token().clone(), target_type })
         }
@@ -4691,8 +4691,8 @@ mod tests {
                                     typ: Type::String,
                                     name: "a".to_string(),
                                     is_mutable: false,
-                                    scope_depth: 1
-                                }
+                                    scope_depth: 1,
+                                },
                             )
                         ]),
                         orig_node: None,
@@ -4725,7 +4725,7 @@ mod tests {
                     TypedLambdaNode {
                         typ: Type::Fn(
                             vec![("a".to_string(), Type::String, false), ("b".to_string(), Type::String, true)],
-                            Box::new(Type::String)
+                            Box::new(Type::String),
                         ),
                         args: vec![
                             (ident_token!((2, 7), "a"), Type::String, None),

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -36,6 +36,7 @@ impl Prelude {
             ("Float", Type::Float),
             ("Bool", Type::Bool),
             ("String", Type::String),
+            ("Unit", Type::Unit),
         ];
         for (type_name, typ) in prelude_types {
             let binding = PreludeBinding {

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -325,6 +325,14 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.end()
                 }
+                TypecheckerError::InvalidInstantiation { token, typ } => {
+                    let mut obj = serializer.serialize_map(Some(4))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidInstantiation")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("type", &JsType(typ))?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {


### PR DESCRIPTION
- We need to add a `Unit` type that can be referenced in function type
identifiers, since otherwise there's no way to represent the type of
this function:
```
val fn = a => println(a)
```
- This also fills in some missing implementations for TypecheckerErrors