### PR TITLE
Refactor function invocations

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,6 +1,30 @@
-var total = 0
-val arr = [1, 2, 3, 4]
-arr.map(i => {
-  total += i
-  i * 3
-}).concat([total])
+//func getAdder(q: Int, x: Int): (Int) => Int {
+//  //val q = 54
+//  val f: (Int) => Int = (y, z = 3) => x + y + z
+//  f
+//}
+//getAdder(-24, 20)(1)
+
+//val f = if true {
+//  val x = 4
+//  (y: Int) => x + y
+//} else {
+//  (y: Int) => 0
+//}
+//
+//f(1)
+
+func getAdder(x: Int): (Int) => Int {
+  (y, z = 3) => x + y + z
+}
+getAdder(20)(1)
+
+//func map<T, U>(arr: T[], fn: (T) => U): (T) => U[] {
+//  () => []
+//}
+
+func f(): Int {
+  if true { return 24 }
+  return 6
+}
+f()

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -56,7 +56,7 @@ pub enum Opcode {
     Jump(usize),
     JumpIfF(usize),
     JumpB(usize),
-    Invoke(usize, bool),
+    Invoke(usize),
     ClosureMk,
     CloseUpvalue,
     CloseUpvalueAndPop,
@@ -72,27 +72,27 @@ impl Opcode {
         let base = self.to_string();
 
         let imm = match self {
-            Opcode::Constant(const_idx) => Some(const_idx.to_string()),
-            Opcode::New(num_fields) => Some(num_fields.to_string()),
-            Opcode::GetField(field_idx) => Some(field_idx.to_string()),
-            Opcode::GetMethod(method_idx) => Some(method_idx.to_string()),
-            Opcode::SetField(field_idx) => Some(field_idx.to_string()),
+            Opcode::Constant(const_idx) => Some(const_idx),
+            Opcode::New(num_fields) => Some(num_fields),
+            Opcode::GetField(field_idx) => Some(field_idx),
+            Opcode::GetMethod(method_idx) => Some(method_idx),
+            Opcode::SetField(field_idx) => Some(field_idx),
             Opcode::MapMk(size) |
             Opcode::ArrMk(size) |
             Opcode::TupleMk(size) |
-            Opcode::SetMk(size) => Some(size.to_string()),
+            Opcode::SetMk(size) => Some(size),
             Opcode::GStore(slot) |
-            Opcode::LStore(slot) => Some(slot.to_string()),
-            Opcode::UStore(upvalue_idx) => Some(upvalue_idx.to_string()),
+            Opcode::LStore(slot) => Some(slot),
+            Opcode::UStore(upvalue_idx) => Some(upvalue_idx),
             Opcode::GLoad(slot) |
-            Opcode::LLoad(slot) => Some(slot.to_string()),
-            Opcode::ULoad(upvalue_idx) => Some(upvalue_idx.to_string()),
+            Opcode::LLoad(slot) => Some(slot),
+            Opcode::ULoad(upvalue_idx) => Some(upvalue_idx),
             Opcode::Jump(offset) |
             Opcode::JumpIfF(offset) |
-            Opcode::JumpB(offset) => Some(offset.to_string()),
-            Opcode::Invoke(arity, has_return) => Some(format!("{} {}", arity, has_return)),
-            Opcode::Pop(num_pops) => Some(num_pops.to_string()),
-            Opcode::MarkLocal(local_idx) => Some(local_idx.to_string()),
+            Opcode::JumpB(offset) => Some(offset),
+            Opcode::Invoke(arity) => Some(arity),
+            Opcode::Pop(num_pops) => Some(num_pops),
+            Opcode::MarkLocal(local_idx) => Some(local_idx),
             _ => None
         };
         match imm {

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -748,7 +748,6 @@ mod tests {
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(3) as usize),
                 Opcode::LStore(0),
-                Opcode::Pop(1),
                 Opcode::Return
             ],
             upvalues: vec![],


### PR DESCRIPTION
- Previously, every function invocation would first need to push a
return slot of `nil` onto the stack as the 0th argument. Functions would
store return values into that guaranteed 0th element, which would remain
on top of the stack when the function's call frame ended. Rather than
requiring the caller to always pre-allocate this return slot though, we
can be smarter.
  - If there is a "first local" declared in the function's scope, we can
    just store return values into that slot (and not pop that value as
    it exits). If there are no locals in the scope, we can just leave the
    return value on top of the stack as the function exits.
  - This assumption logic gets thrown off when the return value is a
    function which could potentially have closed over the first local in
    the scope. If we attempt to store the returned closure into a slot
    which is already referenced as an upvalue in that closure, things get
    messy. To handle this, callers _do_ need to pre-allocate a
    return slot on the stack as the 0th argument. The behavior in this case
    is the same as before; the return value gets inserted into the first
    local in the scope. Except now, it's guaranteed that this first local
    will never be closed over by that closure.