### PR TITLE
Improving performance for native types

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,1 +1,2 @@
-(-6).toString()
+val arr = [1, 2, 3]
+arr.length = 4

--- a/abra_core/src/builtins/arguments.rs
+++ b/abra_core/src/builtins/arguments.rs
@@ -1,4 +1,4 @@
-use crate::vm::value::{Value, Obj};
+use crate::vm::value::Value;
 use std::vec::IntoIter;
 use std::collections::HashSet;
 
@@ -67,12 +67,7 @@ impl<'a> Arguments<'a> {
 
     pub fn next_string(&mut self) -> String {
         match self.args.next() {
-            Some(Value::Obj(obj)) => {
-                match &*(obj.borrow()) {
-                    Obj::NativeInstanceObj(i) => i.as_string().unwrap()._inner.clone(),
-                    _ => unreachable!()
-                }
-            }
+            Some(Value::StringObj(o)) => o.borrow()._inner.clone(),
             Some(v) => unreachable!(format!("Expected String, received {}", v)),
             None => unreachable!(self.error_str()),
         }
@@ -80,12 +75,7 @@ impl<'a> Arguments<'a> {
 
     pub fn next_string_or_default<S: AsRef<str>>(&mut self, default: S) -> String {
         match self.args.next() {
-            Some(Value::Obj(obj)) => {
-                match &*(obj.borrow()) {
-                    Obj::NativeInstanceObj(i) => i.as_string().unwrap()._inner.clone(),
-                    _ => unreachable!()
-                }
-            }
+            Some(Value::StringObj(o)) => o.borrow()._inner.clone(),
             Some(Value::Nil) => default.as_ref().to_string(),
             Some(v) => unreachable!(format!("Expected String, received {}", v)),
             None => unreachable!(self.error_str()),
@@ -94,12 +84,7 @@ impl<'a> Arguments<'a> {
 
     pub fn next_array(&mut self) -> Vec<Value> {
         match self.args.next() {
-            Some(Value::Obj(obj)) => {
-                match &*(obj.borrow()) {
-                    Obj::NativeInstanceObj(i) => i.as_array().unwrap()._inner.clone(),
-                    _ => unreachable!()
-                }
-            }
+            Some(Value::ArrayObj(o)) => (&*o.borrow())._inner.clone(),
             Some(v) => unreachable!(format!("Expected Array, received {}", v)),
             None => unreachable!(self.error_str()),
         }
@@ -107,12 +92,7 @@ impl<'a> Arguments<'a> {
 
     pub fn next_set(&mut self) -> HashSet<Value> {
         match self.args.next() {
-            Some(Value::Obj(obj)) => {
-                match &*(obj.borrow()) {
-                    Obj::NativeInstanceObj(i) => i.as_set().unwrap()._inner.clone(),
-                    _ => unreachable!()
-                }
-            }
+            Some(Value::SetObj(o)) => (&*o.borrow())._inner.clone(),
             Some(v) => unreachable!(format!("Expected Set, received {}", v)),
             None => unreachable!(self.error_str()),
         }
@@ -128,12 +108,7 @@ impl<'a> Arguments<'a> {
     pub fn varargs(mut self) -> Vec<Value> {
         // Note:   ^ consumes self, since no other args can be accessed after varargs
         match self.args.next() {
-            Some(Value::Obj(obj)) => {
-                match &*(obj.borrow()) {
-                    Obj::NativeInstanceObj(i) => i.as_array().unwrap()._inner.clone(),
-                    _ => unreachable!()
-                }
-            }
+            Some(Value::ArrayObj(o)) => (*o.borrow())._inner.clone(),
             Some(Value::Nil) => vec![],
             Some(v) => unreachable!(format!("Expected Array, received {}", v)),
             None => unreachable!(self.error_str()),

--- a/abra_core/src/builtins/native/common.rs
+++ b/abra_core/src/builtins/native/common.rs
@@ -1,48 +1,7 @@
 use crate::vm::vm::VM;
-use crate::vm::value::{Value, FnValue, ClosureValue, TypeValue, EnumValue, Obj, EnumVariantObj};
-use crate::typechecker::types::Type;
+use crate::vm::value::{Value, FnValue, ClosureValue, TypeValue, EnumValue, EnumVariantObj};
 use crate::builtins::native_fns::NativeFn;
 use itertools::Itertools;
-
-pub trait NativeType {
-    fn get_field_type(name: &str) -> Option<(usize, Type)>;
-    fn get_method_type(name: &str) -> Option<(usize, Type)>;
-    fn get_static_field_or_method(name: &str) -> Option<(usize, Type)>;
-    fn get_field_value(obj: Box<Value>, field_idx: usize) -> Value;
-    fn get_method_value(obj: Box<Value>, method_idx: usize) -> Value;
-    fn get_static_field_values() -> Vec<(String, Value)>;
-
-    fn get_field_idx(field_name: &str) -> usize {
-        match Self::get_field_type(field_name) {
-            Some((idx, _)) => idx,
-            None => unreachable!()
-        }
-    }
-
-    fn get_method_idx(field_name: &str) -> usize {
-        match Self::get_method_type(field_name) {
-            Some((idx, _)) => idx,
-            None => unreachable!()
-        }
-    }
-
-    fn get_field_or_method_type(field_name: &str) -> Option<(usize, Type, bool)> {
-        Self::get_field_type(field_name)
-            .map(|(idx, typ)| (idx, typ, false))
-            .or_else(|| {
-                Self::get_method_type(field_name)
-                    .map(|(idx, typ)| (idx, typ, true))
-            })
-    }
-
-    fn get_field_or_method_value(is_method: bool, inst: Box<Value>, idx: usize) -> Value {
-        if is_method {
-            Self::get_method_value(inst, idx)
-        } else {
-            Self::get_field_value(inst, idx)
-        }
-    }
-}
 
 pub fn invoke_fn(vm: &mut VM, fn_obj: &Value, args: Vec<Value>) -> Value {
     let res = vm.invoke_fn(args, fn_obj.clone());
@@ -56,19 +15,14 @@ pub fn invoke_fn(vm: &mut VM, fn_obj: &Value, args: Vec<Value>) -> Value {
 }
 
 pub fn default_to_string_method(receiver: Option<Value>, _args: Vec<Value>, vm: &mut VM) -> Option<Value> {
-    let str_val = if let Value::Obj(obj) = receiver.unwrap() {
-        match &*(obj.borrow()) {
-            Obj::InstanceObj(obj) => {
-                let type_name = &obj.typ.name;
-                let field_names = &obj.typ.fields;
-                let values = field_names.iter().zip(&obj.fields)
-                    .map(|(field_name, field_value)| format!("{}: {}", field_name, to_string(field_value, vm)))
-                    .join(", ");
-                format!("{}({})", type_name, values)
-            }
-            _ => unreachable!()
-        }
-    } else { unreachable!() };
+    let rcv = receiver.unwrap();
+    let obj = &*rcv.as_instance_obj().borrow();
+    let type_name = &obj.typ.name;
+    let field_names = &obj.typ.fields;
+    let values = field_names.iter().zip(&obj.fields)
+        .map(|(field_name, field_value)| format!("{}: {}", field_name, to_string(field_value, vm)))
+        .join(", ");
+    let str_val = format!("{}({})", type_name, values);
 
     Some(Value::new_string_obj(str_val))
 }
@@ -88,50 +42,56 @@ pub fn to_string(value: &Value, vm: &mut VM) -> String {
             let items = arr._inner.iter().map(|v| to_string(v, vm)).join(", ");
             format!("[{}]", items)
         }
+        Value::TupleObj(o) => {
+            let tup = &*o.borrow();
+            let items = tup.iter().map(|v| to_string(v, vm)).join(", ");
+            format!("({})", items)
+        }
         Value::SetObj(o) => {
             let set = &*o.borrow();
             let items = set._inner.iter().map(|v| to_string(v, vm)).join(", ");
             format!("#{{{}}}", items)
         }
-        Value::Obj(obj) => {
-            match &*(obj.borrow()) {
-                Obj::TupleObj(value) => {
-                    let items = value.iter()
+        Value::MapObj(o) => {
+            let map = &*o.borrow();
+            let fields = map._inner.iter()
+                .map(|(k, v)| {
+                    let k = to_string(k, vm);
+                    let v = to_string(v, vm);
+                    format!("{}: {}", k, v)
+                })
+                .join(", ");
+            format!("{{ {} }}", fields)
+        },
+        Value::InstanceObj(o) => {
+            let o = &*o.borrow();
+
+            let mut tostring_method = o.typ.methods.iter()
+                .find(|(name, _)| name == "toString")
+                .map(|(_, m)| m)
+                .expect("Every instance should have at least the default toString method")
+                .clone();
+            tostring_method.bind_fn_value(value.clone());
+
+            let ret = invoke_fn(vm, &tostring_method, vec![]);
+            let ret = &*ret.as_string().borrow();
+            ret._inner.clone()
+        }
+        Value::NativeInstanceObj(o) => {
+            let i = &*o.borrow();
+            let v = i.inst.method_to_string(vm);
+            let v = &*v.as_string().borrow();
+            v._inner.clone()
+        }
+        Value::EnumVariantObj(o) => {
+            let EnumVariantObj { enum_name, name, values, .. } = &*o.borrow();
+            match values {
+                None => format!("{}.{}", enum_name, name),
+                Some(values) => {
+                    let values = values.iter()
                         .map(|v| to_string(v, vm))
                         .join(", ");
-                    format!("({})", items)
-                }
-                Obj::InstanceObj(o) => {
-                    let mut tostring_method = o.typ.methods.iter()
-                        .find(|(name, _)| name == "toString")
-                        .map(|(_, m)| m)
-                        .expect("Every instance should have at least the default toString method")
-                        .clone();
-                    match &mut tostring_method {
-                        Value::Fn(fn_value) => fn_value.receiver = Some(Box::new(value.clone())),
-                        Value::NativeFn(native_fn_value) => native_fn_value.receiver = Some(Box::new(value.clone())),
-                        _ => unreachable!()
-                    }
-                    if let Value::StringObj(o) = invoke_fn(vm, &tostring_method, vec![]) {
-                        o.borrow()._inner.clone()
-                    } else { unreachable!() }
-                }
-                Obj::NativeInstanceObj(i) => {
-                    let v = i.inst.method_to_string(vm);
-                    if let Value::StringObj(o) = v {
-                        o.borrow()._inner.clone()
-                    } else { unreachable!() }
-                }
-                Obj::EnumVariantObj(EnumVariantObj { enum_name, name, values, .. }) => {
-                    match values {
-                        None => format!("{}.{}", enum_name, name),
-                        Some(values) => {
-                            let values = values.iter()
-                                .map(|v| to_string(v, vm))
-                                .join(", ");
-                            format!("{}.{}({})", enum_name, name, values)
-                        }
-                    }
+                    format!("{}.{}({})", enum_name, name, values)
                 }
             }
         }

--- a/abra_core/src/builtins/native/mod.rs
+++ b/abra_core/src/builtins/native/mod.rs
@@ -10,7 +10,7 @@ mod native_map;
 mod native_set;
 mod native_string;
 
-pub use common::{NativeType, to_string, default_to_string_method};
+pub use common::{to_string, default_to_string_method};
 
 pub use native_array::NativeArray;
 pub use native_float::NativeFloat;

--- a/abra_core/src/builtins/native/native_set.rs
+++ b/abra_core/src/builtins/native/native_set.rs
@@ -3,14 +3,12 @@ use crate::vm::value::Value;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use crate::vm::vm::VM;
-use crate::builtins::native::to_string;
-use itertools::Itertools;
 use crate::builtins::native::common::invoke_fn;
 use std::collections::HashSet;
 use crate::builtins::arguments::Arguments;
 
 #[derive(AbraType, Debug, Clone, Eq, PartialEq)]
-#[abra_type(signature = "Set<T>")]
+#[abra_type(signature = "Set<T>", variant = "SetObj")]
 pub struct NativeSet {
     pub _inner: HashSet<Value>,
 
@@ -33,12 +31,6 @@ impl NativeSet {
     #[abra_setter(field = "size")]
     fn set_size(&mut self, value: Value) {
         self.size = *value.as_int() as usize;
-    }
-
-    #[abra_to_string]
-    fn to_string(&self, vm: &mut VM) -> String {
-        let items = self._inner.iter().map(|v| to_string(v, vm)).join(", ");
-        format!("#{{{}}}", items)
     }
 
     #[abra_method(signature = "isEmpty(): Bool")]

--- a/abra_core/src/builtins/native/native_string.rs
+++ b/abra_core/src/builtins/native/native_string.rs
@@ -8,7 +8,7 @@ use crate::builtins::arguments::Arguments;
 use crate::builtins::native::to_string;
 
 #[derive(AbraType, Debug, Clone, Eq, Hash, PartialEq)]
-#[abra_type(signature = "String", noconstruct = true)]
+#[abra_type(signature = "String", noconstruct = true, variant = "StringObj")]
 pub struct NativeString {
     pub _inner: String,
 
@@ -33,11 +33,6 @@ impl NativeString {
     #[abra_setter(field = "length")]
     fn set_length(&mut self, value: Value) {
         self.length = *value.as_int() as usize;
-    }
-
-    #[abra_to_string]
-    fn to_string(&self, _vm: &mut VM) -> String {
-        self._inner.clone()
     }
 
     #[abra_method(signature = "toLower(): String")]
@@ -179,278 +174,278 @@ impl NativeString {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::builtins::native::test_utils::{interpret, new_string_obj};
-//     use crate::vm::value::Value;
-//
-//     #[test]
-//     fn test_string_length() {
-//         let result = interpret("\"asdf qwer\".length");
-//         let expected = Value::Int(9);
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_to_string() {
-//         let result = interpret("\"hello\".toString()");
-//         let expected = new_string_obj("hello");
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_to_lower() {
-//         let result = interpret("\"aSDF qWER\".toLower()");
-//         let expected = new_string_obj("asdf qwer");
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_to_upper() {
-//         let result = interpret("\"Asdf Qwer\".toUpper()");
-//         let expected = new_string_obj("ASDF QWER");
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_pad_left() {
-//         let result = interpret("\"asdf\".padLeft(7, \"!\")");
-//         let expected = new_string_obj("!!!asdf");
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"asdf\".padLeft(4, \"!\")");
-//         let expected = new_string_obj("asdf");
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"asdf\".padLeft(-14, \"!\")");
-//         let expected = new_string_obj("asdf");
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_trim() {
-//         let result = interpret("\"  asdf   \".trim()");
-//         let expected = new_string_obj("asdf");
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_trim_start() {
-//         let result = interpret("\"  asdf   \".trimStart()");
-//         let expected = new_string_obj("asdf   ");
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"!!asdf   \".trimStart(pattern: \"!\")");
-//         let expected = new_string_obj("asdf   ");
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"!!!asdf   \".trimStart(\"!!\")");
-//         let expected = new_string_obj("!asdf   ");
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_trim_end() {
-//         let result = interpret("\"  asdf   \".trimEnd()");
-//         let expected = new_string_obj("  asdf");
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"  asdf!!\".trimEnd(pattern: \"!\")");
-//         let expected = new_string_obj("  asdf");
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"  asdf!!!\".trimEnd(\"!!\")");
-//         let expected = new_string_obj("  asdf!");
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_split() {
-//         let result = interpret("\"a s d f\".split(splitter: \" \")");
-//         let expected = array![
-//           new_string_obj("a"),
-//           new_string_obj("s"),
-//           new_string_obj("d"),
-//           new_string_obj("f")
-//         ];
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"  a  b  c d\".split(\"  \")");
-//         let expected = array![
-//           new_string_obj(""),
-//           new_string_obj("a"),
-//           new_string_obj("b"),
-//           new_string_obj("c d")
-//         ];
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"asdf\".split(\"qwer\")");
-//         let expected = array![
-//           new_string_obj("asdf")
-//         ];
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"asdf\".split(\"\")");
-//         let expected = array![
-//           new_string_obj("a"),
-//           new_string_obj("s"),
-//           new_string_obj("d"),
-//           new_string_obj("f")
-//         ];
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"a\\ns\\nd\\nf\".split(\"\\n\")");
-//         let expected = array![
-//           new_string_obj("a"),
-//           new_string_obj("s"),
-//           new_string_obj("d"),
-//           new_string_obj("f")
-//         ];
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_split_at() {
-//         let result = interpret(r#"
-//           val arr = "hello!"
-//           arr.splitAt(0)
-//         "#);
-//         let expected = tuple!(
-//             new_string_obj(""),
-//             new_string_obj("hello!")
-//         );
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret(r#"
-//           val arr = "hello!"
-//           arr.splitAt(1)
-//         "#);
-//         let expected = tuple!(
-//             new_string_obj("h"),
-//             new_string_obj("ello!")
-//         );
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret(r#"
-//           val arr = "hello!"
-//           arr.splitAt(-1)
-//         "#);
-//         let expected = tuple!(
-//             new_string_obj("hello"),
-//             new_string_obj("!")
-//         );
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret(r#"
-//           val arr = "hello!"
-//           arr.splitAt(-8)
-//         "#);
-//         let expected = tuple!(
-//             new_string_obj(""),
-//             new_string_obj("hello!")
-//         );
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret(r#"
-//           val arr = "hello!"
-//           arr.splitAt(10)
-//         "#);
-//         let expected = tuple!(
-//             new_string_obj("hello!"),
-//             new_string_obj("")
-//         );
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_lines() {
-//         let result = interpret("\"asdf\\nqwer\\nzxcv\".lines()");
-//         let expected = array![
-//           new_string_obj("asdf"),
-//           new_string_obj("qwer"),
-//           new_string_obj("zxcv")
-//         ];
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_chars() {
-//         let result = interpret("\"asdf\".chars()");
-//         let expected = array![
-//           new_string_obj("a"),
-//           new_string_obj("s"),
-//           new_string_obj("d"),
-//           new_string_obj("f")
-//         ];
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_parse_int() {
-//         let result = interpret("\"hello\".parseInt()");
-//         let expected = Value::Nil;
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"123 456\".parseInt()");
-//         let expected = Value::Nil;
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"123456.7\".parseInt()");
-//         let expected = Value::Nil;
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"123456\".parseInt()");
-//         let expected = Value::Int(123456);
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"-123456\".parseInt()");
-//         let expected = Value::Int(-123456);
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"ba55\".parseInt(radix: 16)");
-//         let expected = Value::Int(47701);
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_parse_float() {
-//         let result = interpret("\"hello\".parseFloat()");
-//         let expected = Value::Nil;
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"123 456\".parseFloat()");
-//         let expected = Value::Nil;
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"123456.7\".parseFloat()");
-//         let expected = Value::Float(123456.7);
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"-123456.7\".parseFloat()");
-//         let expected = Value::Float(-123456.7);
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"123456\".parseFloat()");
-//         let expected = Value::Float(123456.0);
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"-123456\".parseFloat()");
-//         let expected = Value::Float(-123456.0);
-//         assert_eq!(Some(expected), result);
-//     }
-//
-//     #[test]
-//     fn test_string_concat() {
-//         let result = interpret("\"hello\".concat(\"!\")");
-//         let expected = new_string_obj("hello!");
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"hello\".concat(\" \", \"world\", \"!\")");
-//         let expected = new_string_obj("hello world!");
-//         assert_eq!(Some(expected), result);
-//
-//         let result = interpret("\"asdf\".concat(true, [1, 2, 3], {a:1})");
-//         let expected = new_string_obj("asdftrue[1, 2, 3]{ a: 1 }");
-//         assert_eq!(Some(expected), result);
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::builtins::native::test_utils::{interpret, new_string_obj};
+    use crate::vm::value::Value;
+
+    #[test]
+    fn test_string_length() {
+        let result = interpret("\"asdf qwer\".length");
+        let expected = Value::Int(9);
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_to_string() {
+        let result = interpret("\"hello\".toString()");
+        let expected = new_string_obj("hello");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_to_lower() {
+        let result = interpret("\"aSDF qWER\".toLower()");
+        let expected = new_string_obj("asdf qwer");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_to_upper() {
+        let result = interpret("\"Asdf Qwer\".toUpper()");
+        let expected = new_string_obj("ASDF QWER");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_pad_left() {
+        let result = interpret("\"asdf\".padLeft(7, \"!\")");
+        let expected = new_string_obj("!!!asdf");
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"asdf\".padLeft(4, \"!\")");
+        let expected = new_string_obj("asdf");
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"asdf\".padLeft(-14, \"!\")");
+        let expected = new_string_obj("asdf");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_trim() {
+        let result = interpret("\"  asdf   \".trim()");
+        let expected = new_string_obj("asdf");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_trim_start() {
+        let result = interpret("\"  asdf   \".trimStart()");
+        let expected = new_string_obj("asdf   ");
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"!!asdf   \".trimStart(pattern: \"!\")");
+        let expected = new_string_obj("asdf   ");
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"!!!asdf   \".trimStart(\"!!\")");
+        let expected = new_string_obj("!asdf   ");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_trim_end() {
+        let result = interpret("\"  asdf   \".trimEnd()");
+        let expected = new_string_obj("  asdf");
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"  asdf!!\".trimEnd(pattern: \"!\")");
+        let expected = new_string_obj("  asdf");
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"  asdf!!!\".trimEnd(\"!!\")");
+        let expected = new_string_obj("  asdf!");
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_split() {
+        let result = interpret("\"a s d f\".split(splitter: \" \")");
+        let expected = array![
+          new_string_obj("a"),
+          new_string_obj("s"),
+          new_string_obj("d"),
+          new_string_obj("f")
+        ];
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"  a  b  c d\".split(\"  \")");
+        let expected = array![
+          new_string_obj(""),
+          new_string_obj("a"),
+          new_string_obj("b"),
+          new_string_obj("c d")
+        ];
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"asdf\".split(\"qwer\")");
+        let expected = array![
+          new_string_obj("asdf")
+        ];
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"asdf\".split(\"\")");
+        let expected = array![
+          new_string_obj("a"),
+          new_string_obj("s"),
+          new_string_obj("d"),
+          new_string_obj("f")
+        ];
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"a\\ns\\nd\\nf\".split(\"\\n\")");
+        let expected = array![
+          new_string_obj("a"),
+          new_string_obj("s"),
+          new_string_obj("d"),
+          new_string_obj("f")
+        ];
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_split_at() {
+        let result = interpret(r#"
+          val arr = "hello!"
+          arr.splitAt(0)
+        "#);
+        let expected = tuple!(
+            new_string_obj(""),
+            new_string_obj("hello!")
+        );
+        assert_eq!(Some(expected), result);
+
+        let result = interpret(r#"
+          val arr = "hello!"
+          arr.splitAt(1)
+        "#);
+        let expected = tuple!(
+            new_string_obj("h"),
+            new_string_obj("ello!")
+        );
+        assert_eq!(Some(expected), result);
+
+        let result = interpret(r#"
+          val arr = "hello!"
+          arr.splitAt(-1)
+        "#);
+        let expected = tuple!(
+            new_string_obj("hello"),
+            new_string_obj("!")
+        );
+        assert_eq!(Some(expected), result);
+
+        let result = interpret(r#"
+          val arr = "hello!"
+          arr.splitAt(-8)
+        "#);
+        let expected = tuple!(
+            new_string_obj(""),
+            new_string_obj("hello!")
+        );
+        assert_eq!(Some(expected), result);
+
+        let result = interpret(r#"
+          val arr = "hello!"
+          arr.splitAt(10)
+        "#);
+        let expected = tuple!(
+            new_string_obj("hello!"),
+            new_string_obj("")
+        );
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_lines() {
+        let result = interpret("\"asdf\\nqwer\\nzxcv\".lines()");
+        let expected = array![
+          new_string_obj("asdf"),
+          new_string_obj("qwer"),
+          new_string_obj("zxcv")
+        ];
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_chars() {
+        let result = interpret("\"asdf\".chars()");
+        let expected = array![
+          new_string_obj("a"),
+          new_string_obj("s"),
+          new_string_obj("d"),
+          new_string_obj("f")
+        ];
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_parse_int() {
+        let result = interpret("\"hello\".parseInt()");
+        let expected = Value::Nil;
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"123 456\".parseInt()");
+        let expected = Value::Nil;
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"123456.7\".parseInt()");
+        let expected = Value::Nil;
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"123456\".parseInt()");
+        let expected = Value::Int(123456);
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"-123456\".parseInt()");
+        let expected = Value::Int(-123456);
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"ba55\".parseInt(radix: 16)");
+        let expected = Value::Int(47701);
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_parse_float() {
+        let result = interpret("\"hello\".parseFloat()");
+        let expected = Value::Nil;
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"123 456\".parseFloat()");
+        let expected = Value::Nil;
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"123456.7\".parseFloat()");
+        let expected = Value::Float(123456.7);
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"-123456.7\".parseFloat()");
+        let expected = Value::Float(-123456.7);
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"123456\".parseFloat()");
+        let expected = Value::Float(123456.0);
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"-123456\".parseFloat()");
+        let expected = Value::Float(-123456.0);
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn test_string_concat() {
+        let result = interpret("\"hello\".concat(\"!\")");
+        let expected = new_string_obj("hello!");
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"hello\".concat(\" \", \"world\", \"!\")");
+        let expected = new_string_obj("hello world!");
+        assert_eq!(Some(expected), result);
+
+        let result = interpret("\"asdf\".concat(true, [1, 2, 3], {a:1})");
+        let expected = new_string_obj("asdftrue[1, 2, 3]{ a: 1 }");
+        assert_eq!(Some(expected), result);
+    }
+}

--- a/abra_core/src/builtins/native_fns.rs
+++ b/abra_core/src/builtins/native_fns.rs
@@ -1,6 +1,6 @@
 use crate::builtins::native::to_string;
 use crate::typechecker::types::{Type, FnType};
-use crate::vm::value::{Value, Obj};
+use crate::vm::value::Value;
 use crate::vm::vm::VM;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
@@ -131,17 +131,12 @@ fn println(_receiver: Option<Value>, args: Vec<Value>, vm: &mut VM) -> Option<Va
 
     let mut args = args.into_iter();
     if let Some(arg) = args.next() {
-        if let Value::Obj(obj) = arg {
-            match &*(obj.borrow()) {
-                Obj::NativeInstanceObj(i) => {
-                    let vals = &i.as_array().unwrap()._inner;
-                    let num_vals = vals.len();
-                    for (idx, val) in vals.into_iter().enumerate() {
-                        let sp = if idx == num_vals - 1 { "" } else { " " };
-                        print_fn(&format!("{}{}", to_string(val, vm), sp));
-                    }
-                }
-                _ => unreachable!()
+        if let Value::ArrayObj(o) = arg {
+            let vals = &*o.borrow()._inner;
+            let num_vals = vals.len();
+            for (idx, val) in vals.into_iter().enumerate() {
+                let sp = if idx == num_vals - 1 { "" } else { " " };
+                print_fn(&format!("{}{}", to_string(val, vm), sp));
             }
         } else if arg != Value::Nil { unreachable!() }
     }
@@ -176,11 +171,8 @@ fn range(_receiver: Option<Value>, args: Vec<Value>, _vm: &mut VM) -> Option<Val
 
 fn read_file(_receiver: Option<Value>, args: Vec<Value>, _vm: &mut VM) -> Option<Value> {
     let file_name = args.into_iter().next().expect("readFile requires 1 argument");
-    let file_name = if let Value::Obj(obj) = file_name {
-        match &(*obj.borrow()) {
-            Obj::NativeInstanceObj(i) => i.as_string().unwrap()._inner.clone(),
-            _ => unreachable!()
-        }
+    let file_name = if let Value::StringObj(obj) = file_name {
+        obj.borrow()._inner.clone()
     } else {
         panic!("readFile requires a String as first argument")
     };

--- a/abra_core/src/lib.rs
+++ b/abra_core/src/lib.rs
@@ -14,6 +14,8 @@ pub mod common;
 pub mod lexer;
 pub mod parser;
 pub mod typechecker;
+
+#[macro_use]
 pub mod vm;
 
 pub enum Error {

--- a/abra_core/src/lib.rs
+++ b/abra_core/src/lib.rs
@@ -14,8 +14,6 @@ pub mod common;
 pub mod lexer;
 pub mod parser;
 pub mod typechecker;
-
-#[macro_use]
 pub mod vm;
 
 pub enum Error {

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -1,5 +1,5 @@
 use crate::builtins::native_value_trait::NativeValue;
-use crate::builtins::native::{NativeArray, NativeMap, NativeSet, NativeString};
+use crate::builtins::native::{NativeArray, NativeMap, NativeSet, NativeString, NativeInt, NativeFloat};
 use crate::builtins::native_fns::native_fns;
 use crate::typechecker::types::Type;
 use crate::vm::value::{Value, TypeValue};
@@ -47,8 +47,8 @@ impl Prelude {
         bindings.push(PreludeBinding { name: "None".to_string(), typ: Type::Option(Box::new(Type::Placeholder)), value: Value::Nil });
 
         let prelude_types = vec![
-            ("Int", Type::Int, None),
-            ("Float", Type::Float, None),
+            ("Int", Type::Int, Some(NativeInt::get_type_value())),
+            ("Float", Type::Float, Some(NativeFloat::get_type_value())),
             ("Bool", Type::Bool, None),
             ("String", Type::String, Some(NativeString::get_type_value())),
             ("Unit", Type::Unit, None),

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -9,7 +9,7 @@ mod tests {
     use crate::vm::compiler::compile;
     use crate::vm::prelude::PRELUDE_NUM_CONSTS;
     use crate::vm::opcode::Opcode;
-    use crate::vm::value::{Value, Obj, FnValue};
+    use crate::vm::value::{Value, FnValue};
     use crate::vm::vm::{VM, VMContext};
     use itertools::Itertools;
 
@@ -323,17 +323,11 @@ mod tests {
 
     #[inline]
     fn assert_maps_eq(expected: Vec<(Value, Value)>, map_value: Value) {
-        let actual = if let Value::Obj(obj) = map_value {
-            match &*obj.borrow() {
-                Obj::NativeInstanceObj(i) => {
-                    i.as_map().unwrap()._inner
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect::<Vec<(Value, Value)>>()
-                }
-                _ => unreachable!()
-            }
-        } else { panic!("Result should be a Map instance") };
+        let map = &*map_value.as_map().borrow();
+        let actual = map._inner
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect::<Vec<(Value, Value)>>();
 
         let len = expected.len();
         let perms = expected.into_iter().permutations(len).collect::<Vec<_>>();

--- a/abra_wasm/src/js_value/value.rs
+++ b/abra_wasm/src/js_value/value.rs
@@ -35,6 +35,30 @@ impl<'a> Serialize for JsWrappedValue<'a> {
                 obj.serialize_entry("value", &val)?;
                 obj.end()
             }
+            Value::StringObj(o) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "stringObj")?;
+                obj.serialize_entry("value", &*o.borrow()._inner)?;
+                obj.end()
+            }
+            Value::ArrayObj(o) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "arrayObj")?;
+
+                let values = &*o.borrow()._inner;
+                let values: Vec<JsWrappedValue> = values.iter().map(|i| JsWrappedValue(i)).collect();
+                obj.serialize_entry("values", &values)?;
+                obj.end()
+            }
+            Value::SetObj(o) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "setObj")?;
+
+                let values = &(*o.borrow())._inner;
+                let values: Vec<JsWrappedValue> = values.iter().map(|i| JsWrappedValue(i)).collect();
+                obj.serialize_entry("values", &values)?;
+                obj.end()
+            },
             Value::Obj(o) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "obj")?;

--- a/abra_wasm/src/js_value/value.rs
+++ b/abra_wasm/src/js_value/value.rs
@@ -1,5 +1,5 @@
 use abra_core::builtins::native_fns::NativeFn;
-use abra_core::vm::value::{Value, Obj, FnValue, ClosureValue, TypeValue, EnumValue, EnumVariantObj};
+use abra_core::vm::value::{Value, FnValue, ClosureValue, TypeValue, EnumValue, EnumVariantObj};
 use serde::{Serializer, Serialize};
 
 pub struct JsWrappedValue<'a>(pub &'a Value);
@@ -50,6 +50,15 @@ impl<'a> Serialize for JsWrappedValue<'a> {
                 obj.serialize_entry("values", &values)?;
                 obj.end()
             }
+            Value::TupleObj(o) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "tupleObj")?;
+
+                let values = &*o.borrow();
+                let values: Vec<JsWrappedValue> = values.iter().map(|i| JsWrappedValue(i)).collect();
+                obj.serialize_entry("values", &values)?;
+                obj.end()
+            }
             Value::SetObj(o) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "setObj")?;
@@ -58,11 +67,44 @@ impl<'a> Serialize for JsWrappedValue<'a> {
                 let values: Vec<JsWrappedValue> = values.iter().map(|i| JsWrappedValue(i)).collect();
                 obj.serialize_entry("values", &values)?;
                 obj.end()
-            },
-            Value::Obj(o) => {
+            }
+            Value::MapObj(o) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
-                obj.serialize_entry("kind", "obj")?;
-                obj.serialize_entry("value", &JsWrappedObjValue(&*o.borrow()))?;
+                obj.serialize_entry("kind", "mapObj")?;
+
+                let values = &(*o.borrow())._inner;
+                let values: Vec<(JsWrappedValue, JsWrappedValue)> = values.iter().map(|(k, v)| (JsWrappedValue(k), JsWrappedValue(v))).collect();
+                obj.serialize_entry("values", &values)?;
+                obj.end()
+            }
+            Value::InstanceObj(o) => {
+                let inst = &*o.borrow();
+
+                let mut obj = serializer.serialize_map(Some(3))?;
+                obj.serialize_entry("kind", "instanceObj")?;
+                obj.serialize_entry("type", &JsWrappedValue(&Value::Type(inst.typ.clone())))?;
+                let value: Vec<JsWrappedValue> = inst.fields.iter().map(|i| JsWrappedValue(i)).collect();
+                obj.serialize_entry("value", &value)?;
+                obj.end()
+            }
+            Value::NativeInstanceObj(o) => {
+                let inst = &*o.borrow();
+
+                let mut obj = serializer.serialize_map(Some(3))?;
+                obj.serialize_entry("kind", "nativeInstanceObj")?;
+                obj.serialize_entry("type", &JsWrappedValue(&Value::Type(inst.typ.clone())))?;
+
+                let field_values = inst.inst.get_field_values();
+                let value: Vec<JsWrappedValue> = field_values.iter().map(|i| JsWrappedValue(i)).collect();
+                obj.serialize_entry("value", &value)?;
+                obj.end()
+            }
+            Value::EnumVariantObj(o) => {
+                let EnumVariantObj { enum_name, name, .. } = &*o.borrow();
+                let mut obj = serializer.serialize_map(Some(3))?;
+                obj.serialize_entry("kind", "type")?;
+                obj.serialize_entry("enumName", &enum_name)?;
+                obj.serialize_entry("name", &name)?;
                 obj.end()
             }
             Value::Fn(FnValue { name: fn_name, .. }) |
@@ -99,47 +141,40 @@ impl<'a> Serialize for JsWrappedValue<'a> {
     }
 }
 
-pub struct JsWrappedObjValue<'a>(pub &'a Obj);
-
-impl<'a> Serialize for JsWrappedObjValue<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
-    {
-        use serde::ser::SerializeMap;
-
-        match &self.0 {
-            Obj::TupleObj(value) => {
-                let mut obj = serializer.serialize_map(Some(2))?;
-                obj.serialize_entry("kind", "tupleObj")?;
-                let value: Vec<JsWrappedValue> = value.iter().map(|i| JsWrappedValue(i)).collect();
-                obj.serialize_entry("value", &value)?;
-                obj.end()
-            }
-            Obj::InstanceObj(inst) => {
-                let mut obj = serializer.serialize_map(Some(3))?;
-                obj.serialize_entry("kind", "instanceObj")?;
-                obj.serialize_entry("type", &JsWrappedValue(&Value::Type(inst.typ.clone())))?;
-                let value: Vec<JsWrappedValue> = inst.fields.iter().map(|i| JsWrappedValue(i)).collect();
-                obj.serialize_entry("value", &value)?;
-                obj.end()
-            }
-            Obj::NativeInstanceObj(inst) => {
-                let mut obj = serializer.serialize_map(Some(3))?;
-                obj.serialize_entry("kind", "nativeInstanceObj")?;
-                obj.serialize_entry("type", &JsWrappedValue(&Value::Type(inst.typ.clone())))?;
-
-                let field_values = inst.inst.get_field_values();
-                let value: Vec<JsWrappedValue> = field_values.iter().map(|i| JsWrappedValue(i)).collect();
-                obj.serialize_entry("value", &value)?;
-                obj.end()
-            }
-            Obj::EnumVariantObj(EnumVariantObj { enum_name, name, .. }) => {
-                let mut obj = serializer.serialize_map(Some(3))?;
-                obj.serialize_entry("kind", "type")?;
-                obj.serialize_entry("enumName", &enum_name)?;
-                obj.serialize_entry("name", &name)?;
-                obj.end()
-            }
-        }
-    }
-}
+// pub struct JsWrappedObjValue<'a>(pub &'a Obj);
+//
+// impl<'a> Serialize for JsWrappedObjValue<'a> {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//         where S: Serializer
+//     {
+//         use serde::ser::SerializeMap;
+//
+//         match &self.0 {
+//             // Obj::InstanceObj(inst) => {
+//             //     let mut obj = serializer.serialize_map(Some(3))?;
+//             //     obj.serialize_entry("kind", "instanceObj")?;
+//             //     obj.serialize_entry("type", &JsWrappedValue(&Value::Type(inst.typ.clone())))?;
+//             //     let value: Vec<JsWrappedValue> = inst.fields.iter().map(|i| JsWrappedValue(i)).collect();
+//             //     obj.serialize_entry("value", &value)?;
+//             //     obj.end()
+//             // }
+//             // Obj::NativeInstanceObj(inst) => {
+//             //     let mut obj = serializer.serialize_map(Some(3))?;
+//             //     obj.serialize_entry("kind", "nativeInstanceObj")?;
+//             //     obj.serialize_entry("type", &JsWrappedValue(&Value::Type(inst.typ.clone())))?;
+//             //
+//             //     let field_values = inst.inst.get_field_values();
+//             //     let value: Vec<JsWrappedValue> = field_values.iter().map(|i| JsWrappedValue(i)).collect();
+//             //     obj.serialize_entry("value", &value)?;
+//             //     obj.end()
+//             // }
+//             // Obj::EnumVariantObj(EnumVariantObj { enum_name, name, .. }) => {
+//             //     let mut obj = serializer.serialize_map(Some(3))?;
+//             //     obj.serialize_entry("kind", "type")?;
+//             //     obj.serialize_entry("enumName", &enum_name)?;
+//             //     obj.serialize_entry("name", &name)?;
+//             //     obj.end()
+//             // }
+//         }
+//     }
+// }

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -17,11 +17,10 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 use abra_core::builtins::native_fns::NativeFn;
 use abra_core::{Error, typecheck, compile, compile_and_disassemble};
-use abra_core::vm::value::{Obj, Value, FnValue, ClosureValue, TypeValue, EnumValue, EnumVariantObj, NativeInstanceObj};
+use abra_core::vm::value::{Value, FnValue, ClosureValue, TypeValue, EnumValue, NativeInstanceObj};
 use abra_core::vm::vm::{VMContext, VM};
 use abra_core::vm::compiler::Module;
 use abra_core::common::display_error::DisplayError;
-use abra_core::builtins::native::NativeMap;
 
 pub struct RunResultValue(Option<Value>);
 
@@ -53,52 +52,54 @@ impl Serialize for RunResultValue {
                 });
                 arr.end()
             }
-            Value::SetObj(o) => {
-                let arr = &*o.borrow();
-                let array = &arr._inner;
-                let mut arr = serializer.serialize_seq(Some((*array).len()))?;
-                array.iter().for_each(|val| {
+            Value::TupleObj(o) => {
+                let tup = &*o.borrow();
+                let mut arr = serializer.serialize_seq(Some((*tup).len()))?;
+                tup.iter().for_each(|val| {
                     arr.serialize_element(&RunResultValue(Some((*val).clone()))).unwrap();
                 });
                 arr.end()
             }
-            Value::Obj(obj) => match &*obj.borrow() {
-                Obj::TupleObj(value) => {
-                    let mut arr = serializer.serialize_seq(Some((*value).len()))?;
-                    value.into_iter().for_each(|val| {
-                        arr.serialize_element(&RunResultValue(Some((*val).clone()))).unwrap();
-                    });
-                    arr.end()
-                }
-                Obj::InstanceObj(inst) => {
-                    let fields = &inst.fields;
-                    let mut arr = serializer.serialize_seq(Some(fields.len()))?;
-                    fields.into_iter().for_each(|val| {
-                        arr.serialize_element(&RunResultValue(Some((*val).clone()))).unwrap();
-                    });
-                    arr.end()
-                }
-                Obj::NativeInstanceObj(NativeInstanceObj { typ, inst, .. }) => {
-                    if let Some(map) = inst.downcast_ref::<NativeMap>() {
-                        let map = &map._inner;
-
-                        let mut obj = serializer.serialize_map(Some((*map).len()))?;
-                        map.into_iter().for_each(|(key, val)| {
-                            obj.serialize_entry(&RunResultValue(Some(key.clone())), &RunResultValue(Some(val.clone()))).unwrap();
-                        });
-                        obj.end()
-                    } else {
-                        let mut obj = serializer.serialize_map(Some(typ.fields.len()))?;
-
-                        for (field_name, field_value) in typ.fields.iter().zip(inst.get_field_values()) {
-                            obj.serialize_entry(field_name, &RunResultValue(Some(field_value)))?;
-                        }
-
-                        obj.end()
-                    }
-                }
-                Obj::EnumVariantObj(EnumVariantObj { name, .. }) => serializer.serialize_str(name)
+            Value::SetObj(o) => {
+                let set = &*o.borrow();
+                let items = &set._inner;
+                let mut set = serializer.serialize_seq(Some((*items).len()))?;
+                items.iter().for_each(|val| {
+                    set.serialize_element(&RunResultValue(Some((*val).clone()))).unwrap();
+                });
+                set.end()
             }
+            Value::MapObj(o) => {
+                let map = &*o.borrow();
+                let map = &map._inner;
+                let mut obj = serializer.serialize_map(Some((*map).len()))?;
+                map.into_iter().for_each(|(key, val)| {
+                    obj.serialize_entry(&RunResultValue(Some(key.clone())), &RunResultValue(Some(val.clone()))).unwrap();
+                });
+                obj.end()
+            }
+            Value::InstanceObj(o) => {
+                let inst = &*o.borrow();
+
+                let fields = &inst.fields;
+                let mut arr = serializer.serialize_seq(Some(fields.len()))?;
+                fields.into_iter().for_each(|val| {
+                    arr.serialize_element(&RunResultValue(Some((*val).clone()))).unwrap();
+                });
+                arr.end()
+            }
+            Value::NativeInstanceObj(o) => {
+                let NativeInstanceObj { typ, inst } = &*o.borrow();
+
+                let mut obj = serializer.serialize_map(Some(typ.fields.len()))?;
+
+                for (field_name, field_value) in typ.fields.iter().zip(inst.get_field_values()) {
+                    obj.serialize_entry(field_name, &RunResultValue(Some(field_value)))?;
+                }
+
+                obj.end()
+            }
+            Value::EnumVariantObj(o) => serializer.serialize_str(&*o.borrow().name),
             Value::Fn(FnValue { name, .. }) => serializer.serialize_str(name),
             Value::Closure(ClosureValue { name, .. }) => serializer.serialize_str(name),
             Value::NativeFn(NativeFn { name, .. }) => serializer.serialize_str(name),


### PR DESCRIPTION
- After using AOC2020 Day 22 as a benchmark, I noticed that the
performance degraded a lot (~20s to ~95s) after the native types
refactor. So I needed to tidy things up a bit, adding native
implementations for String, Array, and Set. The ultimate goal here is
ultimately to retire the `Value::Obj` variant (and thus, the `Obj`
enum entirely), in favor of more top-level `Value` variants. These will
be easier to work with as it won't involve as much ambiguity when
borrowing the `Arc`s. This will become more relevant when implementing
gc.
- This also removes the `derive(PartialOrd)` from all `Value` variant
substructs, since it's really unnecessary.