### PR TITLE
Generics: Adding native array methods

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -10,22 +10,7 @@
 //  }
 //}
 
-func map<T, U>(arr: T[], fn: (T) => U, start: U? = None): U[] {
-  val newArr: U[] = []
-
-  if start |u| {
-    newArr.push(u)
-  }
-
-  for i in arr {
-    newArr.push(fn(i))
-  }
-  newArr
-}
-
-val lengths = map(
-   arr: ["1", "23", "456"],
-   fn: s => (s + "!").length,
-   start: 17
-)
-println(lengths)
+val arr = [1, 2, 3]
+arr.push(4)
+arr.push(5)
+arr

--- a/abra_core/src/builtins/native_fns.rs
+++ b/abra_core/src/builtins/native_fns.rs
@@ -1,6 +1,6 @@
 use crate::typechecker::types::{Type, FnType};
 use crate::vm::value::{Value, Obj};
-use crate::vm::vm::VMContext;
+use crate::vm::vm::VM;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
@@ -8,13 +8,14 @@ use std::cell::RefCell;
 
 // Native functions must return a Value, even if they're of return type Unit.
 // If their return type is Unit, they should return None//Value::Nil.
-pub type NativeAbraFn = fn(&VMContext, &Option<Arc<RefCell<Obj>>>, Vec<Value>) -> Option<Value>;
+pub type NativeAbraFn = fn(&Option<Arc<RefCell<Obj>>>, Vec<Value>, &mut VM) -> Option<Value>;
 
 #[derive(Clone)]
 pub struct NativeFn {
     pub name: &'static str,
     pub receiver: Option<Arc<RefCell<Obj>>>,
     pub native_fn: NativeAbraFn,
+    pub has_return: bool,
 }
 
 impl Debug for NativeFn {
@@ -36,39 +37,44 @@ impl PartialOrd for NativeFn {
 }
 
 impl NativeFn {
-    pub fn invoke(&self, ctx: &VMContext, args: Vec<Value>) -> Option<Value> {
+    pub fn invoke(&self, args: Vec<Value>, vm_ref: &mut VM) -> Option<Value> {
         let func = self.native_fn;
-        let receiver = &self.receiver;
-        func(ctx, receiver, args)
+        func(&self.receiver, args, vm_ref)
     }
 }
 
-pub struct NativeFnDesc<'a> {
+pub struct NativeFnDesc {
     pub name: &'static str,
-    pub args: Vec<(&'static str, &'a Type)>,
-    pub opt_args: Vec<(&'static str, &'a Type)>,
+    pub type_args: Vec<&'static str>,
+    pub args: Vec<(&'static str, Type)>,
+    pub opt_args: Vec<(&'static str, Type)>,
     pub return_type: Type,
 }
 
-impl NativeFnDesc<'_> {
+impl NativeFnDesc {
     pub fn get_fn_type(&self) -> Type {
+        let type_args = self.type_args.iter()
+            .map(|name| name.to_string())
+            .collect();
+
         let req_args = self.args.iter()
             .map(|(name, typ)| (name.to_string(), typ.clone().clone(), false));
         let opt_args = self.opt_args.iter()
             .map(|(name, typ)| (name.to_string(), typ.clone().clone(), true));
         let arg_types = req_args.chain(opt_args).collect();
 
-        Type::Fn(FnType { arg_types, type_args: vec![], ret_type: Box::new(self.return_type.clone()) })
+        Type::Fn(FnType { arg_types, type_args, ret_type: Box::new(self.return_type.clone()) })
     }
 }
 
-pub fn native_fns() -> Vec<(NativeFnDesc<'static>, NativeFn)> {
+pub fn native_fns() -> Vec<(NativeFnDesc, NativeFn)> {
     let mut native_fns = Vec::new();
 
     native_fns.push((
         NativeFnDesc {
             name: "println",
-            args: vec![("_", &Type::Any)],
+            type_args: vec![],
+            args: vec![("_", Type::Any)],
             opt_args: vec![],
             return_type: Type::Unit,
         },
@@ -76,32 +82,35 @@ pub fn native_fns() -> Vec<(NativeFnDesc<'static>, NativeFn)> {
             name: "println",
             receiver: None,
             native_fn: println,
+            has_return: false,
         }));
 
     native_fns.push((
         NativeFnDesc {
             name: "range",
-            args: vec![("from", &Type::Int), ("to", &Type::Int)],
-            opt_args: vec![("increment", &Type::Int)],
+            type_args: vec![],
+            args: vec![("from", Type::Int), ("to", Type::Int)],
+            opt_args: vec![("increment", Type::Int)],
             return_type: Type::Array(Box::new(Type::Int)),
         },
         NativeFn {
             name: "range",
             receiver: None,
             native_fn: range,
+            has_return: true,
         }));
 
     native_fns
 }
 
-fn println(ctx: &VMContext, _receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>) -> Option<Value> {
+fn println(_receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>, vm: &mut VM) -> Option<Value> {
     let val = args.first().unwrap();
-    let print_fn = ctx.print;
+    let print_fn = vm.ctx.print;
     print_fn(&format!("{}", val.to_string()));
     None
 }
 
-fn range(_ctx: &VMContext, _receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>) -> Option<Value> {
+fn range(_receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
     let mut start = if let Some(Value::Int(i)) = args.get(0) { *i } else {
         panic!("range requires an Int as first argument")
     };
@@ -128,13 +137,20 @@ fn range(_ctx: &VMContext, _receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Valu
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::vm::compiler::Module;
+    use crate::vm::vm::VMContext;
+
+    fn make_vm() -> VM {
+        let module = Module { code: vec![], constants: vec![] };
+        VM::new(module, VMContext::default())
+    }
 
     #[test]
     fn range_returning_int_array() {
-        let ctx = VMContext::default();
+        let mut vm = make_vm();
 
         // Test w/ increment of 1
-        let arr = range(&ctx, &None, vec![Value::Int(0), Value::Int(5), Value::Int(1)]);
+        let arr = range(&None, vec![Value::Int(0), Value::Int(5), Value::Int(1)], &mut vm);
         let expected = Some(Value::new_array_obj(vec![
             Value::Int(0),
             Value::Int(1),
@@ -145,7 +161,7 @@ mod test {
         assert_eq!(expected, arr);
 
         // Test w/ increment of 2
-        let arr = range(&ctx, &None, vec![Value::Int(0), Value::Int(5), Value::Int(2)]);
+        let arr = range(&None, vec![Value::Int(0), Value::Int(5), Value::Int(2)], &mut vm);
         let expected = Some(Value::new_array_obj(vec![
             Value::Int(0),
             Value::Int(2),
@@ -156,20 +172,20 @@ mod test {
 
     #[test]
     fn range_returning_single_element_int_array() {
-        let ctx = VMContext::default();
+        let mut vm = make_vm();
 
         // Test w/ increment larger than range
-        let arr = range(&ctx, &&None, vec![Value::Int(0), Value::Int(5), Value::Int(5)]);
+        let arr = range(&&None, vec![Value::Int(0), Value::Int(5), Value::Int(5)], &mut vm);
         let expected = Some(Value::new_array_obj(vec![Value::Int(0)]));
         assert_eq!(expected, arr);
 
         // Test w/ [0, 1)
-        let arr = range(&ctx, &None, vec![Value::Int(0), Value::Int(1), Value::Int(1)]);
+        let arr = range(&None, vec![Value::Int(0), Value::Int(1), Value::Int(1)], &mut vm);
         let expected = Some(Value::new_array_obj(vec![Value::Int(0)]));
         assert_eq!(expected, arr);
 
         // Test w/ [0, 0) -> Empty array
-        let arr = range(&ctx, &None, vec![Value::Int(0), Value::Int(0), Value::Int(1)]);
+        let arr = range(&None, vec![Value::Int(0), Value::Int(0), Value::Int(1)], &mut vm);
         let expected = Some(Value::new_array_obj(vec![]));
         assert_eq!(expected, arr);
     }

--- a/abra_core/src/builtins/native_types.rs
+++ b/abra_core/src/builtins/native_types.rs
@@ -1,13 +1,13 @@
-use crate::typechecker::types::Type;
+use crate::typechecker::types::{Type, FnType};
 use crate::vm::value::{Value, Obj};
 use crate::builtins::native_fns::{NativeFn, NativeFnDesc};
-use crate::vm::vm::VMContext;
+use crate::vm::vm::VM;
 use std::sync::Arc;
 use std::cell::RefCell;
 
 pub trait NativeType {
     fn fields(typ: &Type) -> Vec<(&'static str, Type)>;
-    fn methods(typ: &Type) -> Vec<NativeFnDesc<'_>>;
+    fn methods(typ: &Type) -> Vec<NativeFnDesc>;
     fn get_field_value(obj: &Arc<RefCell<Obj>>, field_idx: usize) -> Value;
 
     fn fields_and_methods(typ: &Type) -> Vec<(&'static str, Type)> {
@@ -40,22 +40,22 @@ pub fn field_for_type(typ: &Type, field_name: &str) -> Option<(usize, (&'static 
     }
 }
 
-// TODO: This could stand to be cleaned up a bit, esp to handle generic field types
+// TODO: This could stand to be cleaned up a bit
 pub struct NativeArray;
 
 impl NativeArray {
-    fn push(_ctx: &VMContext, receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>) -> Option<Value> {
+    fn push(receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
         let item = args.into_iter().next().expect("Array::push requires 1 argument");
 
         let mut receiver = receiver.as_ref().unwrap().borrow_mut();
         match *receiver {
-            Obj::ArrayObj(ref mut value) => value.push(item),
+            Obj::ArrayObj(ref mut array) => array.push(item),
             _ => unreachable!()
         };
         None
     }
 
-    fn concat(_ctx: &VMContext, receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>) -> Option<Value> {
+    fn concat(receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
         let arg = args.into_iter().next().expect("Array::concat requires 1 argument");
         let mut other_arr = match arg {
             Value::Obj(obj) => match &*obj.borrow() {
@@ -66,9 +66,9 @@ impl NativeArray {
         };
 
         let result = match &*receiver.as_ref().unwrap().borrow() {
-            Obj::ArrayObj(value) => {
-                let mut new_arr = Vec::with_capacity(value.len() + other_arr.len());
-                let mut old_arr = value.clone();
+            Obj::ArrayObj(array) => {
+                let mut new_arr = Vec::with_capacity(array.len() + other_arr.len());
+                let mut old_arr = array.clone();
                 new_arr.append(&mut old_arr);
                 new_arr.append(&mut other_arr);
                 Value::new_array_obj(new_arr)
@@ -77,6 +77,73 @@ impl NativeArray {
         };
 
         Some(result)
+    }
+
+    fn map(receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>, vm: &mut VM) -> Option<Value> {
+        match &*receiver.as_ref().unwrap().borrow() {
+            Obj::ArrayObj(array) => {
+                let callback = args.into_iter().next().expect("Array::map requires 1 argument");
+
+                let mut new_array_items = Vec::new();
+
+                for value in array {
+                    let args = vec![value.clone()];
+                    let new_value = vm.invoke_fn(args, callback.clone())
+                        .unwrap_or(Some(Value::Nil))
+                        .unwrap_or(Value::Nil);
+                    new_array_items.push(new_value);
+                }
+
+                Some(Value::new_array_obj(new_array_items))
+            }
+            _ => unreachable!()
+        }
+    }
+
+    fn filter(receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>, vm: &mut VM) -> Option<Value> {
+        match &*receiver.as_ref().unwrap().borrow() {
+            Obj::ArrayObj(array) => {
+                let callback = args.into_iter().next().expect("Array::filter requires 1 argument");
+
+                let mut new_array_items = Vec::new();
+
+                for value in array {
+                    let args = vec![value.clone()];
+                    let new_value = vm.invoke_fn(args, callback.clone())
+                        .unwrap_or(Some(Value::Bool(false)))
+                        .unwrap_or(Value::Bool(false));
+                    if let Value::Bool(true) = new_value {
+                        new_array_items.push(value.clone());
+                    }
+                }
+
+                Some(Value::new_array_obj(new_array_items))
+            }
+            _ => unreachable!()
+        }
+    }
+
+    fn reduce(receiver: &Option<Arc<RefCell<Obj>>>, args: Vec<Value>, vm: &mut VM) -> Option<Value> {
+        match &*receiver.as_ref().unwrap().borrow() {
+            Obj::ArrayObj(array) => {
+                let mut args = args.into_iter();
+                let initial_value = args.next().expect("Array::reduce requires 2 arguments");
+                let callback = args.next().expect("Array::reduce requires 2 arguments");
+
+                let mut accumulator = initial_value;
+
+                for value in array {
+                    let args = vec![accumulator, value.clone()];
+                    let new_value = vm.invoke_fn(args, callback.clone())
+                        .unwrap_or(Some(Value::Nil))
+                        .unwrap_or(Value::Nil);
+                    accumulator = new_value;
+                }
+
+                Some(accumulator)
+            }
+            _ => unreachable!()
+        }
     }
 }
 
@@ -87,7 +154,7 @@ impl NativeType for NativeArray {
         ]
     }
 
-    fn methods(typ: &Type) -> Vec<NativeFnDesc<'_>> {
+    fn methods(typ: &Type) -> Vec<NativeFnDesc> {
         let inner_type = match typ {
             Type::Array(inner_type) => &**inner_type,
             _ => unreachable!()
@@ -96,15 +163,60 @@ impl NativeType for NativeArray {
         vec![
             NativeFnDesc {
                 name: "push",
-                args: vec![("item", inner_type)],
+                type_args: vec![],
+                args: vec![("item", inner_type.clone())],
                 opt_args: vec![],
                 return_type: Type::Unit,
             },
             NativeFnDesc {
                 name: "concat",
-                args: vec![("items", inner_type)],
+                type_args: vec![],
+                args: vec![("items", typ.clone())],
                 opt_args: vec![],
                 return_type: typ.clone(),
+            },
+            NativeFnDesc {
+                name: "map",
+                type_args: vec!["U"],
+                args: vec![("fn", Type::Fn(FnType {
+                    arg_types: vec![
+                        ("item".to_string(), inner_type.clone(), false),
+                    ],
+                    type_args: vec!["U".to_string()],
+                    ret_type: Box::new(Type::Generic("U".to_string())),
+                }))],
+                opt_args: vec![],
+                return_type: Type::Array(Box::new(Type::Generic("U".to_string()))),
+            },
+            NativeFnDesc {
+                name: "filter",
+                type_args: vec![],
+                args: vec![("fn", Type::Fn(FnType {
+                    arg_types: vec![
+                        ("item".to_string(), inner_type.clone(), false),
+                    ],
+                    type_args: vec![],
+                    ret_type: Box::new(Type::Bool), // TODO: Allow returning of Optionals
+                }))],
+                opt_args: vec![],
+                return_type: typ.clone(),
+            },
+            NativeFnDesc {
+                name: "reduce",
+                type_args: vec!["U"],
+                args: vec![
+                    ("initialValue", Type::Generic("U".to_string())),
+                    ("fn", Type::Fn(FnType {
+                        arg_types: vec![
+                            ("accumulator".to_string(), Type::Generic("U".to_string()), false),
+                            ("item".to_string(), inner_type.clone(), false),
+                        ],
+                        type_args: vec!["U".to_string()],
+                        ret_type: Box::new(Type::Generic("U".to_string())),
+                    })),
+                ],
+                opt_args: vec![],
+                return_type: Type::Generic("U".to_string()),
             }
         ]
     }
@@ -118,11 +230,31 @@ impl NativeType for NativeArray {
                         name: "push",
                         receiver: Some(obj.clone()),
                         native_fn: NativeArray::push,
+                        has_return: false,
                     }),
                     2 => Value::NativeFn(NativeFn {
                         name: "concat",
                         receiver: Some(obj.clone()),
                         native_fn: NativeArray::concat,
+                        has_return: true,
+                    }),
+                    3 => Value::NativeFn(NativeFn {
+                        name: "map",
+                        receiver: Some(obj.clone()),
+                        native_fn: NativeArray::map,
+                        has_return: true,
+                    }),
+                    4 => Value::NativeFn(NativeFn {
+                        name: "filter",
+                        receiver: Some(obj.clone()),
+                        native_fn: NativeArray::filter,
+                        has_return: true,
+                    }),
+                    5 => Value::NativeFn(NativeFn {
+                        name: "reduce",
+                        receiver: Some(obj.clone()),
+                        native_fn: NativeArray::reduce,
+                        has_return: true,
                     }),
                     _ => unreachable!()
                 }
@@ -135,7 +267,7 @@ impl NativeType for NativeArray {
 pub struct NativeString;
 
 impl NativeString {
-    fn to_lower(_ctx: &VMContext, receiver: &Option<Arc<RefCell<Obj>>>, _args: Vec<Value>) -> Option<Value> {
+    fn to_lower(receiver: &Option<Arc<RefCell<Obj>>>, _args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
         let string = match &*(receiver.as_ref().unwrap().borrow()) {
             Obj::StringObj(value) => value.clone(),
             _ => unreachable!()
@@ -144,7 +276,7 @@ impl NativeString {
         Some(Value::new_string_obj(string.to_lowercase()))
     }
 
-    fn to_upper(_ctx: &VMContext, receiver: &Option<Arc<RefCell<Obj>>>, _args: Vec<Value>) -> Option<Value> {
+    fn to_upper(receiver: &Option<Arc<RefCell<Obj>>>, _args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
         let string = match &*(receiver.as_ref().unwrap().borrow()) {
             Obj::StringObj(value) => value.clone(),
             _ => unreachable!()
@@ -161,16 +293,18 @@ impl NativeType for NativeString {
         ]
     }
 
-    fn methods(_: &Type) -> Vec<NativeFnDesc<'_>> {
+    fn methods(_: &Type) -> Vec<NativeFnDesc> {
         vec![
             NativeFnDesc {
                 name: "toLower",
+                type_args: vec![],
                 args: vec![],
                 opt_args: vec![],
                 return_type: Type::String,
             },
             NativeFnDesc {
                 name: "toUpper",
+                type_args: vec![],
                 args: vec![],
                 opt_args: vec![],
                 return_type: Type::String,
@@ -187,16 +321,195 @@ impl NativeType for NativeString {
                         name: "toLower",
                         receiver: Some(obj.clone()),
                         native_fn: NativeString::to_lower,
+                        has_return: true,
                     }),
                     2 => Value::NativeFn(NativeFn {
                         name: "toUpper",
                         receiver: Some(obj.clone()),
                         native_fn: NativeString::to_upper,
+                        has_return: true,
                     }),
                     _ => unreachable!()
                 }
             }
             _ => unreachable!()
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::lexer::lexer::tokenize;
+    use crate::parser::parser::parse;
+    use crate::typechecker::typechecker::typecheck;
+    use crate::vm::compiler::compile;
+    use crate::vm::value::Value;
+    use crate::vm::vm::{VM, VMContext};
+
+    fn new_string_obj(string: &str) -> Value {
+        Value::new_string_obj(string.to_string())
+    }
+
+    macro_rules! array {
+        ($($i:expr),*) => { Value::new_array_obj(vec![$($i),*]) };
+    }
+
+    macro_rules! int_array {
+        ($($i:expr),*) => { Value::new_array_obj(vec![$($i),*].into_iter().map(Value::Int).collect()) };
+    }
+
+    macro_rules! string_array {
+        ($($i:expr),*) => { Value::new_array_obj(vec![$($i),*].into_iter().map(new_string_obj).collect()) };
+    }
+
+    fn interpret(input: &str) -> Option<Value> {
+        let tokens = tokenize(&input.to_string()).unwrap();
+        let ast = parse(tokens).unwrap();
+        let (_, typed_ast) = typecheck(ast).unwrap();
+        let (module, _) = compile(typed_ast).unwrap();
+
+        let mut vm = VM::new(module, VMContext::default());
+        vm.run(false).unwrap()
+    }
+
+    #[test]
+    fn test_string_length() {
+        let result = interpret("\"asdf qwer\".length");
+        let expected = Value::Int(9);
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_to_upper() {
+        let result = interpret("\"Asdf Qwer\".toUpper()");
+        let expected = new_string_obj("ASDF QWER");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_to_lower() {
+        let result = interpret("\"aSDF qWER\".toLower()");
+        let expected = new_string_obj("asdf qwer");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_array_length() {
+        let result = interpret("[1, 2, 3, 4, 5].length");
+        let expected = Value::Int(5);
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_array_push() {
+        let result = interpret(r#"
+          val arr = [1, 2, 3]
+          arr.push(4)
+          arr.push(5)
+          arr
+        "#);
+        let expected = int_array!(1, 2, 3, 4, 5);
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_array_concat() {
+        let result = interpret(r#"
+          val arr1 = [1, 2, 3]
+          val arr2 = [4, 5, 6]
+          arr1.concat(arr2)
+        "#);
+        let expected = int_array![1, 2, 3, 4, 5, 6];
+        assert_eq!(Some(expected), result);
+
+        // Verify that the original arrays aren't modified
+        let result = interpret(r#"
+          val arr1 = [1, 2, 3]
+          val arr2 = [4, 5, 6]
+          val arr3 = arr1.concat(arr2)
+          [arr1, arr2]
+        "#);
+        let expected = array![
+            int_array![1, 2, 3],
+            int_array![4, 5, 6]
+        ];
+        assert_eq!(Some(expected), result);
+
+        // Verify that the arrays' items are copied by reference
+        let result = interpret(r#"
+          type Counter {
+            count: Int = 0
+            func inc(self): Int { self.count += 1 }
+          }
+
+          val arr1 = [Counter(), Counter()]
+          val arr2 = [Counter(), Counter()]
+          val arr3 = arr1.concat(arr2)
+
+          if arr1[0] |c| c.inc()
+          if arr2[1] |c| c.inc()
+
+          [
+            arr1.map(c => c.count),
+            arr2.map(c => c.count),
+            arr3.map(c => c.count)
+          ]
+        "#);
+        let expected = array![
+            int_array![1, 0],
+            int_array![0, 1],
+            int_array![1, 0, 0, 1]
+        ];
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_array_map() {
+        let result = interpret(r#"
+          val arr = [1, 2, 3, 4]
+          arr.map(i => i * 3)
+        "#);
+        let expected = int_array![3, 6, 9, 12];
+        assert_eq!(Some(expected), result);
+
+        // Verify closures work
+        let result = interpret(r#"
+          var total = 0
+          val arr = [1, 2, 3, 4]
+          val arr2 = arr.map(i => {
+            total += i
+            i * 3
+          })
+          arr2.concat([total])
+        "#);
+        let expected = int_array![3, 6, 9, 12, 10];
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_array_filter() {
+        let result = interpret(r#"
+          val arr = ["a", "bc", "def", "ghij", "klmno"]
+          arr.filter(w => w.length < 4)
+        "#);
+        let expected = string_array!["a", "bc", "def"];
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_array_reduce() {
+        let result = interpret(r#"
+          val arr = [1, 2, 3, 4, 5]
+          arr.reduce(0, (acc, i) => acc + i)
+        "#);
+        let expected = Value::Int(15);
+        assert_eq!(Some(expected), result);
+
+        let result = interpret(r#"
+          val arr = [1, 2, 3, 4, 5]
+          arr.reduce("", (acc, i) => acc + i)
+        "#);
+        let expected = new_string_obj("12345");
+        assert_eq!(Some(expected), result);
     }
 }

--- a/abra_core/src/lib.rs
+++ b/abra_core/src/lib.rs
@@ -57,7 +57,7 @@ pub fn compile(input: String) -> Result<(Module, Metadata), Error> {
 pub fn compile_and_run(input: String, ctx: VMContext) -> Result<Option<Value>, Error> {
     let (module, _) = compile(input)?;
     let mut vm = vm::vm::VM::new(module, ctx);
-    match vm.run() {
+    match vm.run(false) {
         Ok(Some(v)) => Ok(Some(v)),
         Ok(None) => Ok(None),
         Err(e) => Err(Error::InterpretError(e)),

--- a/abra_core/src/vm/disassembler.rs
+++ b/abra_core/src/vm/disassembler.rs
@@ -98,9 +98,7 @@ impl Disassembler {
                 }
                 Opcode::Invoke => {
                     let arity = imms[0].expect("Invoke requires an arity");
-                    let has_return = imms[1].expect("Invoke requires an arity") == &1;
-
-                    acc.push(format!("\t; (arity: {}, has_return: {})", arity, has_return))
+                    acc.push(format!("\t; (arity: {})", arity))
                 }
                 Opcode::GetField => {
                     let ident = self.metadata.field_gets.get(self.current_field_get)

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -186,8 +186,8 @@ impl Opcode {
             Opcode::New |
             Opcode::MarkLocal |
             Opcode::GetField |
+            Opcode::Invoke |
             Opcode::SetField => 1,
-            Opcode::Invoke => 2,
             _ => 0
         }
     }

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -13,6 +13,7 @@ pub struct FnValue {
     pub code: Vec<u8>,
     pub upvalues: Vec<Upvalue>,
     pub receiver: Option<Arc<RefCell<Obj>>>,
+    pub has_return: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -21,6 +22,7 @@ pub struct ClosureValue {
     pub code: Vec<u8>,
     pub captures: Vec<Arc<RefCell<vm::Upvalue>>>,
     pub receiver: Option<Arc<RefCell<Obj>>>,
+    pub has_return: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -24,7 +24,7 @@ mod tests {
         let ctx = VMContext::default();
 
         let mut vm = VM::new(module, ctx);
-        vm.run().unwrap()
+        vm.run(false).unwrap()
     }
 
     #[test]
@@ -669,6 +669,7 @@ mod tests {
             ],
             upvalues: vec![],
             receiver: None,
+            has_return: true,
         });
         assert_eq!(expected, result);
     }


### PR DESCRIPTION
- Adding `map`/`filter`/`reduce` methods for Array:
  - This requires proper handling of generics for NativeFns
  - This also requires some way of invoking bytecode-backed
functions/lambdas from native rust-land, which required some refactoring
within the VM. As a result of this, NativeAbraFns now accept a mutable
reference to the VM. Also the mechanisms surrounding function invocation
needed to be changed a bit.
- Changes to function invocation:
  - The `Invoke` opcode no longer accepts 2 arguments, instead the
`has_return` is obtained from the FnValue/ClosureValue/NativeFnValue
itself. This was necessary in order to programmatically invoke
bytecode-backed function values from rust-land.