### PR TITLE
Some minor lambda cleanups

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,5 +1,17 @@
-func getAdder(x: Int): (Int) => Int {
-  y => x + y
+var f: () => Int
+if false {
+  val x = 0
+  f = () => x
+} else {
+  val y = 1
+  f = () => y
 }
 
-println(getAdder(3)(2))
+println(f())
+
+while true {
+  val x = 123
+  f = () => x
+  break
+}
+println(f())

--- a/abra_core/src/common/typed_ast_util.rs
+++ b/abra_core/src/common/typed_ast_util.rs
@@ -1,4 +1,4 @@
-use crate::typechecker::typed_ast::{TypedAstNode, TypedInvocationNode, TypedFunctionDeclNode};
+use crate::typechecker::typed_ast::{TypedAstNode, TypedInvocationNode, TypedLambdaNode};
 use crate::lexer::tokens::Token;
 use crate::typechecker::types::Type;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -13,36 +13,26 @@ pub fn get_anon_name() -> String {
 // in its own isolated scope, without polluting the outer scope. This is especially useful/needed
 // for if-expressions and expressions which compile down to if-expressions (opt-safe accessors and
 // coalesce operations).
-// This version of the `wrap_in_iife` is meant to be called from the compiler, and passes bogus
-// values for `typ` and `scope_depth` (since post-typechecker stages don't care about those values).
+// This version of the `wrap_in_iife` is meant to be called from the compiler, and passes a bogus
+// values for `typ` (since post-typechecker stages don't care about it).
 pub fn wrap_in_iife(token: &Token, expr_node: TypedAstNode) -> TypedAstNode {
-    wrap_in_proper_iife(token, expr_node, &Type::Placeholder, 0)
+    wrap_in_proper_iife(token, expr_node, &Type::Placeholder)
 }
 
-// Unlike `wrap_in_iife`, `wrap_in_proper_iife` allows to specify `typ` and `scope_depth`, and is
-// meant to be called from the typechecker, where those fields are used.
-pub fn wrap_in_proper_iife(
-    token: &Token,
-    expr_node: TypedAstNode,
-    typ: &Type,
-    scope_depth: usize,
-) -> TypedAstNode {
-    let anon_fn_name = get_anon_name();
-
+// Unlike `wrap_in_iife`, `wrap_in_proper_iife` allows to specify `typ`, and is
+// meant to be called from the typechecker, where that field is used.
+pub fn wrap_in_proper_iife(token: &Token, expr_node: TypedAstNode, typ: &Type) -> TypedAstNode {
     TypedAstNode::Invocation(
         Token::LParen(token.get_position(), false),
         TypedInvocationNode {
             typ: typ.clone(),
-            target: Box::new(TypedAstNode::FunctionDecl(
-                Token::Func(token.get_position()),
-                TypedFunctionDeclNode {
-                    name: Token::Ident(token.get_position(), anon_fn_name),
+            target: Box::new(TypedAstNode::Lambda(
+                Token::Arrow(token.get_position()),
+                TypedLambdaNode {
+                    typ: Type::Fn(vec![], Box::new(typ.clone())),
                     args: vec![],
-                    ret_type: typ.clone(),
-                    body: vec![expr_node],
-                    scope_depth,
-                    is_recursive: false,
-                    is_anon: true,
+                    typed_body: Some(vec![expr_node]),
+                    orig_node: None,
                 },
             )),
             args: vec![],

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -758,7 +758,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         }
         let scope_depth = self.scopes.len() - 1;
 
-        Ok(TypedAstNode::FunctionDecl(token, TypedFunctionDeclNode { name, args, ret_type, body, scope_depth, is_recursive, is_anon: false }))
+        Ok(TypedAstNode::FunctionDecl(token, TypedFunctionDeclNode { name, args, ret_type, body, scope_depth, is_recursive }))
     }
 
     fn visit_type_decl(&mut self, token: Token, node: TypeDeclNode) -> Result<TypedAstNode, TypecheckerError> {
@@ -1191,8 +1191,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         // If-expressions will be compiled to IIFEs, in order to ensure proper local
         // management and to ensure the stack doesn't get polluted mid-expression.
         let if_expr_node = TypedAstNode::IfExpression(token.clone(), node);
-        let scope_depth = self.scopes.len() - 1;
-        Ok(wrap_in_proper_iife(&token, if_expr_node, &typ, scope_depth))
+        Ok(wrap_in_proper_iife(&token, if_expr_node, &typ))
     }
 
     fn visit_invocation(&mut self, token: Token, node: InvocationNode) -> Result<TypedAstNode, TypecheckerError> {
@@ -2366,7 +2365,6 @@ mod tests {
                 ],
                 scope_depth: 0,
                 is_recursive: false,
-                is_anon: false,
             },
         );
         assert_eq!(expected, typed_ast[0]);
@@ -2398,7 +2396,6 @@ mod tests {
                 ],
                 scope_depth: 0,
                 is_recursive: false,
-                is_anon: false,
             },
         );
         assert_eq!(expected, typed_ast[0]);
@@ -2443,7 +2440,6 @@ mod tests {
                 ],
                 scope_depth: 0,
                 is_recursive: false,
-                is_anon: false,
             },
         );
         assert_eq!(expected, typed_ast[0]);
@@ -2789,7 +2785,6 @@ mod tests {
                                 ],
                                 scope_depth: 1,
                                 is_recursive: false,
-                                is_anon: false,
                             },
                         ),
                     ),
