### PR TITLE
Static method refactoring!

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,12 +1,5 @@
-func fromPairs<T1, T2>(pairs: (T1, T2)[]): Map<T1, T2> {
-  val map: Map<T1, T2> = {}
+val alphabet = "abcdefghijklmnopqrstuvwxyz"
 
-  for p in pairs {
-    map[p[0]] = p[1]
-  }
+val pairs = Array.fill(alphabet.length, ("a", 123))
 
-  map
-}
-
-val pairs = [("b", 456), ("a", 123)]
-fromPairs(pairs)
+Map.fromPairs(pairs)

--- a/abra_core/src/builtins/native_types.abra
+++ b/abra_core/src/builtins/native_types.abra
@@ -32,6 +32,10 @@ type NativeString {
 type NativeArray<T> {
   length: Int
 
+  func fill<T1>(amount: Int, value: T1): T1[] {}
+  func fillBy<T1>(amount: Int, fn: (Int) => T1): T1[] {}
+
+  func isEmpty(self): Bool {}
   func push(self, item: T): Unit {}
   func concat(self, other: T[]): T[] {}
   func map<U>(self, fn: (T) => U): U[] {}
@@ -54,12 +58,12 @@ type NativeArray<T> {
 type NativeMap<K, V> {
   size: Int
 
+  func fromPairs<T1, T2>(pairs: (T1, T2)[]): Map<T1, T2> {}
+
+  func isEmpty(self): Bool {}
   func keys(self): K[] {}
   func values(self): V[] {}
   func entries(self): (K, V)[] {}
   func containsKey(self, key: K): Bool {}
   func mapValues<U>(self, fn: (K, V) => U): Map<K, U> {}
-  //func filter<U>(self, fn: (K, V) => (Bool | U?)): Map<K, V> {}
-  //func merge(self, other: Map<K, V>): Map<K, V> {}
-  //func mergePairs(self, pairs: (K, V)[]): Map<K, V> {}
 }

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -2270,6 +2270,14 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                             });
                         Ok((field_data, HashMap::new()))
                     }
+                    Type::Array(_) => {
+                        let field_data = NativeArray::get_static_field_or_method(&field_name);
+                        Ok((field_data, HashMap::new()))
+                    }
+                    Type::Map(_, _) => {
+                        let field_data = NativeMap::get_static_field_or_method(&field_name);
+                        Ok((field_data, HashMap::new()))
+                    }
                     _ => unimplemented!()
                 }
                 Type::Enum(enum_type) => {

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -970,7 +970,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
                     method_node.body,
                     method_node.scope_depth,
                 )?;
-                compiled_static_fields.push((method_name, method));
+                compiled_static_fields.push((method_name, Value::Fn(method)));
             }
         }
 
@@ -1051,7 +1051,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
                     method_node.body,
                     method_node.scope_depth,
                 )?;
-                compiled_static_fields.push((method_name, method));
+                compiled_static_fields.push((method_name, Value::Fn(method)));
             }
         }
 

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -2,6 +2,7 @@ use crate::vm::value::{Value, TypeValue};
 use crate::typechecker::types::Type;
 use crate::builtins::native_fns::native_fns;
 use std::collections::HashMap;
