### PR TITLE
Uniform iteration API

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,3 +1,5 @@
-val s1 = #{3, 1, "a"}
-val s2 = #{1, 3, 3}
-s1.intersection(s2)
+val map = { a: 123, b: true, c: "asdf" }
+
+for k, v in map {
+  println("num: " + k + ", idx: " + v)
+}

--- a/abra_core/src/builtins/gen_native_types.rs
+++ b/abra_core/src/builtins/gen_native_types.rs
@@ -389,6 +389,7 @@ pub trait NativeArrayMethodsAndFields {
         vm: &mut VM,
     ) -> Option<Value>;
     fn method_is_empty(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
+    fn method_enumerate(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_push(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_concat(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_map(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
@@ -420,8 +421,19 @@ impl NativeType for NativeArray {
                     ret_type: Box::new(Type::Bool),
                 }),
             )),
-            "push" => Some((
+            "enumerate" => Some((
                 2usize,
+                Type::Fn(FnType {
+                    type_args: vec![],
+                    arg_types: vec![],
+                    ret_type: Box::new(Type::Array(Box::new(Type::Tuple(vec![
+                        Type::Generic("T".to_string()),
+                        Type::Int,
+                    ])))),
+                }),
+            )),
+            "push" => Some((
+                3usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![("item".to_string(), Type::Generic("T".to_string()), false)],
@@ -429,7 +441,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "concat" => Some((
-                3usize,
+                4usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![(
@@ -441,7 +453,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "map" => Some((
-                4usize,
+                5usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -461,7 +473,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "filter" => Some((
-                5usize,
+                6usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![(
@@ -481,7 +493,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "reduce" => Some((
-                6usize,
+                7usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![
@@ -507,7 +519,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "join" => Some((
-                7usize,
+                8usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![("joiner".to_string(), Type::String, true)],
@@ -515,7 +527,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "contains" => Some((
-                8usize,
+                9usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![("item".to_string(), Type::Generic("T".to_string()), false)],
@@ -523,7 +535,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "find" => Some((
-                9usize,
+                10usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -546,29 +558,6 @@ impl NativeType for NativeArray {
                 }),
             )),
             "any" => Some((
-                10usize,
-                Type::Fn(FnType {
-                    type_args: vec!["U".to_string()],
-                    arg_types: vec![(
-                        "fn".to_string(),
-                        Type::Fn(FnType {
-                            type_args: vec![],
-                            arg_types: vec![(
-                                "_".to_string(),
-                                Type::Generic("T".to_string()),
-                                false,
-                            )],
-                            ret_type: Box::new(Type::Union(vec![
-                                Type::Bool,
-                                Type::Option(Box::new(Type::Generic("U".to_string()))),
-                            ])),
-                        }),
-                        false,
-                    )],
-                    ret_type: Box::new(Type::Bool),
-                }),
-            )),
-            "all" => Some((
                 11usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
@@ -591,7 +580,7 @@ impl NativeType for NativeArray {
                     ret_type: Box::new(Type::Bool),
                 }),
             )),
-            "none" => Some((
+            "all" => Some((
                 12usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
@@ -614,8 +603,31 @@ impl NativeType for NativeArray {
                     ret_type: Box::new(Type::Bool),
                 }),
             )),
-            "sortBy" => Some((
+            "none" => Some((
                 13usize,
+                Type::Fn(FnType {
+                    type_args: vec!["U".to_string()],
+                    arg_types: vec![(
+                        "fn".to_string(),
+                        Type::Fn(FnType {
+                            type_args: vec![],
+                            arg_types: vec![(
+                                "_".to_string(),
+                                Type::Generic("T".to_string()),
+                                false,
+                            )],
+                            ret_type: Box::new(Type::Union(vec![
+                                Type::Bool,
+                                Type::Option(Box::new(Type::Generic("U".to_string()))),
+                            ])),
+                        }),
+                        false,
+                    )],
+                    ret_type: Box::new(Type::Bool),
+                }),
+            )),
+            "sortBy" => Some((
+                14usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![
@@ -638,7 +650,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "dedupe" => Some((
-                14usize,
+                15usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -646,7 +658,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "dedupeBy" => Some((
-                15usize,
+                16usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -666,7 +678,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "partition" => Some((
-                16usize,
+                17usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -689,7 +701,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "tally" => Some((
-                17usize,
+                18usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -700,7 +712,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "tallyBy" => Some((
-                18usize,
+                19usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -723,7 +735,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "asSet" => Some((
-                19usize,
+                20usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -778,108 +790,114 @@ impl NativeType for NativeArray {
                 has_return: true,
             }),
             2usize => Value::NativeFn(NativeFn {
+                name: "enumerate",
+                receiver: Some(obj),
+                native_fn: Self::method_enumerate,
+                has_return: true,
+            }),
+            3usize => Value::NativeFn(NativeFn {
                 name: "push",
                 receiver: Some(obj),
                 native_fn: Self::method_push,
                 has_return: false,
             }),
-            3usize => Value::NativeFn(NativeFn {
+            4usize => Value::NativeFn(NativeFn {
                 name: "concat",
                 receiver: Some(obj),
                 native_fn: Self::method_concat,
                 has_return: true,
             }),
-            4usize => Value::NativeFn(NativeFn {
+            5usize => Value::NativeFn(NativeFn {
                 name: "map",
                 receiver: Some(obj),
                 native_fn: Self::method_map,
                 has_return: true,
             }),
-            5usize => Value::NativeFn(NativeFn {
+            6usize => Value::NativeFn(NativeFn {
                 name: "filter",
                 receiver: Some(obj),
                 native_fn: Self::method_filter,
                 has_return: true,
             }),
-            6usize => Value::NativeFn(NativeFn {
+            7usize => Value::NativeFn(NativeFn {
                 name: "reduce",
                 receiver: Some(obj),
                 native_fn: Self::method_reduce,
                 has_return: true,
             }),
-            7usize => Value::NativeFn(NativeFn {
+            8usize => Value::NativeFn(NativeFn {
                 name: "join",
                 receiver: Some(obj),
                 native_fn: Self::method_join,
                 has_return: true,
             }),
-            8usize => Value::NativeFn(NativeFn {
+            9usize => Value::NativeFn(NativeFn {
                 name: "contains",
                 receiver: Some(obj),
                 native_fn: Self::method_contains,
                 has_return: true,
             }),
-            9usize => Value::NativeFn(NativeFn {
+            10usize => Value::NativeFn(NativeFn {
                 name: "find",
                 receiver: Some(obj),
                 native_fn: Self::method_find,
                 has_return: true,
             }),
-            10usize => Value::NativeFn(NativeFn {
+            11usize => Value::NativeFn(NativeFn {
                 name: "any",
                 receiver: Some(obj),
                 native_fn: Self::method_any,
                 has_return: true,
             }),
-            11usize => Value::NativeFn(NativeFn {
+            12usize => Value::NativeFn(NativeFn {
                 name: "all",
                 receiver: Some(obj),
                 native_fn: Self::method_all,
                 has_return: true,
             }),
-            12usize => Value::NativeFn(NativeFn {
+            13usize => Value::NativeFn(NativeFn {
                 name: "none",
                 receiver: Some(obj),
                 native_fn: Self::method_none,
                 has_return: true,
             }),
-            13usize => Value::NativeFn(NativeFn {
+            14usize => Value::NativeFn(NativeFn {
                 name: "sortBy",
                 receiver: Some(obj),
                 native_fn: Self::method_sort_by,
                 has_return: true,
             }),
-            14usize => Value::NativeFn(NativeFn {
+            15usize => Value::NativeFn(NativeFn {
                 name: "dedupe",
                 receiver: Some(obj),
                 native_fn: Self::method_dedupe,
                 has_return: true,
             }),
-            15usize => Value::NativeFn(NativeFn {
+            16usize => Value::NativeFn(NativeFn {
                 name: "dedupeBy",
                 receiver: Some(obj),
                 native_fn: Self::method_dedupe_by,
                 has_return: true,
             }),
-            16usize => Value::NativeFn(NativeFn {
+            17usize => Value::NativeFn(NativeFn {
                 name: "partition",
                 receiver: Some(obj),
                 native_fn: Self::method_partition,
                 has_return: true,
             }),
-            17usize => Value::NativeFn(NativeFn {
+            18usize => Value::NativeFn(NativeFn {
                 name: "tally",
                 receiver: Some(obj),
                 native_fn: Self::method_tally,
                 has_return: true,
             }),
-            18usize => Value::NativeFn(NativeFn {
+            19usize => Value::NativeFn(NativeFn {
                 name: "tallyBy",
                 receiver: Some(obj),
                 native_fn: Self::method_tally_by,
                 has_return: true,
             }),
-            19usize => Value::NativeFn(NativeFn {
+            20usize => Value::NativeFn(NativeFn {
                 name: "asSet",
                 receiver: Some(obj),
                 native_fn: Self::method_as_set,
@@ -920,6 +938,7 @@ pub trait NativeMapMethodsAndFields {
         vm: &mut VM,
     ) -> Option<Value>;
     fn method_is_empty(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
+    fn method_enumerate(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_keys(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_values(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_entries(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
@@ -939,8 +958,19 @@ impl NativeType for NativeMap {
                     ret_type: Box::new(Type::Bool),
                 }),
             )),
-            "keys" => Some((
+            "enumerate" => Some((
                 2usize,
+                Type::Fn(FnType {
+                    type_args: vec![],
+                    arg_types: vec![],
+                    ret_type: Box::new(Type::Array(Box::new(Type::Tuple(vec![
+                        Type::Generic("K".to_string()),
+                        Type::Generic("V".to_string()),
+                    ])))),
+                }),
+            )),
+            "keys" => Some((
+                3usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -948,7 +978,7 @@ impl NativeType for NativeMap {
                 }),
             )),
             "values" => Some((
-                3usize,
+                4usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -956,7 +986,7 @@ impl NativeType for NativeMap {
                 }),
             )),
             "entries" => Some((
-                4usize,
+                5usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -967,7 +997,7 @@ impl NativeType for NativeMap {
                 }),
             )),
             "containsKey" => Some((
-                5usize,
+                6usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![("key".to_string(), Type::Generic("K".to_string()), false)],
@@ -975,7 +1005,7 @@ impl NativeType for NativeMap {
                 }),
             )),
             "mapValues" => Some((
-                6usize,
+                7usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -1032,30 +1062,36 @@ impl NativeType for NativeMap {
                 has_return: true,
             }),
             2usize => Value::NativeFn(NativeFn {
+                name: "enumerate",
+                receiver: Some(obj),
+                native_fn: Self::method_enumerate,
+                has_return: true,
+            }),
+            3usize => Value::NativeFn(NativeFn {
                 name: "keys",
                 receiver: Some(obj),
                 native_fn: Self::method_keys,
                 has_return: true,
             }),
-            3usize => Value::NativeFn(NativeFn {
+            4usize => Value::NativeFn(NativeFn {
                 name: "values",
                 receiver: Some(obj),
                 native_fn: Self::method_values,
                 has_return: true,
             }),
-            4usize => Value::NativeFn(NativeFn {
+            5usize => Value::NativeFn(NativeFn {
                 name: "entries",
                 receiver: Some(obj),
                 native_fn: Self::method_entries,
                 has_return: true,
             }),
-            5usize => Value::NativeFn(NativeFn {
+            6usize => Value::NativeFn(NativeFn {
                 name: "containsKey",
                 receiver: Some(obj),
                 native_fn: Self::method_contains_key,
                 has_return: true,
             }),
-            6usize => Value::NativeFn(NativeFn {
+            7usize => Value::NativeFn(NativeFn {
                 name: "mapValues",
                 receiver: Some(obj),
                 native_fn: Self::method_map_values,
@@ -1080,6 +1116,7 @@ pub struct NativeSet;
 pub trait NativeSetMethodsAndFields {
     fn field_size(obj: Box<Value>) -> Value;
     fn method_is_empty(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
+    fn method_enumerate(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_contains(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_map(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_filter(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
@@ -1102,8 +1139,19 @@ impl NativeType for NativeSet {
                     ret_type: Box::new(Type::Bool),
                 }),
             )),
-            "contains" => Some((
+            "enumerate" => Some((
                 2usize,
+                Type::Fn(FnType {
+                    type_args: vec![],
+                    arg_types: vec![],
+                    ret_type: Box::new(Type::Array(Box::new(Type::Tuple(vec![
+                        Type::Generic("T".to_string()),
+                        Type::Int,
+                    ])))),
+                }),
+            )),
+            "contains" => Some((
+                3usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![("value".to_string(), Type::Generic("T".to_string()), false)],
@@ -1111,7 +1159,7 @@ impl NativeType for NativeSet {
                 }),
             )),
             "map" => Some((
-                3usize,
+                4usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -1131,7 +1179,7 @@ impl NativeType for NativeSet {
                 }),
             )),
             "filter" => Some((
-                4usize,
+                5usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![(
@@ -1151,7 +1199,7 @@ impl NativeType for NativeSet {
                 }),
             )),
             "reduce" => Some((
-                5usize,
+                6usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![
@@ -1177,7 +1225,7 @@ impl NativeType for NativeSet {
                 }),
             )),
             "asArray" => Some((
-                6usize,
+                7usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -1185,18 +1233,6 @@ impl NativeType for NativeSet {
                 }),
             )),
             "union" => Some((
-                7usize,
-                Type::Fn(FnType {
-                    type_args: vec![],
-                    arg_types: vec![(
-                        "other".to_string(),
-                        Type::Set(Box::new(Type::Generic("T".to_string()))),
-                        false,
-                    )],
-                    ret_type: Box::new(Type::Set(Box::new(Type::Generic("T".to_string())))),
-                }),
-            )),
-            "difference" => Some((
                 8usize,
                 Type::Fn(FnType {
                     type_args: vec![],
@@ -1208,8 +1244,20 @@ impl NativeType for NativeSet {
                     ret_type: Box::new(Type::Set(Box::new(Type::Generic("T".to_string())))),
                 }),
             )),
-            "intersection" => Some((
+            "difference" => Some((
                 9usize,
+                Type::Fn(FnType {
+                    type_args: vec![],
+                    arg_types: vec![(
+                        "other".to_string(),
+                        Type::Set(Box::new(Type::Generic("T".to_string()))),
+                        false,
+                    )],
+                    ret_type: Box::new(Type::Set(Box::new(Type::Generic("T".to_string())))),
+                }),
+            )),
+            "intersection" => Some((
+                10usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![(
@@ -1236,48 +1284,54 @@ impl NativeType for NativeSet {
                 has_return: true,
             }),
             2usize => Value::NativeFn(NativeFn {
+                name: "enumerate",
+                receiver: Some(obj),
+                native_fn: Self::method_enumerate,
+                has_return: true,
+            }),
+            3usize => Value::NativeFn(NativeFn {
                 name: "contains",
                 receiver: Some(obj),
                 native_fn: Self::method_contains,
                 has_return: true,
             }),
-            3usize => Value::NativeFn(NativeFn {
+            4usize => Value::NativeFn(NativeFn {
                 name: "map",
                 receiver: Some(obj),
                 native_fn: Self::method_map,
                 has_return: true,
             }),
-            4usize => Value::NativeFn(NativeFn {
+            5usize => Value::NativeFn(NativeFn {
                 name: "filter",
                 receiver: Some(obj),
                 native_fn: Self::method_filter,
                 has_return: true,
             }),
-            5usize => Value::NativeFn(NativeFn {
+            6usize => Value::NativeFn(NativeFn {
                 name: "reduce",
                 receiver: Some(obj),
                 native_fn: Self::method_reduce,
                 has_return: true,
             }),
-            6usize => Value::NativeFn(NativeFn {
+            7usize => Value::NativeFn(NativeFn {
                 name: "asArray",
                 receiver: Some(obj),
                 native_fn: Self::method_as_array,
                 has_return: true,
             }),
-            7usize => Value::NativeFn(NativeFn {
+            8usize => Value::NativeFn(NativeFn {
                 name: "union",
                 receiver: Some(obj),
                 native_fn: Self::method_union,
                 has_return: true,
             }),
-            8usize => Value::NativeFn(NativeFn {
+            9usize => Value::NativeFn(NativeFn {
                 name: "difference",
                 receiver: Some(obj),
                 native_fn: Self::method_difference,
                 has_return: true,
             }),
-            9usize => Value::NativeFn(NativeFn {
+            10usize => Value::NativeFn(NativeFn {
                 name: "intersection",
                 receiver: Some(obj),
                 native_fn: Self::method_intersection,

--- a/abra_core/src/builtins/native_types.abra
+++ b/abra_core/src/builtins/native_types.abra
@@ -36,6 +36,7 @@ type NativeArray<T> {
   func fillBy<T1>(amount: Int, fn: (Int) => T1): T1[] {}
 
   func isEmpty(self): Bool {}
+  func enumerate(self): (T, Int)[] {}
   func push(self, item: T): Unit {}
   func concat(self, other: T[]): T[] {}
   func map<U>(self, fn: (T) => U): U[] {}
@@ -62,6 +63,7 @@ type NativeMap<K, V> {
   func fromPairs<T1, T2>(pairs: (T1, T2)[]): Map<T1, T2> {}
 
   func isEmpty(self): Bool {}
+  func enumerate(self): (K, V)[] {}
   func keys(self): Set<K> {}
   func values(self): Set<V> {}
   func entries(self): Set<(K, V)> {}
@@ -73,6 +75,7 @@ type NativeSet<T> {
   size: Int
 
   func isEmpty(self): Bool {}
+  func enumerate(self): (T, Int)[] {}
   func contains(self, value: T): Bool {}
   func map<U>(self, fn: (T) => U): U[] {}
   func filter(self, fn: (T) => Bool): Set<T> {}

--- a/abra_core/src/builtins/native_types.rs
+++ b/abra_core/src/builtins/native_types.rs
@@ -331,6 +331,21 @@ impl NativeArrayMethodsAndFields for crate::builtins::gen_native_types::NativeAr
         } else { unreachable!() }
     }
 
+    fn method_enumerate(receiver: Option<Value>, _args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
+        if let Value::Obj(obj) = receiver.unwrap() {
+            match &*(obj.borrow()) {
+                Obj::ArrayObj(array) => {
+                    let tuples = array.iter().enumerate()
+                        .map(|(idx, value)| {
+                            Value::new_tuple_obj(vec![value.clone(), Value::Int(idx as i64)])
+                        }).collect();
+                    Some(Value::new_array_obj(tuples))
+                }
+                _ => unreachable!()
+            }
+        } else { unreachable!() }
+    }
+
     fn method_push(receiver: Option<Value>, args: Vec<Value>, _: &mut VM) -> Option<Value> {
         let item = args.into_iter().next().expect("Array::push requires 1 argument");
 
@@ -794,6 +809,21 @@ impl NativeSetMethodsAndFields for NativeSet {
         } else { unreachable!() }
     }
 
+    fn method_enumerate(receiver: Option<Value>, _args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
+        if let Value::Obj(obj) = receiver.unwrap() {
+            match &*(obj.borrow()) {
+                Obj::SetObj(set) => {
+                    let tuples = set.iter().enumerate()
+                        .map(|(idx, value)| {
+                            Value::new_tuple_obj(vec![value.clone(), Value::Int(idx as i64)])
+                        }).collect();
+                    Some(Value::new_array_obj(tuples))
+                }
+                _ => unreachable!()
+            }
+        } else { unreachable!() }
+    }
+
     fn method_contains(receiver: Option<Value>, args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
         let item = args.into_iter().next().expect("Set::contains requires 1 argument");
 
@@ -993,6 +1023,21 @@ impl NativeMapMethodsAndFields for NativeMap {
         if let Value::Obj(obj) = receiver.unwrap() {
             match &*(obj.borrow()) {
                 Obj::MapObj(value) => Some(Value::Bool(value.is_empty())),
+                _ => unreachable!()
+            }
+        } else { unreachable!() }
+    }
+
+    fn method_enumerate(receiver: Option<Value>, _args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
+        if let Value::Obj(obj) = receiver.unwrap() {
+            match &*(obj.borrow()) {
+                Obj::MapObj(map) => {
+                    let tuples = map.iter()
+                        .map(|(key, value)| {
+                            Value::new_tuple_obj(vec![key.clone(), value.clone()])
+                        }).collect();
+                    Some(Value::new_array_obj(tuples))
+                }
                 _ => unreachable!()
             }
         } else { unreachable!() }

--- a/abra_core/src/vm/disassembler.rs
+++ b/abra_core/src/vm/disassembler.rs
@@ -63,7 +63,7 @@ impl Disassembler {
                 Opcode::Constant => {
                     let imm = imms[0].expect("Constant requires an immediate");
                     let constant = self.module.constants.get(*imm as usize)
-                        .expect("The constant at the index should exist");
+                        .expect(format!("The constant at index {} should exist", imm).as_str());
                     acc.push(format!("\t; {}", constant))
                 }
                 Opcode::JumpIfF | Opcode::Jump => {

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -105,9 +105,17 @@ impl<'a> Serialize for JsWrappedError<'a> {
                 TypecheckerError::InvalidIfConditionType { token, actual } => {
                     let mut obj = serializer.serialize_map(Some(5))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
-                    obj.serialize_entry("subKind", "mismatch")?;
+                    obj.serialize_entry("subKind", "invalidIfConditionType")?;
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.serialize_entry("actual", &JsType(actual))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
+                TypecheckerError::InvalidLoopTarget { target_type, .. } => {
+                    let mut obj = serializer.serialize_map(Some(2))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidLoopTarget")?;
+                    obj.serialize_entry("targetType", &JsType(target_type))?;
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }


### PR DESCRIPTION
Addresses #221 

- Introduce concept of an iteration API; anything that's a target of a
for-loop must have an `enumerate()` method. This method will be called
when the iteration starts, and the tuples returned by that method will
become the values accessible in the for-loop. For example:
```
val strings = ["a", "b", "c"]
val iterator = strings.enumerate() // [("a", 0), ("b", 1), ("c", 2)]
for str, idx in strings {
  // str, idx is a "destructured" tuple from strings.enumerate()
}
```