### PR TITLE
Marking locals

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,17 +1,7 @@
+func call(fn: (Int) => Int, value: Int) = fn(value)
 var f: () => Int
-if false {
-  val x = 0
-  f = () => x
-} else {
-  val y = 1
+call((x, y = 1) => {
   f = () => y
-}
-
-println(f())
-
-while true {
-  val x = 123
-  f = () => x
-  break
-}
+  x + y + 1
+}, 22)
 println(f())

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -77,6 +77,7 @@ pub enum Opcode {
     CloseUpvalueAndPop,
     Pop,
     PopN,
+    MarkLocal,
     Dup,
     Return,
 }
@@ -160,8 +161,9 @@ impl From<&u8> for Opcode {
             73 => Opcode::CloseUpvalueAndPop,
             74 => Opcode::Pop,
             75 => Opcode::PopN,
-            76 => Opcode::Dup,
-            77 => Opcode::Return,
+            76 => Opcode::MarkLocal,
+            77 => Opcode::Dup,
+            78 => Opcode::Return,
             _ => unreachable!()
         }
     }
@@ -182,6 +184,7 @@ impl Opcode {
             Opcode::LLoad |
             Opcode::ULoad |
             Opcode::New |
+            Opcode::MarkLocal |
             Opcode::GetField => 1,
             Opcode::Invoke => 2,
             _ => 0


### PR DESCRIPTION
- Relying on stack location as a 1-1 mapping to local index is somewhat
problematic, particularly when you need to resolve locals when the stack
may be in a polluted state mid-expression. A great example of this is:
```
{
  val a = 1
  a
} + {
  val b = 2
  b
}
```
Resolving the value for `b` (which is local index 0 in this case) would
face interference from the value for `a` (1) which is still on the
stack. This means that we need some other way of mapping locals to stack
addresses, so we introduced the `local_addr` local lookup table (just a
vector, since the keys are monotonically increasing). When resolving a
local by its index (during loads, stores, upvalue resolution), we look
to this table. Values in this table are populated via the
newly-introduced `MarkLocal <local_idx>` instruction, which lets the VM
know that the value currently on top of the stack should be treated as a
local, and thus stored in the `local_addr` table for the current frame.
- Dealing with functions and their arguments is a little bit annoying
here, especially when it comes to lambdas and default-valued arguments.
Function parameters (including the `<ret>` reserved slot) are placed
onto the stack _before_ the function's code executes, so calling
`MarkLocal` on those values would happen too late. Instead, what happens
is the handling of the `Invoke` instruction will pre-fill those values
as it creates the `CallFrame`. Lambdas are annoying because if they have
arguments with default values, those values would not be pushed onto
the stack before the function call, since the arity of the function is
dictated by the caller, not the callee. The nil-checking code still runs
within the function body, but when it does its `LStore` operation, there
will not be a value in the frame's `local_addrs` table, since it wasn't
pre-filled when the `CallFrame` was created, and there was no
`MarkLocal` instruction for it. To resolve this, if there is no value
yet in `local_addrs`, we just push the topmost stack slot. This is
likely problematic and probably going to come back to bite me, but it
works for now so....
- Also, refactor some of the functions in VM to be colocated with relevant
functions, and just some other general cleanup.