@@ -2834,7 +2829,6 @@ mod tests {
                                 ],
                                 scope_depth: 1,
                                 is_recursive: false,
-                                is_anon: false,
                             },
                         ),
                     ),
@@ -2887,7 +2881,6 @@ mod tests {
                                 ],
                                 scope_depth: 1,
                                 is_recursive: false,
-                                is_anon: false,
                             },
                         )),
                     ),
@@ -4736,7 +4729,6 @@ mod tests {
                 ],
                 scope_depth: 0,
                 is_recursive: false,
-                is_anon: false,
             },
         );
         assert_eq!(expected, typed_ast[0]);

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -71,16 +71,7 @@ impl TypedAstNode {
             TypedAstNode::Array(_, node) => node.typ.clone(),
             TypedAstNode::Map(_, node) => node.typ.clone(),
             TypedAstNode::Lambda(_, node) => node.typ.clone(),
-            TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { is_anon, args, ret_type, .. }) => {
-                if !is_anon { return Type::Unit; }
-
-                let args = args.iter().map(|(ident, typ, default_value)| {
-                    let name = Token::get_ident_name(ident);
-                    (name, typ.clone(), default_value.is_some())
-                }).collect();
-
-                Type::Fn(args, Box::new(ret_type.clone()))
-            }
+            TypedAstNode::FunctionDecl(_, _) |
             TypedAstNode::BindingDecl(_, _) |
             TypedAstNode::TypeDecl(_, _) |
             TypedAstNode::WhileLoop(_, _) |
@@ -167,7 +158,7 @@ pub struct TypedFunctionDeclNode {
     pub body: Vec<TypedAstNode>,
     pub scope_depth: usize,
     pub is_recursive: bool,
-    pub is_anon: bool,
+    // pub is_anon: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1384,4 +1384,36 @@ mod tests {
         let expected = Value::Int(24);
         assert_eq!(expected, result);
     }
+
+    #[test]
+    fn interpret_lambdas_closing_over_block_bindings() {
+        let input = "\
+          var f: () => Int\n\
+          if true {\n\
+            val x = 24\n\
+            f = () => x\n\
+          } else {\n\
+            val y = 12\n\
+            f = () => y\n\
+          }\n\
+          f()\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = "\
+          var f: () => Int\n\
+          while true {\n\
+            val x = 24\n\
+            f = () => x\n\
+            break\n\
+          }\n\
+          f()\
+        ";
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+    }
 }


### PR DESCRIPTION
- Replace the FunctionDecl in the IIFE implementation with Lambda, and
remove the `is_anon` field from FunctionDecl.
- Fix issue where values closed over by a lambda in any block other than
a function were not being properly captured; we need to emit a
`CloseUpvalueAndPop` instruction in this case.