### PR TITLE
Adding get/set field attrs

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,3 +1,13 @@
-type Person {
-  name: String { set get }
+type Name {
+  value: String
 }
+
+type Person {
+  name: Name { get }
+}
+
+val p = Person(name: Name(value: "Ken"))
+//p.name = Name(value: "Meg")
+p.name.value = "Meg"
+
+p

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -3,7 +3,7 @@ type Name {
 }
 
 type Person {
-  name: Name { get }
+  name: Name { get set }
 }
 
 val p = Person(name: Name(value: "Ken"))

--- a/abra_core/src/builtins/native/native_array.rs
+++ b/abra_core/src/builtins/native/native_array.rs
@@ -15,7 +15,7 @@ pub struct NativeArray {
     // This field needs to be public so vararg handlers can access the received array's values
     pub _inner: Vec<Value>,
 
-    #[abra_field(name = "length", field_type = "Int", settable = false)]
+    #[abra_field(name = "length", field_type = "Int", readonly)]
     length: usize,
 }
 

--- a/abra_core/src/builtins/native/native_array.rs
+++ b/abra_core/src/builtins/native/native_array.rs
@@ -15,7 +15,7 @@ pub struct NativeArray {
     // This field needs to be public so vararg handlers can access the received array's values
     pub _inner: Vec<Value>,
 
-    #[abra_field(name = "length", field_type = "Int")]
+    #[abra_field(name = "length", field_type = "Int", settable = false)]
     length: usize,
 }
 
@@ -29,11 +29,6 @@ impl NativeArray {
     #[abra_getter(field = "length")]
     fn get_length(&self) -> Value {
         Value::Int(self._inner.len() as i64)
-    }
-
-    #[abra_setter(field = "length")]
-    fn set_length(&mut self, value: Value) {
-        self.length = *value.as_int() as usize;
     }
 
     #[abra_static_method(signature = "fill<T1>(amount: Int, value: T1): T1[]")]

--- a/abra_core/src/builtins/native/native_array.rs
+++ b/abra_core/src/builtins/native/native_array.rs
@@ -441,7 +441,7 @@ impl NativeArray {
 
 #[cfg(test)]
 mod test {
-    use crate::builtins::native::test_utils::{interpret, new_string_obj};
+    use crate::builtins::native::test_utils::{interpret, new_string_obj, interpret_get_result};
     use crate::vm::value::Value;
 
     #[test]
@@ -449,6 +449,10 @@ mod test {
         let result = interpret("[1, 2, 3, 4, 5].length");
         let expected = Value::Int(5);
         assert_eq!(Some(expected), result);
+
+        // Setting length should produce an error
+        let is_err = interpret_get_result("[1, 2, 3].length = 8").is_err();
+        assert!(is_err);
     }
 
     #[test]

--- a/abra_core/src/builtins/native/native_map.rs
+++ b/abra_core/src/builtins/native/native_map.rs
@@ -11,7 +11,7 @@ use crate::builtins::native::common::invoke_fn;
 pub struct NativeMap {
     pub _inner: HashMap<Value, Value>,
 
-    #[abra_field(name = "size", field_type = "Int")]
+    #[abra_field(name = "size", field_type = "Int", settable = false)]
     size: usize,
 }
 
@@ -33,11 +33,6 @@ impl NativeMap {
     #[abra_getter(field = "size")]
     fn get_size(&self) -> Value {
         Value::Int(self._inner.len() as i64)
-    }
-
-    #[abra_setter(field = "size")]
-    fn set_size(&mut self, value: Value) {
-        self.size = *value.as_int() as usize;
     }
 
     #[abra_static_method(signature = "fromPairs<T1, T2>(pairs: (T1, T2)[]): Map<T1, T2>")]

--- a/abra_core/src/builtins/native/native_map.rs
+++ b/abra_core/src/builtins/native/native_map.rs
@@ -150,7 +150,7 @@ impl Hash for NativeMap {
 
 #[cfg(test)]
 mod test {
-    use crate::builtins::native::test_utils::{interpret, new_string_obj};
+    use crate::builtins::native::test_utils::{interpret, new_string_obj, interpret_get_result};
     use crate::vm::value::Value;
 
     #[test]
@@ -162,6 +162,10 @@ mod test {
         let result = interpret("{ a: 123, b: true }.size");
         let expected = Value::Int(2);
         assert_eq!(Some(expected), result);
+
+        // Setting size should produce an error
+        let is_err = interpret_get_result("{ a: 4 }.size = 8").is_err();
+        assert!(is_err);
     }
 
     #[test]

--- a/abra_core/src/builtins/native/native_map.rs
+++ b/abra_core/src/builtins/native/native_map.rs
@@ -11,7 +11,7 @@ use crate::builtins::native::common::invoke_fn;
 pub struct NativeMap {
     pub _inner: HashMap<Value, Value>,
 
-    #[abra_field(name = "size", field_type = "Int", settable = false)]
+    #[abra_field(name = "size", field_type = "Int", readonly)]
     size: usize,
 }
 

--- a/abra_core/src/builtins/native/native_set.rs
+++ b/abra_core/src/builtins/native/native_set.rs
@@ -12,7 +12,7 @@ use crate::builtins::arguments::Arguments;
 pub struct NativeSet {
     pub _inner: HashSet<Value>,
 
-    #[abra_field(name = "size", field_type = "Int", settable = false)]
+    #[abra_field(name = "size", field_type = "Int", readonly)]
     size: usize,
 }
 

--- a/abra_core/src/builtins/native/native_set.rs
+++ b/abra_core/src/builtins/native/native_set.rs
@@ -145,7 +145,7 @@ impl Hash for NativeSet {
 
 #[cfg(test)]
 mod test {
-    use crate::builtins::native::test_utils::{interpret, new_string_obj};
+    use crate::builtins::native::test_utils::{interpret, new_string_obj, interpret_get_result};
     use crate::vm::value::Value;
 
     #[test]
@@ -161,6 +161,10 @@ mod test {
         let result = interpret("#{0, 1, 2, 1, 0}.size");
         let expected = Value::Int(3);
         assert_eq!(Some(expected), result);
+
+        // Setting size should produce an error
+        let is_err = interpret_get_result("#{1, 2, 3}.size = 8").is_err();
+        assert!(is_err);
     }
 
     #[test]

--- a/abra_core/src/builtins/native/native_set.rs
+++ b/abra_core/src/builtins/native/native_set.rs
@@ -12,7 +12,7 @@ use crate::builtins::arguments::Arguments;
 pub struct NativeSet {
     pub _inner: HashSet<Value>,
 
-    #[abra_field(name = "size", field_type = "Int")]
+    #[abra_field(name = "size", field_type = "Int", settable = false)]
     size: usize,
 }
 
@@ -26,11 +26,6 @@ impl NativeSet {
     #[abra_getter(field = "size")]
     fn get_size(&self) -> Value {
         Value::Int(self._inner.len() as i64)
-    }
-
-    #[abra_setter(field = "size")]
-    fn set_size(&mut self, value: Value) {
-        self.size = *value.as_int() as usize;
     }
 
     #[abra_method(signature = "isEmpty(): Bool")]

--- a/abra_core/src/builtins/native/native_string.rs
+++ b/abra_core/src/builtins/native/native_string.rs
@@ -171,7 +171,7 @@ impl NativeString {
 
 #[cfg(test)]
 mod test {
-    use crate::builtins::native::test_utils::{interpret, new_string_obj};
+    use crate::builtins::native::test_utils::{interpret, new_string_obj, interpret_get_result};
     use crate::vm::value::Value;
 
     #[test]
@@ -179,6 +179,10 @@ mod test {
         let result = interpret("\"asdf qwer\".length");
         let expected = Value::Int(9);
         assert_eq!(Some(expected), result);
+
+        // Setting length should produce an error
+        let is_err = interpret_get_result("\"asdf\".length = 8").is_err();
+        assert!(is_err);
     }
 
     #[test]

--- a/abra_core/src/builtins/native/native_string.rs
+++ b/abra_core/src/builtins/native/native_string.rs
@@ -12,7 +12,7 @@ use crate::builtins::native::to_string;
 pub struct NativeString {
     pub _inner: String,
 
-    #[abra_field(name = "length", field_type = "Int", settable = false)]
+    #[abra_field(name = "length", field_type = "Int", readonly)]
     length: usize,
 }
 

--- a/abra_core/src/builtins/native/native_string.rs
+++ b/abra_core/src/builtins/native/native_string.rs
@@ -12,7 +12,7 @@ use crate::builtins::native::to_string;
 pub struct NativeString {
     pub _inner: String,
 
-    #[abra_field(name = "length", field_type = "Int")]
+    #[abra_field(name = "length", field_type = "Int", settable = false)]
     length: usize,
 }
 
@@ -28,11 +28,6 @@ impl NativeString {
     #[abra_getter(field = "length")]
     fn get_length(&self) -> Value {
         Value::Int(self._inner.len() as i64)
-    }
-
-    #[abra_setter(field = "length")]
-    fn set_length(&mut self, value: Value) {
-        self.length = *value.as_int() as usize;
     }
 
     #[abra_method(signature = "toLower(): String")]

--- a/abra_core/src/builtins/native/test_utils.rs
+++ b/abra_core/src/builtins/native/test_utils.rs
@@ -4,6 +4,7 @@ use crate::parser::parser::parse;
 use crate::typechecker::typechecker::typecheck;
 use crate::vm::compiler::compile;
 use crate::vm::vm::{VM, VMContext};
+use crate::Error;
 
 pub fn new_string_obj(string: &str) -> Value {
     Value::new_string_obj(string.to_string())
@@ -41,4 +42,15 @@ pub fn interpret(input: &str) -> Option<Value> {
 
     let mut vm = VM::new(module, VMContext::default());
     vm.run().unwrap()
+}
+
+pub fn interpret_get_result<S: AsRef<str>>(input: S) -> Result<Option<Value>, Error> {
+    let module = match crate::compile(&input.as_ref().to_string()) {
+        Ok((module, _)) => module,
+        Err(error) => return Err(error)
+    };
+
+    let ctx = VMContext { print: |input| print!("{}", input) };
+    let mut vm = VM::new(module, ctx);
+    vm.run().map_err(|e| Error::InterpretError(e))
 }

--- a/abra_core/src/common/ast_visitor.rs
+++ b/abra_core/src/common/ast_visitor.rs
@@ -30,7 +30,7 @@ pub trait AstVisitor<V, E> {
             Break(tok) => self.visit_break(tok),
             ReturnStatement(tok, node) => self.visit_return(tok, node),
             ForLoop(tok, node) => self.visit_for_loop(tok, node),
-            Accessor(tok, node) => self.visit_accessor(tok, node, true),
+            Accessor(tok, node) => self.visit_accessor(tok, node),
             Lambda(tok, node) => self.visit_lambda(tok, node, None),
             Tuple(tok, nodes) => self.visit_tuple(tok, nodes),
         }
@@ -59,7 +59,7 @@ pub trait AstVisitor<V, E> {
     fn visit_while_loop(&mut self, token: Token, node: WhileLoopNode) -> Result<V, E>;
     fn visit_break(&mut self, token: Token) -> Result<V, E>;
     fn visit_return(&mut self, token: Token, node: Option<Box<AstNode>>) -> Result<V, E>;
-    fn visit_accessor(&mut self, token: Token, node: AccessorNode, is_get: bool) -> Result<V, E>;
+    fn visit_accessor(&mut self, token: Token, node: AccessorNode) -> Result<V, E>;
     fn visit_lambda(&mut self, token: Token, node: LambdaNode, args_override: Option<Vec<(Token, Type, Option<TypedAstNode>)>>) -> Result<V, E>;
     fn visit_tuple(&mut self, token: Token, nodes: Vec<AstNode>) -> Result<V, E>;
 }

--- a/abra_core/src/common/ast_visitor.rs
+++ b/abra_core/src/common/ast_visitor.rs
@@ -30,7 +30,7 @@ pub trait AstVisitor<V, E> {
             Break(tok) => self.visit_break(tok),
             ReturnStatement(tok, node) => self.visit_return(tok, node),
             ForLoop(tok, node) => self.visit_for_loop(tok, node),
-            Accessor(tok, node) => self.visit_accessor(tok, node),
+            Accessor(tok, node) => self.visit_accessor(tok, node, true),
             Lambda(tok, node) => self.visit_lambda(tok, node, None),
             Tuple(tok, nodes) => self.visit_tuple(tok, nodes),
         }
@@ -59,7 +59,7 @@ pub trait AstVisitor<V, E> {
     fn visit_while_loop(&mut self, token: Token, node: WhileLoopNode) -> Result<V, E>;
     fn visit_break(&mut self, token: Token) -> Result<V, E>;
     fn visit_return(&mut self, token: Token, node: Option<Box<AstNode>>) -> Result<V, E>;
-    fn visit_accessor(&mut self, token: Token, node: AccessorNode) -> Result<V, E>;
+    fn visit_accessor(&mut self, token: Token, node: AccessorNode, is_get: bool) -> Result<V, E>;
     fn visit_lambda(&mut self, token: Token, node: LambdaNode, args_override: Option<Vec<(Token, Type, Option<TypedAstNode>)>>) -> Result<V, E>;
     fn visit_tuple(&mut self, token: Token, nodes: Vec<AstNode>) -> Result<V, E>;
 }

--- a/abra_core/src/lexer/lexer.rs
+++ b/abra_core/src/lexer/lexer.rs
@@ -288,6 +288,7 @@ impl<'a> Lexer<'a> {
                     let has_newline = saw_newline || self.peek().is_none();
                     Token::Return(pos, has_newline)
                 }
+                "readonly" => Token::Readonly(pos),
                 "None" => Token::None(pos),
                 s @ _ => Token::Ident(pos, s.to_string())
             };
@@ -776,7 +777,7 @@ mod tests {
 
     #[test]
     fn test_tokenize_keywords() {
-        let input = "true false val var if else func while break for in type enum self match";
+        let input = "true false val var if else func while break for in type enum self match readonly";
         let tokens = tokenize(&input.to_string()).unwrap();
         let expected = vec![
             Token::Bool(Position::new(1, 1), true),
@@ -794,6 +795,7 @@ mod tests {
             Token::Enum(Position::new(1, 57)),
             Token::Self_(Position::new(1, 62)),
             Token::Match(Position::new(1, 67)),
+            Token::Readonly(Position::new(1, 73)),
         ];
         assert_eq!(expected, tokens);
     }

--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -9,7 +9,7 @@ impl Default for Position {
     fn default() -> Self { Position { line: 0, col: 0 } }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Range {
     pub start: Position,
     pub end: Position,

--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -48,6 +48,7 @@ pub enum Token {
     #[strum(to_string = "type", serialize = "Type")] Type(Position),
     #[strum(to_string = "enum", serialize = "Enum")] Enum(Position),
     #[strum(to_string = "return", serialize = "Return")] Return(Position, bool),
+    #[strum(to_string = "readonly", serialize = "Readonly")] Readonly(Position),
 
     // Identifiers
     #[strum(to_string = "identifier", serialize = "Ident")] Ident(Position, String),
@@ -121,6 +122,7 @@ impl Token {
             Token::Type(pos) |
             Token::Enum(pos) |
             Token::Return(pos, _) |
+            Token::Readonly(pos) |
 
             Token::Ident(pos, _) |
             Token::Self_(pos) |
@@ -181,7 +183,7 @@ impl Token {
                     pos.col + v.len()
                 } else { unimplemented!() };
                 Range::with_length(pos, pos.col + len_last - 1)
-            },
+            }
             Token::Bool(pos, v) => Range::with_length(pos, format!("{}", v).len() - 1),
 
             Token::Func(pos) => Range::with_length(pos, 3),
@@ -197,6 +199,7 @@ impl Token {
             Token::Type(pos) => Range::with_length(pos, 3),
             Token::Enum(pos) => Range::with_length(pos, 3),
             Token::Return(pos, _) => Range::with_length(pos, 5),
+            Token::Readonly(pos) => Range::with_length(pos, 7),
 
             Token::Ident(pos, i) => Range::with_length(pos, i.len() - 1),
             Token::Self_(pos) => Range::with_length(pos, 3),

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -196,8 +196,7 @@ pub struct TypeDeclField {
     pub ident: Token,
     pub type_ident: TypeIdentifier,
     pub default_value: Option<AstNode>,
-    // Must be Token::Idents
-    pub specs: Vec<Token>,
+    pub readonly: Option<Token>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -2691,7 +2691,6 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                             .find(|(_, EnumVariantType { name, .. })| field_name == name)
                             .map(|(idx, variant_type)| {
                                 let enum_type_ref = Type::Reference(enum_name.clone(), vec![]);
-                                // (idx, Type::EnumVariant(Box::new(enum_type_ref), variant_type.clone(), false), false)
                                 let typ = Type::EnumVariant(Box::new(enum_type_ref), variant_type.clone(), false);
                                 FieldSpec { idx, typ, is_method: false, gettable: true, settable: false }
                             })

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -7100,7 +7100,7 @@ mod tests {
                 field_idx: 0,
                 is_opt_safe: false,
                 is_method: false,
-                is_settable: true,
+                is_settable: false,
             },
         );
         assert_eq!(expected, typed_ast[0]);
@@ -7116,7 +7116,7 @@ mod tests {
                 field_idx: 0,
                 is_opt_safe: false,
                 is_method: false,
-                is_settable: true,
+                is_settable: false,
             },
         );
         assert_eq!(expected, typed_ast[0]);
@@ -7192,7 +7192,7 @@ mod tests {
                 field_idx: 0,
                 is_opt_safe: true,
                 is_method: false,
-                is_settable: true,
+                is_settable: false,
             },
         );
         assert_eq!(expected, typed_ast[2]);

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -4,7 +4,7 @@ use crate::common::ast_visitor::AstVisitor;
 use crate::lexer::tokens::{Token, Position};
 use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, BinaryOp, UnaryOp, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, IndexingMode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode, LambdaNode, TypeIdentifier, EnumDeclNode, MatchNode, MatchCase, MatchCaseType, SetNode, BindingPattern, TypeDeclField};
 use crate::vm::prelude::PRELUDE;
-use crate::typechecker::types::{Type, StructType, FnType, EnumType, EnumVariantType, StructTypeField};
+use crate::typechecker::types::{Type, StructType, FnType, EnumType, EnumVariantType, StructTypeField, FieldSpec};
 use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedUnaryNode, TypedBinaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode, AssignmentTargetKind, TypedLambdaNode, TypedEnumDeclNode, EnumVariantKind, TypedMatchNode, TypedReturnNode, TypedTupleNode, TypedSetNode, TypedTypeDeclField};
 use crate::typechecker::typechecker_error::{TypecheckerError, InvalidAssignmentTargetReason};
 use itertools::Itertools;
@@ -1632,7 +1632,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
 
         let mut field_names = HashMap::<String, Token>::new();
         let fields = fields.into_iter()
-            .map(|TypeDeclField { ident, type_ident, default_value, .. }| {
+            .map(|TypeDeclField { ident, type_ident, default_value, specs }| {
                 let field_type = self.type_from_type_ident(&type_ident)?;
                 let field_name_str = Token::get_ident_name(&ident);
                 if let Some(orig_ident) = field_names.get(&field_name_str) {
@@ -1640,18 +1640,45 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                 } else {
                     field_names.insert(field_name_str.clone(), ident.clone());
                 }
-                Ok((ident, field_type, default_value))
+
+                let mut saw_get_attr = false;
+                let mut saw_set_attr = false;
+                for tok in specs {
+                    if let Token::Ident(_, i) = &tok {
+                        if i == "get" {
+                            if saw_get_attr {
+                                return Err(TypecheckerError::DuplicateFieldSpec { ident: tok, field_name: field_name_str });
+                            } else { saw_get_attr = true; }
+                        } else if i == "set" {
+                            if saw_set_attr {
+                                return Err(TypecheckerError::DuplicateFieldSpec { ident: tok, field_name: field_name_str });
+                            } else { saw_set_attr = true; }
+                        } else {
+                            return Err(TypecheckerError::UnknownFieldSpec { ident: tok, field_name: field_name_str });
+                        }
+                    } else { unreachable!("Field specs must be identifier tokens") }
+                }
+                let (is_gettable, is_settable) = match (saw_get_attr, saw_set_attr) {
+                    (false, false) => (true, true), // If neither present, it's both gettable and settable
+                    (true, false) => (true, false), // If only saw `get`, it's only gettable and NOT settable
+                    (false, true) => (false, true), // If only saw `set`, it's only settable and NOT gettable
+                    (true, true) => (true, true),   // If both present, it's both gettable and settable // todo: Add warning
+                };
+
+                Ok((ident, field_type, default_value, is_gettable, is_settable))
             })
-            .collect::<Result<Vec<(Token, Type, Option<AstNode>)>, _>>();
+            .collect::<Result<Vec<_>, _>>();
         let fields = fields?;
 
         let typedef = if let Some(Type::Struct(typedef)) = self.referencable_types.get_mut(&new_type_name) { typedef } else { unreachable!() };
         typedef.fields = fields.iter()
-            .map(|(name, typ, default_value_node)| {
+            .map(|(name, typ, default_value_node, gettable, settable)| {
                 StructTypeField {
                     name: Token::get_ident_name(name),
                     typ: typ.clone(),
                     has_default_value: default_value_node.is_some(),
+                    gettable: gettable.clone(),
+                    settable: settable.clone(),
                 }
             })
             .collect();
@@ -1667,7 +1694,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         // --------------------------------------------------------------------------------- \\
         // ------------------------ Begin Field/Method Typechecking ------------------------ \\
 
-        let typed_fields = fields.into_iter().map(|(tok, field_type, default_value_node)| {
+        let typed_fields = fields.into_iter().map(|(tok, field_type, default_value_node, _, _)| {
             let default_value = if let Some(default_value) = default_value_node {
                 let mut default_value = self.visit(default_value)?;
                 let default_value_type = default_value.get_type();
@@ -1957,10 +1984,12 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                 }
             }
             AstNode::Accessor(tok, node) => {
-                let typed_target = self.visit_accessor(tok.clone(), node)?;
-                if let TypedAstNode::Accessor(_, TypedAccessorNode { is_method, .. }) = &typed_target {
+                let typed_target = self.visit_accessor(tok.clone(), node, false)?;
+                if let TypedAstNode::Accessor(_, TypedAccessorNode { is_method, is_settable, field_ident, .. }) = &typed_target {
                     if *is_method {
                         return Err(TypecheckerError::InvalidAssignmentTarget { token, typ: None, reason: InvalidAssignmentTargetReason::MethodTarget });
+                    } else if !is_settable {
+                        return Err(TypecheckerError::InvalidAccess { token: field_ident.clone(), is_field: !*is_method, is_get: false });
                     }
                 } else { unreachable!() }
                 let mut typed_expr = self.visit(*expr)?;
@@ -2587,7 +2616,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         }
     }
 
-    fn visit_accessor(&mut self, token: Token, node: AccessorNode) -> Result<TypedAstNode, TypecheckerError> {
+    fn visit_accessor(&mut self, token: Token, node: AccessorNode, is_get: bool) -> Result<TypedAstNode, TypecheckerError> {
         let AccessorNode { target, field, is_opt_safe } = node;
         let target = self.visit(*target)?;
 
@@ -2608,18 +2637,22 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
             target_type: &Type,
             field_name: &String,
             token: &Token,
-        ) -> Result<(Option<(/*idx:*/usize, /*typ:*/Type, /*is_method:*/bool)>, HashMap<String, Type>), TypecheckerError> {
+        ) -> Result<(Option<FieldSpec>, HashMap<String, Type>), TypecheckerError> {
             match zelf.resolve_ref_type(&target_type) {
                 Type::Struct(StructType { fields, methods, type_args, .. }) => {
                     let generics = type_args.into_iter().collect::<HashMap<String, Type>>();
 
                     let field_data = fields.iter().enumerate()
-                        .find_map(|(idx, StructTypeField { name, typ, .. })| {
-                            if field_name == name { Some((idx, typ.clone(), false)) } else { None }
+                        .find_map(|(idx, StructTypeField { name, typ, gettable, settable, .. })| {
+                            if field_name == name {
+                                Some(FieldSpec { idx, typ: typ.clone(), is_method: false, gettable: *gettable, settable: *settable })
+                            } else { None }
                         })
                         .or_else(|| {
                             methods.iter().enumerate().find_map(|(idx, (name, typ))| {
-                                if field_name == name { Some((idx, typ.clone(), true)) } else { None }
+                                if field_name == name {
+                                    Some(FieldSpec { idx, typ: typ.clone(), is_method: true, gettable: true, settable: false })
+                                } else { None }
                             })
                         });
                     Ok((field_data, generics))
@@ -2649,7 +2682,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                     Type::Struct(StructType { static_fields, .. }) => {
                         let field_data = static_fields.iter().enumerate()
                             .find(|(_, (name, _, _))| field_name == name)
-                            .map(|(idx, (_, typ, _))| (idx, typ.clone(), true)); // All static fields are methods at the moment
+                            .map(|(idx, (_, typ, _))| FieldSpec { idx, typ: typ.clone(), is_method: true, gettable: true, settable: false }); // All static fields are methods at the moment
                         Ok((field_data, HashMap::new()))
                     }
                     Type::Enum(enum_type) => {
@@ -2658,11 +2691,15 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                             .find(|(_, EnumVariantType { name, .. })| field_name == name)
                             .map(|(idx, variant_type)| {
                                 let enum_type_ref = Type::Reference(enum_name.clone(), vec![]);
-                                (idx, Type::EnumVariant(Box::new(enum_type_ref), variant_type.clone(), false), false)
+                                // (idx, Type::EnumVariant(Box::new(enum_type_ref), variant_type.clone(), false), false)
+                                let typ = Type::EnumVariant(Box::new(enum_type_ref), variant_type.clone(), false);
+                                FieldSpec { idx, typ, is_method: false, gettable: true, settable: false }
                             })
                             .or_else(|| {
                                 static_fields.iter().enumerate().find_map(|(idx, (name, typ, _))| {
-                                    if field_name == name { Some((idx, typ.clone(), true)) } else { None } // All static fields are methods at the moment
+                                    if field_name == name {
+                                        Some(FieldSpec { idx, typ: typ.clone(), is_method: true, gettable: true, settable: false }) // All static fields are methods at the moment
+                                    } else { None } // All static fields are methods at the moment
                                 })
                             });
                         Ok((field_data, HashMap::new()))
@@ -2679,7 +2716,9 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                 }
                 Type::Enum(enum_type) => {
                     let field_data = enum_type.methods.iter().enumerate().find_map(|(idx, (name, typ))| {
-                        if field_name == name { Some((idx, typ.clone(), true)) } else { None }
+                        if field_name == name {
+                            Some(FieldSpec { idx, typ: typ.clone(), is_method: true, gettable: true, settable: false })
+                        } else { None }
                     });
                     Ok((field_data, HashMap::new()))
                 }
@@ -2690,7 +2729,9 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                             if is_constructed {
                                 arg_types.iter().enumerate()
                                     .find_map(|(idx, (arg_name, arg_type, _))| {
-                                        if field_name == arg_name { Some((idx, arg_type.clone(), false)) } else { None }
+                                        if field_name == arg_name {
+                                            Some(FieldSpec { idx, typ: arg_type.clone(), is_method: false, gettable: true, settable: true })
+                                        } else { None }
                                     })
                             } else {
                                 return Err(TypecheckerError::InvalidUninitializedEnumVariant { token: token.clone() });
@@ -2735,8 +2776,11 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
         }
 
         let (field_data, mut generics) = get_field_data(&self, &target_type, &field_name, &token)?;
-        let (field_idx, mut typ, is_method) = match field_data {
-            Some((field_idx, typ, is_method)) => {
+        let (field_idx, mut typ, is_method, is_settable) = match field_data {
+            Some(FieldSpec { idx, typ, is_method, gettable, settable }) => {
+                if is_get && !gettable {
+                    return Err(TypecheckerError::InvalidAccess { token: field_ident, is_field: !is_method, is_get });
+                }
                 if let Some(ident_type_args) = &ident_type_args {
                     if let Type::Fn(FnType { type_args: fn_type_args, .. }) = &typ {
                         if ident_type_args.len() != fn_type_args.len() {
@@ -2753,7 +2797,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
                         }
                     }
                 }
-                (field_idx, Type::substitute_generics(&typ, &generics), is_method)
+                (idx, Type::substitute_generics(&typ, &generics), is_method, settable)
             }
             None => return Err(TypecheckerError::UnknownMember { token: field_ident, target_type: target_type.clone() })
         };
@@ -2767,7 +2811,7 @@ impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
             } else { unreachable!() }
         } else { (token, is_opt_safe) };
 
-        Ok(TypedAstNode::Accessor(token, TypedAccessorNode { typ, target: Box::new(target), field_name, field_idx, is_opt_safe, is_method }))
+        Ok(TypedAstNode::Accessor(token, TypedAccessorNode { typ, target: Box::new(target), field_ident, field_idx, is_opt_safe, is_method, is_settable }))
     }
 
     fn visit_lambda(
@@ -4582,7 +4626,7 @@ mod tests {
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
-            fields: vec![StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false }],
+            fields: vec![StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true }],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
@@ -4616,8 +4660,8 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false },
-                StructTypeField { name: "age".to_string(), typ: Type::Int, has_default_value: true },
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true },
+                StructTypeField { name: "age".to_string(), typ: Type::Int, has_default_value: true, gettable: true, settable: true },
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -4644,17 +4688,65 @@ mod tests {
             name: "Node".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "value".to_string(), typ: Type::Int, has_default_value: false },
+                StructTypeField { name: "value".to_string(), typ: Type::Int, has_default_value: false, gettable: true, settable: true },
                 StructTypeField {
                     name: "next".to_string(),
                     typ: Type::Option(Box::new(Type::Reference("Node".to_string(), vec![]))),
                     has_default_value: true,
+                    gettable: true,
+                    settable: true,
                 },
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
         assert_eq!(expected_type, typechecker.referencable_types["Node"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn typecheck_type_decl_field_attrs() -> TestResult {
+        let (typechecker, _) = typecheck_get_typechecker("\
+          type Foo {\n\
+            a: Int { get set }\n\
+            b: Int { set }\n\
+            c: Int { get }\n\
+            d: Int\n\
+          }\
+        ");
+        let expected_type = Type::Struct(StructType {
+            name: "Foo".to_string(),
+            type_args: vec![],
+            fields: vec![
+                StructTypeField { name: "a".to_string(), typ: Type::Int, has_default_value: false, gettable: true, settable: true },
+                StructTypeField { name: "b".to_string(), typ: Type::Int, has_default_value: false, gettable: false, settable: true },
+                StructTypeField { name: "c".to_string(), typ: Type::Int, has_default_value: false, gettable: true, settable: false },
+                StructTypeField { name: "d".to_string(), typ: Type::Int, has_default_value: false, gettable: true, settable: true },
+            ],
+            static_fields: vec![],
+            methods: vec![to_string_method_type()],
+        });
+        assert_eq!(expected_type, typechecker.referencable_types["Foo"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn typecheck_type_decl_field_attrs_errors() -> TestResult {
+        let err = typecheck("type Foo { a: Int { get set set } }").unwrap_err();
+        let expected = TypecheckerError::DuplicateFieldSpec {
+            ident: ident_token!((1, 29), "set"),
+            field_name: "a".to_string()
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("type Foo { a: Int { get set unknownThing } }").unwrap_err();
+        let expected = TypecheckerError::UnknownFieldSpec {
+            ident: ident_token!((1, 29), "unknownThing"),
+            field_name: "a".to_string()
+        };
+        assert_eq!(expected, err);
 
         Ok(())
     }
@@ -4753,10 +4845,11 @@ mod tests {
                                                     is_mutable: false,
                                                 },
                                             )),
-                                            field_name: "name".to_string(),
+                                            field_ident: ident_token!((3, 35), "name"),
                                             field_idx: 0,
                                             is_opt_safe: false,
                                             is_method: false,
+                                            is_settable: true,
                                         },
                                     )
                                 ],
@@ -4795,10 +4888,11 @@ mod tests {
                                                                 is_mutable: false,
                                                             },
                                                         )),
-                                                        field_name: "getName".to_string(),
+                                                        field_ident: ident_token!((4, 36), "getName"),
                                                         field_idx: 1,
                                                         is_opt_safe: false,
                                                         is_method: true,
+                                                        is_settable: false,
                                                     },
                                                 )
                                             ),
@@ -4818,7 +4912,7 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false }
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true }
             ],
             static_fields: vec![],
             methods: vec![
@@ -4877,7 +4971,7 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false }
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true }
             ],
             static_fields: vec![
                 ("getName".to_string(), Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::String), is_variadic: false }), true),
@@ -4939,7 +5033,7 @@ mod tests {
             name: "List".to_string(),
             type_args: vec![("T".to_string(), Type::Generic("T".to_string()))],
             fields: vec![
-                StructTypeField { name: "items".to_string(), typ: Type::Array(Box::new(Type::Generic("T".to_string()))), has_default_value: false }
+                StructTypeField { name: "items".to_string(), typ: Type::Array(Box::new(Type::Generic("T".to_string()))), has_default_value: false, gettable: true, settable: true }
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -5161,7 +5255,7 @@ mod tests {
             name: "List".to_string(),
             type_args: vec![("T".to_string(), Type::Generic("T".to_string()))],
             fields: vec![
-                StructTypeField { name: "items".to_string(), typ: Type::Array(Box::new(Type::Generic("T".to_string()))), has_default_value: false }
+                StructTypeField { name: "items".to_string(), typ: Type::Array(Box::new(Type::Generic("T".to_string()))), has_default_value: false, gettable: true, settable: true }
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -5312,9 +5406,10 @@ mod tests {
                                             0
                                         )),
                                         field_idx: 0,
-                                        field_name: "Red".to_string(),
+                                        field_ident: ident_token!((1, 46), "Red"),
                                         is_opt_safe: false,
                                         is_method: false,
+                                        is_settable: false,
                                     },
                                 ))
                             ),
@@ -5643,9 +5738,10 @@ mod tests {
                         typ: Type::String,
                         target: Box::new(identifier!((3, 1), "a", Type::Reference("Person".to_string(), vec![]), 0)),
                         field_idx: 0,
-                        field_name: "name".to_string(),
+                        field_ident: ident_token!((3, 3), "name"),
                         is_opt_safe: false,
                         is_method: false,
+                        is_settable: true,
                     },
                 )),
                 expr: Box::new(string_literal!((3, 10), "qwer")),
@@ -5656,7 +5752,7 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false }
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true }
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -5738,6 +5834,20 @@ mod tests {
             token: Token::Assign(Position::new(6, 7)),
             typ: None,
             reason: InvalidAssignmentTargetReason::MethodTarget,
+        };
+        assert_eq!(expected, err);
+
+        let err = typecheck("\
+          type Person {\n\
+            name: String { get }\n\
+          }\n\
+          val a = Person(name: \"abc\")\n\
+          a.name = \"hello\"\
+        ").unwrap_err();
+        let expected = TypecheckerError::InvalidAccess {
+            token: ident_token!((5, 3), "name"),
+            is_field: true,
+            is_get: false
         };
         assert_eq!(expected, err);
     }
@@ -6399,7 +6509,7 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false }
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true }
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -6429,8 +6539,8 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false },
-                StructTypeField { name: "age".to_string(), typ: Type::Int, has_default_value: true },
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true },
+                StructTypeField { name: "age".to_string(), typ: Type::Int, has_default_value: true, gettable: true, settable: true },
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -6920,10 +7030,11 @@ mod tests {
             TypedAccessorNode {
                 typ: Type::String,
                 target: Box::new(identifier!((3, 1), "p", Type::Reference("Person".to_string(), vec![]), 0)),
-                field_name: "name".to_string(),
+                field_ident: ident_token!((3, 3), "name"),
                 field_idx: 0,
                 is_opt_safe: false,
                 is_method: false,
+                is_settable: true,
             },
         );
         assert_eq!(expected, typed_ast[2]);
@@ -6931,7 +7042,7 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false }
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true }
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -6949,10 +7060,11 @@ mod tests {
             TypedAccessorNode {
                 typ: Type::Int,
                 target: Box::new(identifier!((3, 1), "p", Type::Reference("Person".to_string(), vec![]), 0)),
-                field_name: "age".to_string(),
+                field_ident: ident_token!((3, 3), "age"),
                 field_idx: 1,
                 is_opt_safe: false,
                 is_method: false,
+                is_settable: true,
             },
         );
         assert_eq!(expected, typed_ast[2]);
@@ -6960,8 +7072,8 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false },
-                StructTypeField { name: "age".to_string(), typ: Type::Int, has_default_value: true },
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true },
+                StructTypeField { name: "age".to_string(), typ: Type::Int, has_default_value: true, gettable: true, settable: true },
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -6985,10 +7097,11 @@ mod tests {
                         ],
                     },
                 )),
