### PR TITLE
Returns

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,5 +1,4 @@
-func contains<T>(arr: T[], item: T): Bool {
-  var contains = false
+func contains(arr: Int[], item: Int) {
   for i in arr {
     if item == i {
       return true
@@ -9,4 +8,4 @@ func contains<T>(arr: T[], item: T): Bool {
 }
 
 val arr = [1, 2, 3, 4]
-contains(arr, 7)
+contains(arr, 4)

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,32 +1,12 @@
-//val dArr = [
-//  [0, 1],
-//  [1, 0],
-//]
-//
-//if dArr[1][0] |i| {
-//  println("i: " + i)
-//} else {
-//  println("nope")
-//}
-//
-//val m = {
-//  a: { a: [1, 2, 3] },
-//  b: { b: [4, 5, 6] }
-//}
-//
-//if m["c"]["b"][0] |i| {
-//  println("i: " + i)
-//} else {
-//  println("nope")
-//}
-//
-//dArr[1][0] = 1
-
-val a = [true, false]
-
-// TODO: what does kotlin do here?
-if a[1] |v| {
-  println(v)
-} else {
-  println("else")
+func contains<T>(arr: T[], item: T): Bool {
+  var contains = false
+  for i in arr {
+    if item == i {
+      return true
+    }
+  }
+  false
 }
+
+val arr = [1, 2, 3, 4]
+contains(arr, 7)

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,130 +1,32 @@
-val v1 = "1"
-val v2 = "2"
-val v3 = "3"
-val v4 = "4"
-val v5 = "5"
-val v6 = "6"
-val v7 = "7"
-val v8 = "8"
-val v9 = "9"
-val v10 = "10"
-val v11 = "11"
-val v12 = "12"
-val v13 = "13"
-val v14 = "14"
-val v15 = "15"
-val v16 = "16"
-val v17 = "17"
-val v18 = "18"
-val v19 = "19"
-val v20 = "20"
-val v21 = "21"
-val v22 = "22"
-val v23 = "23"
-val v24 = "24"
-val v25 = "25"
-val v26 = "26"
-val v27 = "27"
-val v28 = "28"
-val v29 = "29"
-val v30 = "30"
-val v31 = "31"
-val v32 = "32"
-val v33 = "33"
-val v34 = "34"
-val v35 = "35"
-val v36 = "36"
-val v37 = "37"
-val v38 = "38"
-val v39 = "39"
-val v40 = "40"
-val v41 = "41"
-val v42 = "42"
-val v43 = "43"
-val v44 = "44"
-val v45 = "45"
-val v46 = "46"
-val v47 = "47"
-val v48 = "48"
-val v49 = "49"
-val v50 = "50"
-val v51 = "51"
-val v52 = "52"
-val v53 = "53"
-val v54 = "54"
-val v55 = "55"
-val v56 = "56"
-val v57 = "57"
-val v58 = "58"
-val v59 = "59"
-val v60 = "60"
-val v61 = "61"
-val v62 = "62"
-val v63 = "63"
-val v64 = "64"
-val v65 = "65"
-val v66 = "66"
-val v67 = "67"
-val v68 = "68"
-val v69 = "69"
-val v70 = "70"
-val v71 = "71"
-val v72 = "72"
-val v73 = "73"
-val v74 = "74"
-val v75 = "75"
-val v76 = "76"
-val v77 = "77"
-val v78 = "78"
-val v79 = "79"
-val v80 = "80"
-val v81 = "81"
-val v82 = "82"
-val v83 = "83"
-val v84 = "84"
-val v85 = "85"
-val v86 = "86"
-val v87 = "87"
-val v88 = "88"
-val v89 = "89"
-val v90 = "90"
-val v91 = "91"
-val v92 = "92"
-val v93 = "93"
-val v94 = "94"
-val v95 = "95"
-val v96 = "96"
-val v97 = "97"
-val v98 = "98"
-val v99 = "99"
-val v100 = "100"
-val v101 = "101"
-val v102 = "102"
-val v103 = "103"
-val v104 = "104"
-val v105 = "105"
-val v106 = "106"
-val v107 = "107"
-val v108 = "108"
-val v109 = "109"
-val v110 = "110"
-val v111 = "111"
-val v112 = "112"
-val v113 = "113"
-val v114 = "114"
-val v115 = "115"
-val v116 = "116"
-val v117 = "117"
-val v118 = "118"
-val v119 = "119"
-val v120 = "120"
-val v121 = "121"
-val v122 = "122"
-val v123 = "123"
-val v124 = "124"
-val v125 = "125"
-val v126 = "126"
-val v127 = "127"
-val v128 = "128"
-val v129 = "129"
-val v130 = "130"
+//val dArr = [
+//  [0, 1],
+//  [1, 0],
+//]
+//
+//if dArr[1][0] |i| {
+//  println("i: " + i)
+//} else {
+//  println("nope")
+//}
+//
+//val m = {
+//  a: { a: [1, 2, 3] },
+//  b: { b: [4, 5, 6] }
+//}
+//
+//if m["c"]["b"][0] |i| {
+//  println("i: " + i)
+//} else {
+//  println("nope")
+//}
+//
+//dArr[1][0] = 1
+
+val a = [true, false]
+
+// TODO: what does kotlin do here?
+if a[1] |v| {
+  println(v)
+} else {
+  println("else")
+}

--- a/abra_core/src/builtins/gen_native_types.rs
+++ b/abra_core/src/builtins/gen_native_types.rs
@@ -398,6 +398,7 @@ pub trait NativeArrayMethodsAndFields {
     fn method_join(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_contains(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_find(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
+    fn method_find_index(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_any(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_all(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
     fn method_none(receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Value>;
@@ -557,7 +558,7 @@ impl NativeType for NativeArray {
                     ret_type: Box::new(Type::Option(Box::new(Type::Generic("T".to_string())))),
                 }),
             )),
-            "any" => Some((
+            "findIndex" => Some((
                 11usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
@@ -577,10 +578,13 @@ impl NativeType for NativeArray {
                         }),
                         false,
                     )],
-                    ret_type: Box::new(Type::Bool),
+                    ret_type: Box::new(Type::Option(Box::new(Type::Tuple(vec![
+                        Type::Generic("T".to_string()),
+                        Type::Int,
+                    ])))),
                 }),
             )),
-            "all" => Some((
+            "any" => Some((
                 12usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
@@ -603,7 +607,7 @@ impl NativeType for NativeArray {
                     ret_type: Box::new(Type::Bool),
                 }),
             )),
-            "none" => Some((
+            "all" => Some((
                 13usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
@@ -626,8 +630,31 @@ impl NativeType for NativeArray {
                     ret_type: Box::new(Type::Bool),
                 }),
             )),
-            "sortBy" => Some((
+            "none" => Some((
                 14usize,
+                Type::Fn(FnType {
+                    type_args: vec!["U".to_string()],
+                    arg_types: vec![(
+                        "fn".to_string(),
+                        Type::Fn(FnType {
+                            type_args: vec![],
+                            arg_types: vec![(
+                                "_".to_string(),
+                                Type::Generic("T".to_string()),
+                                false,
+                            )],
+                            ret_type: Box::new(Type::Union(vec![
+                                Type::Bool,
+                                Type::Option(Box::new(Type::Generic("U".to_string()))),
+                            ])),
+                        }),
+                        false,
+                    )],
+                    ret_type: Box::new(Type::Bool),
+                }),
+            )),
+            "sortBy" => Some((
+                15usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![
@@ -650,7 +677,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "dedupe" => Some((
-                15usize,
+                16usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -658,7 +685,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "dedupeBy" => Some((
-                16usize,
+                17usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -678,7 +705,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "partition" => Some((
-                17usize,
+                18usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -701,7 +728,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "tally" => Some((
-                18usize,
+                19usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -712,7 +739,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "tallyBy" => Some((
-                19usize,
+                20usize,
                 Type::Fn(FnType {
                     type_args: vec!["U".to_string()],
                     arg_types: vec![(
@@ -735,7 +762,7 @@ impl NativeType for NativeArray {
                 }),
             )),
             "asSet" => Some((
-                20usize,
+                21usize,
                 Type::Fn(FnType {
                     type_args: vec![],
                     arg_types: vec![],
@@ -844,60 +871,66 @@ impl NativeType for NativeArray {
                 has_return: true,
             }),
             11usize => Value::NativeFn(NativeFn {
+                name: "findIndex",
+                receiver: Some(obj),
+                native_fn: Self::method_find_index,
+                has_return: true,
+            }),
+            12usize => Value::NativeFn(NativeFn {
                 name: "any",
                 receiver: Some(obj),
                 native_fn: Self::method_any,
                 has_return: true,
             }),
-            12usize => Value::NativeFn(NativeFn {
+            13usize => Value::NativeFn(NativeFn {
                 name: "all",
                 receiver: Some(obj),
                 native_fn: Self::method_all,
                 has_return: true,
             }),
-            13usize => Value::NativeFn(NativeFn {
+            14usize => Value::NativeFn(NativeFn {
                 name: "none",
                 receiver: Some(obj),
                 native_fn: Self::method_none,
                 has_return: true,
             }),
-            14usize => Value::NativeFn(NativeFn {
+            15usize => Value::NativeFn(NativeFn {
                 name: "sortBy",
                 receiver: Some(obj),
                 native_fn: Self::method_sort_by,
                 has_return: true,
             }),
-            15usize => Value::NativeFn(NativeFn {
+            16usize => Value::NativeFn(NativeFn {
                 name: "dedupe",
                 receiver: Some(obj),
                 native_fn: Self::method_dedupe,
                 has_return: true,
             }),
-            16usize => Value::NativeFn(NativeFn {
+            17usize => Value::NativeFn(NativeFn {
                 name: "dedupeBy",
                 receiver: Some(obj),
                 native_fn: Self::method_dedupe_by,
                 has_return: true,
             }),
-            17usize => Value::NativeFn(NativeFn {
+            18usize => Value::NativeFn(NativeFn {
                 name: "partition",
                 receiver: Some(obj),
                 native_fn: Self::method_partition,
                 has_return: true,
             }),
-            18usize => Value::NativeFn(NativeFn {
+            19usize => Value::NativeFn(NativeFn {
                 name: "tally",
                 receiver: Some(obj),
                 native_fn: Self::method_tally,
                 has_return: true,
             }),
-            19usize => Value::NativeFn(NativeFn {
+            20usize => Value::NativeFn(NativeFn {
                 name: "tallyBy",
                 receiver: Some(obj),
                 native_fn: Self::method_tally_by,
                 has_return: true,
             }),
-            20usize => Value::NativeFn(NativeFn {
+            21usize => Value::NativeFn(NativeFn {
                 name: "asSet",
                 receiver: Some(obj),
                 native_fn: Self::method_as_set,

--- a/abra_core/src/builtins/native_types.abra
+++ b/abra_core/src/builtins/native_types.abra
@@ -45,6 +45,7 @@ type NativeArray<T> {
   func join(self, joiner: String = ""): String {}
   func contains(self, item: T): Bool {}
   func find<U>(self, fn: (T) => (Bool | U?)): T? {}
+  func findIndex<U>(self, fn: (T) => (Bool | U?)): (T, Int)? {}
   func any<U>(self, fn: (T) => (Bool | U?)): Bool {}
   func all<U>(self, fn: (T) => (Bool | U?)): Bool {}
   func none<U>(self, fn: (T) => (Bool | U?)): Bool {}

--- a/abra_core/src/builtins/native_types.rs
+++ b/abra_core/src/builtins/native_types.rs
@@ -1556,6 +1556,10 @@ mod test {
 
     #[test]
     fn test_array_contains() {
+        let result = interpret("[].contains(5)");
+        let expected = Value::Bool(false);
+        assert_eq!(Some(expected), result);
+
         let result = interpret("[1, 2, 3, 4, 5].contains(5)");
         let expected = Value::Bool(true);
         assert_eq!(Some(expected), result);
@@ -1587,17 +1591,17 @@ mod test {
     #[test]
     fn test_array_find_index() {
         let result = interpret("[1, 2, 3].findIndex(x => x >= 2)");
-        let expected = tuple![Value::Int(1), Value::Int(2)];
+        let expected = tuple![Value::Int(2), Value::Int(1)];
         assert_eq!(Some(expected), result);
 
-        let result = interpret("[[1, 2], [3, 4]].find(p => p[0])");
+        let result = interpret("[[1, 2], [3, 4]].findIndex(p => p[0])");
         let expected = tuple![
-            Value::Int(0),
-            array![Value::Int(1), Value::Int(2)]
+            array![Value::Int(1), Value::Int(2)],
+            Value::Int(0)
         ];
         assert_eq!(Some(expected), result);
 
-        let result = interpret("[1, 2, 3].find(x => x >= 4)");
+        let result = interpret("[1, 2, 3].findIndex(x => x >= 4)");
         let expected = Value::Nil;
         assert_eq!(Some(expected), result);
     }

--- a/abra_core/src/common/ast_visitor.rs
+++ b/abra_core/src/common/ast_visitor.rs
@@ -28,6 +28,7 @@ pub trait AstVisitor<V, E> {
             Invocation(tok, node) => self.visit_invocation(tok, node),
             WhileLoop(tok, node) => self.visit_while_loop(tok, node),
             Break(tok) => self.visit_break(tok),
+            ReturnStatement(tok, node) => self.visit_return(tok, node),
             ForLoop(tok, node) => self.visit_for_loop(tok, node),
             Accessor(tok, node) => self.visit_accessor(tok, node),
             Lambda(tok, node) => self.visit_lambda(tok, node, None),
@@ -57,6 +58,7 @@ pub trait AstVisitor<V, E> {
     fn visit_for_loop(&mut self, token: Token, node: ForLoopNode) -> Result<V, E>;
     fn visit_while_loop(&mut self, token: Token, node: WhileLoopNode) -> Result<V, E>;
     fn visit_break(&mut self, token: Token) -> Result<V, E>;
+    fn visit_return(&mut self, token: Token, node: Option<Box<AstNode>>) -> Result<V, E>;
     fn visit_accessor(&mut self, token: Token, node: AccessorNode) -> Result<V, E>;
     fn visit_lambda(&mut self, token: Token, node: LambdaNode, args_override: Option<Vec<(Token, Type, Option<TypedAstNode>)>>) -> Result<V, E>;
     fn visit_tuple(&mut self, token: Token, nodes: Vec<AstNode>) -> Result<V, E>;

--- a/abra_core/src/common/typed_ast_visitor.rs
+++ b/abra_core/src/common/typed_ast_visitor.rs
@@ -1,5 +1,5 @@
 use crate::lexer::tokens::Token;
-use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedBinaryNode, TypedUnaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode, TypedLambdaNode, TypedEnumDeclNode, TypedMatchNode, TypedTupleNode, TypedSetNode};
+use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedBinaryNode, TypedUnaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode, TypedLambdaNode, TypedEnumDeclNode, TypedMatchNode, TypedReturnNode, TypedTupleNode, TypedSetNode};
 use crate::typechecker::typed_ast::TypedAstNode::*;
 
 pub trait TypedAstVisitor<V, E> {
@@ -29,6 +29,7 @@ pub trait TypedAstVisitor<V, E> {
             ForLoop(tok, node) => self.visit_for_loop(tok, node),
             WhileLoop(tok, node) => self.visit_while_loop(tok, node),
             Break(tok) => self.visit_break(tok),
+            ReturnStatement(tok, node) => self.visit_return(tok, node),
             MatchStatement(tok, node) => self.visit_match_statement(true, tok, node),
             MatchExpression(tok, node) => self.visit_match_expression(tok, node),
             _Nil(tok) => self.visit_nil(tok),
@@ -59,6 +60,7 @@ pub trait TypedAstVisitor<V, E> {
     fn visit_for_loop(&mut self, token: Token, node: TypedForLoopNode) -> Result<V, E>;
     fn visit_while_loop(&mut self, token: Token, node: TypedWhileLoopNode) -> Result<V, E>;
     fn visit_break(&mut self, token: Token) -> Result<V, E>;
+    fn visit_return(&mut self, token: Token, node: TypedReturnNode) -> Result<V, E>;
     fn visit_match_statement(&mut self, is_stmt: bool, token: Token, node: TypedMatchNode) -> Result<V, E>;
     fn visit_match_expression(&mut self, token: Token, node: TypedMatchNode) -> Result<V, E>;
     fn visit_nil(&mut self, token: Token) -> Result<V, E>;

--- a/abra_core/src/lexer/lexer.rs
+++ b/abra_core/src/lexer/lexer.rs
@@ -231,6 +231,11 @@ impl<'a> Lexer<'a> {
                 "match" => Token::Match(pos),
                 "type" => Token::Type(pos),
                 "enum" => Token::Enum(pos),
+                "return" => {
+                    let saw_newline = self.skip_whitespace();
+                    let has_newline = saw_newline || self.peek().is_none();
+                    Token::Return(pos, has_newline)
+                },
                 "None" => Token::None(pos),
                 s @ _ => Token::Ident(pos, s.to_string())
             };
@@ -658,6 +663,36 @@ mod tests {
             Token::Enum(Position::new(1, 57)),
             Token::Self_(Position::new(1, 62)),
             Token::Match(Position::new(1, 67)),
+        ];
+        assert_eq!(expected, tokens);
+    }
+
+    #[test]
+    fn test_tokenize_keyword_return() {
+        let tokens = tokenize(&"return".to_string()).unwrap();
+        let expected = vec![
+            Token::Return(Position::new(1, 1), true),
+        ];
+        assert_eq!(expected, tokens);
+
+        let tokens = tokenize(&"return     123".to_string()).unwrap();
+        let expected = vec![
+            Token::Return(Position::new(1, 1), false),
+            Token::Int(Position::new(1, 12), 123)
+        ];
+        assert_eq!(expected, tokens);
+
+        let tokens = tokenize(&"return\n123".to_string()).unwrap();
+        let expected = vec![
+            Token::Return(Position::new(1, 1), true),
+            Token::Int(Position::new(2, 1), 123)
+        ];
+        assert_eq!(expected, tokens);
+
+        let tokens = tokenize(&"return  \t  \n123".to_string()).unwrap();
+        let expected = vec![
+            Token::Return(Position::new(1, 1), true),
+            Token::Int(Position::new(2, 1), 123)
         ];
         assert_eq!(expected, tokens);
     }

--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -45,6 +45,7 @@ pub enum Token {
     #[strum(to_string = "match", serialize = "Match")] Match(Position),
     #[strum(to_string = "type", serialize = "Type")] Type(Position),
     #[strum(to_string = "enum", serialize = "Enum")] Enum(Position),
+    #[strum(to_string = "return", serialize = "Return")] Return(Position, bool),
 
     // Identifiers
     #[strum(to_string = "identifier", serialize = "Ident")] Ident(Position, String),
@@ -114,6 +115,7 @@ impl Token {
             Token::Match(pos) |
             Token::Type(pos) |
             Token::Enum(pos) |
+            Token::Return(pos, _) |
 
             Token::Ident(pos, _) |
             Token::Self_(pos) |
@@ -181,6 +183,7 @@ impl Token {
             Token::Match(pos) => Range::with_length(pos, 4),
             Token::Type(pos) => Range::with_length(pos, 3),
             Token::Enum(pos) => Range::with_length(pos, 3),
+            Token::Return(pos, _) => Range::with_length(pos, 5),
 
             Token::Ident(pos, i) => Range::with_length(pos, i.len() - 1),
             Token::Self_(pos) => Range::with_length(pos, 3),

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -27,6 +27,7 @@ pub enum AstNode {
     MatchStatement(Token, MatchNode),
     MatchExpression(Token, MatchNode),
     Tuple(Token, Vec<AstNode>),
+    ReturnStatement(Token, Option<Box<AstNode>>),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -30,6 +30,39 @@ pub enum AstNode {
     ReturnStatement(Token, Option<Box<AstNode>>),
 }
 
+impl AstNode {
+    pub fn get_token(&self) -> &Token {
+        match self {
+            AstNode::Literal(token, _) |
+            AstNode::Unary(token, _) |
+            AstNode::Binary(token, _) |
+            AstNode::Grouped(token, _) |
+            AstNode::Array(token, _) |
+            AstNode::Map(token, _) |
+            AstNode::Set(token, _) |
+            AstNode::Tuple(token, _) |
+            AstNode::Lambda(token, _) |
+            AstNode::BindingDecl(token, _) |
+            AstNode::FunctionDecl(token, _) |
+            AstNode::TypeDecl(token, _) |
+            AstNode::EnumDecl(token, _) |
+            AstNode::Identifier(token, _) |
+            AstNode::Assignment(token, _) |
+            AstNode::Indexing(token, _) |
+            AstNode::IfStatement(token, _) |
+            AstNode::IfExpression(token, _) |
+            AstNode::Invocation(token, _) |
+            AstNode::ForLoop(token, _) |
+            AstNode::WhileLoop(token, _) |
+            AstNode::Break(token) |
+            AstNode::ReturnStatement(token, _) |
+            AstNode::Accessor(token, _) |
+            AstNode::MatchStatement(token, _) |
+            AstNode::MatchExpression(token, _) => token
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum AstLiteralNode {
     IntLiteral(i64),

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -305,17 +305,32 @@ impl Typechecker {
             self.resolve_ref_type(&node.get_type())
         };
 
+        // If the target_type contains an `Unknown` in some shape or form, we should compare by
+        // structure; for example:
+        //   [].contains("a"), [].concat([1, 3]) // Should both pass
         if target_type.is_unknown(&self.referencable_types) {
-            Ok(true) // TODO: This could be wrong
+            let is_same_shape = match (typ, target_type) {
+                (_, Type::Unknown) => true,
+                (Type::Array(_), Type::Array(i2)) if **i2 == Type::Unknown => true,
+                (Type::Set(_), Type::Set(i2)) if **i2 == Type::Unknown => true,
+                (Type::Map(_, _), Type::Map(_, i2)) if **i2 == Type::Unknown => true,
+                _ => false
+            };
+            Ok(is_same_shape)
         } else {
             Ok(typ.is_equivalent_to(target_type, &self.referencable_types))
         }
     }
 
     fn visit_block(&mut self, is_stmt: bool, body: Vec<AstNode>) -> Result<Vec<TypedAstNode>, TypecheckerError> {
+        let mut seen_return = false;
         let len = body.len();
         body.into_iter().enumerate()
             .map(|(idx, mut node)| {
+                if seen_return {
+                    return Err(TypecheckerError::UnreachableCode { token: node.get_token().clone() });
+                }
+
                 // If the last node of an if-expression is an if-statement, treat it as an if-expr.
                 // This is due to the fact that if-blocks are only treated as expressions in certain
                 // situations, namely when an expression is already expected. Otherwise, they're parsed
@@ -329,7 +344,10 @@ impl Typechecker {
                         node = AstNode::MatchExpression(token, match_node)
                     }
                 }
-                self.visit(node)
+                let typed_node = self.visit(node)?;
+                seen_return = Self::all_branches_return(&typed_node);
+
+                Ok(typed_node)
             })
             .collect()
     }
@@ -631,10 +649,40 @@ impl Typechecker {
         Ok(typed_args)
     }
 
+    fn all_branches_return(node: &TypedAstNode) -> bool {
+        match node {
+            TypedAstNode::IfStatement(_, TypedIfNode { if_block, else_block, .. }) |
+            TypedAstNode::IfExpression(_, TypedIfNode { if_block, else_block, .. }) => {
+                let if_block_has_return = if_block.last().map(|n| Self::all_branches_return(n)).unwrap_or(false);
+                if !if_block_has_return {
+                    false
+                } else if let Some(else_block) = else_block {
+                    let else_block_has_return = else_block.last().map(|n| Self::all_branches_return(n)).unwrap_or(false);
+                    if_block_has_return && else_block_has_return
+                } else {
+                    false
+                }
+            }
+            TypedAstNode::MatchStatement(_, TypedMatchNode { branches, .. }) |
+            TypedAstNode::MatchExpression(_, TypedMatchNode { branches, .. }) => {
+                branches.iter().all(|(_, _, _, body, _)| {
+                    body.last().map(|n| Self::all_branches_return(n)).unwrap_or(false)
+                })
+            }
+            TypedAstNode::ReturnStatement(_, _) => true,
+            _ => false
+        }
+    }
+
     fn visit_fn_body(&mut self, body: Vec<AstNode>) -> Result<Vec<TypedAstNode>, TypecheckerError> {
+        let mut seen_return = false;
         let body_len = body.len();
         body.into_iter().enumerate()
             .map(|(idx, node)| {
+                if seen_return {
+                    return Err(TypecheckerError::UnreachableCode { token: node.get_token().clone() });
+                }
+
                 if idx == body_len - 1 {
                     // This is sufficiently gross to warrant a comment. This logic is similar to the
                     // if-block logic in `visit_if_node` above, but slightly different. Like in an
@@ -688,7 +736,10 @@ impl Typechecker {
                         n @ _ => self.visit(n)
                     }
                 } else {
-                    self.visit(node)
+                    let typed_node = self.visit(node)?;
+                    seen_return = Self::all_branches_return(&typed_node);
+
+                    Ok(typed_node)
                 }
             })
             .collect()
@@ -1168,10 +1219,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
     }
 
     fn visit_func_decl(&mut self, token: Token, node: FunctionDeclNode) -> Result<TypedAstNode, TypecheckerError> {
-        let mut old_returns = vec![];
-        std::mem::swap(&mut self.returns, &mut old_returns);
-
-        let FunctionDeclNode { name, type_args, args, ret_type, body, } = node;
+        let FunctionDeclNode { name, type_args, args, ret_type: ret_ann_type, body, } = node;
 
         let func_name = Token::get_ident_name(&name);
         if let Some(ScopeBinding(orig_ident, _, _)) = self.get_binding_in_current_scope(&func_name) {
@@ -1216,7 +1264,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                 }
             })
             .collect::<Vec<_>>();
-        let initial_ret_type = match &ret_type {
+        let initial_ret_type = match &ret_ann_type {
             None => Type::Unknown,
             Some(ret_type) => self.type_from_type_ident(ret_type)?,
         };
@@ -1236,7 +1284,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
             let ret_generics = initial_ret_type.extract_unbound_generics();
             for name in ret_generics {
                 if !valid_return_type_args.contains(&&name) {
-                    let ret_type = ret_type.expect("Should be Some if initial_ret_type is anything but Unknown");
+                    let ret_type = ret_ann_type.expect("Should be Some if initial_ret_type is anything but Unknown");
                     let ident_token = ret_type.get_ident();
                     let ret_type_name = Token::get_ident_name(&ident_token);
                     return Err(TypecheckerError::UnboundGeneric(ident_token, ret_type_name));
@@ -1251,32 +1299,92 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         self.add_binding(&func_name, &name, &func_type, false);
         self.scopes.push(scope);
 
+        let mut old_returns = vec![];
+        std::mem::swap(&mut self.returns, &mut old_returns);
         let mut body = self.visit_fn_body(body)?;
-        let body_type = body.last().map_or(Type::Unit, |node| node.get_type());
+        std::mem::swap(&mut old_returns, &mut self.returns);
+        let returns = old_returns;
 
-        let ret_type = match ret_type {
-            None => body_type,
+        let body_type = body.last().map_or(Type::Unit, |node| {
+            if let TypedAstNode::ReturnStatement(_, TypedReturnNode { target, .. }) = &node {
+                target.as_ref().map(|n| n.get_type()).unwrap_or(Type::Unit)
+            } else {
+                node.get_type()
+            }
+        });
+
+        let mut ret_type = match &ret_ann_type {
+            None => {
+                if body.last().map_or(false, |n| Self::all_branches_return(n)) {
+                    None
+                } else {
+                    Some(body_type)
+                }
+            }
             Some(ret_type) => {
-                let typ = self.type_from_type_ident(&ret_type)?;
+                let typ = self.type_from_type_ident(ret_type)?;
                 match body.last_mut() {
-                    None => body_type,
+                    None => Some(Type::Unit),
                     Some(mut node) => {
-                        let node_type_unknown = node.get_type().is_unknown(&self.referencable_types);
-
-                        if !self.are_types_equivalent(&mut node, &typ)? {
-                            let token = body.last().map_or(name.clone(), |node| node.get_token().clone());
-                            return Err(TypecheckerError::Mismatch { token, actual: body_type, expected: typ });
-                        } else if typ.has_unbound_generic() {
-                            typ
-                        } else if node_type_unknown {
-                            node.get_type()
+                        if Self::all_branches_return(node) {
+                            Some(typ)
                         } else {
-                            typ
+                            let node_type_unknown = node.get_type().is_unknown(&self.referencable_types);
+
+                            if !self.are_types_equivalent(&mut node, &typ)? {
+                                let token = body.last().map_or(name.clone(), |node| node.get_token().clone());
+                                return Err(TypecheckerError::Mismatch { token, actual: body_type, expected: typ });
+                            } else if typ.has_unbound_generic() {
+                                Some(typ)
+                            } else if node_type_unknown {
+                                Some(node.get_type())
+                            } else {
+                                Some(typ)
+                            }
                         }
                     }
                 }
             }
         };
+
+        // Returns that have types that are Type::Unknown will be handled _after_ non-unknown ones
+        let returns = returns.into_iter()
+            .map(|n| if let TypedAstNode::ReturnStatement(tok, node) = n { (tok, node) } else { unreachable!() })
+            .sorted_by_key(|(_, node)| {
+                node.target.as_ref().map_or(false, |n| n.get_type().is_unknown(&self.referencable_types))
+            })
+            .collect::<Vec<_>>();
+        for (return_tok, node) in returns {
+            if let Some(ret_node) = node.target {
+                let ret_node_typ = ret_node.get_type();
+                match &ret_type {
+                    None => ret_type = Some(ret_node_typ),
+                    Some(ret_type) => {
+                        let token = ret_node.get_token().clone();
+                        let mut ret_node = ret_node;
+                        if !self.are_types_equivalent(&mut *ret_node, &ret_type)? {
+                            return Err(TypecheckerError::Mismatch {
+                                token,
+                                actual: ret_node_typ,
+                                expected: ret_type.clone(),
+                            });
+                        }
+                    }
+                }
+            } else if ret_type != Some(Type::Unit) {
+                let ret_ann_type = match &ret_ann_type {
+                    None => Type::Unit,
+                    Some(ret_type_ann) => self.type_from_type_ident(&ret_type_ann)?
+                };
+                return Err(TypecheckerError::Mismatch {
+                    token: return_tok.clone(),
+                    actual: Type::Unit,
+                    expected: ret_ann_type,
+                });
+            }
+        }
+        let ret_type = ret_type.unwrap_or(Type::Unknown);
+
         let fn_scope = self.scopes.pop().unwrap();
         let is_recursive = if let ScopeKind::Function(_, _, is_recursive) = fn_scope.kind {
             is_recursive
@@ -1288,8 +1396,6 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
             *return_type = Box::new(ret_type.clone());
         }
         let scope_depth = self.scopes.len() - 1;
-
-        std::mem::swap(&mut old_returns, &mut self.returns);
 
         Ok(TypedAstNode::FunctionDecl(token, TypedFunctionDeclNode { name, args, ret_type, body, scope_depth, is_recursive }))
     }
@@ -1820,9 +1926,13 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
     fn visit_if_expression(&mut self, token: Token, node: IfNode) -> Result<TypedAstNode, TypecheckerError> {
         let mut node = self.visit_if_node(false, node)?;
 
+        let mut if_block_is_return = false;
         let if_block_type = match &node.if_block.last() {
             None => Err(TypecheckerError::MissingIfExprBranch { if_token: token.clone(), is_if_branch: true }),
-            Some(expr) => Ok(expr.get_type())
+            Some(expr) => {
+                if_block_is_return = Self::all_branches_return(expr);
+                Ok(expr.get_type())
+            }
         }?;
 
         let typ = match &node.else_block {
@@ -1830,15 +1940,28 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                 None => Err(TypecheckerError::MissingIfExprBranch { if_token: token.clone(), is_if_branch: false }),
                 Some(expr) => {
                     let else_block_type = expr.get_type();
-                    let mut if_block_last = node.if_block.last_mut().expect("MissingIfExprBranch should be emitted otherwise");
-                    if !self.are_types_equivalent(&mut if_block_last, &else_block_type)? {
-                        Err(TypecheckerError::IfExprBranchMismatch {
-                            if_token: token.clone(),
-                            if_type: if_block_type,
-                            else_type: else_block_type,
-                        })
+
+                    if if_block_is_return {
+                        if Self::all_branches_return(expr) {
+                            node.typ = Type::Unit;
+                            return Ok(TypedAstNode::IfExpression(token.clone(), node));
+                        } else {
+                            Ok(else_block_type)
+                        }
+                    } else if Self::all_branches_return(expr) {
+                        node.typ = if_block_type;
+                        return Ok(TypedAstNode::IfExpression(token.clone(), node));
                     } else {
-                        Ok(if_block_last.get_type())
+                        let mut if_block_last = node.if_block.last_mut().expect("MissingIfExprBranch should be emitted otherwise");
+                        if !self.are_types_equivalent(&mut if_block_last, &else_block_type)? {
+                            Err(TypecheckerError::IfExprBranchMismatch {
+                                if_token: token.clone(),
+                                if_type: if_block_type,
+                                else_type: else_block_type,
+                            })
+                        } else {
+                            Ok(if_block_last.get_type())
+                        }
                     }
                 }
             }
@@ -1860,6 +1983,10 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
 
         let mut typ = None;
         for (_, _, _, ref mut block, _) in &mut node.branches {
+            if block.last().as_ref().map_or(false, |n| Self::all_branches_return(n)) {
+                continue;
+            }
+
             if let Some(typ) = &typ {
                 let mut block_last = block.last_mut().expect("A case should have a non-empty body");
                 let block_typ = block_last.get_type();
@@ -1876,7 +2003,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
             }
         }
 
-        node.typ = typ.unwrap();
+        node.typ = typ.unwrap_or(Type::Unit);
         Ok(TypedAstNode::MatchExpression(token, node))
     }
 
@@ -2172,10 +2299,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         }
         self.scopes.push(scope);
 
-        let body: Result<Vec<_>, _> = body.into_iter()
-            .map(|node| self.visit(node))
-            .collect();
-        let body = body?;
+        let body = self.visit_block(true, body)?;
         self.scopes.pop();
         self.scopes.pop(); // Pop loop intrinsic-variables outer block
 
@@ -2217,10 +2341,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         }
         self.scopes.push(scope);
 
-        let body: Result<Vec<_>, _> = body.into_iter()
-            .map(|node| self.visit(node))
-            .collect();
-        let body = body?;
+        let body = self.visit_block(true, body)?;
         self.scopes.pop();
 
         // Pop outer block, if created
@@ -2257,15 +2378,14 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         };
 
         if has_fn_parent {
-            let (target, typ) = match node {
-                None => (None, Type::Unit),
+            let target = match node {
+                None => None,
                 Some(target) => {
                     let target = self.visit(*target)?;
-                    let typ = target.get_type();
-                    (Some(Box::new(target)), typ)
+                    Some(Box::new(target))
                 }
             };
-            let node = TypedAstNode::ReturnStatement(token, TypedReturnNode { typ, target });
+            let node = TypedAstNode::ReturnStatement(token, TypedReturnNode { typ: Type::Unit, target });
             self.returns.push(node.clone());
             Ok(node)
         } else {
@@ -4338,18 +4458,6 @@ mod tests {
             token: Token::String(Position::new(12, 8), "abcd".to_string()),
             expected: Type::Int,
             actual: Type::String,
-        };
-        assert_eq!(expected, error);
-
-        let input = format!("{}\n\
-          val l = List(items: [1, 2, 3])\n\
-          l.reduce([], (acc, i) => acc.concat([i]))\
-        ", type_def);
-        let error = typecheck(&input).unwrap_err();
-        let expected = TypecheckerError::Mismatch {
-            token: Token::Arrow(Position::new(12, 23)),
-            expected: Type::Array(Box::new(Type::Unknown)),
-            actual: Type::Array(Box::new(Type::Unknown)),
         };
         assert_eq!(expected, error);
 
@@ -6841,6 +6949,219 @@ mod tests {
         let expected = TypecheckerError::ForbiddenVariableType {
             token: ident_token!((2, 5), "j"),
             typ: Type::Unit,
+        };
+        assert_eq!(expected, err);
+    }
+
+    #[test]
+    fn typecheck_return_statements() {
+        let input = r#"
+          func f() {
+            if true { return 1 }
+            return 2
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+
+        let input = r#"
+          func f() {
+            if true { return 1 }
+            2
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+
+        let input = r#"
+          func f(): Int {
+            if true { return 1 } else { return 2 }
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+
+        let input = r#"
+          func f(i: Int | String): Int {
+            match i {
+              String => { return 3 }
+              Int => { return 3 }
+            }
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+
+        let input = r#"
+          func f(): String {
+            while true {
+              if true { return "a" }
+            }
+            val s = if true { return "1" } else { "a" }
+            s
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+
+        let input = r#"
+          func f(i: Int | String) {
+            while true {
+              if true { return "a" }
+            }
+            val s = match i {
+              Int => { return "a" }
+              String => "st"
+            }
+            s
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+
+        let input = r#"
+          func f(i: Int | String) {
+            for _ in [1, 2] {
+              if true { return [] }
+            }
+            val s = match i {
+              Int => { return ["a"] }
+              String => "st"
+            }
+            [s]
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+
+        let input = r#"
+          func f() {
+            val d = if true {
+              if true { return [] } else { "d" }
+            } else if false {
+              if true { return [] } else { "d" }
+            } else {
+              if true { return [] } else { "d" }
+            }
+            [d]
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+
+        let input = r#"
+          func f() {
+            if true {
+              return (i) => 5
+            }
+            (i: Int) => 6
+          }
+        "#;
+        assert!(typecheck(input).is_ok());
+    }
+
+    #[test]
+    fn typecheck_return_statements_unreachable_code_errors() {
+        let err = typecheck("\
+          func f() {\n\
+            return 3\n\
+            return 6\n\
+          }\
+        ").unwrap_err();
+        let expected = TypecheckerError::UnreachableCode {
+            token: Token::Return(Position::new(3, 1), false)
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("\
+          func f() {\n\
+            if true { return 1 } else { return 2 }\n\
+            return 3\n\
+          }\
+        ").unwrap_err();
+        let expected = TypecheckerError::UnreachableCode {
+            token: Token::Return(Position::new(3, 1), false)
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("\
+          func f() {\n\
+            if true {\
+              return 1\n\
+              val x = 5 + 4\n\
+            }\n\
+          }\
+        ").unwrap_err();
+        let expected = TypecheckerError::UnreachableCode {
+            token: Token::Val(Position::new(3, 1))
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("\
+          func f() {\n\
+            while true {\
+              return 1\n\
+              val x = 5 + 4\n\
+            }\n\
+          }\
+        ").unwrap_err();
+        let expected = TypecheckerError::UnreachableCode {
+            token: Token::Val(Position::new(3, 1))
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("\
+          func f() {\n\
+            for _ in [1, 2] {\
+              return 1\n\
+              val x = 5 + 4\n\
+            }\n\
+          }\
+        ").unwrap_err();
+        let expected = TypecheckerError::UnreachableCode {
+            token: Token::Val(Position::new(3, 1))
+        };
+        assert_eq!(expected, err);
+    }
+
+    #[test]
+    fn typecheck_return_statements_type_errors() {
+        let err = typecheck("func f(): String { return 5 }").unwrap_err();
+        let expected = TypecheckerError::Mismatch {
+            token: Token::Int(Position::new(1, 27), 5),
+            actual: Type::Int,
+            expected: Type::String,
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("\
+          func f() {\n\
+            if true { return \"\" }\n\
+            return 5\n\
+          }\
+        ").unwrap_err();
+        let expected = TypecheckerError::Mismatch {
+            token: Token::Int(Position::new(3, 8), 5),
+            actual: Type::Int,
+            expected: Type::String,
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("\
+          func f() {\n\
+            if true { return [] }\n\
+            return {}\n\
+          }\
+        ").unwrap_err();
+        let expected = TypecheckerError::Mismatch {
+            token: Token::LBrace(Position::new(3, 8)),
+            actual: Type::Map(Box::new(Type::String), Box::new(Type::Unknown)),
+            expected: Type::Array(Box::new(Type::Unknown)),
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("\
+          func f(): Map<String, Int> {\n\
+            if true { return [] }\n\
+            return {}\n\
+          }\
+        ").unwrap_err();
+        let expected = TypecheckerError::Mismatch {
+            token: Token::LBrack(Position::new(2, 18), false),
+            actual: Type::Array(Box::new(Type::Unknown)),
+            expected: Type::Map(Box::new(Type::String), Box::new(Type::Int)),
         };
         assert_eq!(expected, err);
     }

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -640,7 +640,7 @@ impl DisplayError for TypecheckerError {
             }
             TypecheckerError::UnreachableCode { .. } => {
                 format!(
-                    "Unreachable code: ({}:{})\n{}\
+                    "Unreachable code: ({}:{})\n{}\n\
                     Code comes after a return statement",
                     pos.line, pos.col, cursor_line
                 )

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -62,6 +62,7 @@ pub enum TypecheckerError {
     InvalidUninitializedEnumVariant { token: Token },
     InvalidDestructuring { token: Token, typ: Type },
     InvalidDestructuringArity { token: Token, typ: Type, expected: usize, actual: usize },
+    UnreachableCode { token: Token },
 }
 
 impl TypecheckerError {
@@ -115,6 +116,7 @@ impl TypecheckerError {
             TypecheckerError::InvalidUninitializedEnumVariant { token } => token,
             TypecheckerError::InvalidDestructuring { token, .. } => token,
             TypecheckerError::InvalidDestructuringArity { token, .. } => token,
+            TypecheckerError::UnreachableCode { token } => token,
         }
     }
 }
@@ -634,6 +636,13 @@ impl DisplayError for TypecheckerError {
                     Instances of type {} have {} field{}, but the pattern attempts to extract {}",
                     pos.line, pos.col, cursor_line,
                     type_repr(typ), expected, if *expected == 1 { "" } else { "s" }, actual
+                )
+            }
+            TypecheckerError::UnreachableCode { .. } => {
+                format!(
+                    "Unreachable code: ({}:{})\n{}\
+                    Code comes after a return statement",
+                    pos.line, pos.col, cursor_line
                 )
             }
         }

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -38,6 +38,7 @@ pub enum TypecheckerError {
     DuplicateParamName { token: Token },
     RecursiveRefWithoutReturnType { orig_token: Token, token: Token },
     InvalidBreak(Token),
+    InvalidReturn(Token),
     InvalidRequiredArgPosition(Token),
     InvalidIndexingTarget { token: Token, target_type: Type, index_mode: IndexingMode<AstNode> },
     InvalidIndexingSelector { token: Token, target_type: Type, selector_type: Type },
@@ -90,6 +91,7 @@ impl TypecheckerError {
             TypecheckerError::DuplicateParamName { token } => token,
             TypecheckerError::RecursiveRefWithoutReturnType { token, .. } => token,
             TypecheckerError::InvalidBreak(token) => token,
+            TypecheckerError::InvalidReturn(token) => token,
             TypecheckerError::InvalidRequiredArgPosition(token) => token,
             TypecheckerError::InvalidIndexingTarget { token, .. } => token,
             TypecheckerError::InvalidIndexingSelector { token, .. } => token,
@@ -430,7 +432,15 @@ impl DisplayError for TypecheckerError {
             }
             TypecheckerError::InvalidBreak(_token) => {
                 format!(
-                    "Unexpected break keyword: ({}:{})\n{}\nA break keyword cannot appear outside of a loop",
+                    "Unexpected break keyword: ({}:{})\n{}\n\
+                    A break keyword cannot appear outside of a loop",
+                    pos.line, pos.col, cursor_line
+                )
+            }
+            TypecheckerError::InvalidReturn(_) => {
+                format!(
+                    "Unexpected return keyword: ({}:{})\n{}\n\
+                    A return keyword cannot appear outside of a function",
                     pos.line, pos.col, cursor_line
                 )
             }

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -28,6 +28,7 @@ pub enum TypedAstNode {
     ForLoop(Token, TypedForLoopNode),
     WhileLoop(Token, TypedWhileLoopNode),
     Break(Token),
+    ReturnStatement(Token, TypedReturnNode),
     Accessor(Token, TypedAccessorNode),
     MatchStatement(Token, TypedMatchNode),
     MatchExpression(Token, TypedMatchNode),
@@ -60,6 +61,7 @@ impl TypedAstNode {
             TypedAstNode::ForLoop(token, _) |
             TypedAstNode::WhileLoop(token, _) |
             TypedAstNode::Break(token) |
+            TypedAstNode::ReturnStatement(token, _) |
             TypedAstNode::Accessor(token, _) |
             TypedAstNode::MatchStatement(token, _) |
             TypedAstNode::MatchExpression(token, _) |
@@ -90,6 +92,7 @@ impl TypedAstNode {
             TypedAstNode::WhileLoop(_, _) |
             TypedAstNode::Break(_) |
             TypedAstNode::ForLoop(_, _) => Type::Unit,
+            TypedAstNode::ReturnStatement(_, node) => node.typ.clone(),
             TypedAstNode::Identifier(_, node) => node.typ.clone(),
             TypedAstNode::Assignment(_, node) => node.typ.clone(),
             TypedAstNode::Indexing(_, node) => node.typ.clone(),
@@ -297,4 +300,10 @@ pub struct TypedMatchNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
     pub branches: Vec<(/* match_type: */ Type, /* match_type_ident: */ Option<TypeIdentifier>, /* binding: */ Option<String>, /* body: */ Vec<TypedAstNode>, /* args: */ Option<Vec<Token>>)>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TypedReturnNode {
+    pub typ: Type,
+    pub target: Option<Box<TypedAstNode>>,
 }

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -108,7 +108,7 @@ impl Type {
         match (self, target_type) {
             // Easy cases
             (Unit, Unit) | (Int, Int) | (Float, Float) |
-            (String, String) | (Bool, Bool) | (Any, Any) => true,
+            (String, String) | (Bool, Bool) | (Any, Any) | (Unknown, Unknown) => true,
             // For Array / Option types, compare inner type
             (Array(t1), Array(t2)) => t1.is_equivalent_to(t2, referencable_types),
             (Set(t1), Set(t2)) => t1.is_equivalent_to(t2, referencable_types),

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -1196,11 +1196,14 @@ impl TypedAstVisitor<(), ()> for Compiler {
 
         let TypedIndexingNode { target, index, .. } = node;
 
-        let opcode = match &target.get_type() {
+        let mut target_type = target.get_type();
+        if let Type::Option(inner) = target_type { target_type = *inner };
+
+        let opcode = match &target_type {
             Type::Map(_, _) => Opcode::MapLoad,
             Type::Array(_) | Type::String => Opcode::ArrLoad,
             Type::Tuple(_) => Opcode::TupleLoad,
-            _ => unreachable!()
+            t @ _ => {dbg!(t);unreachable!()}
         };
         self.visit(*target)?;
 

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -2,7 +2,7 @@ use crate::common::typed_ast_visitor::TypedAstVisitor;
 use crate::lexer::tokens::Token;
 use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode, TypeIdentifier};
 use crate::vm::opcode::Opcode;
-use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedUnaryNode, TypedBinaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode, AssignmentTargetKind, TypedLambdaNode, TypedEnumDeclNode, EnumVariantKind, TypedMatchNode, TypedTupleNode, TypedSetNode};
+use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedUnaryNode, TypedBinaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode, AssignmentTargetKind, TypedLambdaNode, TypedEnumDeclNode, EnumVariantKind, TypedMatchNode, TypedReturnNode, TypedTupleNode, TypedSetNode};
 use crate::typechecker::types::{Type, FnType, EnumVariantType};
 use crate::vm::value::{Value, FnValue, TypeValue, EnumValue, EnumVariantObj};
 use crate::vm::prelude::{PRELUDE_BINDINGS, PRELUDE_BINDING_VALUES};
@@ -1685,6 +1685,10 @@ impl TypedAstVisitor<(), ()> for Compiler {
         let interrupt_jump_handle = self.begin_jump(Opcode::Jump, line);
         self.interrupt_handles.push(interrupt_jump_handle);
         Ok(())
+    }
+
+    fn visit_return(&mut self, _token: Token, _node: TypedReturnNode) -> Result<(), ()> {
+        todo!()
     }
 }
 

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -49,6 +49,7 @@ pub struct Compiler {
     locals: Vec<Local>,
     upvalues: Vec<Upvalue>,
     interrupt_handles: Vec<JumpHandle>,
+    return_handles: Vec<JumpHandle>,
     metadata: Metadata,
 }
 
@@ -95,6 +96,7 @@ pub fn compile(ast: Vec<TypedAstNode>) -> Result<(Module, Metadata), ()> {
         locals: Vec::new(),
         upvalues: Vec::new(),
         interrupt_handles: Vec::new(),
+        return_handles: Vec::new(),
         metadata,
     };
 
@@ -221,7 +223,7 @@ impl Compiler {
         }
     }
 
-    fn write_pops_for_closure(&mut self, popped_locals: Vec<Local>, line: usize) {
+    fn write_pops_for_closure(&mut self, popped_locals: &Vec<Local>, line: usize) {
         for local in popped_locals.iter().rev() {
             if local.name == "<ret>".to_string() { continue; }
 
@@ -535,9 +537,11 @@ impl Compiler {
 
         let line = token.get_position().line;
 
-        let prev_code = self.code.clone();
-        self.code = Vec::new();
-        // TODO: std::mem::swap?
+        let mut old_code = vec![];
+        std::mem::swap(&mut self.code, &mut old_code);
+
+        let mut old_return_handles = vec![];
+        std::mem::swap(&mut self.return_handles, &mut old_return_handles);
 
         self.push_scope(ScopeKind::Func);
 
@@ -626,15 +630,21 @@ impl Compiler {
                     self.write_store_local_instr(0, line);
                     self.metadata.stores.push("<ret>".to_string());
                 }
-                self.write_pops_for_closure(popped_locals, line);
+                self.write_pops_for_closure(&popped_locals, line);
             }
         }
+
+        std::mem::swap(&mut self.return_handles, &mut old_return_handles);
+        let mut return_handles = old_return_handles;
+        for handle in return_handles.drain(..) {
+            self.close_jump(handle);
+        }
+
         self.write_opcode(Opcode::Return, last_line);
         self.pop_scope();
 
-        let code = self.code.clone();
-        self.code = prev_code;
-        // TODO: std::mem::swap?
+        std::mem::swap(&mut self.code, &mut old_code);
+        let code = old_code;
 
         let fn_upvalues = self.upvalues.iter().rev()
             .take_while(|uv| uv.depth == self.get_fn_depth())
@@ -1691,8 +1701,35 @@ impl TypedAstVisitor<(), ()> for Compiler {
         Ok(())
     }
 
-    fn visit_return(&mut self, _token: Token, _node: TypedReturnNode) -> Result<(), ()> {
-        todo!()
+    fn visit_return(&mut self, token: Token, node: TypedReturnNode) -> Result<(), ()> {
+        let has_return = if let Some(target) = node.target {
+            self.visit(*target)?;
+            true
+        } else { false };
+
+        let mut scopes_iter = self.scopes.iter().rev();
+        let mut split_idx = self.locals.len() as i64;
+        loop {
+            let Scope { num_locals, kind, .. } = scopes_iter.next().unwrap();
+            split_idx -= *num_locals as i64;
+            if kind == &ScopeKind::Func {
+                break;
+            }
+        }
+
+        let line = token.get_position().line;
+        if has_return {
+            self.write_store_local_instr(0, line);
+            self.metadata.stores.push("<ret>".to_string());
+        }
+
+        let mut locals_to_pop = self.locals.split_off(split_idx as usize);
+        self.write_pops_for_closure(&locals_to_pop, line);
+        self.locals.append(&mut locals_to_pop);
+
+        let return_jump_handle = self.begin_jump(Opcode::Jump, line);
+        self.return_handles.push(return_jump_handle);
+        Ok(())
     }
 }
 
@@ -4330,6 +4367,52 @@ mod tests {
                 }),
                 Value::Int(24),
                 Value::Str("f".to_string()),
+            ]),
+        };
+        assert_eq!(expected, chunk);
+    }
+
+    #[test]
+    fn compile_return_statement() {
+        let chunk = compile("\
+          func f() {\n\
+            if true { return 24 }\n\
+            return 6\n\
+          }\
+        ");
+        let expected = Module {
+            code: vec![
+                Opcode::IConst0 as u8,
+                Opcode::Constant as u8, 0, with_prelude_const_offset(0),
+                Opcode::GStore as u8,
+                Opcode::Constant as u8, 0, with_prelude_const_offset(3),
+                Opcode::Constant as u8, 0, with_prelude_const_offset(0),
+                Opcode::GStore as u8,
+                Opcode::Return as u8
+            ],
+            constants: with_prelude_consts(vec![
+                Value::Str("f".to_string()),
+                Value::Int(24),
+                Value::Int(6),
+                Value::Fn(FnValue {
+                    name: "f".to_string(),
+                    code: vec![
+                        Opcode::T as u8,
+                        Opcode::JumpIfF as u8, 0, 8,
+                        Opcode::Constant as u8, 0, with_prelude_const_offset(1),
+                        Opcode::LStore0 as u8,
+                        Opcode::Jump as u8, 0, 9,
+                        Opcode::Pop as u8,
+                        Opcode::Constant as u8, 0, with_prelude_const_offset(2),
+                        Opcode::LStore0 as u8,
+                        Opcode::Jump as u8, 0, 1,
+                        Opcode::LStore0 as u8,
+                        Opcode::Return as u8,
+                    ],
+                    upvalues: vec![],
+                    receiver: None,
+                    has_return: true,
+                }),
             ]),
         };
         assert_eq!(expected, chunk);

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -695,7 +695,14 @@ impl VM {
                 }
                 Opcode::MapLoad => {
                     let key = self.pop_expect()?;
-                    let obj = pop_expect_obj!(self)?;
+                    let obj = match self.pop_expect()? {
+                        Value::Obj(value) => value,
+                        Value::Nil => {
+                            self.push(Value::Nil);
+                            continue;
+                        }
+                        _ => unreachable!()
+                    };
                     let val = match &*obj.borrow() {
                         Obj::MapObj(value) => match value.get(&key) {
                             Some(val) => val.clone(),
@@ -739,7 +746,14 @@ impl VM {
                 }
                 Opcode::ArrLoad | Opcode::TupleLoad => {
                     let idx = pop_expect_int!(self)?;
-                    let obj = pop_expect_obj!(self)?;
+                    let obj = match self.pop_expect()? {
+                        Value::Obj(value) => value,
+                        Value::Nil => {
+                            self.push(Value::Nil);
+                            continue;
+                        }
+                        _ => unreachable!()
+                    };
                     let value = match &*obj.borrow() {
                         Obj::StringObj(values) => {
                             let len = values.len() as i64;

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -553,10 +553,7 @@ impl VM {
                     let val = pop_expect_bool!(self)?;
                     self.push(Value::Bool(!val));
                 }
-                Opcode::LT => {
-                    println!("");
-                    self.comp_values(Opcode::LT)?
-                },
+                Opcode::LT => self.comp_values(Opcode::LT)?,
                 Opcode::LTE => self.comp_values(Opcode::LTE)?,
                 Opcode::GT => self.comp_values(Opcode::GT)?,
                 Opcode::GTE => self.comp_values(Opcode::GTE)?,
@@ -863,10 +860,7 @@ impl VM {
                     self.push(value);
                 }
                 Opcode::LLoad0 => self.load_local(0)?,
-                Opcode::LLoad1 => {
-                    println!("");
-                    self.load_local(1)?
-                },
+                Opcode::LLoad1 => self.load_local(1)?,
                 Opcode::LLoad2 => self.load_local(2)?,
                 Opcode::LLoad3 => self.load_local(3)?,
                 Opcode::LLoad4 => self.load_local(4)?,

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1704,4 +1704,23 @@ mod tests {
         let expected = Value::Int(396);
         assert_eq!(expected, result);
     }
+
+    #[test]
+    pub fn interpret_return_statements() {
+        let input = r#"
+          func contains(arr: Int[], item: Int) {
+            for i in arr {
+              if item == i {
+                return true
+              }
+            }
+            false
+          }
+          val arr = [1, 2, 3, 4]
+          contains(arr, 4)
+        "#;
+        let result = interpret(input).unwrap();
+        let expected = Value::Bool(true);
+        assert_eq!(expected, result);
+    }
 }

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1064,18 +1064,34 @@ mod tests {
 
     #[test]
     fn interpret_while_loop_with_break() {
-        let input = "\
-          var a = 0\n\
-          while true {\n\
-            a = a + 1\n\
-            if a == 3 {\n\
-              break\n\
-            }\n\
-          }\n\
-          a\
-        ";
+        let input = r#"
+          var sum = 0
+          while true {
+            while true {
+              sum += 1
+              if sum.isEven() { break }
+            }
+            if sum > 20 { break }
+          }
+          sum
+        "#;
         let result = interpret(input).unwrap();
-        let expected = Value::Int(3);
+        let expected = Value::Int(22);
+        assert_eq!(expected, result);
+
+        let input = r#"
+          var sum = 0
+          while true {
+            if sum > 20 { break }
+            while true {
+              sum += 1
+              if sum.isEven() { break }
+            }
+          }
+          sum
+        "#;
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(22);
         assert_eq!(expected, result);
     }
 

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -524,6 +524,14 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
+                TypecheckerError::UnreachableCode { token } => {
+                    let mut obj = serializer.serialize_map(Some(3))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "unreachableCode")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -309,6 +309,14 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
+                TypecheckerError::InvalidReturn(token) => {
+                    let mut obj = serializer.serialize_map(Some(4))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidReturn")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
                 TypecheckerError::InvalidRequiredArgPosition(token) => {
                     let mut obj = serializer.serialize_map(Some(4))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
@@ -459,6 +467,7 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "duplicateMatchCase")?;
                     obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
                 TypecheckerError::NonExhaustiveMatch { token } => {
@@ -466,6 +475,7 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "nonExhaustiveMatch")?;
                     obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
                 TypecheckerError::EmptyMatchBlock { token } => {
@@ -473,6 +483,7 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "emptyMatchBlock")?;
                     obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
                 TypecheckerError::MatchBranchMismatch { token, expected, actual } => {
@@ -482,6 +493,7 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.serialize_entry("expected", &JsType(expected))?;
                     obj.serialize_entry("actual", &JsType(actual))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
                 TypecheckerError::InvalidUninitializedEnumVariant { token } => {
@@ -489,6 +501,7 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "invalidUninitializedEnumVariant")?;
                     obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
                 TypecheckerError::InvalidDestructuring { token, typ } => {
@@ -497,6 +510,7 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("subKind", "invalidDestructuring")?;
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.serialize_entry("type", &JsType(typ))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
                 TypecheckerError::InvalidDestructuringArity { token, typ, expected, actual } => {
@@ -507,6 +521,7 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("type", &JsType(typ))?;
                     obj.serialize_entry("expected", expected)?;
                     obj.serialize_entry("actual", actual)?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
             }

--- a/abra_wasm/src/js_value/token.rs
+++ b/abra_wasm/src/js_value/token.rs
@@ -127,6 +127,12 @@ impl<'a> Serialize for JsToken<'a> {
                 obj.serialize_entry("pos", &JsPosition(pos))?;
                 obj.end()
             }
+            Token::Return(pos, _) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "return")?;
+                obj.serialize_entry("pos", &JsPosition(pos))?;
+                obj.end()
+            }
             Token::Ident(pos, val) => {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "ident")?;


### PR DESCRIPTION
Addresses #210

- Parsing `return` expressions
- Return a typechecker error for unreachable code that falls after a
return statement (or any statement from which every path returns).
- Verify all returns typecheck to the same value. If they're all
undeterminable (aka `Unknown`, or empty `[]` or `{}`), compare by
structure (though we first try to determine the type based on
non-`Unknown` returns).
- This still supports returning the last expression in a function body.