### PR TITLE
Global bindings' names should be namespaced

### DIFF
--- a/abra_cli/src/main.rs
+++ b/abra_cli/src/main.rs
@@ -49,7 +49,7 @@ fn cmd_compile_and_run(opts: RunOpts) -> Result<(), ()> {
         print: |input| print!("{}", input)
     };
 
-    let module = match compile(&contents) {
+    let module = match compile(opts.file_name, &contents) {
         Ok((module, _)) => module,
         Err(error) => {
             match error {
@@ -74,7 +74,7 @@ fn cmd_compile_and_run(opts: RunOpts) -> Result<(), ()> {
 fn cmd_disassemble(opts: DisassembleOpts) -> Result<(), ()> {
     let contents = read_file(&opts.file_name)?;
 
-    match compile_and_disassemble(&contents) {
+    match compile_and_disassemble(opts.file_name, &contents) {
         Ok(output) => {
             match opts.out_file {
                 None => println!("{}", output),

--- a/abra_core/src/builtins/native/test_utils.rs
+++ b/abra_core/src/builtins/native/test_utils.rs
@@ -38,14 +38,17 @@ pub fn interpret(input: &str) -> Option<Value> {
     let tokens = tokenize(&input.to_string()).unwrap();
     let ast = parse(tokens).unwrap();
     let (_, typed_ast) = typecheck(ast).unwrap();
-    let (module, _) = compile(typed_ast).unwrap();
+
+    let module_name = "_test.abra".to_string();
+    let (module, _) = compile(module_name, typed_ast).unwrap();
 
     let mut vm = VM::new(module, VMContext::default());
     vm.run().unwrap()
 }
 
 pub fn interpret_get_result<S: AsRef<str>>(input: S) -> Result<Option<Value>, Error> {
-    let module = match crate::compile(&input.as_ref().to_string()) {
+    let module_name = "_test.abra".to_string();
+    let module = match crate::compile(module_name, &input.as_ref().to_string()) {
         Ok((module, _)) => module,
         Err(error) => return Err(error)
     };

--- a/abra_core/src/builtins/native_fns.rs
+++ b/abra_core/src/builtins/native_fns.rs
@@ -178,7 +178,7 @@ mod test {
     use crate::vm::vm::VMContext;
 
     fn make_vm() -> VM {
-        let module = Module { code: vec![], constants: vec![] };
+        let module = Module { name: "_test.abra".to_string(), code: vec![], constants: vec![] };
         VM::new(module, VMContext::default())
     }
 

--- a/abra_core/src/lib.rs
+++ b/abra_core/src/lib.rs
@@ -49,13 +49,13 @@ pub fn typecheck(input: &String) -> Result<Vec<TypedAstNode>, Error> {
     }
 }
 
-pub fn compile(input: &String) -> Result<(Module, Metadata), Error> {
+pub fn compile(module_path: String, input: &String) -> Result<(Module, Metadata), Error> {
     let typed_ast_nodes = typecheck(input)?;
-    let result = vm::compiler::compile(typed_ast_nodes).unwrap();
+    let result = vm::compiler::compile(module_path, typed_ast_nodes).unwrap();
     Ok(result)
 }
 
-pub fn compile_and_disassemble(input: &String) -> Result<String, Error> {
-    let (compiled_module, metadata) = compile(input)?;
+pub fn compile_and_disassemble(module_path: String, input: &String) -> Result<String, Error> {
+    let (compiled_module, metadata) = compile(module_path, input)?;
     Ok(vm::disassembler::disassemble(compiled_module, metadata))
 }

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -100,7 +100,7 @@ const STACK_LIMIT: usize = 1024;
 impl VM {
     pub fn new(module: Module, ctx: VMContext) -> Self {
         let name = "$main".to_string();
-        let Module { code, constants } = module;
+        let Module { code, constants, .. } = module;
         let root_frame = CallFrame { ip: 0, code, start_stack_idx: 0, name, upvalues: vec![], local_addrs: vec![] };
 
         let type_constant_indexes = constants.iter().enumerate()

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -25,7 +25,9 @@ mod tests {
         let tokens = tokenize(&input.to_string()).unwrap();
         let ast = parse(tokens).unwrap();
         let (_, typed_ast) = typecheck(ast).unwrap();
-        let (module, _) = compile(typed_ast).unwrap();
+
+        let module_name = "_test.abra".to_string();
+        let (module, _) = compile(module_name, typed_ast).unwrap();
         let ctx = VMContext::default();
 
         let mut vm = VM::new(module, ctx);

--- a/abra_wasm/src/js_value/module.rs
+++ b/abra_wasm/src/js_value/module.rs
@@ -10,9 +10,10 @@ impl<'a> Serialize for JsModule<'a> {
     {
         use serde::ser::SerializeMap;
 
-        let Module { constants, code } = self.0;
+        let Module { name, constants, code } = self.0;
 
-        let mut obj = serializer.serialize_map(Some(4))?;
+        let mut obj = serializer.serialize_map(Some(3))?;
+        obj.serialize_entry("name", name)?;
 
         let mut bytecode = Vec::<(String, Option<Vec<u32>>)>::new();
         let mut code = code.iter();

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -220,7 +220,8 @@ extern "C" {
 
 #[wasm_bindgen(js_name = disassemble)]
 pub fn disassemble(input: &str) -> JsValue {
-    let result = compile_and_disassemble(&input.to_string());
+    let module_name = "_repl.abra".to_string();
+    let result = compile_and_disassemble(module_name, &input.to_string());
     let disassemble_result = DisassembleResult(result, input.to_string());
     JsValue::from_serde(&disassemble_result)
         .unwrap_or(JsValue::NULL)
@@ -237,7 +238,8 @@ pub fn typecheck_input(input: &str) -> JsValue {
 
 #[wasm_bindgen(js_name = compile)]
 pub fn parse_typecheck_and_compile(input: &str) -> JsValue {
-    let result = compile(&input.to_string())
+    let module_name = "_repl.abra".to_string();
+    let result = compile(module_name, &input.to_string())
         .map(|(module, _)| module);
     let compile_result = CompileResult(result, input.to_string());
     JsValue::from_serde(&compile_result)
@@ -245,7 +247,8 @@ pub fn parse_typecheck_and_compile(input: &str) -> JsValue {
 }
 
 fn compile_and_run(input: String, ctx: VMContext) -> Result<Option<Value>, Error> {
-    let (module, _) = compile(&input)?;
+    let module_name = "_repl.abra".to_string();
+    let (module, _) = compile(module_name, &input)?;
     let mut vm = VM::new(module, ctx);
     match vm.run() {
         Ok(Some(v)) => Ok(Some(v)),


### PR DESCRIPTION
It should be namespaced to the module it's defined in (a module name is its path with `/`s replaced by `.`s and the `.abra` extension trimmed)