-                field_name: "length".to_string(),
+                field_ident: ident_token!((1, 11), "length"),
                 field_idx: 0,
                 is_opt_safe: false,
                 is_method: false,
+                is_settable: true,
             },
         );
         assert_eq!(expected, typed_ast[0]);
@@ -7000,13 +7113,23 @@ mod tests {
             TypedAccessorNode {
                 typ: Type::Int,
                 target: Box::new(string_literal!((1, 1), "hello")),
-                field_name: "length".to_string(),
+                field_ident: ident_token!((1, 9), "length"),
                 field_idx: 0,
                 is_opt_safe: false,
                 is_method: false,
+                is_settable: true,
             },
         );
         assert_eq!(expected, typed_ast[0]);
+
+        // Test setting inner property of readonly field
+        let res = typecheck("\
+          type Name { first: String }\n\
+          type Person { name: Name { get } }\n\
+          val p = Person(name: Name(first: \"Ken\"))\n\
+          p.name.first = \"Meg\"\
+        ").is_ok();
+        assert!(res);
 
         Ok(())
     }
@@ -7023,10 +7146,11 @@ mod tests {
             TypedAccessorNode {
                 typ: Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::String), is_variadic: false }),
                 target: Box::new(identifier!((2, 1), "Person", Type::Type("Person".to_string(), Box::new(Type::Reference("Person".to_string(), vec![])), false), 0)),
