### PR TITLE
Generics: struct types

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,16 +1,57 @@
-//type List<T, U> {
-//  items: T[]
-//
-//  func push(self, item: T) {
-//    self.items.push(T)
-//  }
-//
-//  func get(self, index: Int): T? {
-//    self.items[index]
-//  }
-//}
+type List<T> {
+  items: T[] = []
 
-val arr = [1, 2, 3]
-arr.push(4)
-arr.push(5)
-arr
+  func push(self, item: T): Unit {
+    self.items.push(item)
+  }
+
+  func get(self, index: Int): T? {
+    self.items[index]
+  }
+
+  func map<U>(self, fn: (T) => U): U[] {
+    val newArr: U[] = []
+    for item in self.items
+      newArr.push(fn(item))
+    newArr
+  }
+
+  func reduce<U>(self, initialValue: U, fn: (U, T) => U): U {
+    var acc = initialValue
+    for item in self.items
+      acc = fn(acc, item)
+    acc
+  }
+
+  // Calling this method won't work right now, needs to be fixed.
+  // The error message is 'Expected List<T>, got List<Int>', for the `other` arg. Weird
+  func merge(self, other: List<T>): List<T> {
+    val items = self.items
+    List(items: items.concat(other.items))
+  }
+}
+
+//val list: List<String> = List(items: [])
+
+val list: List<Int> = List(items: [1, 2])
+//list.push(3)
+//list.push(4)
+//println(list.items)
+
+// See comment above on `merge`
+//println(list.merge(list))
+println(
+  List(items: range(1, 10))
+    .merge(List(items: range(10, 15)))
+    .items
+)
+
+//if list.get(0) |i| println(i)
+//
+//val items = list.map(i => i * 7 + "!")
+//println(items)
+//
+//val sum1 = List(items: range(1, 1000))
+//  .map(i => i * 5)
+//  .reduce(0, (acc, i) => acc + i)
+//println("Sum 1: " + sum1)

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -186,19 +186,19 @@ pub struct AccessorNode {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum TypeIdentifier {
-    Normal { ident: Token },
+    Normal { ident: Token, type_args: Option<Vec<TypeIdentifier>> },
     Array { inner: Box<TypeIdentifier> },
     Option { inner: Box<TypeIdentifier> },
     Func {
         args: Vec<TypeIdentifier>,
-        ret: Box<TypeIdentifier>
+        ret: Box<TypeIdentifier>,
     },
 }
 
 impl TypeIdentifier {
     pub fn get_ident(&self) -> Token {
         match self {
-            TypeIdentifier::Normal { ident } => ident.clone(),
+            TypeIdentifier::Normal { ident, .. } => ident.clone(),
             TypeIdentifier::Array { inner } => inner.get_ident(),
             TypeIdentifier::Option { inner } => inner.get_ident(),
             TypeIdentifier::Func { ret, .. } => ret.get_ident()

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1403,6 +1403,45 @@ mod tests {
     }
 
     #[test]
+    fn interpret_structs_generics() {
+        let input = r#"
+          type List<T> {
+            items: T[] = []
+
+            func push(self, item: T): Unit { self.items.push(item) }
+
+            func map<U>(self, fn: (T) => U): U[] {
+              val newArr: U[] = []
+              for item in self.items
+                newArr.push(fn(item))
+              newArr
+            }
+
+            func reduce<U>(self, initialValue: U, fn: (U, T) => U): U {
+              var acc = initialValue
+              for item in self.items
+                acc = fn(acc, item)
+              acc
+            }
+
+            func concat(self, other: List<T>): List<T> {
+              val items = self.items
+              List(items: items.concat(other.items))
+            }
+          }
+
+          var list: List<Int> = List(items: [])
+          for n in range(1, 500) { list.push(n) }
+          list = list.concat(List(items: range(500, 1000)))
+          list = List(items: list.map(i => i * 5))
+          list.reduce(0, (acc, i) => acc + i)
+        "#;
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(2497500);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn interpret_lambdas() {
         let input = "\
           func call(fn: (Int) => Int, value: Int) = fn(value)\n\

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -69,7 +69,7 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("innerType", &JsType(inner_type))?;
                 obj.end()
             }
-            Type::Fn(FnType { arg_types, type_args, ret_type}) => {
+            Type::Fn(FnType { arg_types, type_args, ret_type }) => {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "Fn")?;
                 let args: Vec<(String, JsType)> = arg_types.iter()
@@ -91,10 +91,14 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("kind", "Unknown")?;
                 obj.end()
             }
-            Type::Struct(StructType { name, fields, methods, static_fields }) => {
-                let mut obj = serializer.serialize_map(Some(3))?;
+            Type::Struct(StructType { name, type_args, fields, methods, static_fields }) => {
+                let mut obj = serializer.serialize_map(Some(6))?;
                 obj.serialize_entry("kind", "Struct")?;
                 obj.serialize_entry("name", name)?;
+                let type_args: Vec<(String, JsType)> = type_args.iter()
+                    .map(|(name, typ)| (name.clone(), JsType(typ)))
+                    .collect();
+                obj.serialize_entry("typeArgs", &type_args)?;
                 let fields: Vec<(String, JsType)> = fields.iter()
                     .map(|(name, typ, _)| (name.clone(), JsType(typ)))
                     .collect();
@@ -114,10 +118,14 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("kind", "Placeholder")?;
                 obj.end()
             }
-            Type::Reference(name) => {
-                let mut obj = serializer.serialize_map(Some(2))?;
+            Type::Reference(name, type_args) => {
+                let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "Reference")?;
                 obj.serialize_entry("name", name)?;
+                let type_args: Vec<JsType> = type_args.iter()
+                    .map(|typ| JsType(typ))
+                    .collect();
+                obj.serialize_entry("typeArgs", &type_args)?;
                 obj.end()
             }
             Type::Generic(name) => {

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -160,11 +160,13 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
-                TypecheckerError::UnboundGeneric(ident) => {
-                    let mut obj = serializer.serialize_map(Some(3))?;
+                TypecheckerError::UnboundGeneric(ident, generic_name) => {
+                    let mut obj = serializer.serialize_map(Some(5))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "unboundGeneric")?;
                     obj.serialize_entry("ident", &JsToken(ident))?;
+                    obj.serialize_entry("genericName", generic_name)?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
                 TypecheckerError::UnknownIdentifier { ident } => {
@@ -387,6 +389,17 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("subKind", "invalidInstantiation")?;
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.serialize_entry("type", &JsType(typ))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
+                TypecheckerError::InvalidTypeArgumentArity { token, actual_type, expected, actual } => {
+                    let mut obj = serializer.serialize_map(Some(7))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "missingTypeArguments")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("actualType", &JsType(actual_type))?;
+                    obj.serialize_entry("expected", expected)?;
+                    obj.serialize_entry("actual", actual)?;
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }

--- a/abra_wasm/ts/types/abra-types.d.ts
+++ b/abra_wasm/ts/types/abra-types.d.ts
@@ -9,6 +9,13 @@ export type Type
     | Types.Array
     | Types.Option
     | Types.Fn
+    | Types._Type
+    | Types.Unknown
+    | Types.Struct
+    | Types.Placeholder
+    | Types.Reference
+    | Types.Generic
+
 
 export namespace Types {
     interface Int {
@@ -52,7 +59,41 @@ export namespace Types {
 
     interface Fn {
         kind: 'Fn',
+        typeArgs: string[],
         args: [string, Type][],
         returnType: Type
+    }
+
+    interface _Type {
+        kind: 'type',
+        name: string
+    }
+
+    interface Unknown {
+        kind: 'unknown'
+    }
+
+    interface Struct {
+        kind: 'unknown',
+        name: string,
+        typeArgs: string[],
+        fields: [string, Type][],
+        staticFields: [string, Type][],
+        methods: [string, Type][]
+    }
+
+    interface Placeholder {
+        kind: 'placeholder'
+    }
+
+    interface Reference {
+        kind: 'reference',
+        name: string,
+        typeArgs: string[],
+    }
+
+    interface Generic {
+        kind: 'generic',
+        name: string
     }
 }

--- a/abra_wasm/ts/types/error.d.ts
+++ b/abra_wasm/ts/types/error.d.ts
@@ -102,6 +102,7 @@ export namespace Errors {
         | TypecheckerErrors.InvalidTypeDeclDepth
         | TypecheckerErrors.ForbiddenUnknownType
         | TypecheckerErrors.InvalidInstantiation
+        | TypecheckerErrors.InvalidTypeArgumentArity
 
     export namespace TypecheckerErrors {
         interface Mismatch extends BaseError {
@@ -166,7 +167,8 @@ export namespace Errors {
         interface UnboundGeneric extends BaseError {
             kind: 'typecheckerError',
             subKind: 'unboundGeneric',
-            ident: Token
+            ident: Token,
+            genericName: string
         }
 
         interface UnknownIdentifier extends BaseError {
@@ -338,6 +340,15 @@ export namespace Errors {
             subKind: 'invalidInstantiation',
             token: Token,
             type: Type
+        }
+
+        interface InvalidTypeArgumentArity extends BaseError {
+            kind: 'typecheckerError',
+            subKind: 'invalidTypeArgumentArity',
+            token: Token,
+            actualType: Type,
+            expected: number,
+            actual: number
         }
     }
 


### PR DESCRIPTION
There's a ridiculous amount of changes here, let's go module-by-module:

Parser
- Parsing type identifiers with type arguments `List<Int>`

Types
- Add a list of type parameters to `Reference` types
- Add comparison logic to `is_equivalent_to` for comparing struct types'
type arguments. A note here: if the given type of a struct type arg
comparison is a `Generic`, we give it a pass.
- Cleanup some of the reference type stuff into the `hydrate_reference_type`
helper function
- Did some renaming of "generics" in functions to `unbound_generics` to better
communicate intent
- Adding functionality to `from_type_ident` to return type identifiers with type
arguemnts as `Reference`s with type_args.

Typechecker:
- Add `type_from_type_ident` for some cleanup, as well as returning an
error when the arity of type arguments doesn't match
- Resolving generics with struct types, for fields and methods
- Needed to do some cleanup in a couple of places related to
`self.scopes.push`/`self.scopes.pop` in order to make sure that the
generic type args were within scope at the time of typechecking.