### PR TITLE
Match expressions: enum cases

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,8 +1,8 @@
-func printNth<T>(arr: T[], n: Int) {
-  match arr[n] {
-    T i => println(i)
-    None => println("None")
-  }
-}
+enum Direction { Left, Right }
 
-printNth([1, 2, 3, 4], 7)
+val d = Direction.Left
+
+match d {
+  Direction.Left => println("Left")
+  Direction.Right => println("Right")
+}

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,8 +1,28 @@
-enum Direction { Left, Right }
+enum Color {
+  Red
+  Green
+  Blue
+  RGB(red: Int, green: Int, blue: Int)
 
-val d = Direction.Left
+  func white(): Color = Color.RGB(red: 255, green: 255, blue: 255)
 
-match d {
-  Direction.Left => println("Left")
-  Direction.Right => println("Right")
+  func black(): Color = Color.RGB(red: 0, green: 0, blue: 0)
+
+  func hex(self): String {
+    match self {
+      Color.Red => "0xFF0000"
+      Color.Green => "0x00FF00"
+      Color.Blue => "0x0000FF"
+      Color.RGB c => "0x" + c.red + c.green + c.blue
+    }
+  }
 }
+
+[
+  Color.Red,
+  Color.Green,
+  Color.Blue,
+  Color.black(),
+  Color.white(),
+  Color.RGB(red: 128, green: 128, blue: 128)
+].map(c => c.hex())

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -53,6 +53,7 @@ pub enum TypecheckerError {
     NonExhaustiveMatch { token: Token },
     EmptyMatchBlock { token: Token },
     MatchBranchMismatch { token: Token, expected: Type, actual: Type },
+    InvalidUninitializedEnumVariant { token: Token },
 }
 
 impl TypecheckerError {
@@ -100,6 +101,7 @@ impl TypecheckerError {
             TypecheckerError::NonExhaustiveMatch { token } => token,
             TypecheckerError::EmptyMatchBlock { token } => token,
             TypecheckerError::MatchBranchMismatch { token, .. } => token,
+            TypecheckerError::InvalidUninitializedEnumVariant { token } => token,
         }
     }
 }
@@ -158,7 +160,7 @@ fn type_repr(t: &Type) -> String {
             format!("{}<{}>", name, type_args_repr)
         }
         Type::Enum(EnumType { name, .. }) => format!("{}", name),
-        Type::EnumVariant(enum_type, variant, _) => format!("{}.{}", type_repr(enum_type), variant),
+        Type::EnumVariant(enum_type, variant, _) => format!("{}.{}", type_repr(enum_type), variant.name),
         Type::Placeholder => "_".to_string(),
         Type::Generic(name) => name.clone(),
         Type::Reference(name, type_args) => {
@@ -555,6 +557,13 @@ impl DisplayError for TypecheckerError {
                     "Type mismatch among the match-expression branches: ({}:{})\n{}\n\
                     The type {} does not match with the type {} of the other branches",
                     pos.line, pos.col, cursor_line, type_repr(actual), type_repr(expected)
+                )
+            }
+            TypecheckerError::InvalidUninitializedEnumVariant { .. } => {
+                format!(
+                    "Invalid usage of enum variant: ({}:{})\n{}\n\
+                    This enum variant requires arguments",
+                    pos.line, pos.col, cursor_line
                 )
             }
         }

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -157,9 +157,8 @@ fn type_repr(t: &Type) -> String {
                 .join(", ");
             format!("{}<{}>", name, type_args_repr)
         }