-                field_name: "getName".to_string(),
+                field_ident: ident_token!((2, 8), "getName"),
                 field_idx: 0,
                 is_opt_safe: false,
                 is_method: true,
+                is_settable: false,
             },
         );
         assert_eq!(expected, typed_ast[1]);
@@ -7058,16 +7182,18 @@ mod tests {
                     TypedAccessorNode {
                         typ: Type::Option(Box::new(Type::String)),
                         target: Box::new(identifier!((3, 1), "p", Type::Reference("Person".to_string(), vec![]), 0)),
-                        field_name: "name".to_string(),
+                        field_ident: ident_token!((3, 3), "name"),
                         field_idx: 0,
                         is_opt_safe: false,
                         is_method: false,
+                        is_settable: true,
                     },
                 )),
-                field_name: "length".to_string(),
+                field_ident: ident_token!((3, 9), "length"),
                 field_idx: 0,
                 is_opt_safe: true,
                 is_method: false,
+                is_settable: true,
             },
         );
         assert_eq!(expected, typed_ast[2]);
@@ -7075,7 +7201,7 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::Option(Box::new(Type::String)), has_default_value: true }
+                StructTypeField { name: "name".to_string(), typ: Type::Option(Box::new(Type::String)), has_default_value: true, gettable: true, settable: true }
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -7093,10 +7219,11 @@ mod tests {
             TypedAccessorNode {
                 typ: Type::String,
                 target: Box::new(identifier!((3, 1), "p", Type::Reference("Person".to_string(), vec![]), 0)),
-                field_name: "name".to_string(),
+                field_ident: ident_token!((3, 4), "name"),
                 field_idx: 0,
                 is_opt_safe: false,
                 is_method: false,
+                is_settable: true,
             },
         );
         assert_eq!(expected, typed_ast[2]);