+use crate::builtins::native_types::{NativeMap, NativeType, NativeArray};
 
 #[derive(Debug, Clone)]
 struct PreludeBinding {
@@ -45,23 +46,23 @@ impl Prelude {
         bindings.push(PreludeBinding { name: "None".to_string(), typ: Type::Option(Box::new(Type::Placeholder)), value: Value::Nil });
 
         let prelude_types = vec![
-            ("Int", Type::Int),
-            ("Float", Type::Float),
-            ("Bool", Type::Bool),
-            ("String", Type::String),
-            ("Unit", Type::Unit),
-            ("Any", Type::Any),
-            ("Array", Type::Reference("Array".to_string(), vec![])),
-            ("Map", Type::Reference("Map".to_string(), vec![])),
+            ("Int", Type::Int, None),
+            ("Float", Type::Float, None),
+            ("Bool", Type::Bool, None),
+            ("String", Type::String, None),
+            ("Unit", Type::Unit, None),
+            ("Any", Type::Any, None),
+            ("Array", Type::Reference("Array".to_string(), vec![]), Some(NativeArray::get_static_field_values())),
+            ("Map", Type::Reference("Map".to_string(), vec![]), Some(NativeMap::get_static_field_values())),
         ];
-        for (type_name, typ) in prelude_types {
+        for (type_name, typ, static_fields) in prelude_types {
             let binding = PreludeBinding {
                 name: type_name.to_string(),
                 typ: Type::Type(type_name.to_string(), Box::new(typ.clone()), false), // TODO: is_enum should not be hard-coded false
                 value: Value::Type(TypeValue {
                     name: type_name.to_string(),
                     methods: vec![],
-                    static_fields: vec![],
+                    static_fields: static_fields.unwrap_or(vec![]),
                 }),
             };
             bindings.push(binding);

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -45,7 +45,7 @@ pub struct ClosureValue {
 pub struct TypeValue {
     pub name: String,
     pub methods: Vec<(String, FnValue)>,
-    pub static_fields: Vec<(String, FnValue)>,
+    pub static_fields: Vec<(String, Value)>,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd)]
@@ -53,7 +53,7 @@ pub struct EnumValue {
     pub name: String,
     pub variants: Vec<(String, EnumVariantObj)>,
     pub methods: Vec<(String, FnValue)>,
-    pub static_fields: Vec<(String, FnValue)>,
+    pub static_fields: Vec<(String, Value)>,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd)]

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -626,12 +626,12 @@ impl VM {
                         Value::Int(_) => NativeInt::get_field_value(Box::new(inst), field_idx),
                         Value::Type(TypeValue { static_fields, .. }) => {
                             let (_, field_value) = static_fields[field_idx].clone();
-                            Value::Fn(field_value)
+                            field_value
                         }
                         Value::Enum(EnumValue { variants, static_fields, methods, .. }) => {
                             if field_idx >= variants.len() {
                                 let (_, field_value) = static_fields[field_idx - variants.len()].clone();
-                                Value::Fn(field_value)
+                                field_value
                             } else {
                                 let (_, variant_value) = variants[field_idx].clone();
                                 let instance_value = if let Value::Obj(instance_value) = Value::new_enum_variant_obj(variant_value) {

--- a/gen_native_types/src/main.rs
+++ b/gen_native_types/src/main.rs
@@ -83,7 +83,7 @@ fn generate_code_for_type(typ: &Type) -> TokenStream {
             let ret_type_code = generate_code_for_type(ret_type);
             return quote! {
                 Type::Fn(FnType {
-                    type_args: vec![#(#type_args),*],
+                    type_args: vec![#(#type_args.to_string()),*],
                     arg_types: vec![#(#arg_types_code),*],
                     ret_type: Box::new(#ret_type_code)
                 })
@@ -96,7 +96,7 @@ fn generate_code_for_type(typ: &Type) -> TokenStream {
 }
 
 fn generate_code_for_typedef(typ: StructType) -> TokenStream {
-    let StructType { name: type_name, fields, methods, .. } = typ;
+    let StructType { name: type_name, fields, methods, static_fields, .. } = typ;
 
     let type_name_ident = format_ident!("{}", type_name);
     let trait_name_ident = format_ident!("{}MethodsAndFields", type_name);
@@ -133,9 +133,9 @@ fn generate_code_for_typedef(typ: StructType) -> TokenStream {
             fn #method_method_name_ident(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
         });
 
-        let FnType { type_args, arg_types, ret_type } = if let Type::Fn(t) = method_type { t } else { unreachable!() };
+        let FnType { ret_type, .. } = if let Type::Fn(t) = &method_type { t } else { unreachable!() };
 
-        let has_return = *ret_type != Type::Unit;
+        let has_return = **ret_type != Type::Unit;
         get_method_value_code.push(quote! {
             #field_idx => Value::NativeFn(NativeFn {
                 name: #method_name,
@@ -145,23 +145,47 @@ fn generate_code_for_typedef(typ: StructType) -> TokenStream {
             })
         });
 
-        let mut all_arg_types_code = Vec::new();
-        for (arg_name, arg_type, is_opt) in arg_types {
-            let arg_type_code = generate_code_for_type(&arg_type);
-            all_arg_types_code.push(quote! {
-                (#arg_name.to_string(), #arg_type_code, #is_opt)
-            })
-        }
-        let ret_type_code = generate_code_for_type(&ret_type);
-        let method_type_code = quote! {
-            Type::Fn(FnType {
-                type_args: vec![#(#type_args.to_string()),*],
-                arg_types: vec![#(#all_arg_types_code),*],
-                ret_type: Box::new(#ret_type_code)
-            })
-        };
+        let method_type_code = generate_code_for_type(&method_type);
         native_type_fields_and_methods_code.push(quote! {
             #method_name => Some((#field_idx, #method_type_code))
+        });
+
+        field_idx += 1;
+    }
+
+    field_idx = 0;
+    let mut trait_static_field_methods_code = Vec::new();
+    let mut get_static_method_value_code = Vec::new();
+    let mut native_type_static_fields_and_methods_code = Vec::new();
+    for (name, typ, _) in static_fields {
+        let FnType { ret_type, .. } = if let Type::Fn(t) = &typ { t } else { unimplemented!("Only implemented for static methods at the moment") };
+
+        let static_method_name_ident = format_ident!("static_method_{}", name.to_snake_case());
+        trait_static_field_methods_code.push(quote! {
+            fn #static_method_name_ident(_receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
+        });
+
+        let has_return = **ret_type != Type::Unit;
+        // get_static_method_value_code.push(quote! {
+        //     #field_idx => Value::NativeFn(NativeFn {
+        //         name: #name,
+        //         receiver: None,
+        //         native_fn: Self::#static_method_name_ident,
+        //         has_return: #has_return,
+        //     })
+        // });
+        get_static_method_value_code.push(quote! {
+            (#name.to_string(), Value::NativeFn(NativeFn {
+                name: #name,
+                receiver: None,
+                native_fn: Self::#static_method_name_ident,
+                has_return: #has_return,
+            }))
+        });
+
+        let static_method_type_code = generate_code_for_type(&typ);
+        native_type_static_fields_and_methods_code.push(quote! {
+            #name => Some((#field_idx, #static_method_type_code))
         });
 
         field_idx += 1;
@@ -170,11 +194,42 @@ fn generate_code_for_typedef(typ: StructType) -> TokenStream {
     // For some reason I keep getting a warning on the for-loop above, which goes away when this line is here. Weird
     let _ = 0;
 
+    let get_static_field_value_code = if get_static_method_value_code.is_empty() {
+        let msg = format!("{} has no static values", type_name.replace("Native", ""));
+        quote! {
+            fn get_static_field_values() -> Vec<(String, Value)> {
+                unreachable!(#msg)
+            }
+        }
+    } else {
+        quote! {
+            fn get_static_field_values() -> Vec<(String, Value)> {
+                vec![#(#get_static_method_value_code,)*]
+            }
+        }
+    };
+
+    let get_static_field_or_method_code = if native_type_static_fields_and_methods_code.is_empty() {
+        quote! {
+            fn get_static_field_or_method(_name: &str) -> Option<(usize, Type)> { None }
+        }
+    } else {
+        quote! {
+            fn get_static_field_or_method(name: &str) -> Option<(usize, Type)> {
+                match name {
+                    #(#native_type_static_fields_and_methods_code,)*
+                    _ => None
+                }
+            }
+        }
+    };
+
     quote! {
         pub struct #type_name_ident;
 
         pub trait #trait_name_ident {
             #(#trait_field_methods_code)*
+            #(#trait_static_field_methods_code)*
             #(#trait_method_methods_code)*
         }
 
@@ -186,6 +241,14 @@ fn generate_code_for_typedef(typ: StructType) -> TokenStream {
                 }
             }
 
+            #get_static_field_or_method_code
+            // fn get_static_field_or_method(name: &str) -> Option<(usize, Type)> {
+            //     match name {
+            //         #(#native_type_static_fields_and_methods_code,)*
+            //         _ => None
+            //     }
+            // }
+
             fn get_field_value(obj: Box<Value>, field_idx: usize) -> Value {
                 match field_idx {
                     #(#get_field_value_code,)*
@@ -193,6 +256,14 @@ fn generate_code_for_typedef(typ: StructType) -> TokenStream {
                     _ => unreachable!()
                 }
             }
+
+            #get_static_field_value_code
+            // fn get_static_field_value(obj: Box<Value>, field_idx: usize) -> Value {
+            //     match field_idx {
+            //         #(#get_static_method_value_code,)*
+            //         _ => unreachable!()
+            //     }
+            // }
         }
     }
 }

--- a/gen_native_types/src/main.rs
+++ b/gen_native_types/src/main.rs
@@ -166,14 +166,6 @@ fn generate_code_for_typedef(typ: StructType) -> TokenStream {
         });
 
         let has_return = **ret_type != Type::Unit;
-        // get_static_method_value_code.push(quote! {
-        //     #field_idx => Value::NativeFn(NativeFn {
-        //         name: #name,
-        //         receiver: None,
-        //         native_fn: Self::#static_method_name_ident,
-        //         has_return: #has_return,
-        //     })
-        // });
         get_static_method_value_code.push(quote! {
             (#name.to_string(), Value::NativeFn(NativeFn {
                 name: #name,
@@ -242,12 +234,6 @@ fn generate_code_for_typedef(typ: StructType) -> TokenStream {
             }
 
             #get_static_field_or_method_code
-            // fn get_static_field_or_method(name: &str) -> Option<(usize, Type)> {
-            //     match name {
-            //         #(#native_type_static_fields_and_methods_code,)*
-            //         _ => None
-            //     }
-            // }
 
             fn get_field_value(obj: Box<Value>, field_idx: usize) -> Value {
                 match field_idx {
@@ -258,12 +244,6 @@ fn generate_code_for_typedef(typ: StructType) -> TokenStream {
             }
 
             #get_static_field_value_code
-            // fn get_static_field_value(obj: Box<Value>, field_idx: usize) -> Value {
-            //     match field_idx {
-            //         #(#get_static_method_value_code,)*
-            //         _ => unreachable!()
-            //     }
-            // }
         }
     }
 }


### PR DESCRIPTION
Addresses #215 tangentially

- The `gen_native_types` utility now handles static methods in the
`native_types.abra` file. Native static functions are added to the
`Value::Type` value at startup (in the Prelude)
- Add some static methods to Map and Array