### PR TITLE
Compilation of lambdas

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,37 +1,5 @@
-//type Counter {
-//  value: Int = 0
-//  listener: ((Int) => Int)? = None
-//
-//  func tickUp(self): Counter {
-//    self.value = self.value + 1
-//
-//    if self.listener |fn| fn(self.value)
-//
-//    self
-//  }
-//
-//  func addListener(self, fn: Int => Int): Void {
-//    self.listener = fn
-//  }
-//}
-//
-//let counter = Counter()
-//
-//counter.addListener(v => println("Value: " + v))
-//
-//counter.tickUp().tickUp().tickUp()
+func getAdder(x: Int): (Int) => Int {
+  y => x + y
+}
 
-// var f = (a: ((String) => String) => String, b: String) => a(b)
-// f(f2 => f2("x"), "a")
-
-//var f = (a: String) => a
-//f = f = (a, b = "hello") => a + b
-//f = 123
-
-//type Foo {
-//  func greet(self, greeting: String): String = greeting
-//}
-//f = Foo().greet
-
-func call(fn: (String) => String, value: String) = fn(value)
-call((x, b = "hello") => b, "hello")
+println(getAdder(3)(2))

--- a/abra_core/src/common/typed_ast_util.rs
+++ b/abra_core/src/common/typed_ast_util.rs
@@ -5,6 +5,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub static ANON_IDX: AtomicUsize = AtomicUsize::new(0);
 
+pub fn get_anon_name() -> String {
+    format!("$anon_{}", ANON_IDX.fetch_add(1, Ordering::Relaxed))
+}
+
 // An IIFE (immediately-invoked function expression) denotes a block of code which is meant to run
 // in its own isolated scope, without polluting the outer scope. This is especially useful/needed
 // for if-expressions and expressions which compile down to if-expressions (opt-safe accessors and
