### PR TITLE
Destructuring: For-loops

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -4,8 +4,13 @@
 //println(h)
 //println(m)
 //println(t)
-val [[a], [d], [g, *h]] = ["abc", "def", "ghi"]
-h
+//val [[a], [d], [g, *h]] = ["abc", "def", "ghi"]
+//h
 
 //val [a, *b] = [1, 2, 3]
 //b
+
+val coords = [(1, 2), (3, 4), (5, 6)]
+for (x, y), idx in coords {
+  println("(" + x + ", " + y + "): " + idx)
+}

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -237,7 +237,7 @@ pub struct InvocationNode {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForLoopNode {
-    pub iteratee: Token,
+    pub binding: BindingPattern,
     pub index_ident: Option<Token>,
     pub iterator: Box<AstNode>,
     pub body: Vec<AstNode>,

--- a/abra_core/src/parser/parser.rs
+++ b/abra_core/src/parser/parser.rs
@@ -3974,7 +3974,7 @@ mod tests {
     #[test]
     fn parse_for_loop_error() {
         let error = parse("for 123 in [0, 1] { a }").unwrap_err();
-        let expected = ParseError::ExpectedToken(TokenType::Ident, Token::Int(Position::new(1, 5), 123));
+        let expected = ParseError::UnexpectedToken(Token::Int(Position::new(1, 5), 123));
         assert_eq!(expected, error);
 
         let error = parse("for a [0, 1] { a }").unwrap_err();

--- a/abra_core/src/parser/parser.rs
+++ b/abra_core/src/parser/parser.rs
@@ -635,12 +635,7 @@ impl Parser {
     fn parse_for_statement(&mut self) -> Result<AstNode, ParseError> {
         let token = self.expect_next()?;
 
-        let iteratee = self.expect_next().and_then(|tok| {
-            match tok {
-                Token::Ident(_, _) => Ok(tok),
-                _ => Err(ParseError::ExpectedToken(TokenType::Ident, tok))
-            }
-        })?;
+        let binding = self.parse_binding_pattern()?;
 
         let index_ident = if let Some(Token::Comma(_)) = self.peek() {
             self.expect_next()?; // Consume ','
@@ -659,7 +654,7 @@ impl Parser {
         let iterator = Box::new(self.parse_expr()?);
         let body = self.parse_expr_or_block()?;
 
-        Ok(AstNode::ForLoop(token, ForLoopNode { iteratee, index_ident, iterator, body }))
+        Ok(AstNode::ForLoop(token, ForLoopNode { binding, index_ident, iterator, body }))
     }
 
     fn parse_while_statement(&mut self) -> Result<AstNode, ParseError> {
@@ -3911,7 +3906,7 @@ mod tests {
         let expected = AstNode::ForLoop(
             Token::For(Position::new(1, 1)),
             ForLoopNode {
-                iteratee: ident_token!((1, 5), "a"),
+                binding: BindingPattern::Variable(ident_token!((1, 5), "a")),
                 index_ident: None,
                 iterator: Box::new(AstNode::Array(
                     Token::LBrack(Position::new(1, 10), false),
@@ -3931,7 +3926,7 @@ mod tests {
         let expected = AstNode::ForLoop(
             Token::For(Position::new(1, 1)),
             ForLoopNode {
-                iteratee: ident_token!((1, 5), "a"),
+                binding: BindingPattern::Variable(ident_token!((1, 5), "a")),
                 index_ident: Some(ident_token!((1, 8), "i")),
                 iterator: Box::new(AstNode::Array(
                     Token::LBrack(Position::new(1, 13), false),
@@ -3943,6 +3938,32 @@ mod tests {
                     },
                 )),
                 body: vec![identifier!((1, 22), "a")],
+            },
+        );
+        assert_eq!(expected, ast[0]);
+
+        let ast = parse("for (x, y), i in [a, b] { x }")?;
+        let expected = AstNode::ForLoop(
+            Token::For(Position::new(1, 1)),
+            ForLoopNode {
+                binding: BindingPattern::Tuple(
+                    Token::LParen(Position::new(1, 5), false),
+                    vec![
+                        BindingPattern::Variable(ident_token!((1, 6), "x")),
+                        BindingPattern::Variable(ident_token!((1, 9), "y"))
+                    ],
+                ),
+                index_ident: Some(ident_token!((1, 13), "i")),
+                iterator: Box::new(AstNode::Array(
+                    Token::LBrack(Position::new(1, 18), false),
+                    ArrayNode {
+                        items: vec![
+                            identifier!((1, 19), "a"),
+                            identifier!((1, 22), "b")
+                        ]
+                    },
+                )),
+                body: vec![identifier!((1, 27), "x")],
             },
         );
         assert_eq!(expected, ast[0]);

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -2389,16 +2389,11 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
 
         self.scopes.push(Scope::new(ScopeKind::Block)); // Wrap loop in block where intrinsic variables $idx and $iter will be stored
         self.scopes.push(Scope::new(ScopeKind::Loop));
-        // let mut scope = Scope::new(ScopeKind::Loop);
         self.visit_binding_pattern(&mut binding, &iteratee_type, false)?;
-        // let iteratee_name = Token::get_ident_name(&iteratee).clone();
-        // scope.bindings.insert(iteratee_name, ScopeBinding(iteratee.clone(), iteratee_type, false));
         if let Some(ident) = &index_ident {
             let ident_name = Token::get_ident_name(&ident).clone();
-            // scope.bindings.insert(ident_name, ScopeBinding(ident.clone(), index_type, false));
             self.add_binding(ident_name.as_str(), ident, &index_type, false);
         }
-        // self.scopes.push(scope);
 
         self.hoist_declarations_in_scope(&body)?;
         let body = self.visit_block(true, body)?;

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -278,7 +278,7 @@ pub struct TypedWhileLoopNode {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TypedForLoopNode {
-    pub iteratee: Token,
+    pub binding: BindingPattern,
     pub index_ident: Option<Token>,
     pub iterator: Box<TypedAstNode>,
     pub body: Vec<TypedAstNode>,

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -1742,7 +1742,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
     fn visit_for_loop(&mut self, token: Token, node: TypedForLoopNode) -> Result<(), ()> {
         let line = token.get_position().line;
 
-        let TypedForLoopNode { iteratee, index_ident, iterator, body } = node;
+        let TypedForLoopNode { binding, index_ident, iterator, body } = node;
         let iterator_type = iterator.get_type();
 
         // Push intrinsic variable $idx, to track position in $iter
@@ -1801,7 +1801,8 @@ impl TypedAstVisitor<(), ()> for Compiler {
         self.write_opcode(Opcode::ArrLoad, line);
         self.write_opcode(Opcode::IConst0, line);
         self.write_opcode(Opcode::TupleLoad, line);
-        self.push_local(Token::get_ident_name(&iteratee), line, true);
+        // self.push_local(Token::get_ident_name(&iteratee), line, true);
+        self.visit_pattern(binding);
         if let Some(ident) = index_ident {
             // If present, index = $iter[$idx][1]
             load_intrinsic(self, "$iter", line);

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -1795,13 +1795,13 @@ impl TypedAstVisitor<(), ()> for Compiler {
         // Insert iteratee and index bindings (if indexer expected) into loop scope
         //   $iter[$idx] is a tuple, of (<iteratee>, <index>)
         //   So, iteratee = $iter[$idx][0]
+        // This value will then be destructured, if a pattern is used
         self.push_scope(ScopeKind::Block);
         load_intrinsic(self, "$iter", line);
         load_intrinsic(self, "$idx", line);
         self.write_opcode(Opcode::ArrLoad, line);
         self.write_opcode(Opcode::IConst0, line);
         self.write_opcode(Opcode::TupleLoad, line);
-        // self.push_local(Token::get_ident_name(&iteratee), line, true);
         self.visit_pattern(binding);
         if let Some(ident) = index_ident {
             // If present, index = $iter[$idx][1]

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -1931,4 +1931,31 @@ mod tests {
         let expected = Value::Int(10);
         assert_eq!(expected, result);
     }
+
+    #[test]
+    fn interpret_destructuring_for_loop() {
+        let input = r#"
+          val coords = [(1, 2), (3, 4), (5, 6)]
+          var total = 0
+          for (x, y), i in coords {
+            total += (x + y + i)
+          }
+          total
+        "#;
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = r#"
+          val arrays = [[1], [2, 3], [4, 5, 6]]
+          var total = 0
+          for [_, *r], i in arrays {
+            total += (r.length + i)
+          }
+          total
+        "#;
+        let result = interpret(input).unwrap();
+        let expected = Value::Int(6);
+        assert_eq!(expected, result);
+    }
 }


### PR DESCRIPTION
- Adding the ability to destructure the iteratee in a for-loop, just
like how we can currently destructure assignments.