### PR TITLE
Match statements: enum destructuring

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,28 +1,64 @@
-enum Color {
-  Red
-  Green
-  Blue
-  RGB(red: Int, green: Int, blue: Int)
-
-  func white(): Color = Color.RGB(red: 255, green: 255, blue: 255)
-
-  func black(): Color = Color.RGB(red: 0, green: 0, blue: 0)
-
-  func hex(self): String {
-    match self {
-      Color.Red => "0xFF0000"
-      Color.Green => "0x00FF00"
-      Color.Blue => "0x0000FF"
-      Color.RGB c => "0x" + [c.red, c.green, c.blue].map(c => c.asBase(16).padLeft(2, "0")).join()
-    }
-  }
+enum Shade {
+  Light
+  Dark
 }
 
-[
-  Color.Red,
-  Color.Green,
-  Color.Blue,
-  Color.black(),
-  Color.white(),
-  Color.RGB(red: 128, green: 128, blue: 128)
-].map(c => c.hex())
+enum Color {
+  Red
+  RGB(r: Int, shade: Shade)
+}
+
+val c: Color | Int = Color.RGB(r: 1, shade: Shade.Dark)
+//println(c)
+//match c {
+//  Color.RGB(r, g) x => {
+//    x.r = g
+//    x.g = r
+//  }
+//  _ => {}
+//}
+//println(c)
+
+val s = match c {
+  Color.RGB(r, shade) => {
+    val s = match shade {
+      Shade.Dark s => "dark"
+      Shade.Light s => "light"
+    }
+    s + ", r: " + r
+  }
+  Int i => "int: " + i
+  Color.Red => "red"
+  //_ z => ""
+}
+println(s)
+
+
+//enum Color {
+//  Red
+//  Green
+//  Blue
+//  RGB(red: Int, green: Int, blue: Int)
+//
+//  func white(): Color = Color.RGB(red: 255, green: 255, blue: 255)
+//
+//  func black(): Color = Color.RGB(red: 0, green: 0, blue: 0)
+//
+//  func hex(self): String {
+//    match self {
+//      Color.Red => "0xFF0000",
+//      Color.Green => "0x00FF00",
+//      Color.Blue => "0x0000FF",
+//      Color.RGB c => "0x" + [c.red, c.green, c.blue].map(c => c.asBase(16).padLeft(2, "0")).join(),
+//    }
+//  }
+//}
+//
+//[
+//  Color.Red,
+//  Color.Green,
+//  Color.Blue,
+//  Color.black,
+//  Color.white,
+//  Color.RGB(red: 128, green: 128, blue: 128)
+//].map(c => c.hex())

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -206,7 +206,8 @@ pub struct MatchNode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct MatchCase {
     pub match_type: MatchCaseType,
-    pub case_binding: Option<Token>
+    pub case_binding: Option<Token>,
+    pub args: Option<Vec<Token>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -54,6 +54,8 @@ pub enum TypecheckerError {
     EmptyMatchBlock { token: Token },
     MatchBranchMismatch { token: Token, expected: Type, actual: Type },
     InvalidUninitializedEnumVariant { token: Token },
+    InvalidDestructuring { token: Token, typ: Type },
+    InvalidDestructuringArity { token: Token, typ: Type, expected: usize, actual: usize },
 }
 
 impl TypecheckerError {
@@ -102,6 +104,8 @@ impl TypecheckerError {
             TypecheckerError::EmptyMatchBlock { token } => token,
             TypecheckerError::MatchBranchMismatch { token, .. } => token,
             TypecheckerError::InvalidUninitializedEnumVariant { token } => token,
+            TypecheckerError::InvalidDestructuring { token, .. } => token,
+            TypecheckerError::InvalidDestructuringArity { token, .. } => token,
         }
     }
 }
@@ -564,6 +568,21 @@ impl DisplayError for TypecheckerError {
                     "Invalid usage of enum variant: ({}:{})\n{}\n\
                     This enum variant requires arguments",
                     pos.line, pos.col, cursor_line
+                )
+            }
+            TypecheckerError::InvalidDestructuring { typ, .. } => {
+                format!(
+                    "Invalid destructuring: ({}:{})\n{}\n\
+                    Cannot destructure an instance of type {}",
+                    pos.line, pos.col, cursor_line, type_repr(typ)
+                )
+            }
+            TypecheckerError::InvalidDestructuringArity { typ, expected, actual, .. } => {
+                format!(
+                    "Invalid destructuring pattern: ({}:{})\n{}\n\
+                    Instances of type {} have {} field{}, but the pattern attempts to extract {}",
+                    pos.line, pos.col, cursor_line,
+                    type_repr(typ), expected, if *expected == 1 { "" } else { "s" }, actual
                 )
             }
         }

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -278,5 +278,5 @@ pub struct TypedAccessorNode {
 pub struct TypedMatchNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
-    pub branches: Vec<(/* match_type: */ Type, /* match_type_ident: */ Option<TypeIdentifier>, /* binding: */ Option<String>, /* body: */ Vec<TypedAstNode>)>,
+    pub branches: Vec<(/* match_type: */ Type, /* match_type_ident: */ Option<TypeIdentifier>, /* binding: */ Option<String>, /* body: */ Vec<TypedAstNode>, /* args: */ Option<Vec<Token>>)>,
 }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1368,6 +1368,25 @@ mod tests {
     }
 
     #[test]
+    fn interpret_match_destructuring_enum() {
+        let input = r#"
+          enum Foo { Bar(baz: Int, qux: Int) }
+
+          val f: Foo = Foo.Bar(baz: 6, qux: 24)
+          match f {
+            Foo.Bar(baz, qux) bar => {
+              bar.baz = qux
+              bar.qux = baz
+            }
+          }
+          "" + f
+        "#;
+        let result = interpret(input).unwrap();
+        let expected = new_string_obj("Foo.Bar(24, 6)");
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn interpret_linked_list_kinda() {
         // Verify self-referential types, as well as the usage of static methods in default field values
         let input = "\

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -461,6 +461,24 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.end()
                 }
+                TypecheckerError::InvalidDestructuring { token, typ } => {
+                    let mut obj = serializer.serialize_map(Some(4))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidDestructuring")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("type", &JsType(typ))?;
+                    obj.end()
+                }
+                TypecheckerError::InvalidDestructuringArity { token, typ, expected, actual } => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidDestructuring")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("type", &JsType(typ))?;
+                    obj.serialize_entry("expected", expected)?;
+                    obj.serialize_entry("actual", actual)?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {


### PR DESCRIPTION
- Allow for the destructuring of enum variants in match
statements/expressions. As of right now, this only applies to enum
variants; attempting to destructure other types will present an error.