### PR TITLE
Varargs in stdlib methods

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,6 +1,5 @@
-func abc(a: Int, *b: Int[]) {
-  println()
-  println(a, b)
-}
+println("abc".concat(true, [1, 2, 3], { a: 1 }))
 
-abc(a: 1, b: [3])
+val arr = [1, 2, 3]
+arr.push(4, 5, "6")
+arr

--- a/abra_core/src/builtins/native_types.abra
+++ b/abra_core/src/builtins/native_types.abra
@@ -32,6 +32,7 @@ type NativeString {
   func chars(self): String[] {}
   func parseInt(self, radix: Int = 10): Int? {}
   func parseFloat(self): Float? {}
+  func concat(self, str: Any, *others: Any[]): String {}
 }
 
 type NativeArray<T> {
@@ -43,7 +44,7 @@ type NativeArray<T> {
   func toString(self): String {}
   func isEmpty(self): Bool {}
   func enumerate(self): (T, Int)[] {}
-  func push(self, item: T): Unit {}
+  func push(self, item: T, *others: T[]): Unit {}
   func pop(self): T? {}
   func popFront(self): T? {}
   func splitAt(self, index: Int): (T[], T[]) {}

--- a/gen_native_types/src/main.rs
+++ b/gen_native_types/src/main.rs
@@ -44,6 +44,7 @@ fn generate_code_for_type(typ: &Type) -> TokenStream {
         Type::Float => "Float".to_string(),
         Type::String => "String".to_string(),
         Type::Unit => "Unit".to_string(),
+        Type::Any => "Any".to_string(),
         Type::Reference(ref_name, _) => ref_name.replace("Native", ""),
         Type::Array(inner_type) => {
             let inner_type_code = generate_code_for_type(inner_type);


### PR DESCRIPTION
- Add support for having varargs methods in standard library types'
methods, and add two: `Array::push` and the new method `String::concat`.
This second method will be used to facilitate string interpolation.