### PR TITLE
Breaking change to function signatures

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,6 +1,16 @@
-func abc(): Int = def()
-func def(): String = "3"
-abc()
+//func abc(): String = def()
+//func def(): String = "3"
+//abc()
+
+//if true { if true { abc() } func abc() = println("") }
+if true { func def() { if true { abc() } } func abc() = println("") }
+
+//if true {
+//  if true {
+//    abc()
+//  }
+//  func abc() = println("")
+//}
 
 //func abc(): Int {
 //  func def(): Int = ghi()

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,1 +1,21 @@
-func a(): Int? = None
+func abc(): Int = def()
+func def(): String = "3"
+abc()
+
+//func abc(): Int {
+//  func def(): Int = ghi()
+//
+//  func ghi(): Int = 4
+//
+//  def()
+//}
+//
+//abc()
+
+//func a() {
+//  b()
+//}
+//
+//func b() {
+//  println("Ok")
+//}

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,4 +1,1 @@
-func abc() {
-  if true { println("hello") }
-}
-println(abc())
+func a(): Int? = None

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -3,7 +3,7 @@
 //abc()
 
 //if true { if true { abc() } func abc() = println("") }
-if true { func def() { if true { abc() } } func abc() = println("") }
+//if true { func def() { if true { abc() } } func abc() = println("") }
 
 //if true {
 //  if true {
@@ -12,15 +12,26 @@ if true { func def() { if true { abc() } } func abc() = println("") }
 //  func abc() = println("")
 //}
 
-//func abc(): Int {
-//  func def(): Int = ghi()
-//
-//  func ghi(): Int = 4
-//
-//  def()
-//}
-//
-//abc()
+func a() {
+  func b() {
+    func d() {
+      c()
+      b()
+    }
+  }
+  func c() { println("c") }
+}
+a()
+
+func abc(): Int {
+  func def(): Int = ghi()
+
+  func ghi(): Int = 4
+
+  def()
+}
+
+abc()
 
 //func a() {
 //  b()
@@ -29,3 +40,36 @@ if true { func def() { if true { abc() } } func abc() = println("") }
 //func b() {
 //  println("Ok")
 //}
+
+func abc2(): () => Int {
+  var count = -1
+
+  func def(): Int {
+    //val _fib = fib
+    count += 1
+
+    func qrs(): Int {
+      //_fib(count)
+      fib(count)
+    }
+    qrs()
+  }
+
+  func fib(n: Int): Int {
+    if n <= 1 {
+      return 1
+    }
+    fib(n - 1) + fib(n - 2)
+  }
+
+  def
+}
+
+val f = abc2()
+//println(f(7))
+println(f())
+println(f())
+println(f())
+println(f())
+println(f())
+println(f())

