### PR TITLE
Generics: Typechecking bare functions

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,19 +1,31 @@
-type List<T, U> {
-  items: T[]
+//type List<T, U> {
+//  items: T[]
+//
+//  func push(self, item: T) {
+//    self.items.push(T)
+//  }
+//
+//  func get(self, index: Int): T? {
+//    self.items[index]
+//  }
+//}
 
-  func push(self, item: T) {
-    self.items.push(T)
-  }
+func map<T, U>(arr: T[], fn: (T) => U, start: U? = None): U[] {
+  val newArr: U[] = []
 
-  func get(self, index: Int): T? {
-    self.items[index]
+  if start |u| {
+    newArr.push(u)
+  } else {}
+
+  for i in arr {
+    newArr.push(fn(i))
   }
+  newArr
 }
 
-func push<T>(self, arr: T[], item: T) {
-  arr.push(item)
-}
-
-val arr: Int[] = []
-push(arr: arr, item: 123)
-println(arr)
+val lengths = map(
+   arr: ["1", "23", "456"],
+   fn: s => (s + "!").length,
+   start: 17
+)
+println(lengths)

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -15,7 +15,7 @@ func map<T, U>(arr: T[], fn: (T) => U, start: U? = None): U[] {
 
   if start |u| {
     newArr.push(u)
-  } else {}
+  }
 
   for i in arr {
     newArr.push(fn(i))

--- a/abra_core/src/builtins/native_fns.rs
+++ b/abra_core/src/builtins/native_fns.rs
@@ -1,4 +1,4 @@
-use crate::typechecker::types::Type;
+use crate::typechecker::types::{Type, FnType};
 use crate::vm::value::{Value, Obj};
 use crate::vm::vm::VMContext;
 use std::cmp::Ordering;
@@ -56,9 +56,9 @@ impl NativeFnDesc<'_> {
             .map(|(name, typ)| (name.to_string(), typ.clone().clone(), false));
         let opt_args = self.opt_args.iter()
             .map(|(name, typ)| (name.to_string(), typ.clone().clone(), true));
-        let args = req_args.chain(opt_args).collect();
+        let arg_types = req_args.chain(opt_args).collect();
 
-        Type::Fn(args, Box::new(self.return_type.clone()))
+        Type::Fn(FnType { arg_types, type_args: vec![], ret_type: Box::new(self.return_type.clone()) })
     }
 }
 

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -15,13 +15,22 @@ pub enum Type {
     Array(Box<Type>),
     Map(/* fields: */ Vec<(String, Type)>, /* homogeneous_type: */ Option<Box<Type>>),
     Option(Box<Type>),
-    Fn(/* arg_types: */ Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, /* ret_type: */ Box<Type>),
+    // Fn(/* arg_types: */ Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>, /* ret_type: */ Box<Type>),
+    Fn(FnType),
     Type(/* type_name: */ String, /* underlying_type: */ Box<Type>),
     Struct(StructType),
     // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
     Unknown,
     Placeholder,
+    Generic(/* name: */ String),
     Reference(/* name: */ String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct FnType {
+    pub arg_types: Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>,
+    pub type_args: Vec<String>,
+    pub ret_type: Box<Type>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -68,9 +77,9 @@ impl Type {
                 true
             }
             // For Fn types compare arities, param types, and return type
-            (Fn(args, ret), Fn(target_args, target_ret)) => {
+            (Fn(FnType { arg_types: args, ret_type: ret, .. }), Fn(FnType { arg_types: target_args, ret_type: target_ret, .. })) => {
                 let num_req_args = args.iter().filter(|(_, _, has_default)| !*has_default).count();
-                let num_target_req_args = args.iter().filter(|(_, _, has_default)| !*has_default).count();
+                let num_target_req_args = target_args.iter().filter(|(_, _, has_default)| !*has_default).count();
                 if num_req_args != num_target_req_args {
                     return false;
                 }
@@ -137,6 +146,7 @@ impl Type {
                     other.is_equivalent_to(&referenced_type, referencable_types)
                 } else { false }
             }
+            (Generic(t1), Generic(t2)) => t1 == t2,
             (_, _) => false
         }
     }
@@ -146,7 +156,7 @@ impl Type {
             Type::Or(type_opts) => type_opts.iter().any(|typ| typ.is_unknown(referencable_types)),
             Type::Array(inner_type) |
             Type::Option(inner_type) => inner_type.is_unknown(referencable_types),
-            Type::Fn(arg_types, ret_type) => {
+            Type::Fn(FnType { arg_types, ret_type, .. }) => {
                 let has_unknown_arg = arg_types.iter().any(|(_, typ, _)| typ.is_unknown(referencable_types));
                 if has_unknown_arg {
                     return true;
@@ -161,6 +171,84 @@ impl Type {
             }
             Type::Unknown => true,
             _ => false
+        }
+    }
+
+    pub fn extract_generics(&self) -> Vec<String> {
+        match self {
+            Type::Generic(name) => vec![name.clone()],
+            Type::Or(type_opts) => {
+                type_opts.iter()
+                    .flat_map(|typ| typ.extract_generics().into_iter())
+                    .collect::<Vec<String>>()
+            },
+            Type::Array(inner_type) |
+            Type::Option(inner_type) => inner_type.extract_generics(),
+            Type::Fn(FnType { arg_types, ret_type, .. }) => {
+                arg_types.iter()
+                    .map(|(_, typ, _)| typ)
+                    .chain(std::iter::once(&**ret_type))
+                    .flat_map(|typ| typ.extract_generics().into_iter())
+                    .collect::<Vec<String>>()
+            }
+            _ => vec![]
+        }
+    }
+
+    pub fn is_generic(&self) -> bool {
+        !self.extract_generics().is_empty()
+    }
+
+    pub fn substitute_generics(typ: &Type, available_generics: &HashMap<String, Type>) -> Type {
+        match typ {
+            Type::Generic(name) => available_generics.get(name).unwrap_or(typ).clone(),
+            Type::Array(inner_type) => Type::Array(Box::new(Type::substitute_generics(inner_type, available_generics))),
+            Type::Option(inner_type) => Type::Option(Box::new(Type::substitute_generics(inner_type, available_generics))),
+            Type::Fn(FnType { arg_types, type_args, ret_type }) => {
+                let arg_types = arg_types.iter()
+                    .map(|(name, typ, is_optional)| {
+                        (name.clone(), Type::substitute_generics(typ, available_generics), is_optional.clone())
+                    })
+                    .collect();
+                let ret_type = Type::substitute_generics(ret_type, available_generics);
+                Type::Fn(FnType { arg_types, type_args: type_args.clone(), ret_type: Box::new(ret_type) })
+            }
+            // Type::Struct(_) => {},
+            // Type::Or(_) => {},
+            // Type::Map(_, _) => {},
+            t @ _ => t.clone(),
+        }
+    }
+
+    pub fn try_fit_generics(typ: &Type, target_type: &Type) -> Option<Vec<(String, Type)>> {
+        if !target_type.is_generic() { return None; }
+
+        match (target_type, typ) {
+            (Type::Generic(name), target_type) => Some(vec![(name.clone(), target_type.clone())]),
+            (Type::Fn(FnType { arg_types: target_arg_types, ret_type: target_ret_type, .. }), Type::Fn(FnType { arg_types, ret_type, .. })) => {
+                let mut pairs = Vec::new();
+                let mut seen = HashSet::new();
+                for ((_, target_arg_type, _), (_, arg_type, _)) in target_arg_types.iter().zip(arg_types.iter()) {
+                    if let Some(items) = Self::try_fit_generics(arg_type, target_arg_type) {
+                        for (type_arg_name, potential_type) in items {
+                            if seen.contains(&type_arg_name) { continue; }
+                            seen.insert(type_arg_name.clone());
+                            pairs.push((type_arg_name, potential_type))
+                        }
+                    }
+                }
+                if let Some(items) = Self::try_fit_generics(ret_type, target_ret_type) {
+                    for (type_arg_name, potential_type) in items {
+                        if seen.contains(&type_arg_name) { continue; }
+                        seen.insert(type_arg_name.clone());
+                        pairs.push((type_arg_name, potential_type))
+                    }
+                }
+                Some(pairs)
+            }
+            (Type::Option(target_inner), Type::Option(inner)) => Self::try_fit_generics(inner, target_inner),
+            (Type::Array(target_inner), Type::Array(inner)) => Self::try_fit_generics(inner, target_inner),
+            _ => None
         }
     }
 
@@ -184,7 +272,7 @@ impl Type {
                     .collect::<Result<Vec<_>, _>>();
                 let arg_types = arg_types?.into_iter().map(|arg_type| ("_".to_string(), arg_type, false)).collect();
                 let ret_type = Type::from_type_ident(ret, types)?;
-                Ok(Type::Fn(arg_types, Box::new(ret_type)))
+                Ok(Type::Fn(FnType { arg_types, type_args: vec![], ret_type: Box::new(ret_type) }))
             }
             // TODO: Choice type ident, eg. Int | Float
         }
@@ -281,5 +369,155 @@ mod test {
         let t1 = Int;
         let t2 = Option(Box::new(Int));
         assert_eq!(false, t2.is_equivalent_to(&t1, &referencable_types));
+    }
+
+    #[test]
+    fn try_fit_generics_tests() {
+        // Given: String[] vs Int[]; Expect: { }
+        let t = Array(Box::new(String));
+        let target = Array(Box::new(Int));
+        let result = super::Type::try_fit_generics(&t, &target);
+        assert_eq!(None, result);
+
+        // Given: T[] & Int[]; Expect: { T: Int }
+        let t = Array(Box::new(Int));
+        let target = Array(Box::new(Generic("T".to_string())));
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![("T".to_string(), Int)];
+        assert_eq!(Some(expected), result);
+
+        // Given: T[][] & Int[][]; Expect: { T: Int }
+        let t = Array(Box::new(Array(Box::new(Int))));
+        let target = Array(Box::new(Array(Box::new(Generic("T".to_string())))));
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![("T".to_string(), Int)];
+        assert_eq!(Some(expected), result);
+
+        // Given: T? & String?; Expect: { T: String }
+        let t = Option(Box::new(String));
+        let target = Option(Box::new(Generic("T".to_string())));
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![("T".to_string(), String)];
+        assert_eq!(Some(expected), result);
+
+        // Given: T? & String??; Expect: { T: String? }
+        let t = Option(Box::new(Option(Box::new(String))));
+        let target = Option(Box::new(Generic("T".to_string())));
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![("T".to_string(), Option(Box::new(String)))];
+        assert_eq!(Some(expected), result);
+
+        // Given: T?[] & Int?[]; Expect: { T: Int }
+        let t = Array(Box::new(Option(Box::new(Int))));
+        let target = Array(Box::new(Option(Box::new(Generic("T".to_string())))));
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![("T".to_string(), Int)];
+        assert_eq!(Some(expected), result);
+
+        // Given: (T) => Int & (String) => Int; Expect: { T: String }
+        let t = Fn(FnType { arg_types: vec![("_".to_string(), String, false)], type_args: vec![], ret_type: Box::new(Int) });
+        let target = Fn(FnType { arg_types: vec![("_".to_string(), Generic("T".to_string()), false)], type_args: vec![], ret_type: Box::new(Int) });
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![("T".to_string(), String)];
+        assert_eq!(Some(expected), result);
+
+        // Given: (T[], Int) => Int & (Int[][], Int) => Int; Expect: { T: Int[] }
+        let t = Fn(FnType {
+            arg_types: vec![("_".to_string(), Array(Box::new(Array(Box::new(Int)))), false), ("_".to_string(), Int, false)],
+            type_args: vec![],
+            ret_type: Box::new(Int),
+        });
+        let target = Fn(FnType {
+            arg_types: vec![("_".to_string(), Array(Box::new(Generic("T".to_string()))), false), ("_".to_string(), Int, false)],
+            type_args: vec![],
+            ret_type: Box::new(Int),
+        });
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![("T".to_string(), Array(Box::new(Int)))];
+        assert_eq!(Some(expected), result);
+
+        // Given: (T, U) => Int & (Int[], String) => Int; Expect: { T: Int[], U: String }
+        let t = Fn(FnType {
+            arg_types: vec![("_".to_string(), Array(Box::new(Int)), false), ("_".to_string(), String, false)],
+            type_args: vec![],
+            ret_type: Box::new(Int),
+        });
+        let target = Fn(FnType {
+            arg_types: vec![("_".to_string(), Generic("T".to_string()), false), ("_".to_string(), Generic("U".to_string()), false)],
+            type_args: vec![],
+            ret_type: Box::new(Int),
+        });
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![
+            ("T".to_string(), Array(Box::new(Int))),
+            ("U".to_string(), String),
+        ];
+        assert_eq!(Some(expected), result);
+
+        // Given: (T, T) => Int & (Int, String) => Int; Expect: { T: Int }
+        let t = Fn(FnType {
+            arg_types: vec![("_".to_string(), Int, false), ("_".to_string(), String, false)],
+            type_args: vec![],
+            ret_type: Box::new(Int),
+        });
+        let target = Fn(FnType {
+            arg_types: vec![("_".to_string(), Generic("T".to_string()), false), ("_".to_string(), Generic("T".to_string()), false)],
+            type_args: vec![],
+            ret_type: Box::new(Int),
+        });
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![("T".to_string(), Int)];
+        assert_eq!(Some(expected), result);
+
+        // Given: (T) => U & (Int) => Int; Expect: { T: Int, U: Int }
+        let t = Fn(FnType {
+            arg_types: vec![("_".to_string(), Int, false)],
+            type_args: vec![],
+            ret_type: Box::new(Int),
+        });
+        let target = Fn(FnType {
+            arg_types: vec![("_".to_string(), Generic("T".to_string()), false)],
+            type_args: vec![],
+            ret_type: Box::new(Generic("U".to_string())),
+        });
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![
+            ("T".to_string(), Int),
+            ("U".to_string(), Int),
+        ];
+        assert_eq!(Some(expected), result);
+
+        // Given: ((T) => U) => U & ((Int) => String) => String; Expect: { T: Int, U: String }
+        let t = Fn(FnType {
+            arg_types: vec![
+                ("_".to_string(), Fn(FnType {
+                    arg_types: vec![("_".to_string(), Int, false)],
+                    type_args: vec![],
+                    ret_type: Box::new(String),
+                }),
+                 false
+                )],
+            type_args: vec![],
+            ret_type: Box::new(String),
+        });
+        let target = Fn(FnType {
+            arg_types: vec![
+                ("_".to_string(),
+                 Fn(FnType {
+                     arg_types: vec![("_".to_string(), Generic("T".to_string()), false)],
+                     type_args: vec![],
+                     ret_type: Box::new(Generic("U".to_string())),
+                 }),
+                 false)
+            ],
+            type_args: vec![],
+            ret_type: Box::new(Generic("U".to_string())),
+        });
+        let result = super::Type::try_fit_generics(&t, &target);
+        let expected = vec![
+            ("T".to_string(), Int),
+            ("U".to_string(), String),
+        ];
+        assert_eq!(Some(expected), result);
     }
 }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -990,6 +990,33 @@ mod tests {
     }
 
     #[test]
+    fn interpret_func_invocation_generics() {
+        let input = r#"
+          func map<T, U>(arr: T[], fn: (T) => U, start: U? = None): U[] {
+            val newArr: U[] = []
+
+            if start |u| { newArr.push(u) } else {}
+
+            for i in arr { newArr.push(fn(i)) }
+            newArr
+          }
+          map(
+             arr: ["1", "23", "456"],
+             fn: s => (s + "!").length,
+             start: 17
+          )
+        "#;
+        let result = interpret(input).unwrap();
+        let expected = Value::new_array_obj(vec![
+            Value::Int(17),
+            Value::Int(2),
+            Value::Int(3),
+            Value::Int(4),
+        ]);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn interpret_while_loop() {
         let input = "\
           var a = 0\n\

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -995,7 +995,7 @@ mod tests {
           func map<T, U>(arr: T[], fn: (T) => U, start: U? = None): U[] {
             val newArr: U[] = []
 
-            if start |u| { newArr.push(u) } else {}
+            if start |u| newArr.push(u)
 
             for i in arr { newArr.push(fn(i)) }
             newArr

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -151,6 +151,22 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
+                TypecheckerError::DuplicateTypeArgument { ident, orig_ident } => {
+                    let mut obj = serializer.serialize_map(Some(5))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "duplicateTypeArgument")?;
+                    obj.serialize_entry("ident", &JsToken(ident))?;
+                    obj.serialize_entry("origIdent", &JsToken(orig_ident))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
+                TypecheckerError::UnboundGeneric(ident) => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "unboundGeneric")?;
+                    obj.serialize_entry("ident", &JsToken(ident))?;
+                    obj.end()
+                }
                 TypecheckerError::UnknownIdentifier { ident } => {
                     let mut obj = serializer.serialize_map(Some(4))?;
                     obj.serialize_entry("kind", "typecheckerError")?;

--- a/abra_wasm/ts/types/error.d.ts
+++ b/abra_wasm/ts/types/error.d.ts
@@ -74,6 +74,8 @@ export namespace Errors {
         | TypecheckerErrors.DuplicateBinding
         | TypecheckerErrors.DuplicateField
         | TypecheckerErrors.DuplicateType
+        | TypecheckerErrors.DuplicateTypeArgument
+        | TypecheckerErrors.UnboundGeneric
         | TypecheckerErrors.UnknownIdentifier
         | TypecheckerErrors.InvalidAssignmentTarget
         | TypecheckerErrors.AssignmentToImmutable
@@ -152,6 +154,19 @@ export namespace Errors {
             subKind: 'duplicateType',
             ident: Token,
             origIdent: Token | null
+        }
+
+        interface DuplicateTypeArgument extends BaseError {
+            kind: 'typecheckerError',
+            subKind: 'duplicateTypeArgument',
+            ident: Token,
+            origIdent: Token
+        }
+
+        interface UnboundGeneric extends BaseError {
+            kind: 'typecheckerError',
+            subKind: 'unboundGeneric',
+            ident: Token
         }
 
         interface UnknownIdentifier extends BaseError {


### PR DESCRIPTION
- `Type::Fn(_, _)` => `Type::Fn(FnType { .. })`
- Adding type arguments to functions
- Resolve generics on function invocation, for both named and unnamed
argument calling convention