### PR TITLE
Fixing bug with recursion within lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Abra
 A small programming language, written in Rust
 
-[![Build Status](https://travis-ci.org/kengorab/abra-lang.svg?branch=master)](https://travis-ci.org/kengorab/abra-lang)
+![Build & Test](https://github.com/kengorab/abra-lang/workflows/Build%20&%20Test/badge.svg)
 
 This project is very much a work in progress: you can check the [documentation site](https://abra.kenrg.co) for more information
 

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -112,7 +112,7 @@ pub struct VM {
     open_upvalues: HashMap<usize, Arc<RefCell<Upvalue>>>,
 }
 
-const STACK_LIMIT: usize = 64;
+const STACK_LIMIT: usize = 1024;
 
 impl VM {
     pub fn new(module: Module, ctx: VMContext) -> Self {

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1634,4 +1634,28 @@ mod tests {
         let expected = Value::Int(5);
         assert_eq!(expected, result);
     }
+
+    #[test]
+    pub fn interpret_recursive_func_in_lambda() {
+        // This is an utterly pointless, super contrived example, but the main test case here is
+        // whether a non-root-scope function will be correctly recognized as recursive if its only
+        // usage is within a lambda
+        let input = r#"
+          func abc() {
+            func def(nums: Int[]): Int {
+              if nums[0] |n| {
+                n + nums[1:].reduce(0, (acc, i) => acc + def([i]))
+              } else {
+                0
+              }
+            }
+
+            def([1, 2, 3, 4])
+          }
+          abc()
+        "#;
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(10);
+        assert_eq!(expected, result);
+    }
 }


### PR DESCRIPTION
- There was a bug where non-root-level recursive functions which
recursed within a lambda were not correctly tagged as recursive calls,
so the functions were unknown at compile-time. This was fixed in the
typechecker.
- There was _another_ bug where, if code within a lambda (which gets
executed from a native context) does not return a successful `Result`,
that error will be swallowed and the function will instead return
`Value::Nil`. This was super confusing! Now, if such a lambda encounters
an error, the process will halt and the error will be printed as a
runtime error. There is currently no way to recover from runtime errors
(but they should also be impossible, aside from a language
implementation bug).
- Also increased the max stack frame count from 64 to 1024.