-        Type::Enum(EnumType { name, .. }) => {
-            format!("{}", name)
-        }
+        Type::Enum(EnumType { name, .. }) => format!("{}", name),
+        Type::EnumVariant(enum_type, variant, _) => format!("{}.{}", type_repr(enum_type), variant),
         Type::Placeholder => "_".to_string(),
         Type::Generic(name) => name.clone(),
         Type::Reference(name, type_args) => {

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -18,6 +18,7 @@ pub enum Type {
     Type(/* type_name: */ String, /* underlying_type: */ Box<Type>, /* is_enum: */ bool),
     Struct(StructType),
     Enum(EnumType),
+    EnumVariant(/* ref: */ Box<Type>, /* variant_name: */ String, /* variant_idx: */ usize),
     // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
     Unknown,
     Placeholder,

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -18,7 +18,7 @@ pub enum Type {
     Type(/* type_name: */ String, /* underlying_type: */ Box<Type>, /* is_enum: */ bool),
     Struct(StructType),
     Enum(EnumType),
-    EnumVariant(/* ref: */ Box<Type>, /* variant_name: */ String, /* variant_idx: */ usize),
+    EnumVariant(/* enum_type_ref: */ Box<Type>, /* variant_type: */ EnumVariantType, /* constructed: */ bool),
     // Acts as a sentinel value, right now only for when a function is referenced recursively without an explicit return type
     Unknown,
     Placeholder,
@@ -45,9 +45,16 @@ pub struct StructType {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct EnumType {
     pub name: String,
-    pub variants: Vec<(/* name: */ String, /* type: */ Type)>,
+    pub variants: Vec<EnumVariantType>,
     pub static_fields: Vec<(/* name: */ String, /* type: */ Type, /* has_default_value: */ bool)>,
     pub methods: Vec<(String, Type)>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct EnumVariantType {
+    pub name: String,
+    pub variant_idx: usize,
+    pub arg_types: Option<Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>>,
 }
 
 impl Type {
@@ -147,6 +154,15 @@ impl Type {
             }
             (Enum(EnumType { name: name1, .. }), Enum(EnumType { name: name2, .. })) => {
                 name1 == name2
+            }
+            (EnumVariant(enum_type, variant, _), t @ Enum(_)) => {
+                if !enum_type.is_equivalent_to(t, referencable_types) {
+                    false
+                } else if let Enum(enum_type_target) = t {
+                    enum_type_target.variants.contains(variant)
+                } else {
+                    unreachable!()
+                }
             }
             // TODO (This should be unreachable right now anwyay...)
             (Map(_fields1, _), Map(_fields2, _)) => {

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -589,7 +589,17 @@ impl VM {
                     let value = match inst {
                         Value::Obj(obj) => match &*obj.borrow() {
                             Obj::InstanceObj(inst) => inst.fields[field_idx].clone(),
-                            Obj::EnumVariantObj(inst) => inst.methods[field_idx].clone(),
+                            Obj::EnumVariantObj(inst) => {
+                                let num_methods = inst.methods.len();
+                                if field_idx < num_methods {
+                                    inst.methods[field_idx].clone()
+                                } else if let Some(values) = &inst.values {
+                                    values[field_idx - num_methods].clone()
+                                } else {
+                                    // This _should_ be unreachable, but just in case
+                                    Value::Nil
+                                }
+                            },
                             Obj::StringObj { .. } => NativeString::get_field_value(&obj, field_idx),
                             Obj::ArrayObj { .. } => NativeArray::get_field_value(&obj, field_idx),
                             _ => unreachable!()

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -377,6 +377,11 @@ impl VM {
             (Value::Float(a), Value::Float(b)) => a.partial_cmp(&b),
             (Value::Float(a), Value::Int(b)) => a.partial_cmp(&(b as f64)),
             (Value::Type(TypeValue { name: name1, .. }), Value::Type(TypeValue { name: name2, .. })) => name1.partial_cmp(&name2),
+            (Value::Obj(obj), Value::Int(b)) => {
+                if let Obj::EnumVariantObj(evv) = &*obj.borrow() {
+                    evv.idx.partial_cmp(&(b as usize))
+                } else { Some(Ordering::Less) }
+            }
             (a @ _, b @ _) => a.partial_cmp(&b),
         };
 

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -131,6 +131,14 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("methods", &methods)?;
                 obj.end()
             }
+            Type::EnumVariant(enum_type, variant, idx) => {
+                let mut obj = serializer.serialize_map(Some(3))?;
+                obj.serialize_entry("kind", "EnumVariant")?;
+                obj.serialize_entry("enumType", &JsType(enum_type))?;
+                obj.serialize_entry("variant", variant)?;
+                obj.serialize_entry("index", idx)?;
+                obj.end()
+            }
             Type::Placeholder => {
                 let mut obj = serializer.serialize_map(Some(1))?;
                 obj.serialize_entry("kind", "Placeholder")?;

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -118,7 +118,7 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("kind", "Enum")?;
                 obj.serialize_entry("name", name)?;
                 let variants: Vec<String> = variants.iter()
-                    .map(|(name, _)| name.clone())
+                    .map(|variant| variant.name.clone())
                     .collect();
                 obj.serialize_entry("variants", &variants)?;
                 let static_fields: Vec<(String, JsType)> = static_fields.iter()
@@ -131,12 +131,12 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("methods", &methods)?;
                 obj.end()
             }
-            Type::EnumVariant(enum_type, variant, idx) => {
+            Type::EnumVariant(enum_type, variant, _) => {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "EnumVariant")?;
                 obj.serialize_entry("enumType", &JsType(enum_type))?;
-                obj.serialize_entry("variant", variant)?;
-                obj.serialize_entry("index", idx)?;
+                obj.serialize_entry("variantName", &variant.name)?;
+                obj.serialize_entry("index", &variant.variant_idx)?;
                 obj.end()
             }
             Type::Placeholder => {

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -454,6 +454,13 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("actual", &JsType(actual))?;
                     obj.end()
                 }
+                TypecheckerError::InvalidUninitializedEnumVariant { token } => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidUninitializedEnumVariant")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {


### PR DESCRIPTION
- Add ability to match on enums in match statements/expressions.
This does not currently support destructuring
(ie.  `Color.RGB(r, g, b) => ...`), but that's coming soon