--- a/abra_core/src/builtins/native/native_array.rs
+++ b/abra_core/src/builtins/native/native_array.rs
@@ -661,9 +661,9 @@ mod test {
 
         // Verify deep call stack initiated from native fn call
         let result = interpret(r#"
-          func mult1(a: Int) = a * 1
-          func sub1(a: Int) = mult1(a) - 1
-          func sameNum(a: Int) = sub1(a) + 1
+          func mult1(a: Int): Int = a * 1
+          func sub1(a: Int): Int = mult1(a) - 1
+          func sameNum(a: Int): Int = sub1(a) + 1
           [1, 2].map(i => sameNum(i))
         "#);
         let expected = int_array![1, 2];

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -178,6 +178,8 @@ pub struct TypeDeclNode {
 pub struct EnumDeclNode {
     // Must be a Token::Ident
     pub name: Token,
+    // Must be Token::Idents
+    pub type_args: Vec<Token>,
     // Tokens represent arg idents, and must be Token::Ident
     pub variants: Vec<(/* ident: */ Token, /* args: */ Option<Vec<(Token, Option<TypeIdentifier>, Option<AstNode>)>>)>,
     pub methods: Vec<AstNode>,

--- a/abra_core/src/parser/parser.rs
+++ b/abra_core/src/parser/parser.rs
@@ -538,7 +538,8 @@ impl Parser {
         self.expect_next_token(TokenType::RBrace)?;
 
         if is_enum {
-            Ok(AstNode::EnumDecl(keyword_tok, EnumDeclNode { name, variants, methods }))
+            let type_args = vec![];
+            Ok(AstNode::EnumDecl(keyword_tok, EnumDeclNode { name, variants, methods, type_args }))
         } else {
             Ok(AstNode::TypeDecl(keyword_tok, TypeDeclNode { name, fields, methods, type_args }))
         }
@@ -2811,6 +2812,7 @@ mod tests {
             Token::Enum(Position::new(1, 1)),
             EnumDeclNode {
                 name: ident_token!((1, 6), "Color"),
+                type_args: vec![],
                 variants: vec![
                     (ident_token!((2, 1), "Red"), None),
                     (ident_token!((3, 1), "Blue"), None),
@@ -2826,6 +2828,7 @@ mod tests {
             Token::Enum(Position::new(1, 1)),
             EnumDeclNode {
                 name: ident_token!((1, 6), "Direction"),
+                type_args: vec![],
                 variants: vec![
                     (ident_token!((1, 18), "Red"), None),
                     (ident_token!((1, 23), "Blue"), None),
@@ -2841,6 +2844,7 @@ mod tests {
             Token::Enum(Position::new(1, 1)),
             EnumDeclNode {
                 name: ident_token!((1, 6), "Direction"),
+                type_args: vec![],
                 variants: vec![
                     (ident_token!((1, 18), "Red"), None),
                     (ident_token!((1, 23), "Blue"), None),

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -1715,9 +1715,9 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
 
                 if let Type::Fn(_) = typ {
                     for scope in self.scopes.iter_mut().rev() {
-                        if let ScopeKind::Function(func_token, func_name, _) = &scope.kind {
+                        if let ScopeKind::Function(_, func_name, ref mut is_recursive) = &mut scope.kind {
                             if &name == func_name {
-                                scope.kind = ScopeKind::Function(func_token.clone(), func_name.clone(), true);
+                                *is_recursive = true;
                             }
                         }
                     }

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -69,11 +69,23 @@ impl PartialEq for Type {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, Hash)]
 pub struct FnType {
     pub arg_types: Vec<(/* arg_name: */ String, /* arg_type: */ Type, /* is_optional: */ bool)>,
     pub type_args: Vec<String>,
     pub ret_type: Box<Type>,
+}
+
+impl PartialEq for FnType {
+    fn eq(&self, other: &Self) -> bool {
+        if !self.type_args.eq(&other.type_args) || !self.ret_type.eq(&other.ret_type) {
+            false
+        } else {
+            let arg_types = self.arg_types.iter().map(|(_, ty, is_o)| (ty, is_o)).collect::<Vec<_>>();
+            let other_arg_types = other.arg_types.iter().map(|(_, ty, is_o)| (ty, is_o)).collect::<Vec<_>>();
+            arg_types.eq(&other_arg_types)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -2303,7 +2303,7 @@ mod tests {
 
     #[test]
     fn compile_ident_upvalues() {
-        let chunk = compile("func a(i: Int) {\nval b = 3\nfunc c() { b + 1 }\n}");
+        let chunk = compile("func a(i: Int) {\nval b = 3\nfunc c(): Int { b + 1 }\n}");
         let expected = Module {
             code: vec![
                 Opcode::IConst0 as u8,
@@ -2358,7 +2358,7 @@ mod tests {
 
     #[test]
     fn compile_ident_upvalues_skip_level() {
-        let chunk = compile("func a(i: Int) {\nval b = 3\nfunc c() { func d() { b + 1 }\n}\n}");
+        let chunk = compile("func a(i: Int) {\nval b = 3\nfunc c() { func d(): Int { b + 1 }\n}\n}");
         let expected = Module {
             code: vec![
                 Opcode::IConst0 as u8,
@@ -2498,7 +2498,7 @@ mod tests {
 
     #[test]
     fn compile_assignment_globals() {
-        let chunk = compile("var a = 1\nfunc abc() { a = 3 }");
+        let chunk = compile("var a = 1\nfunc abc(): Int { a = 3 }");
         let expected = Module {
             code: vec![
                 Opcode::IConst1 as u8,
@@ -2537,7 +2537,7 @@ mod tests {
 
     #[test]
     fn compile_assignment_upvalues() {
-        let chunk = compile("func outer() {\nvar a = 1\nfunc inner() { a = 3 }\n}");
+        let chunk = compile("func outer() {\nvar a = 1\nfunc inner(): Int { a = 3 }\n}");
         let expected = Module {
             code: vec![
                 Opcode::IConst0 as u8,
@@ -2967,16 +2967,16 @@ mod tests {
 
     #[test]
     fn compile_function_declaration() {
-        let chunk = compile("\
-          val a = 1\n\
-          val b = 2\n\
-          val c = 3\n\
-          func abc(b: Int) {\n\
-            val a1 = a\n\
-            val c = b + a1\n\
-            c\n\
-          }\
-        ");
+        let chunk = compile(r#"
+          val a = 1
+          val b = 2
+          val c = 3
+          func abc(b: Int): Int {
+            val a1 = a
+            val c = b + a1
+            c
+          }
+        "#);
         let expected = Module {
             code: vec![
                 Opcode::IConst1 as u8,
@@ -3071,7 +3071,7 @@ mod tests {
 
     #[test]
     fn compile_function_declaration_default_args() {
-        let chunk = compile("func add(a: Int, b = 2) = a + b\nadd(1)\nadd(1, 2)");
+        let chunk = compile("func add(a: Int, b = 2): Int = a + b\nadd(1)\nadd(1, 2)");
         let expected = Module {
             code: vec![
                 Opcode::IConst0 as u8,
@@ -3127,13 +3127,13 @@ mod tests {
 
     #[test]
     fn compile_function_declaration_with_inner() {
-        let chunk = compile("\
-          func abc(b: Int) {\n\
-            func def(g: Int) { g + 1 }
-            val c = b + def(b)\n\
-            c\n\
-          }\
-        ");
+        let chunk = compile(r#"
+          func abc(b: Int): Int {
+            func def(g: Int): Int { g + 1 }
+            val c = b + def(b)
+            c
+          }
+        "#);
         let expected = Module {
             code: vec![
                 Opcode::IConst0 as u8,
@@ -3299,13 +3299,13 @@ mod tests {
 
     #[test]
     fn compile_function_invocation() {
-        let chunk = compile("\
-          val one = 1\n\
-          func inc(number: Int) {\n\
-            number + 1\n\
-          }\n
-          val two = inc(number: one)\
-        ");
+        let chunk = compile(r#"
+          val one = 1
+          func inc(number: Int): Int {
+            number + 1
+          }
+          val two = inc(number: one)
+        "#);
         let expected = Module {
             code: vec![
                 Opcode::IConst1 as u8,
@@ -4377,12 +4377,12 @@ mod tests {
 
     #[test]
     fn compile_return_statement() {
-        let chunk = compile("\
-          func f() {\n\
-            if true { return 24 }\n\
-            return 6\n\
-          }\
-        ");
+        let chunk = compile(r#"
+          func f(): Int {
+            if true { return 24 }
+            return 6
+          }
+        "#);
         let expected = Module {
             code: vec![
                 Opcode::IConst0 as u8,

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -354,7 +354,7 @@ impl VM {
             (Value::Int(a), Value::Int(b)) => {
                 self.push(Value::Int(f(a, b)))
             }
-            _ => unreachable!()
+            v@_ => {dbg!(v);unreachable!()}
         };
         Ok(())
     }
@@ -868,8 +868,12 @@ impl VM {
                     let stack_slot = self.read_byte_expect()?;
                     self.load_local(stack_slot)?
                 }
-                Opcode::ULoad0 => self.load_upvalue(0)?,
-                Opcode::ULoad1 => self.load_upvalue(1)?,
+                Opcode::ULoad0 => {
+                    self.load_upvalue(0)?
+                },
+                Opcode::ULoad1 => {
+                    self.load_upvalue(1)?
+                },
                 Opcode::ULoad2 => self.load_upvalue(2)?,
                 Opcode::ULoad3 => self.load_upvalue(3)?,
                 Opcode::ULoad4 => self.load_upvalue(4)?,

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -105,7 +105,7 @@ mod tests {
     fn interpret_binary_boolean_short_circuiting() {
         let preface = "\n\
           var called = false\n\
-          func getTrue() {\n\
+          func getTrue(): Bool {\n\
             called = true\n\
             true\n\
           }\n\
@@ -114,7 +114,7 @@ mod tests {
         let input = format!("{}\n\
           val res = true || getTrue()
           res + \" \" + called",
-                            preface
+          preface
         );
         let result = interpret(&input).unwrap();
         let expected = new_string_obj("true false");
@@ -123,7 +123,7 @@ mod tests {
         let input = format!("{}\n\
           val res = false && getTrue()
           res + \" \" + called",
-                            preface
+          preface
         );
         let result = interpret(&input).unwrap();
         let expected = new_string_obj("false false");
@@ -623,14 +623,14 @@ mod tests {
 
     #[test]
     fn interpret_if_else_expressions() {
-        let input = "\
-          val abc = if (1 != 2) {\
-            123\
-          } else {\
-            456\
-          }\
+        let input = r#"
+          val abc = if (1 != 2) {
+            123
+          } else {
+            456
+          }
           abc
-        ";
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Int(123);
         assert_eq!(expected, result);
@@ -640,16 +640,16 @@ mod tests {
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
-        let input = "\
-          func abc() {\n\
-            val a = 20\n\
-            4 + if (true) {\n\
-              val b = 123\n\
-              a\n\
-            } else { 0 }\n\
-          }\n\
-          abc()\
-        ";
+        let input = r#"
+          func abc(): Int {
+            val a = 20
+            4 + if (true) {
+              val b = 123
+              a
+            } else { 0 }
+          }
+          abc()
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Int(24);
         assert_eq!(expected, result);
@@ -735,9 +735,9 @@ mod tests {
     #[test]
     fn interpret_func_invocation_closures() {
         let input = "\
-          func getCounter() {\n\
+          func getCounter(): () => Int {\n\
             var count = 100\n\
-            func tick() { count = count + 1 }\n\
+            func tick(): Int { count = count + 1 }\n\
             count = 0\n\
             tick\n\
           }\n\
@@ -757,11 +757,11 @@ mod tests {
 
         // Test deeply nested upvalue access
         let input = "\
-          func getCounter() {\n\
+          func getCounter(): () => Int {\n\
             var count = 100\n\
-            func unnecessaryLayer1() {\n\
-              func unnecessaryLayer2() {\n\
-                func tick() { count = count + 1 }\n\
+            func unnecessaryLayer1(): () => () => Int {\n\
+              func unnecessaryLayer2(): () => Int {\n\
+                func tick(): Int { count = count + 1 }\n\
                 tick\n\
               }\n\
               unnecessaryLayer2\n\
@@ -786,39 +786,39 @@ mod tests {
 
     #[test]
     fn interpret_func_invocation_closures_upvalues_not_yet_closed() {
-        let input = "\
-          func abc() {\n\
-            val a = 20\n\
-            func def() { a }\n\
-            4 + def()\n\
-          }\n\
-          abc()\
-        ";
+        let input = r#"
+          func abc(): Int {
+            val a = 20
+            func def(): Int { a }
+            4 + def()
+          }
+          abc()
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
-        let input = "\
-          func abc() {\n\
-            var a = 20\n\
-            func wrapper() {\n\
-              val b = 123\n\
-              func wrapper2() {\n\
-                val c = 456\n\
-                if (true) {\n\
-                  val b = 456\n\
-                  a = 24\n\
-                  a\n\
-                } else {\n\
-                  0\n\
-                }\n\
-              }\n\
-              wrapper2()\n\
-            }\n\
-            wrapper()\n\
-          }\n\
-          abc()\
-        ";
+        let input = r#"
+          func abc(): Int {
+            var a = 20
+            func wrapper(): Int {
+              val b = 123
+              func wrapper2(): Int {
+                val c = 456
+                if (true) {
+                  val b = 456
+                  a = 24
+                  a
+                } else {
+                  0
+                }
+              }
+              wrapper2()
+            }
+            wrapper()
+          }
+          abc()
+        "#;
 
         let result = interpret(input).unwrap();
         let expected = Value::Int(24);
@@ -829,11 +829,11 @@ mod tests {
     fn interpret_func_invocation_callstack() {
         let input = "\
           val greeting = \"Hello\"\n\
-          func exclaim(word: String) {\n\
+          func exclaim(word: String): String {\n\
             val abc = 123\n\
             word + \"!\"\n\
           }\n\
-          func greet(recipient: String) {\n\
+          func greet(recipient: String): String {\n\
             greeting + \", \" + exclaim(recipient)\n\
           }\n\
           val languageName = \"Abra\"\n\
@@ -846,22 +846,22 @@ mod tests {
 
     #[test]
     fn interpret_func_invocation_nested_if() {
-        let input = "\
-          val prefix = \"Save the\"\n\
-          func exclaim(word: String) {\n\
-            val abc = 123\n\
-            word + \"!\"\n\
-          }\n\
-          func save(recipient: String) {\n\
-            if (recipient == \"World\") {
+        let input = r#"
+          val prefix = "Save the"
+          func exclaim(word: String): String {
+            val abc = 123
+            word + "!"
+          }
+          func save(recipient: String): String {
+            if (recipient == "World") {
               val target = exclaim(recipient)
-              prefix + \" \" + target\n\
+              prefix + " " + target
             } else {
-              prefix + \" \" + recipient\n\
+              prefix + " " + recipient
             }
-          }\n\
-          save(\"Cheerleader\") + \", \" + save(\"World\")\n\
-        ";
+          }
+          save("Cheerleader") + ", " + save("World")
+        "#;
         let result = interpret(input).unwrap();
         let expected = new_string_obj("Save the Cheerleader, Save the World!");
         assert_eq!(expected, result);
@@ -932,10 +932,10 @@ mod tests {
 
     #[test]
     fn interpret_func_invocation_default_args() {
-        let input = "\
-          func abc(a: Int = 2, b = 3, c = 5) { a * b * c }\n\
-          [abc(), abc(7), abc(7, 11), abc(7, 11, 13)]\n\
-        ";
+        let input = r#"
+          func abc(a: Int = 2, b = 3, c = 5): Int { a * b * c }
+          [abc(), abc(7), abc(7, 11), abc(7, 11, 13)]
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::new_array_obj(vec![
             Value::Int(30),
@@ -948,30 +948,30 @@ mod tests {
 
     #[test]
     fn interpret_func_invocation_default_args_closure() {
-        let input = "
+        let input = r#"
           var called = false
-          func getOne() {
+          func getOne(): Int {
             called = true
             1
           }
-          func abc(def = getOne()) = def
+          func abc(def = getOne()): Int = def
           abc(1)
           called
-        ";
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Bool(false);
         assert_eq!(expected, result);
 
-        let input = "
+        let input = r#"
           var called = false
-          func getOne() {
+          func getOne(): Int {
             called = true
             1
           }
-          func abc(def = getOne()) = def
+          func abc(def = getOne()): Int = def
           abc()
           called
-        ";
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
@@ -979,17 +979,17 @@ mod tests {
 
     #[test]
     fn interpret_func_invocation_default_args_laziness() {
-        let input = "
-          func getOne() = 1
-          func outer() {
-            func abc(def = getOne(), ghi = def, jkl = def + ghi) {
+        let input = r#"
+          func getOne(): Int = 1
+          func outer(): () => Int {
+            func abc(def = getOne(), ghi = def, jkl = def + ghi): Int {
               def + ghi + jkl
             }
             abc
           }
           val fn = outer()
           fn()
-        ";
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Int(4);
         assert_eq!(expected, result);
@@ -1517,7 +1517,7 @@ mod tests {
             }
           }
 
-          func sum(list: Int[]) = list.reduce(0, (acc, i) => acc + i)
+          func sum(list: Int[]): Int = list.reduce(0, (acc, i) => acc + i)
 
           var list: List<Int> = List(items: [])
           for n in range(1, 500) { list.push(n) }
@@ -1536,28 +1536,28 @@ mod tests {
 
     #[test]
     fn interpret_lambdas() {
-        let input = "\
-          func call(fn: (Int) => Int, value: Int) = fn(value)\n\
-          call(x => x + 1, 23)\
-        ";
+        let input = r#"
+          func call(fn: (Int) => Int, value: Int): Int = fn(value)
+          call(x => x + 1, 23)
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
-        let input = "\
-          func call(fn: (Int) => Int, value: Int) = fn(value)\n\
-          call((x, y = 1) => x + y + 1, 22)\
-        ";
+        let input = r#"
+          func call(fn: (Int) => Int, value: Int): Int = fn(value)
+          call((x, y = 1) => x + y + 1, 22)
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
-        let input = "\
-          func getAdder(x: Int): (Int) => Int {\n\
-            (y, z = 3) => x + y + z\n\
-          }\n\
-          getAdder(20)(1)\
-        ";
+        let input = r#"
+          func getAdder(x: Int): (Int) => Int {
+            (y, z = 3) => x + y + z
+          }
+          getAdder(20)(1)
+        "#;
         let result = interpret(input).unwrap();
         let expected = Value::Int(24);
         assert_eq!(expected, result);
@@ -1657,7 +1657,7 @@ mod tests {
         // whether a non-root-scope function will be correctly recognized as recursive if its only
         // usage is within a lambda
         let input = r#"
-          func abc() {
+          func abc(): Int {
             func def(nums: Int[]): Int {
               if nums[0] |n| {
                 n + nums[1:].reduce(0, (acc, i) => acc + def([i]))
@@ -1708,7 +1708,7 @@ mod tests {
     #[test]
     pub fn interpret_return_statements() {
         let input = r#"
-          func contains(arr: Int[], item: Int) {
+          func contains(arr: Int[], item: Int): Bool {
             for i in arr {
               if item == i {
                 return true

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -292,15 +292,6 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
-                TypecheckerError::RecursiveRefWithoutReturnType { orig_token, token } => {
-                    let mut obj = serializer.serialize_map(Some(6))?;
-                    obj.serialize_entry("kind", "typecheckerError")?;
-                    obj.serialize_entry("subKind", "recursiveRefWithoutReturnType")?;
-                    obj.serialize_entry("token", &JsToken(token))?;
-                    obj.serialize_entry("origToken", &JsToken(orig_token))?;
-                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
-                    obj.end()
-                }
                 TypecheckerError::InvalidBreak(token) => {
                     let mut obj = serializer.serialize_map(Some(4))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
@@ -402,14 +393,6 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     let mut obj = serializer.serialize_map(Some(4))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "invalidSelfParam")?;
-                    obj.serialize_entry("token", &JsToken(token))?;
-                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
-                    obj.end()
-                }
-                TypecheckerError::MissingRequiredTypeAnnotation { token } => {
-                    let mut obj = serializer.serialize_map(Some(4))?;
-                    obj.serialize_entry("kind", "typecheckerError")?;
-                    obj.serialize_entry("subKind", "missingRequiredTypeAnnotation")?;
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
@@ -529,6 +512,19 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "unreachableCode")?;
                     obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
+                TypecheckerError::ReturnTypeMismatch { token, fn_name, fn_missing_ret_ann, bare_return, expected, actual } => {
+                    let mut obj = serializer.serialize_map(Some(9))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "returnTypeMismatch")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("fnName", fn_name)?;
+                    obj.serialize_entry("fnMissingReturnAnnotation", fn_missing_ret_ann)?;
+                    obj.serialize_entry("bareReturn", bare_return)?;
+                    obj.serialize_entry("expected", &JsType(expected))?;
+                    obj.serialize_entry("actual", &JsType(actual))?;
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }


### PR DESCRIPTION
Contributes to #67 

- Previously, functions' return types could be inferred from the body.
However, this inference became very complicated, especially when trying
to typecheck functions which reference not-yet-defined functions. So for
now, the breaking change is that **all functions will now be required to
have a return type annotation**. This could change in the future (I
hope), but it certainly makes a lot of things easier for now.
- Because of this new requirement, we can actually clean a bunch of
stuff up. Return types can no longer by `Unknown`, so we get to remove a
bunch of code related to that. All functions will have return types, so
we don't need to handle recursive functions separately; so that error
can be deleted entirely. Same goes for the `MissingRequiredReturnType`
error that had previously been thrown for methods within a typedef. Good
cleanup all around!

**Minor bug fix**:
- The prior implementation of "hoisting" allowed for potential
situations where functions were accessed before they were actually
defined. This can lead to all sorts of weird scenarios, like:
```
if true {
  if true {
    abc() // This references `a`, which hasn't been defined yet
  }
  var a = "hello"
  func abc() = println(a)
}
```
To mitigate this situation, we keep track of the function definitions in
each scope in a first pass over that scope, and then use those
definitions as part of binding resolution. If we've crossed a function
boundary, then fns in outer scopes are eligible for calling.

**Functions can be referenced out-of-order**:
- Functions in a given scope can now be referenced and called out of
declaration order. This applies to the root-level scope, nested function
scopes, if-/match-expressions, if while-/for-loops.
- This also fixes an upvalue issue that had been present before. The
following code would not work before:
```
func a() {
  func b() = println("hello")
  func c() {
    func d() = b()
  }
}
```
Since `b` was not in `c`'s scope, we have to look up an additional level
to `a`'s scope; it's there, so we create an upvalue in `a`'s scope and
also in `c`'s scope. This was fine, this had worked before. The problem
however was in the code to peel upvalues off of the array based on
fn_depth. Since the intermediate, transitive upvalue was added in
between 2 higher-depth upvalues, the existing code would not pick it off
of the list. The updated logic now fixes that.