@@ -23,7 +27,8 @@ pub fn wrap_in_proper_iife(
     typ: &Type,
     scope_depth: usize,
 ) -> TypedAstNode {
-    let anon_fn_name = format!("$anon_{}", ANON_IDX.fetch_add(1, Ordering::Relaxed));
+    let anon_fn_name = get_anon_name();
+
     TypedAstNode::Invocation(
         Token::LParen(token.get_position(), false),
         TypedInvocationNode {

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -1,6 +1,7 @@
 use crate::typechecker::types::Type;
 use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode, LambdaNode};
 use crate::lexer::tokens::Token;
+use crate::typechecker::typechecker::Scope;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum TypedAstNode {
@@ -144,7 +145,7 @@ pub struct TypedLambdaNode {
     pub typ: Type,
     pub args: Vec<(Token, Type, Option<TypedAstNode>)>,
     pub typed_body: Option<Vec<TypedAstNode>>,
-    pub orig_node: Option<LambdaNode>,
+    pub orig_node: Option<(LambdaNode, Vec<Scope>)>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -8,7 +8,7 @@ use crate::vm::value::{Value, FnValue, TypeValue};
 use crate::vm::prelude::Prelude;
 use crate::builtins::native_types::{NativeArray, NativeType};
 use crate::common::util::random_string;
-use crate::common::typed_ast_util::wrap_in_iife;
+use crate::common::typed_ast_util::{wrap_in_iife, get_anon_name};
 
 #[derive(Debug, PartialEq)]
 pub struct Local {
@@ -388,9 +388,19 @@ impl Compiler {
         Ok(last_line)
     }
 
-    fn compile_function_decl(&mut self, token: Token, node: TypedFunctionDeclNode) -> Result<FnValue, ()> {
-        let TypedFunctionDeclNode { name, args, body, ret_type, scope_depth, .. } = node;
-        let func_name = Token::get_ident_name(&name);
+    fn compile_function_decl(
+        &mut self,
+        token: Token,
+        name: Option<Token>,
+        args: Vec<(Token, Type, Option<TypedAstNode>)>,
+        ret_type: Type,
+        body: Vec<TypedAstNode>,
+        scope_depth: usize,
+    ) -> Result<FnValue, ()> {
+        let func_name = match name {
+            Some(name) => Token::get_ident_name(&name),
+            None => get_anon_name()
+        };
 
         let line = token.get_position().line;
 
@@ -657,9 +667,24 @@ impl TypedAstVisitor<(), ()> for Compiler {
         Ok(())
     }
 
-    fn visit_lambda(&mut self, _token: Token, node: TypedLambdaNode) -> Result<(), ()> {
-        dbg!(&node);
-        return Ok(());
+    fn visit_lambda(&mut self, token: Token, node: TypedLambdaNode) -> Result<(), ()> {
+        let line = token.get_position().line;
+
+        let ret_type = if let Type::Fn(_, ret_type) = node.typ { *ret_type } else { unreachable!() };
+        let body = node.typed_body.unwrap();
+        let scope_depth = self.get_fn_depth();
+        let fn_value = self.compile_function_decl(token, None, node.args, ret_type, body, scope_depth)?;
+
+        let has_upvalues = !&fn_value.upvalues.is_empty();
+        let const_idx = self.add_constant(Value::Fn(fn_value));
+
+        self.write_opcode(Opcode::Constant, line);
+        self.write_byte(const_idx, line);
+        if has_upvalues {
+            self.write_opcode(Opcode::ClosureMk, line);
+        }
+
+        Ok(())
     }
 
     fn visit_binding_decl(&mut self, token: Token, node: TypedBindingDeclNode) -> Result<(), ()> {
@@ -709,7 +734,14 @@ impl TypedAstVisitor<(), ()> for Compiler {
             }
         }
 
-        let fn_value = self.compile_function_decl(token, node)?;
+        let fn_value = self.compile_function_decl(
+            token,
+            Some(node.name),
+            node.args,
+            node.ret_type,
+            node.body,
+            node.scope_depth,
+        )?;
 
         let has_upvalues = !&fn_value.upvalues.is_empty();
         let const_idx = self.add_constant(Value::Fn(fn_value));
@@ -762,7 +794,14 @@ impl TypedAstVisitor<(), ()> for Compiler {
                 _ => unreachable!()
             };
 
-            let method = self.compile_function_decl(method_tok, method_node)?;
+            let method = self.compile_function_decl(
+                method_tok,
+                Some(method_node.name),
+                method_node.args,
+                method_node.ret_type,
+                method_node.body,
+                method_node.scope_depth,
+            )?;
             compiled_methods.push((method_name, method));
         }
 
@@ -770,7 +809,14 @@ impl TypedAstVisitor<(), ()> for Compiler {
         for (_, _, value) in static_fields {
             if let Some(TypedAstNode::FunctionDecl(method_tok, method_node)) = value {
                 let method_name = Token::get_ident_name(&method_node.name).clone();
-                let method = self.compile_function_decl(method_tok, method_node)?;
+                let method = self.compile_function_decl(
+                    method_tok,
+                    Some(method_node.name),
+                    method_node.args,
+                    method_node.ret_type,
+                    method_node.body,
+                    method_node.scope_depth,
+                )?;
                 compiled_static_fields.push((method_name, method));
             }
         }
@@ -3113,6 +3159,38 @@ mod tests {
             ],
             constants: vec![
                 new_string_obj("hello"),
+            ],
+        };
+        assert_eq!(expected, chunk);
+    }
+
+    #[test]
+    fn compile_lambda_declaration_returns_unit_type() {
+        let chunk = compile("\
+          val abc = () => println(\"hello\")\
+        ");
+        let expected = Module {
+            code: vec![
+                Opcode::Constant as u8, 2,
+                Opcode::Constant as u8, 3,
+                Opcode::GStore as u8,
+                Opcode::Return as u8
+            ],
+            constants: vec![
+                new_string_obj("hello"),
+                Value::NativeFn(get_native_fn("println")),
+                Value::Fn(FnValue {
+                    name: "$anon_0".to_string(),
+                    code: vec![
+                        Opcode::Constant as u8, 0,
+                        Opcode::Constant as u8, 1,
+                        Opcode::Invoke as u8, 1, 0,
+                        Opcode::Return as u8,
+                    ],
+                    upvalues: vec![],
+                    receiver: None,
+                }),
+                Value::Str("abc".to_string()),
             ],
         };
         assert_eq!(expected, chunk);

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -131,10 +131,14 @@ impl VM {
         match self.stack.get_mut(index) {
             Some(slot) => *slot = value,
             None => {
-                let frame = self.call_stack.last().unwrap();
-                let chunk_name = &frame.name;
-                let offset = frame.ip;
-                panic!("Runtime error [{}+{}]:\n  No stack slot available at index {}", chunk_name, offset, index)
+                if index == self.stack.len() {
+                    self.stack.push(value)
+                } else {
+                    let frame = self.call_stack.last().unwrap();
+                    let chunk_name = &frame.name;
+                    let offset = frame.ip;
+                    panic!("Runtime error [{}+{}]:\n  No stack slot available at index {}", chunk_name, offset, index)
+                }
             }
         }
     }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1355,4 +1355,33 @@ mod tests {
         let expected = new_string_obj("a, b, c, d");
         assert_eq!(expected, result);
     }
+
+    #[test]
+    fn interpret_lambdas() {
+        let input = "\
+          func call(fn: (Int) => Int, value: Int) = fn(value)\n\
+          call(x => x + 1, 23)\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = "\
+          func call(fn: (Int) => Int, value: Int) = fn(value)\n\
+          call((x, y = 1) => x + y + 1, 22)\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = "\
+          func getAdder(x: Int): (Int) => Int {\n\
+            (y, z = 3) => x + y + z\n\
+          }\n\
+          getAdder(20)(1)\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+    }
 }


### PR DESCRIPTION
- Compile TypedAstNode::Lambda nodes!
- Modifies the LStore instruction to push a new value if the stack slot
does not exist _but_ it would be the next available slot. This is
essential to making default-valued arguments work in lambdas where the
type is not guaranteed to be known ahead of time:
```
func call(fn: (Int) => Int, value: Int) = fn(value)
call((x, y = 1, z = 2) => x + y + z, 3) // returns 6
```
- Note that this does _not_ cover inference in cases like:
```
((a, b) => a + b)(1, 2)

val fn: ((Int) => Int)? = [
  x => x + 1,
  y => y + 1
][0]
```
All of this will need to be addressed, along with less esoteric
examples, such as
```
val nums: Int[] = []
```
which is currently being handled in a one-off special case.