### PR TITLE
Adding support for Union types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ name = "abra_core"
 version = "0.4.0"
 dependencies = [
  "peekmore 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "permutate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -185,6 +186,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "permutate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
@@ -529,6 +535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum peekmore 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7963b024d9df0af1eb5f426a21684ee1d292b7bbeabbdbe24dfc59012b9cba"
+"checksum permutate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53b7d5b19a715ffab38693a9dd44b067fdfa2b18eef65bd93562dfe507022fae"
 "checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 "checksum proc-macro-error 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "53c98547ceaea14eeb26fcadf51dc70d01a2479a7839170eae133721105e4428"
 "checksum proc-macro-error-attr 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c2bf5d493cf5d3e296beccfd61794e445e830dfc8070a9c248ad3ee071392c6c"

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,2 +1,13 @@
-val arr = [1, 2, 3]
-arr.reduce<Int, Int>(0, (acc, i) => acc + i)
+// import std/math as Math
+// Math.cos(45)
+//import cos from std/math
+//cos(45)
+
+// std/math.abra
+// export native func cos(angle: Int | Float): Float
+
+val i: Int | Float = 0
+
+func cos<T>(angle: T | Int | Float) = angle
+
+val x = cos(i)

--- a/abra_core/Cargo.toml
+++ b/abra_core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 peekmore = "0.5.2"
+permutate = "0.3.2"
 strum = "0.15.0"
 strum_macros = "0.15.0"
 rand = "0.7.3"

--- a/abra_core/src/lib.rs
+++ b/abra_core/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate permutate;
 extern crate strum;
 #[macro_use]
 extern crate strum_macros;

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -190,6 +190,7 @@ pub enum TypeIdentifier {
     Normal { ident: Token, type_args: Option<Vec<TypeIdentifier>> },
     Array { inner: Box<TypeIdentifier> },
     Option { inner: Box<TypeIdentifier> },
+    Union { left: Box<TypeIdentifier>, right: Box<TypeIdentifier> },
     Func {
         args: Vec<TypeIdentifier>,
         ret: Box<TypeIdentifier>,
@@ -202,6 +203,7 @@ impl TypeIdentifier {
             TypeIdentifier::Normal { ident, .. } => ident.clone(),
             TypeIdentifier::Array { inner } => inner.get_ident(),
             TypeIdentifier::Option { inner } => inner.get_ident(),
+            TypeIdentifier::Union { left, .. } => left.get_ident(),
             TypeIdentifier::Func { ret, .. } => ret.get_ident()
         }
     }

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -113,11 +113,11 @@ fn type_repr(t: &Type) -> String {
         Type::Float => "Float".to_string(),
         Type::String => "String".to_string(),
         Type::Bool => "Bool".to_string(),
-        Type::Or(options) => {
+        Type::Union(options) => {
             let type_opts: Vec<String> = options.iter()
-                .map(|t| type_repr(t))
+                .map(|t| wrap_type_repr(t))
                 .collect();
-            format!("one of ({})", type_opts.join(", "))
+            format!("{}", type_opts.join(" | "))
         }
         Type::Array(typ) => format!("{}[]", wrap_type_repr(typ)),
         Type::Map(fields, _) => {
@@ -524,13 +524,13 @@ Type mismatch (1:5)
     fn test_mismatch_error_with_ortype() {
         let src = "1 + 4.4".to_string();
         let token = Token::Float(Position::new(1, 5), 4.4);
-        let err = TypecheckerError::Mismatch { token, expected: Type::Or(vec![Type::Int, Type::Float]), actual: Type::Int };
+        let err = TypecheckerError::Mismatch { token, expected: Type::Union(vec![Type::Int, Type::Float]), actual: Type::Int };
 
         let expected = format!("\
 Type mismatch (1:5)
   |  1 + 4.4
          ^^^
-  Expected one of (Int, Float), got Int"
+  Expected Int | Float, got Int"
         );
         assert_eq!(expected, err.get_message(&src));
     }

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -25,7 +25,7 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("kind", "Any")?;
                 obj.end()
             }
-            Type::Or(opts) => {
+            Type::Union(opts) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "Or")?;
                 let opts: Vec<JsType> = opts.iter().map(|opt| JsType(opt)).collect();


### PR DESCRIPTION
- Rename `Type::Or` to `Type::Union`
- Add support for parsing union type identifiers
- Resolve union types in generic substitution, and make sure resulting
options list is always flattened
- Clean up and simplify error message a bit for mismatch on a union type