### PR TITLE
Generics  generic methods

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,43 +1,50 @@
-type Node<T> {
-  value: T
-  next: Node<T>? = None
-}
+type List<T> {
+  items: T[] = []
 
-type LinkedList<T> {
-  count: Int = 0
-  head: Node<T>? = None
+  func push(self, item: T): Unit {
+    self.items.push(item)
+  }
 
-  func push(self, item: T): LinkedList<T> {
-    if self.head |head| {
-      var node = head
-      while node.next |n| { node = n }
-      node.next = Node(value: item)
+  func get(self, index: Int): T? {
+    self.items[index]
+  }
+
+  func map<U>(self, fn: (T) => U): U[] {
+    val newArr: U[] = []
+    for item in self.items
+      newArr.push(fn(item))
+    newArr
+  }
+
+  func reduce<U>(self, initialValue: U, fn: (U, T) => U): U {
+    var acc = initialValue
+    for item in self.items
+      acc = fn(acc, item)
+    acc
+  }
+
+  func merge(self, other: List<T>): List<T> {
+    val items = self.items
+    List(items: items.concat(other.items))
+  }
+
+  func slice(self, start: Int): List<T> {
+    List(items: self.items[start:])
+  }
+
+  func join(self, joiner = ","): String {
+    if self.items[0] |head| {
+      var str = "" + head
+      self.slice(1).reduce(str, (acc, i) => acc + joiner + i)
     } else {
-      self.head = Node(value: item)
+      ""
     }
-
-    self
-  }
-
-  func toString(self): String {
-    var str = "["
-    if self.head |head| {
-      var node = head
-
-      while node.next |n| {
-        str = str + node.value + ", "
-        node = n
-      }
-
-      str += node.value
-    }
-    str + "]"
   }
 }
 
-val list: LinkedList<String> = LinkedList()
-list.push("a")
-  .push("b")
-  .push("c")
-  .push("d")
-  .toString()
+func sum(list: List<Int>): Int = list.reduce(0, (acc, i) => acc + i)
+
+val items = range(0, 1001)
+sum(List(items: items))
+
+List(items: items).slice(987).join(joiner: ", ")

--- a/abra_core/src/common/ast_visitor.rs
+++ b/abra_core/src/common/ast_visitor.rs
@@ -1,4 +1,4 @@
-use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode, LambdaNode};
+use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode, LambdaNode, TypeIdentifier};
 use crate::parser::ast::AstNode::*;
 use crate::lexer::tokens::Token;
 use crate::typechecker::types::Type;
@@ -16,7 +16,7 @@ pub trait AstVisitor<V, E> {
             BindingDecl(tok, node) => self.visit_binding_decl(tok, node),
             FunctionDecl(tok, node) => self.visit_func_decl(tok, node),
             TypeDecl(tok, node) => self.visit_type_decl(tok, node),
-            Identifier(tok) => self.visit_ident(tok),
+            Identifier(tok, type_args) => self.visit_ident(tok, type_args),
             Assignment(tok, node) => self.visit_assignment(tok, node),
             Indexing(tok, node) => self.visit_indexing(tok, node),
             IfStatement(tok, node) => self.visit_if_statement(tok, node),
@@ -39,7 +39,7 @@ pub trait AstVisitor<V, E> {
     fn visit_binding_decl(&mut self, token: Token, node: BindingDeclNode) -> Result<V, E>;
     fn visit_func_decl(&mut self, token: Token, node: FunctionDeclNode) -> Result<V, E>;
     fn visit_type_decl(&mut self, token: Token, node: TypeDeclNode) -> Result<V, E>;
-    fn visit_ident(&mut self, token: Token) -> Result<V, E>;
+    fn visit_ident(&mut self, token: Token, type_args: Option<Vec<TypeIdentifier>>) -> Result<V, E>;
     fn visit_assignment(&mut self, token: Token, node: AssignmentNode) -> Result<V, E>;
     fn visit_indexing(&mut self, token: Token, node: IndexingNode) -> Result<V, E>;
     fn visit_if_statement(&mut self, token: Token, node: IfNode) -> Result<V, E>;

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -11,7 +11,7 @@ pub enum AstNode {
     BindingDecl(Token, BindingDeclNode),
     FunctionDecl(Token, FunctionDeclNode),
     TypeDecl(Token, TypeDeclNode),
-    Identifier(Token),
+    Identifier(Token, Option<Vec<TypeIdentifier>>),
     Assignment(Token, AssignmentNode),
     Indexing(Token, IndexingNode),
     IfStatement(Token, IfNode),
@@ -180,7 +180,8 @@ pub struct WhileLoopNode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct AccessorNode {
     pub target: Box<AstNode>,
-    pub field: Token,
+    // Must be an AstNode::Identifier
+    pub field: Box<AstNode>,
     pub is_opt_safe: bool,
 }
 

--- a/abra_core/src/parser/test_helpers.rs
+++ b/abra_core/src/parser/test_helpers.rs
@@ -65,7 +65,8 @@ macro_rules! identifier {
         match $pos {
             (line, col) => {
                 AstNode::Identifier(
-                    Token::Ident(Position::new(line, col), $ident_name.to_string())
+                    Token::Ident(Position::new(line, col), $ident_name.to_string()),
+                    None
                 )
             }
         }

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -222,6 +222,7 @@ impl Type {
                     .flat_map(|typ| typ.extract_unbound_generics())
                     .collect()
             }
+            Type::Type(_, typ) => typ.extract_unbound_generics(),
             _ => vec![]
         }
     }
@@ -248,6 +249,7 @@ impl Type {
                 let type_args = type_args.iter().map(|t| Type::substitute_generics(t, available_generics)).collect();
                 Type::Reference(name.clone(), type_args)
             }
+            Type::Type(name, typ) => Type::Type(name.clone(), Box::new(Type::substitute_generics(typ, available_generics))),
             // Type::Struct(_) => {},
             // Type::Or(_) => {},
             // Type::Map(_, _) => {},

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1430,11 +1430,17 @@ mod tests {
             }
           }
 
+          func sum(list: Int[]) = list.reduce(0, (acc, i) => acc + i)
+
           var list: List<Int> = List(items: [])
           for n in range(1, 500) { list.push(n) }
           list = list.concat(List(items: range(500, 1000)))
           list = List(items: list.map(i => i * 5))
-          list.reduce(0, (acc, i) => acc + i)
+          val nums = list.reduce<Int[]>([], (acc, i) => {
+            acc.push(i)
+            acc
+          })
+          sum(nums)
         "#;
         let result = interpret(input).unwrap();
         let expected = Value::Int(2497500);


### PR DESCRIPTION
- Change to parser: instances of `AstNode::Identifier` can now have type
arguments, if the next character is a `(` (denoting a function call with
provided type arguments).
- Changes to typechecker: when method fields are accessed off of
bindings, make sure to perform any generic substitions when determining
the type of that field, if generics are provided and the function itself
can accept type arguments.