@@ -7104,7 +7231,7 @@ mod tests {
             name: "Person".to_string(),
             type_args: vec![],
             fields: vec![
-                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: true }
+                StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: true, gettable: true, settable: true }
             ],
             static_fields: vec![],
             methods: vec![to_string_method_type()],
@@ -7131,6 +7258,18 @@ mod tests {
         let expected = TypecheckerError::UnknownMember {
             token: ident_token!((1, 6), "value"),
             target_type: Type::Bool,
+        };
+        assert_eq!(expected, error);
+
+        let error = typecheck("\
+          type Person { name: String { set } }\n\
+          val p = Person(name: \"Sam\")\n\
+          p.name\
+        ").unwrap_err();
+        let expected = TypecheckerError::InvalidAccess {
+            token: ident_token!((3, 3), "name"),
+            is_field: true,
+            is_get: true,
         };
         assert_eq!(expected, error);
     }

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -23,12 +23,10 @@ pub enum TypecheckerError {
     MissingRequiredAssignment { ident: Token },
     DuplicateBinding { ident: Token, orig_ident: Token },
     DuplicateField { ident: Token, orig_ident: Token, orig_is_field: bool, orig_is_enum_variant: bool },
-    DuplicateFieldSpec { ident: Token, field_name: String },
     DuplicateType { ident: Token, orig_ident: Option<Token> },
     DuplicateTypeArgument { ident: Token, orig_ident: Token },
     UnboundGeneric(Token, String),
     UnknownIdentifier { ident: Token },
-    UnknownFieldSpec { ident: Token, field_name: String },
     InvalidAssignmentTarget { token: Token, typ: Option<Type>, reason: InvalidAssignmentTargetReason },
     AssignmentToImmutable { orig_ident: Token, token: Token },
     UnannotatedUninitialized { ident: Token, is_mutable: bool },
@@ -88,9 +86,7 @@ impl TypecheckerError {
             TypecheckerError::DuplicateTypeArgument { ident, .. } => ident,
             TypecheckerError::UnboundGeneric(token, _) => token,
             TypecheckerError::DuplicateField { ident, .. } => ident,
-            TypecheckerError::DuplicateFieldSpec { ident, .. } => ident,
             TypecheckerError::UnknownIdentifier { ident } => ident,
-            TypecheckerError::UnknownFieldSpec { ident, .. } => ident,
             TypecheckerError::InvalidAssignmentTarget { token, .. } => token,
             TypecheckerError::AssignmentToImmutable { token, .. } => token,
             TypecheckerError::UnannotatedUninitialized { ident, .. } => ident,
@@ -308,12 +304,6 @@ impl DisplayError for TypecheckerError {
 
                 format!("{}\n{}", first_msg, second_msg)
             }
-            TypecheckerError::DuplicateFieldSpec { field_name, .. } => {
-                format!(
-                    "Duplicate attribute declared for field '{}': ({}:{})\n{}",
-                    field_name, pos.line, pos.col, cursor_line
-                )
-            }
             TypecheckerError::DuplicateType { ident, orig_ident } => { // orig_ident will be None if it's a builtin type
                 let ident = Token::get_ident_name(&ident);
                 let first_msg = format!("Duplicate type '{}': ({}:{})\n{}", ident, pos.line, pos.col, cursor_line);
@@ -362,13 +352,6 @@ impl DisplayError for TypecheckerError {
                         ident, pos.line, pos.col, cursor_line
                     )
                 }
-            }
-            TypecheckerError::UnknownFieldSpec { ident, field_name } => {
-                let attr = Token::get_ident_name(ident);
-                format!(
-                    "Unknown attribute '{}' declared for field '{}': ({}:{})\n{}",
-                    attr, field_name, pos.line, pos.col, cursor_line
-                )
             }
             TypecheckerError::InvalidAssignmentTarget { typ, reason, .. } => {
                 let msg = match reason {
@@ -1206,7 +1189,7 @@ Type Int[] does not have a member with name 'size'"
                 name: "Person".to_string(),
                 type_args: vec![],
                 fields: vec![
-                    StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, gettable: true, settable: true }
+                    StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, readonly: true }
                 ],
                 static_fields: vec![],
                 methods: vec![],

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -300,7 +300,7 @@ pub struct TypedAccessorNode {
     pub field_idx: usize,
     pub is_opt_safe: bool,
     pub is_method: bool,
-    pub is_settable: bool,
+    pub is_readonly: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -295,10 +295,13 @@ pub struct TypedForLoopNode {
 pub struct TypedAccessorNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
-    pub field_name: String,
+    // pub field_name: String,
+    // Must be Token::Ident
+    pub field_ident: Token,
     pub field_idx: usize,
     pub is_opt_safe: bool,
     pub is_method: bool,
+    pub is_settable: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -295,7 +295,6 @@ pub struct TypedForLoopNode {
 pub struct TypedAccessorNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
-    // pub field_name: String,
     // Must be Token::Ident
     pub field_ident: Token,
     pub field_idx: usize,

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -103,34 +103,32 @@ pub struct StructTypeField {
     pub name: String,
     pub typ: Type,
     pub has_default_value: bool,
-    pub gettable: bool,
-    pub settable: bool,
+    pub readonly: bool,
 }
 
 pub struct FieldSpec {
     pub idx: usize,
     pub typ: Type,
     pub is_method: bool,
-    pub gettable: bool,
-    pub settable: bool,
+    pub readonly: bool,
 }
 
 impl StructType {
     pub fn get_field_or_method<S: AsRef<str>>(&self, name: S) -> Option<FieldSpec> {
         self.fields.iter().enumerate()
             .find(|(_, f)| f.name == name.as_ref())
-            .map(|(idx, f)| FieldSpec { idx, typ: f.typ.clone(), is_method: false, gettable: f.gettable, settable: f.settable })
+            .map(|(idx, f)| FieldSpec { idx, typ: f.typ.clone(), is_method: false, readonly: f.readonly })
             .or_else(|| {
                 self.methods.iter().enumerate()
                     .find(|(_, f)| f.0 == name.as_ref())
-                    .map(|(idx, f)| FieldSpec { idx, typ: f.1.clone(), is_method: true, gettable: true, settable: false })
+                    .map(|(idx, f)| FieldSpec { idx, typ: f.1.clone(), is_method: true, readonly: true })
             })
     }
 
     pub fn get_static_field_or_method<S: AsRef<str>>(&self, name: S) -> Option<FieldSpec> {
         self.static_fields.iter().enumerate()
             .find(|(_, f)| f.0 == name.as_ref())
-            .map(|(idx, f)| FieldSpec { idx, typ: f.1.clone(), is_method: true, gettable: true, settable: false }) // All static fields are methods atm
+            .map(|(idx, f)| FieldSpec { idx, typ: f.1.clone(), is_method: true, readonly: true }) // All static fields are methods atm
     }
 
     pub fn get_field_idx<S: AsRef<str>>(&self, name: S) -> Option<usize> {

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -103,24 +103,34 @@ pub struct StructTypeField {
     pub name: String,
     pub typ: Type,
     pub has_default_value: bool,
+    pub gettable: bool,
+    pub settable: bool,
+}
+
+pub struct FieldSpec {
+    pub idx: usize,
+    pub typ: Type,
+    pub is_method: bool,
+    pub gettable: bool,
+    pub settable: bool,
 }
 
 impl StructType {
-    pub fn get_field_or_method<S: AsRef<str>>(&self, name: S) -> Option<(usize, Type, /* is_method: */ bool)> {
+    pub fn get_field_or_method<S: AsRef<str>>(&self, name: S) -> Option<FieldSpec> {
         self.fields.iter().enumerate()
             .find(|(_, f)| f.name == name.as_ref())
-            .map(|(idx, f)| (idx, f.typ.clone(), false))
+            .map(|(idx, f)| FieldSpec { idx, typ: f.typ.clone(), is_method: false, gettable: f.gettable, settable: f.settable })
             .or_else(|| {
                 self.methods.iter().enumerate()
                     .find(|(_, f)| f.0 == name.as_ref())
-                    .map(|(idx, f)| (idx, f.1.clone(), true))
+                    .map(|(idx, f)| FieldSpec { idx, typ: f.1.clone(), is_method: true, gettable: true, settable: false })
             })
     }
 
-    pub fn get_static_field_or_method<S: AsRef<str>>(&self, name: S) -> Option<(usize, Type, /* is_method: */ bool)> {
+    pub fn get_static_field_or_method<S: AsRef<str>>(&self, name: S) -> Option<FieldSpec> {
         self.static_fields.iter().enumerate()
             .find(|(_, f)| f.0 == name.as_ref())
-            .map(|(idx, f)| (idx, f.1.clone(), true)) // All static fields are methods atm
+            .map(|(idx, f)| FieldSpec { idx, typ: f.1.clone(), is_method: true, gettable: true, settable: false }) // All static fields are methods atm
     }
 
     pub fn get_field_idx<S: AsRef<str>>(&self, name: S) -> Option<usize> {

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -1702,7 +1702,7 @@ impl TypedAstVisitor<(), ()> for Compiler {
                         TypedAstNode::Accessor(tok, node) => {
                             let prev_cond_binding_name = format!("${}", layer_number - 1);
                             let target = Box::new(make_dummy_ident_node(&token, prev_cond_binding_name));
-                            TypedAstNode::Accessor(tok, TypedAccessorNode { typ: node.typ, target, field_name: node.field_name, field_idx: node.field_idx, is_method: node.is_method, is_opt_safe: false })
+                            TypedAstNode::Accessor(tok, TypedAccessorNode { target, is_opt_safe: false, ..node })
                         }
                         _ => unimplemented!()
                     }
@@ -1730,7 +1730,8 @@ impl TypedAstVisitor<(), ()> for Compiler {
 
             self.visit(if_node)?;
         } else {
-            let TypedAccessorNode { target, field_name, field_idx, is_method, .. } = node;
+            let TypedAccessorNode { target, field_ident, field_idx, is_method, .. } = node;
+            let field_name = Token::get_ident_name(&field_ident);
             self.metadata.field_gets.push(field_name);
 
             self.visit(*target)?;

--- a/abra_native/src/lib.rs
+++ b/abra_native/src/lib.rs
@@ -773,7 +773,7 @@ fn gen_native_type_code(type_spec: &TypeSpec) -> TokenStream {
     });
 
     let fields = type_spec.fields.iter().map(|field| {
-        let FieldSpec { name, typ, has_default, .. } = field;
+        let FieldSpec { name, typ, has_default, gettable, settable, ..  } = field;
         let typ = gen_rust_type_path(typ, type_name);
 
         quote! {
@@ -781,8 +781,8 @@ fn gen_native_type_code(type_spec: &TypeSpec) -> TokenStream {
                 name: #name.to_string(),
                 typ: #typ,
                 has_default_value: #has_default,
-                gettable: true,
-                settable: true,
+                gettable: #gettable,
+                settable: #settable,
             }
         }
     });

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -616,24 +616,6 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
-                TypecheckerError::DuplicateFieldSpec { ident, field_name } => {
-                    let mut obj = serializer.serialize_map(Some(5))?;
-                    obj.serialize_entry("kind", "typecheckerError")?;
-                    obj.serialize_entry("subKind", "duplicateFieldSpec")?;
-                    obj.serialize_entry("token", &JsToken(ident))?;
-                    obj.serialize_entry("fieldName", field_name)?;
-                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
-                    obj.end()
-                }
-                TypecheckerError::UnknownFieldSpec { ident, field_name } => {
-                    let mut obj = serializer.serialize_map(Some(5))?;
-                    obj.serialize_entry("kind", "typecheckerError")?;
-                    obj.serialize_entry("subKind", "unknownFieldSpec")?;
-                    obj.serialize_entry("token", &JsToken(ident))?;
-                    obj.serialize_entry("fieldName", field_name)?;
-                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
-                    obj.end()
-                }
                 TypecheckerError::InvalidAccess { token, is_field, is_get } => {
                     let mut obj = serializer.serialize_map(Some(6))?;
                     obj.serialize_entry("kind", "typecheckerError")?;

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -616,6 +616,34 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
+                TypecheckerError::DuplicateFieldSpec { ident, field_name } => {
+                    let mut obj = serializer.serialize_map(Some(5))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "duplicateFieldSpec")?;
+                    obj.serialize_entry("token", &JsToken(ident))?;
+                    obj.serialize_entry("fieldName", field_name)?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
+                TypecheckerError::UnknownFieldSpec { ident, field_name } => {
+                    let mut obj = serializer.serialize_map(Some(5))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "unknownFieldSpec")?;
+                    obj.serialize_entry("token", &JsToken(ident))?;
+                    obj.serialize_entry("fieldName", field_name)?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
+                TypecheckerError::InvalidAccess { token, is_field, is_get } => {
+                    let mut obj = serializer.serialize_map(Some(6))?;
+                    obj.serialize_entry("kind", "typecheckerError")?;
+                    obj.serialize_entry("subKind", "invalidAccess")?;
+                    obj.serialize_entry("token", &JsToken(token))?;
+                    obj.serialize_entry("isField", is_field)?;
+                    obj.serialize_entry("isGet", is_get)?;
+                    obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
+                    obj.end()
+                }
             }
             Error::InterpretError(interpret_error) => match interpret_error {
                 InterpretError::StackEmpty => {

--- a/abra_wasm/src/js_value/token.rs
+++ b/abra_wasm/src/js_value/token.rs
@@ -136,6 +136,12 @@ impl<'a> Serialize for JsToken<'a> {
                 obj.serialize_entry("pos", &JsPosition(pos))?;
                 obj.end()
             }
+            Token::Readonly(pos) => {
+                let mut obj = serializer.serialize_map(Some(2))?;
+                obj.serialize_entry("kind", "readonly")?;
+                obj.serialize_entry("pos", &JsPosition(pos))?;
+                obj.end()
+            }
             Token::Return(pos, _) => {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("kind", "return")?;


### PR DESCRIPTION
Addresses #277 

- The `get`/`set` field attributes control get-/set-ability from outside
the type. A field with no attributes will default to being gettable and
settable; and field with both `get` and `set` will also be both gettable
and settable (though this will produce a warning in a future version).
Otherwise, a field with just `get` will _only_ be gettable (and not
settable), and a field with just `set` will _only_ be settable (and not
gettable).
  - This last example will also produce a warning in a future version,
  since it doesn't really make sense for a field to be settable but
  _not_ gettable. Also, an empty field attr list
  (`type A { a: Int { } }`) will also produce a warning in a future
  version.