### PR TITLE
Type Ids

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,2 +1,9 @@
-val arr = [1, 2, 3]
-arr.length = 4
+type Person {
+  name: String
+}
+
+Person(name: "Ken").name
+
+val d1 = Date(year: 2021, month: 1, day: 27)
+val d2 = Date.now()
+println(d1, d2)

--- a/abra_core/src/builtins/native/common.rs
+++ b/abra_core/src/builtins/native/common.rs
@@ -17,8 +17,10 @@ pub fn invoke_fn(vm: &mut VM, fn_obj: &Value, args: Vec<Value>) -> Value {
 pub fn default_to_string_method(receiver: Option<Value>, _args: Vec<Value>, vm: &mut VM) -> Option<Value> {
     let rcv = receiver.unwrap();
     let obj = &*rcv.as_instance_obj().borrow();
-    let type_name = &obj.typ.name;
-    let field_names = &obj.typ.fields;
+
+    let type_value = vm.load_type(obj.type_id);
+    let type_name = type_value.name.clone();
+    let field_names = type_value.fields.clone();
     let values = field_names.iter().zip(&obj.fields)
         .map(|(field_name, field_value)| format!("{}: {}", field_name, to_string(field_value, vm)))
         .join(", ");
@@ -66,7 +68,8 @@ pub fn to_string(value: &Value, vm: &mut VM) -> String {
         Value::InstanceObj(o) => {
             let o = &*o.borrow();
 
-            let mut tostring_method = o.typ.methods.iter()
+            let type_value = vm.load_type(o.type_id);
+            let mut tostring_method = type_value.methods.iter()
                 .find(|(name, _)| name == "toString")
                 .map(|(_, m)| m)
                 .expect("Every instance should have at least the default toString method")

--- a/abra_core/src/builtins/native/mod.rs
+++ b/abra_core/src/builtins/native/mod.rs
@@ -4,6 +4,7 @@ mod test_utils;
 
 mod common;
 mod native_array;
+mod native_date;
 mod native_float;
 mod native_int;
 mod native_map;
@@ -13,6 +14,7 @@ mod native_string;
 pub use common::{to_string, default_to_string_method};
 
 pub use native_array::NativeArray;
+pub use native_date::NativeDate;
 pub use native_float::NativeFloat;
 pub use native_int::NativeInt;
 pub use native_map::NativeMap;

--- a/abra_core/src/builtins/native/native_date.rs
+++ b/abra_core/src/builtins/native/native_date.rs
@@ -1,0 +1,109 @@
+use abra_native::{AbraType, abra_methods};
+use crate::vm::value::Value;
+use std::fmt::Debug;
+use std::hash::Hash;
+use crate::builtins::arguments::Arguments;
+
+#[derive(AbraType, Debug, Clone, Eq, Hash, PartialEq)]
+#[abra_type(signature = "Date")]
+pub struct NativeDate {
+    #[abra_field(name = "year", field_type = "Int")]
+    year: i64,
+
+    #[abra_field(name = "month", field_type = "Int")]
+    month: i64,
+
+    #[abra_field(name = "day", field_type = "Int")]
+    day: i64,
+
+    #[abra_field(name = "hour", field_type = "Int", has_default = true)]
+    hour: i64,
+
+    #[abra_field(name = "minute", field_type = "Int", has_default = true)]
+    minute: i64,
+
+    #[abra_field(name = "second", field_type = "Int", has_default = true)]
+    second: i64,
+}
+
+#[abra_methods]
+impl NativeDate {
+    #[abra_constructor]
+    pub(crate) fn new(args: Vec<Value>) -> Self {
+        let mut args = Arguments::new("Date", 6, args);
+
+        Self {
+            year: args.next_int(),
+            month: args.next_int(),
+            day: args.next_int(),
+            hour: args.next_int_or_default(0),
+            minute: args.next_int_or_default(0),
+            second: args.next_int_or_default(0),
+        }
+    }
+
+    #[abra_getter(field = "year")]
+    fn get_year(&self) -> Value {
+        Value::Int(self.year)
+    }
+
+    #[abra_setter(field = "year")]
+    fn set_year(&mut self, value: Value) {
+        self.year = *value.as_int();
+    }
+
+    #[abra_getter(field = "month")]
+    fn get_month(&self) -> Value {
+        Value::Int(self.month)
+    }
+
+    #[abra_setter(field = "month")]
+    fn set_month(&mut self, value: Value) {
+        self.month = *value.as_int();
+    }
+
+    #[abra_getter(field = "day")]
+    fn get_day(&self) -> Value {
+        Value::Int(self.day)
+    }
+
+    #[abra_setter(field = "day")]
+    fn set_day(&mut self, value: Value) {
+        self.day = *value.as_int();
+    }
+
+    #[abra_getter(field = "hour")]
+    fn get_hour(&self) -> Value {
+        Value::Int(self.hour)
+    }
+
+    #[abra_setter(field = "hour")]
+    fn set_hour(&mut self, value: Value) {
+        self.hour = *value.as_int();
+    }
+
+    #[abra_getter(field = "minute")]
+    fn get_minute(&self) -> Value {
+        Value::Int(self.minute)
+    }
+
+    #[abra_setter(field = "minute")]
+    fn set_minute(&mut self, value: Value) {
+        self.minute = *value.as_int();
+    }
+
+    #[abra_getter(field = "second")]
+    fn get_second(&self) -> Value {
+        Value::Int(self.second)
+    }
+
+    #[abra_setter(field = "second")]
+    fn set_second(&mut self, value: Value) {
+        self.second = *value.as_int();
+    }
+
+    #[abra_static_method(signature = "now(): Date")]
+    fn now() -> Self {
+        Self { year: 0, month: 0, day: 0, hour: 0, minute: 0, second: 0 }
+    }
+}

--- a/abra_core/src/builtins/native_value_trait.rs
+++ b/abra_core/src/builtins/native_value_trait.rs
@@ -10,15 +10,8 @@ pub trait NativeTyp {
 }
 
 pub trait NativeValue: NativeTyp + DynHash + Debug + Downcast {
-    fn construct(args: Vec<Value>) -> Value where Self: Sized;
+    fn construct(type_id: usize, args: Vec<Value>) -> Value where Self: Sized;
     fn get_type_value() -> TypeValue where Self: Sized;
-
-    fn init(self) -> Value where Self: Sized {
-        Value::new_native_instance_obj(
-            Self::get_type_value(),
-            Box::new(self),
-        )
-    }
 
     fn is_equal(&self, other: &Box<dyn NativeValue>) -> bool;
     fn method_to_string(&self, vm: &mut VM) -> Value;

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -4528,11 +4528,11 @@ mod tests {
                     ])
                     .collect(),
                 vec![
-                    Opcode::Constant as u8, 0, 255 as u8,
-                    Opcode::Constant as u8, 1, 0 as u8,
-                    Opcode::GStore as u8
+                    // Opcode::Constant as u8, 0, 255 as u8,
+                    // Opcode::Constant as u8, 1, 0 as u8,
+                    // Opcode::GStore as u8
                 ],
-                (1..56).step_by(2).into_iter()
+                (0..57).step_by(2).into_iter()
                     .flat_map(|i| vec![
                         Opcode::Constant as u8, 1, i as u8,
                         Opcode::Constant as u8, 1, (i + 1) as u8,

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -1,5 +1,5 @@
 use crate::builtins::native_value_trait::NativeValue;
-use crate::builtins::native::{NativeArray, NativeMap, NativeSet, NativeString, NativeInt, NativeFloat};
+use crate::builtins::native::{NativeArray, NativeMap, NativeSet, NativeString, NativeInt, NativeFloat, NativeDate};
 use crate::builtins::native_fns::native_fns;
 use crate::typechecker::types::Type;
 use crate::vm::value::{Value, TypeValue};
@@ -56,6 +56,7 @@ impl Prelude {
             ("Array", Type::Reference("Array".to_string(), vec![Type::Generic("T".to_string())]), Some(NativeArray::get_type_value())),
             ("Map", Type::Reference("Map".to_string(), vec![Type::Generic("K".to_string()), Type::Generic("V".to_string())]), Some(NativeMap::get_type_value())),
             ("Set", Type::Reference("Set".to_string(), vec![Type::Generic("T".to_string())]), Some(NativeSet::get_type_value())),
+            ("Date", Type::Reference("Date".to_string(), vec![]), Some(NativeDate::get_type_value())),
         ];
         for (type_name, typ, type_value) in prelude_types {
             let value = match type_value {

--- a/abra_wasm/src/js_value/value.rs
+++ b/abra_wasm/src/js_value/value.rs
@@ -82,7 +82,7 @@ impl<'a> Serialize for JsWrappedValue<'a> {
 
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "instanceObj")?;
-                obj.serialize_entry("type", &JsWrappedValue(&Value::Type(inst.typ.clone())))?;
+                obj.serialize_entry("type_id", &inst.type_id)?;
                 let value: Vec<JsWrappedValue> = inst.fields.iter().map(|i| JsWrappedValue(i)).collect();
                 obj.serialize_entry("value", &value)?;
                 obj.end()
@@ -92,7 +92,7 @@ impl<'a> Serialize for JsWrappedValue<'a> {
 
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "nativeInstanceObj")?;
-                obj.serialize_entry("type", &JsWrappedValue(&Value::Type(inst.typ.clone())))?;
+                obj.serialize_entry("type_id", &inst.type_id)?;
 
                 let field_values = inst.inst.get_field_values();
                 let value: Vec<JsWrappedValue> = field_values.iter().map(|i| JsWrappedValue(i)).collect();

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -89,15 +89,15 @@ impl Serialize for RunResultValue {
                 arr.end()
             }
             Value::NativeInstanceObj(o) => {
-                let NativeInstanceObj { typ, inst } = &*o.borrow();
+                let NativeInstanceObj { inst, .. } = &*o.borrow();
 
-                let mut obj = serializer.serialize_map(Some(typ.fields.len()))?;
-
-                for (field_name, field_value) in typ.fields.iter().zip(inst.get_field_values()) {
-                    obj.serialize_entry(field_name, &RunResultValue(Some(field_value)))?;
+                let fields = &inst.get_field_values();
+                let mut arr = serializer.serialize_seq(Some(fields.len()))?;
+                for field_value in inst.get_field_values() {
+                    arr.serialize_element(&RunResultValue(Some(field_value)))?;
                 }
 
-                obj.end()
+                arr.end()
             }
             Value::EnumVariantObj(o) => serializer.serialize_str(&*o.borrow().name),
             Value::Fn(FnValue { name, .. }) => serializer.serialize_str(name),


### PR DESCRIPTION
- Rather than including `TypeValue` in every value instance, only use
`type_id` which can be looked up in the VM
- Create a `Date` placeholder native type, since all the other native
types had been migrated in the prior changeset to have native support,
and I want to verify that things still work there.