### PR TITLE
Typechecker returns `TypedModule`

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,30 +1,4 @@
-//func getAdder(q: Int, x: Int): (Int) => Int {
-//  //val q = 54
-//  val f: (Int) => Int = (y, z = 3) => x + y + z
-//  f
-//}
-//getAdder(-24, 20)(1)
-
-//val f = if true {
-//  val x = 4
-//  (y: Int) => x + y
-//} else {
-//  (y: Int) => 0
-//}
-//
-//f(1)
-
-func getAdder(x: Int): (Int) => Int {
-  (y, z = 3) => x + y + z
-}
-getAdder(20)(1)
-
-//func map<T, U>(arr: T[], fn: (T) => U): (T) => U[] {
-//  () => []
-//}
-
-func f(): Int {
-  if true { return 24 }
-  return 6
-}
-f()
+val m: Map<Int[], Int> = {}
+m[[1, 2]] = 2
+m[[1, 2, 3]] = 3
+m.keys()

--- a/abra_core/src/builtins/native/test_utils.rs
+++ b/abra_core/src/builtins/native/test_utils.rs
@@ -35,12 +35,12 @@ macro_rules! string_array {
 }
 
 pub fn interpret(input: &str) -> Option<Value> {
+    let module_name = "_test.abra".to_string();
+
     let tokens = tokenize(&input.to_string()).unwrap();
     let ast = parse(tokens).unwrap();
-    let module = typecheck(ast).unwrap();
-
-    let module_name = "_test.abra".to_string();
-    let (module, _) = compile(module_name, module).unwrap();
+    let module = typecheck(module_name, ast).unwrap();
+    let (module, _) = compile(module).unwrap();
 
     let mut vm = VM::new(module, VMContext::default());
     vm.run().unwrap()

--- a/abra_core/src/builtins/native/test_utils.rs
+++ b/abra_core/src/builtins/native/test_utils.rs
@@ -37,10 +37,10 @@ macro_rules! string_array {
 pub fn interpret(input: &str) -> Option<Value> {
     let tokens = tokenize(&input.to_string()).unwrap();
     let ast = parse(tokens).unwrap();
-    let (_, typed_ast) = typecheck(ast).unwrap();
+    let module = typecheck(ast).unwrap();
 
     let module_name = "_test.abra".to_string();
-    let (module, _) = compile(module_name, typed_ast).unwrap();
+    let (module, _) = compile(module_name, module).unwrap();
 
     let mut vm = VM::new(module, VMContext::default());
     vm.run().unwrap()

--- a/abra_core/src/lib.rs
+++ b/abra_core/src/lib.rs
@@ -6,7 +6,7 @@ extern crate strum;
 extern crate strum_macros;
 
 use crate::vm::compiler::{Metadata, Module};
-use crate::typechecker::typed_ast::TypedAstNode;
+use crate::typechecker::typechecker::TypedModule;
 use crate::common::display_error::DisplayError;
 
 pub mod builtins;
@@ -34,7 +34,7 @@ impl DisplayError for Error {
     }
 }
 
-pub fn typecheck(input: &String) -> Result<Vec<TypedAstNode>, Error> {
+pub fn typecheck(input: &String) -> Result<TypedModule, Error> {
     match lexer::lexer::tokenize(input) {
         Err(e) => Err(Error::LexerError(e)),
         Ok(tokens) => match parser::parser::parse(tokens) {
@@ -42,7 +42,7 @@ pub fn typecheck(input: &String) -> Result<Vec<TypedAstNode>, Error> {
             Ok(ast) => {
                 match typechecker::typechecker::typecheck(ast) {
                     Err(e) => Err(Error::TypecheckerError(e)),
-                    Ok((_, nodes)) => Ok(nodes)
+                    Ok(module) => Ok(module)
                 }
             }
         }

--- a/abra_core/src/lib.rs
+++ b/abra_core/src/lib.rs
@@ -34,13 +34,13 @@ impl DisplayError for Error {
     }
 }
 
-pub fn typecheck(input: &String) -> Result<TypedModule, Error> {
+pub fn typecheck(module_path: String, input: &String) -> Result<TypedModule, Error> {
     match lexer::lexer::tokenize(input) {
         Err(e) => Err(Error::LexerError(e)),
         Ok(tokens) => match parser::parser::parse(tokens) {
             Err(e) => Err(Error::ParseError(e)),
             Ok(ast) => {
-                match typechecker::typechecker::typecheck(ast) {
+                match typechecker::typechecker::typecheck(module_path, ast) {
                     Err(e) => Err(Error::TypecheckerError(e)),
                     Ok(module) => Ok(module)
                 }
@@ -50,8 +50,8 @@ pub fn typecheck(input: &String) -> Result<TypedModule, Error> {
 }
 
 pub fn compile(module_path: String, input: &String) -> Result<(Module, Metadata), Error> {
-    let typed_ast_nodes = typecheck(input)?;
-    let result = vm::compiler::compile(module_path, typed_ast_nodes).unwrap();
+    let module = typecheck(module_path, input)?;
+    let result = vm::compiler::compile(module).unwrap();
     Ok(result)
 }
 

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -58,18 +58,20 @@ impl Scope {
 
 #[derive(Debug, Clone)]
 pub struct TypedModule {
+    pub module_name: String,
     pub typed_nodes: Vec<TypedAstNode>,
     pub referencable_types: HashMap<String, Type>,
     pub global_bindings: HashMap<String, ScopeBinding>,
     pub types: HashMap<String, Type>,
 }
 
-pub fn typecheck(ast: Vec<AstNode>) -> Result<TypedModule, TypecheckerError> {
+pub fn typecheck(module_path: String, ast: Vec<AstNode>) -> Result<TypedModule, TypecheckerError> {
     let mut referencable_types = HashMap::new();
     referencable_types.insert("Array".to_string(), Type::Array(Box::new(Type::Generic("T".to_string()))));
     referencable_types.insert("Map".to_string(), Type::Map(Box::new(Type::Generic("K".to_string())), Box::new(Type::Generic("V".to_string()))));
     referencable_types.insert("Set".to_string(), Type::Set(Box::new(Type::Generic("T".to_string()))));
     referencable_types.insert("Date".to_string(), Type::Struct(NativeDate::get_type()));
+
 
     let mut typechecker = Typechecker {
         cur_typedef: None,
@@ -87,6 +89,7 @@ pub fn typecheck(ast: Vec<AstNode>) -> Result<TypedModule, TypecheckerError> {
     let scope = typechecker.scopes.pop().expect("There should be a top-level scope");
 
     let module = TypedModule {
+        module_name: module_path.replace(".abra", "").replace("/", "."),
         typed_nodes: results?,
         referencable_types: typechecker.referencable_types.clone(),
         global_bindings: scope.bindings,
@@ -2880,7 +2883,8 @@ mod tests {
         let tokens = tokenize(&input.to_string()).unwrap();
         let ast = parse(tokens).unwrap();
 
-        let module = super::typecheck(ast)?;
+        let module_path = "_test.abra".to_string();
+        let module = super::typecheck(module_path, ast)?;
         Ok(module)
     }
 

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -56,6 +56,46 @@ impl Scope {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TypedModule {
+    pub typed_nodes: Vec<TypedAstNode>,
+    pub referencable_types: HashMap<String, Type>,
+    pub global_bindings: HashMap<String, ScopeBinding>,
+    pub types: HashMap<String, Type>,
+}
+
+pub fn typecheck(ast: Vec<AstNode>) -> Result<TypedModule, TypecheckerError> {
+    let mut referencable_types = HashMap::new();
+    referencable_types.insert("Array".to_string(), Type::Array(Box::new(Type::Generic("T".to_string()))));
+    referencable_types.insert("Map".to_string(), Type::Map(Box::new(Type::Generic("K".to_string())), Box::new(Type::Generic("V".to_string()))));
+    referencable_types.insert("Set".to_string(), Type::Set(Box::new(Type::Generic("T".to_string()))));
+    referencable_types.insert("Date".to_string(), Type::Struct(NativeDate::get_type()));
+
+    let mut typechecker = Typechecker {
+        cur_typedef: None,
+        scopes: vec![Scope::root_scope()],
+        referencable_types,
+        returns: vec![],
+    };
+
+    typechecker.hoist_declarations_in_scope(&ast)?;
+
+    let results: Result<Vec<TypedAstNode>, TypecheckerError> = ast.into_iter()
+        .map(|node| typechecker.visit(node))
+        .collect();
+
+    let scope = typechecker.scopes.pop().expect("There should be a top-level scope");
+
+    let module = TypedModule {
+        typed_nodes: results?,
+        referencable_types: typechecker.referencable_types.clone(),
+        global_bindings: scope.bindings,
+        types: scope.types.into_iter().map(|(k, (t, _))| (k, t)).collect(),
+    };
+
+    Ok(module)
+}
+
 pub struct Typechecker {
     pub(crate) cur_typedef: Option<Type>,
     pub(crate) scopes: Vec<Scope>,
@@ -1075,28 +1115,6 @@ impl Typechecker {
 
         Ok(())
     }
-}
-
-pub fn typecheck(ast: Vec<AstNode>) -> Result<(Typechecker, Vec<TypedAstNode>), TypecheckerError> {
-    let mut referencable_types = HashMap::new();
-    referencable_types.insert("Array".to_string(), Type::Array(Box::new(Type::Generic("T".to_string()))));
-    referencable_types.insert("Map".to_string(), Type::Map(Box::new(Type::Generic("K".to_string())), Box::new(Type::Generic("V".to_string()))));
-    referencable_types.insert("Set".to_string(), Type::Set(Box::new(Type::Generic("T".to_string()))));
-    referencable_types.insert("Date".to_string(), Type::Struct(NativeDate::get_type()));
-
-    let mut typechecker = Typechecker {
-        cur_typedef: None,
-        scopes: vec![Scope::root_scope()],
-        referencable_types,
-        returns: vec![],
-    };
-
-    typechecker.hoist_declarations_in_scope(&ast)?;
-
-    let results: Result<Vec<TypedAstNode>, TypecheckerError> = ast.into_iter()
-        .map(|node| typechecker.visit(node))
-        .collect();
-    Ok((typechecker, results?))
 }
 
 impl AstVisitor<TypedAstNode, TypecheckerError> for Typechecker {
@@ -2858,19 +2876,12 @@ mod tests {
 
     type TestResult = Result<(), TypecheckerError>;
 
-    fn typecheck(input: &str) -> Result<Vec<TypedAstNode>, TypecheckerError> {
+    fn typecheck(input: &str) -> Result<TypedModule, TypecheckerError> {
         let tokens = tokenize(&input.to_string()).unwrap();
         let ast = parse(tokens).unwrap();
 
-        let (_, nodes) = super::typecheck(ast)?;
-        Ok(nodes)
-    }
-
-    fn typecheck_get_typechecker(input: &str) -> (Typechecker, Vec<TypedAstNode>) {
-        let tokens = tokenize(&input.to_string()).unwrap();
-        let ast = parse(tokens).unwrap();
-
-        super::typecheck(ast).unwrap()
+        let module = super::typecheck(ast)?;
+        Ok(module)
     }
 
     fn to_string_method_type() -> (String, Type) {
@@ -2879,18 +2890,18 @@ mod tests {
 
     #[test]
     fn typecheck_literals() -> TestResult {
-        let typed_ast = typecheck("1 2.34 \"hello\"")?;
+        let module = typecheck("1 2.34 \"hello\"")?;
         let expected = vec![
             int_literal!((1, 1), 1),
             float_literal!((1, 3), 2.34),
             string_literal!((1, 8), "hello")
         ];
-        Ok(assert_eq!(expected, typed_ast))
+        Ok(assert_eq!(expected, module.typed_nodes))
     }
 
     #[test]
     fn typecheck_unary() -> TestResult {
-        let typed_ast = typecheck("-1")?;
+        let module = typecheck("-1")?;
         let expected = vec![
             TypedAstNode::Unary(
                 Token::Minus(Position::new(1, 1)),
@@ -2901,9 +2912,9 @@ mod tests {
                 },
             ),
         ];
-        assert_eq!(expected, typed_ast);
+        assert_eq!(expected, module.typed_nodes);
 
-        let typed_ast = typecheck("-2.34")?;
+        let module = typecheck("-2.34")?;
         let expected = vec![
             TypedAstNode::Unary(
                 Token::Minus(Position::new(1, 1)),
@@ -2914,9 +2925,9 @@ mod tests {
                 },
             ),
         ];
-        assert_eq!(expected, typed_ast);
+        assert_eq!(expected, module.typed_nodes);
 
-        let typed_ast = typecheck("!true")?;
+        let module = typecheck("!true")?;
         let expected = vec![
             TypedAstNode::Unary(
                 Token::Bang(Position::new(1, 1)),
@@ -2927,7 +2938,8 @@ mod tests {
                 },
             ),
         ];
-        Ok(assert_eq!(expected, typed_ast))
+        assert_eq!(expected, module.typed_nodes);
+        Ok(())
     }
 
     #[test]
@@ -2967,7 +2979,7 @@ mod tests {
 
     #[test]
     fn typecheck_binary_numeric_operators() -> TestResult {
-        let typed_ast = typecheck("1 + 2")?;
+        let module = typecheck("1 + 2")?;
         let expected = TypedAstNode::Binary(
             Token::Plus(Position::new(1, 3)),
             TypedBinaryNode {
@@ -2977,9 +2989,9 @@ mod tests {
                 right: Box::new(int_literal!((1, 5), 2)),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("1 % 2")?;
+        let module = typecheck("1 % 2")?;
         let expected = TypedAstNode::Binary(
             Token::Percent(Position::new(1, 3)),
             TypedBinaryNode {
@@ -2989,9 +3001,9 @@ mod tests {
                 right: Box::new(int_literal!((1, 5), 2)),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("1.1 % 2")?;
+        let module = typecheck("1.1 % 2")?;
         let expected = TypedAstNode::Binary(
             Token::Percent(Position::new(1, 5)),
             TypedBinaryNode {
@@ -3001,9 +3013,9 @@ mod tests {
                 right: Box::new(int_literal!((1, 7), 2)),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("1 % 2.3")?;
+        let module = typecheck("1 % 2.3")?;
         let expected = TypedAstNode::Binary(
             Token::Percent(Position::new(1, 3)),
             TypedBinaryNode {
@@ -3013,9 +3025,9 @@ mod tests {
                 right: Box::new(float_literal!((1, 5), 2.3)),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("2 ** 3")?;
+        let module = typecheck("2 ** 3")?;
         let expected = TypedAstNode::Binary(
             Token::StarStar(Position::new(1, 3)),
             TypedBinaryNode {
@@ -3025,9 +3037,9 @@ mod tests {
                 right: Box::new(int_literal!((1, 6), 3)),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("1 ** 2.3")?;
+        let module = typecheck("1 ** 2.3")?;
         let expected = TypedAstNode::Binary(
             Token::StarStar(Position::new(1, 3)),
             TypedBinaryNode {
@@ -3037,14 +3049,14 @@ mod tests {
                 right: Box::new(float_literal!((1, 6), 2.3)),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         Ok(())
     }
 
     #[test]
     fn typecheck_binary_numeric_operators_nested() -> TestResult {
-        let typed_ast = typecheck("1 + 2.3 - -4.5")?;
+        let module = typecheck("1 + 2.3 - -4.5")?;
         let expected = TypedAstNode::Binary(
             Token::Minus(Position::new(1, 9)),
             TypedBinaryNode {
@@ -3073,12 +3085,12 @@ mod tests {
                 ),
             },
         );
-        Ok(assert_eq!(expected, typed_ast[0]))
+        Ok(assert_eq!(expected, module.typed_nodes[0]))
     }
 
     #[test]
     fn typecheck_binary_str_concat() -> TestResult {
-        let typed_ast = typecheck("\"hello \" + \"world\"")?;
+        let module = typecheck("\"hello \" + \"world\"")?;
         let expected = TypedAstNode::Binary(
             Token::Plus(Position::new(1, 10)),
             TypedBinaryNode {
@@ -3088,9 +3100,9 @@ mod tests {
                 right: Box::new(string_literal!((1, 12), "world")),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("\"hello \" + 3")?;
+        let module = typecheck("\"hello \" + 3")?;
         let expected = TypedAstNode::Binary(
             Token::Plus(Position::new(1, 10)),
             TypedBinaryNode {
@@ -3100,9 +3112,9 @@ mod tests {
                 right: Box::new(int_literal!((1, 12), 3)),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("3.14 + \"world\"")?;
+        let module = typecheck("3.14 + \"world\"")?;
         let expected = TypedAstNode::Binary(
             Token::Plus(Position::new(1, 6)),
             TypedBinaryNode {
@@ -3112,9 +3124,9 @@ mod tests {
                 right: Box::new(string_literal!((1, 8), "world")),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("false + \" world\"")?;
+        let module = typecheck("false + \" world\"")?;
         let expected = TypedAstNode::Binary(
             Token::Plus(Position::new(1, 7)),
             TypedBinaryNode {
@@ -3124,7 +3136,9 @@ mod tests {
                 right: Box::new(string_literal!((1, 9), " world")),
             },
         );
-        Ok(assert_eq!(expected, typed_ast[0]))
+        assert_eq!(expected, module.typed_nodes[0]);
+
+        Ok(())
     }
 
     #[test]
@@ -3208,7 +3222,7 @@ mod tests {
 
     #[test]
     fn typecheck_binary_boolean() -> TestResult {
-        let typed_ast = typecheck("true && true || false")?;
+        let module = typecheck("true && true || false")?;
         let expected = TypedAstNode::IfExpression(Token::If(Position::new(1, 14)), TypedIfNode {
             typ: Type::Bool,
             condition: Box::new(
@@ -3232,9 +3246,9 @@ mod tests {
                 bool_literal!((1, 17), false),
             ]),
         });
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("true ^ true")?;
+        let module = typecheck("true ^ true")?;
         let expected = TypedAstNode::Binary(
             Token::Caret(Position::new(1, 6)),
             TypedBinaryNode {
@@ -3244,7 +3258,9 @@ mod tests {
                 right: Box::new(bool_literal!((1, 8), true)),
             },
         );
-        Ok(assert_eq!(expected, typed_ast[0]))
+        assert_eq!(expected, module.typed_nodes[0]);
+
+        Ok(())
     }
 
     #[test]
@@ -3292,7 +3308,7 @@ mod tests {
             ("1 == 2", Box::new(Token::Eq), BinaryOp::Eq),
         ];
         for (input, token, op) in cases {
-            let typed_ast = typecheck(input)?;
+            let module = typecheck(input)?;
             let expected = TypedAstNode::Binary(
                 token(Position::new(1, 3)),
                 TypedBinaryNode {
@@ -3302,7 +3318,7 @@ mod tests {
                     right: Box::new(int_literal!((1, 6), 2)),
                 },
             );
-            assert_eq!(expected, typed_ast[0]);
+            assert_eq!(expected, module.typed_nodes[0]);
         };
 
         let cases: Vec<(&str, Box<dyn Fn(Position) -> Token>, BinaryOp)> = vec![
@@ -3314,7 +3330,7 @@ mod tests {
             ("\"abc\" != \"def\"", Box::new(Token::Neq), BinaryOp::Neq),
         ];
         for (input, token, op) in cases {
-            let typed_ast = typecheck(input)?;
+            let module = typecheck(input)?;
             let expected = TypedAstNode::Binary(
                 token(Position::new(1, 7)),
                 TypedBinaryNode {
@@ -3324,7 +3340,7 @@ mod tests {
                     right: Box::new(string_literal!((1, 10), "def")),
                 },
             );
-            assert_eq!(expected, typed_ast[0]);
+            assert_eq!(expected, module.typed_nodes[0]);
         }
 
         let cases: Vec<(&str, Box<dyn Fn(Position) -> Token>, BinaryOp)> = vec![
@@ -3332,7 +3348,7 @@ mod tests {
             ("\"abc\" != 3", Box::new(Token::Neq), BinaryOp::Neq),
         ];
         for (input, token, op) in cases {
-            let typed_ast = typecheck(input)?;
+            let module = typecheck(input)?;
             let expected = TypedAstNode::Binary(
                 token(Position::new(1, 7)),
                 TypedBinaryNode {
@@ -3342,7 +3358,7 @@ mod tests {
                     right: Box::new(int_literal!((1, 10), 3)),
                 },
             );
-            assert_eq!(expected, typed_ast[0]);
+            assert_eq!(expected, module.typed_nodes[0]);
         }
 
         Ok(())
@@ -3386,8 +3402,8 @@ mod tests {
         ];
 
         for (input, expected_type) in cases {
-            let typed_ast = typecheck(input)?;
-            assert_eq!(expected_type, typed_ast[0].get_type());
+            let module = typecheck(input)?;
+            assert_eq!(expected_type, module.typed_nodes[0].get_type());
         };
 
         Ok(())
@@ -3420,7 +3436,7 @@ mod tests {
 
     #[test]
     fn typecheck_grouped() -> TestResult {
-        let typed_ast = typecheck("(1 + 2)")?;
+        let module = typecheck("(1 + 2)")?;
         let expected = TypedAstNode::Grouped(
             Token::LParen(Position::new(1, 1), false),
             TypedGroupedNode {
@@ -3438,17 +3454,17 @@ mod tests {
                 ),
             },
         );
-        Ok(assert_eq!(expected, typed_ast[0]))
+        Ok(assert_eq!(expected, module.typed_nodes[0]))
     }
 
     #[test]
     fn typecheck_array_empty() -> TestResult {
-        let typed_ast = typecheck("[]")?;
+        let module = typecheck("[]")?;
         let expected = TypedAstNode::Array(
             Token::LBrack(Position::new(1, 1), false),
             TypedArrayNode { typ: Type::Array(Box::new(Type::Unknown)), items: vec![] },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         // Verify explicit type annotations works
         let res = typecheck("val a: Int[] = []");
@@ -3461,7 +3477,7 @@ mod tests {
 
     #[test]
     fn typecheck_array_nonempty() -> TestResult {
-        let typed_ast = typecheck("[1, 2, 3]")?;
+        let module = typecheck("[1, 2, 3]")?;
         let expected = TypedAstNode::Array(
             Token::LBrack(Position::new(1, 1), false),
             TypedArrayNode {
@@ -3473,9 +3489,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("[\"a\", true]")?;
+        let module = typecheck("[\"a\", true]")?;
         let expected = TypedAstNode::Array(
             Token::LBrack(Position::new(1, 1), false),
             TypedArrayNode {
@@ -3486,7 +3502,7 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         // Verify explicit type annotations works
         let res = typecheck("val a: Bool[] = [true, false]");
@@ -3499,9 +3515,9 @@ mod tests {
 
     #[test]
     fn typecheck_array_nested() -> TestResult {
-        let typed_ast = typecheck("[[1, 2], [3, 4]]")?;
+        let module = typecheck("[[1, 2], [3, 4]]")?;
         let expected_type = Type::Array(Box::new(Type::Array(Box::new(Type::Int))));
-        assert_eq!(expected_type, typed_ast[0].get_type());
+        assert_eq!(expected_type, module.typed_nodes[0].get_type());
 
         // TODO: Handle edge cases, like [[1, 2.3], [3.4, 5]], which should be (Int | Float)[][]
 
@@ -3510,12 +3526,12 @@ mod tests {
 
     #[test]
     fn typecheck_set_empty() -> TestResult {
-        let typed_ast = typecheck("#{}")?;
+        let module = typecheck("#{}")?;
         let expected = TypedAstNode::Set(
             Token::LBraceHash(Position::new(1, 1)),
             TypedSetNode { typ: Type::Set(Box::new(Type::Unknown)), items: vec![] },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         // Verify explicit type annotations works
         let res = typecheck("val a: Set<Int> = #{}");
@@ -3526,7 +3542,7 @@ mod tests {
 
     #[test]
     fn typecheck_set_nonempty() -> TestResult {
-        let typed_ast = typecheck("#{1, 2, 3}")?;
+        let module = typecheck("#{1, 2, 3}")?;
         let expected = TypedAstNode::Set(
             Token::LBraceHash(Position::new(1, 1)),
             TypedSetNode {
@@ -3538,9 +3554,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("#{\"a\", 12}")?;
+        let module = typecheck("#{\"a\", 12}")?;
         let expected = TypedAstNode::Set(
             Token::LBraceHash(Position::new(1, 1)),
             TypedSetNode {
@@ -3551,7 +3567,7 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         // Verify explicit type annotations works
         let res = typecheck("val a: Set<Int> = #{1, 2, 3}");
@@ -3562,9 +3578,9 @@ mod tests {
 
     #[test]
     fn typecheck_set_nested() -> TestResult {
-        let typed_ast = typecheck("#{#{1, 2}, #{3, 4}}")?;
+        let module = typecheck("#{#{1, 2}, #{3, 4}}")?;
         let expected_type = Type::Set(Box::new(Type::Set(Box::new(Type::Int))));
-        assert_eq!(expected_type, typed_ast[0].get_type());
+        assert_eq!(expected_type, module.typed_nodes[0].get_type());
 
         // Verify explicit type annotations works
         let res = typecheck("val a: Set<Set<Int>> = #{#{1, 2}, #{3, 4}}");
@@ -3575,17 +3591,17 @@ mod tests {
 
     #[test]
     fn typecheck_tuple() -> TestResult {
-        let typed_ast = typecheck("(1, \"hello\")")?;
+        let module = typecheck("(1, \"hello\")")?;
         let expected_type = Type::Tuple(vec![Type::Int, Type::String]);
-        assert_eq!(expected_type, typed_ast[0].get_type());
+        assert_eq!(expected_type, module.typed_nodes[0].get_type());
 
-        let typed_ast = typecheck("(1, (\"hello\", \"world\"), 3)")?;
+        let module = typecheck("(1, (\"hello\", \"world\"), 3)")?;
         let expected_type = Type::Tuple(vec![
             Type::Int,
             Type::Tuple(vec![Type::String, Type::String]),
             Type::Int,
         ]);
-        assert_eq!(expected_type, typed_ast[0].get_type());
+        assert_eq!(expected_type, module.typed_nodes[0].get_type());
 
         let res = typecheck("val t: (Int, Int, String) = (1, 2, \"three\")");
         assert!(res.is_ok());
@@ -3595,14 +3611,14 @@ mod tests {
 
     #[test]
     fn typecheck_tuple_generics() -> TestResult {
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           func abc<T>(t: T): (T, T[]) = (t, [t])\
           abc(1)
         ")?;
         let expected_type = Type::Tuple(vec![Type::Int, Type::Array(Box::new(Type::Int))]);
-        assert_eq!(expected_type, typed_ast[1].get_type());
+        assert_eq!(expected_type, module.typed_nodes[1].get_type());
 
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           func abc<T, U, V>(t: T, u: U, v: V): (T, U, V) = (t, u, v)\
           abc(1, \"2\", [3])
         ")?;
@@ -3611,14 +3627,14 @@ mod tests {
             Type::String,
             Type::Array(Box::new(Type::Int))
         ]);
-        assert_eq!(expected_type, typed_ast[1].get_type());
+        assert_eq!(expected_type, module.typed_nodes[1].get_type());
 
         Ok(())
     }
 
     #[test]
     fn typecheck_map_empty() -> TestResult {
-        let typed_ast = typecheck("{}")?;
+        let module = typecheck("{}")?;
         let expected = TypedAstNode::Map(
             Token::LBrace(Position::new(1, 1)),
             TypedMapNode {
@@ -3626,14 +3642,14 @@ mod tests {
                 items: vec![],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         Ok(())
     }
 
     #[test]
     fn typecheck_map_nonempty() -> TestResult {
-        let typed_ast = typecheck("{ a: 1, b: 2 }")?;
+        let module = typecheck("{ a: 1, b: 2 }")?;
         let expected = TypedAstNode::Map(
             Token::LBrace(Position::new(1, 1)),
             TypedMapNode {
@@ -3644,9 +3660,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("{ a: { c: true }, b: { c: false } }")?;
+        let module = typecheck("{ a: { c: true }, b: { c: false } }")?;
         let expected = TypedAstNode::Map(
             Token::LBrace(Position::new(1, 1)),
             TypedMapNode {
@@ -3672,20 +3688,20 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("{ a: 1, b: true, c: \"hello\" }")?;
+        let module = typecheck("{ a: 1, b: true, c: \"hello\" }")?;
         let expected_type = Type::Map(
             Box::new(Type::String),
             Box::new(Type::Union(vec![Type::Int, Type::Bool, Type::String])),
         );
-        assert_eq!(expected_type, typed_ast[0].get_type());
+        assert_eq!(expected_type, module.typed_nodes[0].get_type());
 
         Ok(())
     }
 
     #[test]
-    fn typecheck_type_annotation() {
+    fn typecheck_type_annotation() -> TestResult {
         let cases = vec![
             // Simple cases
             ("var abc: Int", Type::Int),
@@ -3698,16 +3714,15 @@ mod tests {
         ];
 
         for (input, expected_binding_type) in cases {
-            let (typechecker, _) = typecheck_get_typechecker(input);
-            let (ScopeBinding(_, typ, _), scope_depth) = typechecker.get_binding("abc").unwrap();
-            assert_eq!(expected_binding_type, *typ);
-            assert_eq!(0, scope_depth);
+            let module = typecheck(input)?;
+            assert_eq!(expected_binding_type, module.global_bindings["abc"].1);
         }
+        Ok(())
     }
 
     #[test]
     fn typecheck_binding_decl() -> TestResult {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("val abc = 123");
+        let module = typecheck("val abc = 123")?;
         let expected = TypedAstNode::BindingDecl(
             Token::Val(Position::new(1, 1)),
             TypedBindingDeclNode {
@@ -3717,17 +3732,16 @@ mod tests {
                 scope_depth: 0,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let (binding, scope_depth) = typechecker.get_binding("abc").unwrap();
+        assert_eq!(expected, module.typed_nodes[0]);
+        let binding = &module.global_bindings["abc"];
         let expected_binding = ScopeBinding(
             Token::Ident(Position::new(1, 5), "abc".to_string()),
             Type::Int,
             false,
         );
         assert_eq!(&expected_binding, binding);
-        assert_eq!(0, scope_depth);
 
-        let (typechecker, typed_ast) = typecheck_get_typechecker("var abc: Int");
+        let module = typecheck("var abc: Int")?;
         let expected = TypedAstNode::BindingDecl(
             Token::Var(Position::new(1, 1)),
             TypedBindingDeclNode {
@@ -3737,15 +3751,14 @@ mod tests {
                 scope_depth: 0,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let (binding, scope_depth) = typechecker.get_binding("abc").unwrap();
+        assert_eq!(expected, module.typed_nodes[0]);
+        let binding = &module.global_bindings["abc"];
         let expected_binding = ScopeBinding(
             Token::Ident(Position::new(1, 5), "abc".to_string()),
             Type::Int,
             true,
         );
         assert_eq!(&expected_binding, binding);
-        assert_eq!(0, scope_depth);
 
         assert!(typecheck("val arr: Int[] = []").is_ok());
 
@@ -3791,7 +3804,7 @@ mod tests {
     #[test]
     fn typecheck_binding_decl_destructuring() -> TestResult {
         // Tuples
-        let (typechecker, typed_ast) = typecheck_get_typechecker("val (a, b, c) = (1, \"2\", [1, 2, 3])");
+        let module = typecheck("val (a, b, c) = (1, \"2\", [1, 2, 3])")?;
         let expected = TypedAstNode::BindingDecl(
             Token::Val(Position::new(1, 1)),
             TypedBindingDeclNode {
@@ -3828,19 +3841,19 @@ mod tests {
                 scope_depth: 0,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let binding = typechecker.get_binding("a").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 6), "a"), Type::Int, false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("b").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 9), "b"), Type::String, false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("c").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 12), "c"), Type::Array(Box::new(Type::Int)), false), 0);
-        assert_eq!(expected_binding, binding);
+        assert_eq!(expected, module.typed_nodes[0]);
+        let binding = &module.global_bindings["a"];
+        let expected_binding = ScopeBinding(ident_token!((1, 6), "a"), Type::Int, false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["b"];
+        let expected_binding = ScopeBinding(ident_token!((1, 9), "b"), Type::String, false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["c"];
+        let expected_binding = ScopeBinding(ident_token!((1, 12), "c"), Type::Array(Box::new(Type::Int)), false);
+        assert_eq!(&expected_binding, binding);
 
         // Arrays
-        let (typechecker, typed_ast) = typecheck_get_typechecker("val [a, *b, c] = [1, 2, 3]");
+        let module = typecheck("val [a, *b, c] = [1, 2, 3]")?;
         let expected = TypedAstNode::BindingDecl(
             Token::Val(Position::new(1, 1)),
             TypedBindingDeclNode {
@@ -3868,19 +3881,19 @@ mod tests {
                 scope_depth: 0,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let binding = typechecker.get_binding("a").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 6), "a"), Type::Option(Box::new(Type::Int)), false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("b").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 10), "b"), Type::Array(Box::new(Type::Int)), false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("c").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 13), "c"), Type::Option(Box::new(Type::Int)), false), 0);
-        assert_eq!(expected_binding, binding);
+        assert_eq!(expected, module.typed_nodes[0]);
+        let binding = &module.global_bindings["a"];
+        let expected_binding = ScopeBinding(ident_token!((1, 6), "a"), Type::Option(Box::new(Type::Int)), false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["b"];
+        let expected_binding = ScopeBinding(ident_token!((1, 10), "b"), Type::Array(Box::new(Type::Int)), false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["c"];
+        let expected_binding = ScopeBinding(ident_token!((1, 13), "c"), Type::Option(Box::new(Type::Int)), false);
+        assert_eq!(&expected_binding, binding);
 
         // Strings
-        let (typechecker, typed_ast) = typecheck_get_typechecker("val [a, *b, c] = \"hello\"");
+        let module = typecheck("val [a, *b, c] = \"hello\"")?;
         let expected = TypedAstNode::BindingDecl(
             Token::Val(Position::new(1, 1)),
             TypedBindingDeclNode {
@@ -3898,19 +3911,19 @@ mod tests {
                 scope_depth: 0,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let binding = typechecker.get_binding("a").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 6), "a"), Type::String, false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("b").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 10), "b"), Type::String, false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("c").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 13), "c"), Type::String, false), 0);
-        assert_eq!(expected_binding, binding);
+        assert_eq!(expected, module.typed_nodes[0]);
+        let binding = &module.global_bindings["a"];
+        let expected_binding = ScopeBinding(ident_token!((1, 6), "a"), Type::String, false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["b"];
+        let expected_binding = ScopeBinding(ident_token!((1, 10), "b"), Type::String, false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["c"];
+        let expected_binding = ScopeBinding(ident_token!((1, 13), "c"), Type::String, false);
+        assert_eq!(&expected_binding, binding);
 
         // Nested
-        let (typechecker, typed_ast) = typecheck_get_typechecker("val [(x1, y1), (x2, y2)] = [(1, 2), (3, 4)]");
+        let module = typecheck("val [(x1, y1), (x2, y2)] = [(1, 2), (3, 4)]")?;
         let expected = TypedAstNode::BindingDecl(
             Token::Val(Position::new(1, 1)),
             TypedBindingDeclNode {
@@ -3972,19 +3985,19 @@ mod tests {
                 scope_depth: 0,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let binding = typechecker.get_binding("x1").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 7), "x1"), Type::Option(Box::new(Type::Int)), false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("y1").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 11), "y1"), Type::Option(Box::new(Type::Int)), false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("x2").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 17), "x2"), Type::Option(Box::new(Type::Int)), false), 0);
-        assert_eq!(expected_binding, binding);
-        let binding = typechecker.get_binding("y2").unwrap();
-        let expected_binding = (&ScopeBinding(ident_token!((1, 21), "y2"), Type::Option(Box::new(Type::Int)), false), 0);
-        assert_eq!(expected_binding, binding);
+        assert_eq!(expected, module.typed_nodes[0]);
+        let binding = &module.global_bindings["x1"];
+        let expected_binding = ScopeBinding(ident_token!((1, 7), "x1"), Type::Option(Box::new(Type::Int)), false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["y1"];
+        let expected_binding = ScopeBinding(ident_token!((1, 11), "y1"), Type::Option(Box::new(Type::Int)), false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["x2"];
+        let expected_binding = ScopeBinding(ident_token!((1, 17), "x2"), Type::Option(Box::new(Type::Int)), false);
+        assert_eq!(&expected_binding, binding);
+        let binding = &module.global_bindings["y2"];
+        let expected_binding = ScopeBinding(ident_token!((1, 21), "y2"), Type::Option(Box::new(Type::Int)), false);
+        assert_eq!(&expected_binding, binding);
 
         Ok(())
     }
@@ -4067,7 +4080,7 @@ mod tests {
 
     #[test]
     fn typecheck_function_decl() -> TestResult {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("func abc(): Int = 123");
+        let module = typecheck("func abc(): Int = 123")?;
         let expected = TypedAstNode::FunctionDecl(
             Token::Func(Position::new(1, 1)),
             TypedFunctionDeclNode {
@@ -4081,14 +4094,12 @@ mod tests {
                 is_recursive: false,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let (ScopeBinding(_, typ, _), scope_depth) = typechecker.get_binding("abc")
-            .expect("The function abc should be defined");
+        assert_eq!(expected, module.typed_nodes[0]);
+        let ScopeBinding(_, typ, _) = &module.global_bindings["abc"];
         let expected_type = Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::Int), is_variadic: false });
         assert_eq!(&expected_type, typ);
-        assert_eq!(0, scope_depth);
 
-        let typed_ast = typecheck("func abc(a: Int): Int = a + 1")?;
+        let module = typecheck("func abc(a: Int): Int = a + 1")?;
         let expected = TypedAstNode::FunctionDecl(
             Token::Func(Position::new(1, 1)),
             TypedFunctionDeclNode {
@@ -4109,9 +4120,9 @@ mod tests {
                 is_recursive: false,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let (typechecker, typed_ast) = typecheck_get_typechecker("func abc(): Int[] { val a = [1, 2] a }");
+        let module = typecheck("func abc(): Int[] { val a = [1, 2] a }")?;
         let expected = TypedAstNode::FunctionDecl(
             Token::Func(Position::new(1, 1)),
             TypedFunctionDeclNode {
@@ -4145,27 +4156,25 @@ mod tests {
                 is_recursive: false,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let (ScopeBinding(_, typ, _), scope_depth) = typechecker.get_binding("abc")
-            .expect("The function abc should be defined");
+        assert_eq!(expected, module.typed_nodes[0]);
+        let ScopeBinding(_, typ, _) = &module.global_bindings["abc"];
         let expected_type = Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::Array(Box::new(Type::Int))), is_variadic: false });
         assert_eq!(&expected_type, typ);
-        assert_eq!(0, scope_depth);
 
-        let typed_ast = typecheck("func abc(): Int = 123")?;
-        let ret_type = match typed_ast.first().unwrap() {
+        let module = typecheck("func abc(): Int = 123")?;
+        let ret_type = match module.typed_nodes.first().unwrap() {
             TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { ret_type, .. }) => ret_type,
             _ => panic!("Node must be a FunctionDecl")
         };
         assert_eq!(&Type::Int, ret_type);
 
         // Test that bindings assigned to functions have the proper type
-        let (typechecker, _) = typecheck_get_typechecker("func abc(a: Int): Bool = a == 1\nval def = abc");
-        let (ScopeBinding(_, typ, _), _) = typechecker.get_binding("def").unwrap();
+        let module = typecheck("func abc(a: Int): Bool = a == 1\nval def = abc")?;
+        let ScopeBinding(_, typ, _) = &module.global_bindings["def"];
         assert_eq!(&Type::Fn(FnType { arg_types: vec![("a".to_string(), Type::Int, false)], type_args: vec![], ret_type: Box::new(Type::Bool), is_variadic: false }), typ);
 
-        let (typechecker, _) = typecheck_get_typechecker("func abc(): Bool[] = []");
-        let (ScopeBinding(_, typ, _), _) = typechecker.get_binding("abc").unwrap();
+        let module = typecheck("func abc(): Bool[] = []")?;
+        let ScopeBinding(_, typ, _) = &module.global_bindings["abc"];
         let expected_type = Type::Fn(FnType {
             arg_types: vec![],
             type_args: vec![],
@@ -4174,8 +4183,8 @@ mod tests {
         });
         assert_eq!(&expected_type, typ);
 
-        let (typechecker, _) = typecheck_get_typechecker("func abc(): Bool[]? = None");
-        let (ScopeBinding(_, typ, _), _) = typechecker.get_binding("abc").unwrap();
+        let module = typecheck("func abc(): Bool[]? = None")?;
+        let ScopeBinding(_, typ, _) = &module.global_bindings["abc"];
         let expected_type = Type::Fn(FnType {
             arg_types: vec![],
             type_args: vec![],
@@ -4189,8 +4198,8 @@ mod tests {
 
     #[test]
     fn typecheck_function_decl_args() -> TestResult {
-        let typed_ast = typecheck("func abc(a: Int): Int = 123")?;
-        let args = match typed_ast.first().unwrap() {
+        let module = typecheck("func abc(a: Int): Int = 123")?;
+        let args = match module.typed_nodes.first().unwrap() {
             TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { args, .. }) => args,
             _ => panic!("Node must be a FunctionDecl")
         };
@@ -4199,8 +4208,8 @@ mod tests {
         ];
         assert_eq!(&expected, args);
 
-        let typed_ast = typecheck("func abc(a: Int, b: Bool?, c: Int[]): Int = 123")?;
-        let args = match typed_ast.first().unwrap() {
+        let module = typecheck("func abc(a: Int, b: Bool?, c: Int[]): Int = 123")?;
+        let args = match module.typed_nodes.first().unwrap() {
             TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { args, .. }) => args,
             _ => panic!("Node must be a FunctionDecl")
         };
@@ -4211,8 +4220,8 @@ mod tests {
         ];
         assert_eq!(&expected, args);
 
-        let typed_ast = typecheck("func abc(a: Int = 1, b = [1, 2, 3]): Int = 123")?;
-        let args = match typed_ast.first().unwrap() {
+        let module = typecheck("func abc(a: Int = 1, b = [1, 2, 3]): Int = 123")?;
+        let args = match module.typed_nodes.first().unwrap() {
             TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { args, .. }) => args,
             _ => panic!("Node must be a FunctionDecl")
         };
@@ -4235,12 +4244,12 @@ mod tests {
         assert_eq!(&expected, args);
 
         // A function with default-valued arguments beyond those required should still be acceptable
-        let typed_ast = typecheck(r#"
+        let result = typecheck(r#"
           func call(fn: (Int) => Int, value: Int): Int = fn(value)
           func incr(v: Int, incBy = 3): Int = v + incBy
           call(incr, 21)
         "#);
-        assert!(typed_ast.is_ok());
+        assert!(result.is_ok());
 
         Ok(())
     }
@@ -4273,8 +4282,8 @@ mod tests {
 
     #[test]
     fn typecheck_function_decl_varargs() -> TestResult {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("func abc(*a: Int[]): Int = 123");
-        let args = match typed_ast.first().unwrap() {
+        let module = typecheck("func abc(*a: Int[]): Int = 123")?;
+        let args = match module.typed_nodes.first().unwrap() {
             TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { args, .. }) => args,
             _ => panic!("Node must be a FunctionDecl")
         };
@@ -4287,7 +4296,7 @@ mod tests {
             )
         ];
         assert_eq!(&expected, args);
-        let (ScopeBinding(_, typ, _), _) = typechecker.get_binding("abc").unwrap();
+        let ScopeBinding(_, typ, _) = &module.global_bindings["abc"];
         let expected_type = Type::Fn(FnType {
             arg_types: vec![("a".to_string(), Type::Array(Box::new(Type::Int)), true)],
             type_args: vec![],
@@ -4344,24 +4353,25 @@ mod tests {
     }
 
     #[test]
-    fn typecheck_function_decl_recursion() {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("func abc(): Int {\nabc()\n}");
-        let (ScopeBinding(_, typ, _), _) = typechecker.get_binding("abc")
-            .expect("The function abc should be defined");
+    fn typecheck_function_decl_recursion() -> TestResult {
+        let module = typecheck("func abc(): Int {\nabc()\n}")?;
+        let ScopeBinding(_, typ, _) = &module.global_bindings["abc"];
         let expected_type = Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::Int), is_variadic: false });
         assert_eq!(&expected_type, typ);
 
-        let is_recursive = match typed_ast.first().unwrap() {
+        let is_recursive = match module.typed_nodes.first().unwrap() {
             TypedAstNode::FunctionDecl(_, TypedFunctionDeclNode { is_recursive, .. }) => is_recursive,
             _ => panic!("Node must be a FunctionDecl")
         };
         assert_eq!(&true, is_recursive);
+
+        Ok(())
     }
 
     #[test]
     fn typecheck_function_decl_inner_function() -> TestResult {
-        let typed_ast = typecheck("func a(): Int {\nfunc b(): Int { 1 }\n b()\n}")?;
-        let func = match typed_ast.first().unwrap() {
+        let module = typecheck("func a(): Int {\nfunc b(): Int { 1 }\n b()\n}")?;
+        let func = match module.typed_nodes.first().unwrap() {
             TypedAstNode::FunctionDecl(_, func) => func,
             _ => panic!("Node must be a FunctionDecl")
         };
@@ -4457,44 +4467,44 @@ mod tests {
 
     #[test]
     fn typecheck_function_decl_generics() -> TestResult {
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func abc<T>(t: T): T { t }
           val a = abc(123)
           a
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         assert_eq!(Type::Int, typ);
 
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func abc<T, U>(t: T, u: U): U { u }
           val a = abc(123, "asdf")
           a
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         assert_eq!(Type::String, typ);
 
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func map<T, U>(arr: T[], fn: (T) => U): U[] { [] }
           val a = map([0, 1, 2], x => x + "!")
           a
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         assert_eq!(Type::Array(Box::new(Type::String)), typ);
 
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func map<T, U>(arr: T[], fn: (T) => U): U[] { [] }
           val a = map([[0, 1], [2, 3]], a => a.length)
           a
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         assert_eq!(Type::Array(Box::new(Type::Int)), typ);
 
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func map<T, U>(arr: T[], fn: (T) => U): (T) => U[] { t => [] }
           val a = map([[0, 1], [2, 3]], a => a.length)
           a
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         let expected = Type::Fn(FnType {
             arg_types: vec![("_".to_string(), Type::Array(Box::new(Type::Int)), false)],
             type_args: vec![],
@@ -4504,21 +4514,21 @@ mod tests {
         assert_eq!(expected, typ);
 
         // Verify generic resolution works for maps
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func abc<T>(item: T): Map<String, T> = { a: item }
           val a = abc("hello")["a"]
           a
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         assert_eq!(Type::Option(Box::new(Type::String)), typ);
 
         // Verify generic resolution works for named arguments too
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func map<T, U>(arr: T[], fn: (T) => U): (T) => U[] { t => [] }
           val a = map(fn: a => a.length, arr: [[0, 1], [2, 3]])
           a
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         let expected = Type::Fn(FnType {
             arg_types: vec![("_".to_string(), Type::Array(Box::new(Type::Int)), false)],
             type_args: vec![],
@@ -4528,18 +4538,18 @@ mod tests {
         assert_eq!(expected, typ);
 
         // Verify generic resolution works for union types
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func cos<T>(angle: T | Float): T | Float = angle
           cos(1.23)
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         let expected = Type::Union(vec![Type::Float, Type::Float]); // <- Redundant, I know
         assert_eq!(expected, typ);
-        let typed_ast = typecheck(r#"
+        let module = typecheck(r#"
           func cos<T>(angle: T | Float): T | Float = angle
           cos(12)
         "#)?;
-        let typ = typed_ast.last().unwrap().get_type();
+        let typ = module.typed_nodes.last().unwrap().get_type();
         let expected = Type::Union(vec![Type::Int, Type::Float]);
         assert_eq!(expected, typ);
 
@@ -4576,7 +4586,7 @@ mod tests {
 
     #[test]
     fn typecheck_type_decl() -> TestResult {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("type Person { name: String }");
+        let module = typecheck("type Person { name: String }")?;
         let expected = TypedAstNode::TypeDecl(
             Token::Type(Position::new(1, 1)),
             TypedTypeDeclNode {
@@ -4592,9 +4602,8 @@ mod tests {
                 methods: vec![],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let (typ, _) = typechecker.get_type(&"Person".to_string()).unwrap();
-        assert_eq!(Type::Reference("Person".to_string(), vec![]), typ);
+        assert_eq!(expected, module.typed_nodes[0]);
+        assert_eq!(Type::Reference("Person".to_string(), vec![]), module.types["Person"]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -4602,9 +4611,9 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
-        let (typechecker, typed_ast) = typecheck_get_typechecker("type Person { name: String, age: Int = 0 }");
+        let module = typecheck("type Person { name: String, age: Int = 0 }")?;
         let expected = TypedAstNode::TypeDecl(
             Token::Type(Position::new(1, 1)),
             TypedTypeDeclNode {
@@ -4625,9 +4634,8 @@ mod tests {
                 methods: vec![],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
-        let (typ, _) = typechecker.get_type(&"Person".to_string()).unwrap();
-        assert_eq!(Type::Reference("Person".to_string(), vec![]), typ);
+        assert_eq!(expected, module.typed_nodes[0]);
+        assert_eq!(Type::Reference("Person".to_string(), vec![]), module.types["Person"]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -4638,24 +4646,24 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
         Ok(())
     }
 
     #[test]
     fn typecheck_type_decl_self_referencing() -> TestResult {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Node {\n\
             value: Int\n\
             next: Node? = None\n\
           }\n\
           val node = Node(value: 1, next: Node(value: 2))\n\
           node\n\
-        ");
+        ")?;
 
         let expected = identifier!((6, 1), "node", Type::Reference("Node".to_string(), vec![]), 0);
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
         let expected_type = Type::Struct(StructType {
             name: "Node".to_string(),
             type_args: vec![],
@@ -4671,19 +4679,19 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Node"]);
+        assert_eq!(expected_type, module.referencable_types["Node"]);
 
         Ok(())
     }
 
     #[test]
     fn typecheck_type_decl_readonly_fields() -> TestResult {
-        let (typechecker, _) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Foo {\n\
             a: Int\n\
             b: Int readonly \n\
           }\
-        ");
+        ")?;
         let expected_type = Type::Struct(StructType {
             name: "Foo".to_string(),
             type_args: vec![],
@@ -4694,7 +4702,7 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Foo"]);
+        assert_eq!(expected_type, module.referencable_types["Foo"]);
 
         Ok(())
     }
@@ -4754,7 +4762,7 @@ mod tests {
             func getName2(self): String = self.getName()\n\
           }
         ";
-        let (typechecker, typed_ast) = typecheck_get_typechecker(input);
+        let module = typecheck(input)?;
         let person_type = Type::Reference("Person".to_string(), vec![]);
         let expected = TypedAstNode::TypeDecl(
             Token::Type(Position::new(1, 1)),
@@ -4855,7 +4863,7 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -4869,7 +4877,7 @@ mod tests {
                 ("getName2".to_string(), Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::String), is_variadic: false }))
             ],
         });
-        Ok(assert_eq!(expected_type, typechecker.referencable_types["Person"]))
+        Ok(assert_eq!(expected_type, module.referencable_types["Person"]))
     }
 
     #[test]
@@ -4880,7 +4888,7 @@ mod tests {
             func getName(): String = \"hello\"\n\
           }
         ";
-        let (typechecker, typed_ast) = typecheck_get_typechecker(input);
+        let module = typecheck(input)?;
         let expected = TypedAstNode::TypeDecl(
             Token::Type(Position::new(1, 1)),
             TypedTypeDeclNode {
@@ -4914,7 +4922,7 @@ mod tests {
                 methods: vec![],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -4926,7 +4934,7 @@ mod tests {
             ],
             methods: vec![to_string_method_type()],
         });
-        Ok(assert_eq!(expected_type, typechecker.referencable_types["Person"]))
+        Ok(assert_eq!(expected_type, module.referencable_types["Person"]))
     }
 
     #[test]
@@ -4961,7 +4969,6 @@ mod tests {
           }
         ";
         let error = typecheck(input).unwrap_err();
-        // let expected = TypecheckerError::MissingRequiredTypeAnnotation { token: ident_token!((2, 6), "hello") };
         let expected = TypecheckerError::ReturnTypeMismatch {
             token: Token::String(Position::new(2, 20), "hello".to_string()),
             fn_name: "hello".to_string(),
@@ -4976,7 +4983,7 @@ mod tests {
     #[test]
     fn typecheck_type_decl_generics() -> TestResult {
         let input = "type List<T> { items: T[] }";
-        let (typechecker, _) = typecheck_get_typechecker(input);
+        let module = typecheck(input)?;
         let expected_type = Type::Struct(StructType {
             name: "List".to_string(),
             type_args: vec![("T".to_string(), Type::Generic("T".to_string()))],
@@ -4986,15 +4993,15 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["List"]);
+        assert_eq!(expected_type, module.referencable_types["List"]);
 
         let input = r#"
           type List<T> { items: T[] }
           val l = List(items: [1, 2, 3])
           l
         "#;
-        let typed_ast = typecheck(input)?;
-        let actual_type = typed_ast.last().unwrap().get_type();
+        let module = typecheck(input)?;
+        let actual_type = module.typed_nodes.last().unwrap().get_type();
         let expected_type = Type::Reference("List".to_string(), vec![Type::Int]);
         assert_eq!(expected_type, actual_type);
 
@@ -5237,7 +5244,7 @@ mod tests {
 
     #[test]
     fn typecheck_enum_decl() -> TestResult {
-        let typed_ast = typecheck("enum Temp { Hot, Cold }")?;
+        let module = typecheck("enum Temp { Hot, Cold }")?;
         let expected = TypedAstNode::EnumDecl(
             Token::Enum(Position::new(1, 1)),
             TypedEnumDeclNode {
@@ -5258,9 +5265,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           enum AngleMode { Radians(rads: Float), Degrees(degs: Float) }\
         ")?;
         let expected = TypedAstNode::EnumDecl(
@@ -5295,10 +5302,10 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         // Verify that constructor variants can have default arg values that are themselves enum variants
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           enum Color { Red, Darken(base: Color = Color.Red, amount: Float = 10.0) }\
         ")?;
         let expected = TypedAstNode::EnumDecl(
@@ -5371,7 +5378,7 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         Ok(())
     }
@@ -5553,7 +5560,7 @@ mod tests {
 
     #[test]
     fn typecheck_ident() -> TestResult {
-        let typed_ast = typecheck("val abc = 123\nabc")?;
+        let module = typecheck("val abc = 123\nabc")?;
         let expected = vec![
             TypedAstNode::BindingDecl(
                 Token::Val(Position::new(1, 1)),
@@ -5566,7 +5573,7 @@ mod tests {
             ),
             identifier!((2, 1), "abc", Type::Int, 0)
         ];
-        assert_eq!(expected, typed_ast);
+        assert_eq!(expected, module.typed_nodes);
         Ok(())
     }
 
@@ -5594,7 +5601,7 @@ mod tests {
 
     #[test]
     fn typecheck_assignment_identifier() -> TestResult {
-        let typed_ast = typecheck("var abc = 123\nabc = 456")?;
+        let module = typecheck("var abc = 123\nabc = 456")?;
         let expected = vec![
             TypedAstNode::BindingDecl(
                 Token::Var(Position::new(1, 1)),
@@ -5615,13 +5622,13 @@ mod tests {
                 },
             )
         ];
-        assert_eq!(expected, typed_ast);
+        assert_eq!(expected, module.typed_nodes);
         Ok(())
     }
 
     #[test]
     fn typecheck_assignment_indexing() -> TestResult {
-        let typed_ast = typecheck("var abc = [1, 2]\nabc[0] = 2")?;
+        let module = typecheck("var abc = [1, 2]\nabc[0] = 2")?;
         let expected = TypedAstNode::Assignment(
             Token::Assign(Position::new(2, 8)),
             TypedAssignmentNode {
@@ -5638,9 +5645,9 @@ mod tests {
                 expr: Box::new(int_literal!((2, 10), 2)),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let typed_ast = typecheck("var abc = {a: 2}\nabc[\"a\"] = 3")?;
+        let module = typecheck("var abc = {a: 2}\nabc[\"a\"] = 3")?;
         let expected = TypedAstNode::Assignment(
             Token::Assign(Position::new(2, 10)),
             TypedAssignmentNode {
@@ -5657,7 +5664,7 @@ mod tests {
                 expr: Box::new(int_literal!((2, 12), 3)),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
         let res = typecheck("var abc = {a: 2, b: true}\nabc[\"c\"] = 3");
         assert!(res.is_ok());
@@ -5670,11 +5677,11 @@ mod tests {
 
     #[test]
     fn typecheck_assignment_field() -> TestResult {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Person { name: String }\n\
           val a = Person(name: \"abc\")\n\
           a.name = \"qwer\"\n\
-        ");
+        ")?;
         let expected = TypedAstNode::Assignment(
             Token::Assign(Position::new(3, 8)),
             TypedAssignmentNode {
@@ -5695,7 +5702,7 @@ mod tests {
                 expr: Box::new(string_literal!((3, 10), "qwer")),
             },
         );
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -5705,7 +5712,7 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
         // Test setting inner property of readonly field
         let res = typecheck("\
@@ -5838,7 +5845,7 @@ mod tests {
 
     #[test]
     fn typecheck_indexing() -> TestResult {
-        let typed_ast = typecheck("val abc = [1, 2, 3]\nabc[1]")?;
+        let module = typecheck("val abc = [1, 2, 3]\nabc[1]")?;
         let expected = TypedAstNode::Indexing(
             Token::LBrack(Position::new(2, 4), false),
             TypedIndexingNode {
@@ -5847,9 +5854,9 @@ mod tests {
                 index: IndexingMode::Index(Box::new(int_literal!((2, 5), 1))),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let typed_ast = typecheck("val idx = 1\nval abc = [1, 2, 3]\nabc[idx:]")?;
+        let module = typecheck("val idx = 1\nval abc = [1, 2, 3]\nabc[idx:]")?;
         let expected = TypedAstNode::Indexing(
             Token::LBrack(Position::new(3, 4), false),
             TypedIndexingNode {
@@ -5861,9 +5868,9 @@ mod tests {
                 ),
             },
         );
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
 
-        let typed_ast = typecheck("val idx = 1\n\"abc\"[:idx * 2]")?;
+        let module = typecheck("val idx = 1\n\"abc\"[:idx * 2]")?;
         let expected = TypedAstNode::Indexing(
             Token::LBrack(Position::new(2, 6), false),
             TypedIndexingNode {
@@ -5885,9 +5892,9 @@ mod tests {
                 ),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let typed_ast = typecheck("val map = { a: 1, b: 2 }\nmap[\"a\"]")?;
+        let module = typecheck("val map = { a: 1, b: 2 }\nmap[\"a\"]")?;
         let expected = TypedAstNode::Indexing(
             Token::LBrack(Position::new(2, 4), false),
             TypedIndexingNode {
@@ -5896,9 +5903,9 @@ mod tests {
                 index: IndexingMode::Index(Box::new(string_literal!((2, 5), "a"))),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let typed_ast = typecheck("val map = { a: 1, b: true }\nmap[\"a\"]")?;
+        let module = typecheck("val map = { a: 1, b: true }\nmap[\"a\"]")?;
         let expected = TypedAstNode::Indexing(
             Token::LBrack(Position::new(2, 4), false),
             TypedIndexingNode {
@@ -5912,9 +5919,9 @@ mod tests {
                 index: IndexingMode::Index(Box::new(string_literal!((2, 5), "a"))),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let typed_ast = typecheck("(1, 2)[0]")?;
+        let module = typecheck("(1, 2)[0]")?;
         let expected = TypedAstNode::Indexing(
             Token::LBrack(Position::new(1, 7), false),
             TypedIndexingNode {
@@ -5929,7 +5936,7 @@ mod tests {
                 index: IndexingMode::Index(Box::new(int_literal!((1, 8), 0))),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         Ok(())
     }
@@ -6026,7 +6033,7 @@ mod tests {
 
     #[test]
     fn typecheck_if_statement() -> TestResult {
-        let typed_ast = typecheck("if 1 < 2 1234")?;
+        let module = typecheck("if 1 < 2 1234")?;
         let expected = TypedAstNode::IfStatement(
             Token::If(Position::new(1, 1)),
             TypedIfNode {
@@ -6047,9 +6054,9 @@ mod tests {
                 else_block: None,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("if 1 < 2 1234 else 1 + 2")?;
+        let module = typecheck("if 1 < 2 1234 else 1 + 2")?;
         let expected = TypedAstNode::IfStatement(
             Token::If(Position::new(1, 1)),
             TypedIfNode {
@@ -6080,9 +6087,9 @@ mod tests {
                 ]),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           val i: Int? = 0\n\
           if i 1 else 2\
         ")?;
@@ -6096,14 +6103,14 @@ mod tests {
                 else_block: Some(vec![int_literal!((2, 13), 2)]),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
         Ok(())
     }
 
     #[test]
     fn typecheck_if_statement_condition_binding() -> TestResult {
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           val i: Int? = 0\n\
           if i |i| i else 2\
         ")?;
@@ -6119,9 +6126,9 @@ mod tests {
                 else_block: Some(vec![int_literal!((2, 17), 2)]),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let typed_ast = typecheck("if true |v| v else false")?;
+        let module = typecheck("if true |v| v else false")?;
         let expected = TypedAstNode::IfStatement(
             Token::If(Position::new(1, 1)),
             TypedIfNode {
@@ -6134,7 +6141,7 @@ mod tests {
                 else_block: Some(vec![bool_literal!((1, 20), false)]),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         Ok(())
     }
@@ -6151,7 +6158,7 @@ mod tests {
 
     #[test]
     fn typecheck_if_statement_scopes() -> TestResult {
-        let typed_ast = typecheck("if 1 < 2 { val a = \"hello\" a }")?;
+        let module = typecheck("if 1 < 2 { val a = \"hello\" a }")?;
         let expected = TypedAstNode::IfStatement(
             Token::If(Position::new(1, 1)),
             TypedIfNode {
@@ -6183,9 +6190,9 @@ mod tests {
                 else_block: None,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck(
+        let module = typecheck(
             "val a = \"hello\"\nif 1 < 2 { val b = \"world\" a + b } else { a + \"!\" }"
         )?;
         let expected = TypedAstNode::IfStatement(
@@ -6237,7 +6244,7 @@ mod tests {
                 ]),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
         Ok(())
     }
@@ -6264,7 +6271,7 @@ mod tests {
 
     #[test]
     fn typecheck_if_expression_conversion_to_statement() -> TestResult {
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           func abc() {\n\
             if true { println(\"hello\") }\n\
           }\
@@ -6308,39 +6315,23 @@ mod tests {
                 is_recursive: false,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         Ok(())
     }
 
     #[test]
-    fn typecheck_if_expression() {
-        let (typechecker, _) = typecheck_get_typechecker("val a = if (1 < 2) 123 else 456");
-        match typechecker.get_binding("a") {
-            Some((ScopeBinding(_, typ, _), scope_depth)) => {
-                assert_eq!(&Type::Int, typ);
-                assert_eq!(0, scope_depth);
-            }
-            _ => panic!("There should be a binding named 'a'"),
-        }
+    fn typecheck_if_expression() -> TestResult {
+        let module = typecheck("val a = if (1 < 2) 123 else 456")?;
+        assert_eq!(Type::Int, module.global_bindings["a"].1);
 
-        let (typechecker, _) = typecheck_get_typechecker("val a = if (1 < 2) 123");
-        match typechecker.get_binding("a") {
-            Some((ScopeBinding(_, typ, _), scope_depth)) => {
-                assert_eq!(&Type::Option(Box::new(Type::Int)), typ);
-                assert_eq!(0, scope_depth);
-            }
-            _ => panic!("There should be a binding named 'a'"),
-        }
+        let module = typecheck("val a = if (1 < 2) 123")?;
+        assert_eq!(Type::Option(Box::new(Type::Int)), module.global_bindings["a"].1);
 
-        let (typechecker, _) = typecheck_get_typechecker("val a = if (1 < 2) { if (true) 123 } else if (false) 456");
-        match typechecker.get_binding("a") {
-            Some((ScopeBinding(_, typ, _), scope_depth)) => {
-                assert_eq!(&Type::Option(Box::new(Type::Int)), typ);
-                assert_eq!(0, scope_depth);
-            }
-            _ => panic!("There should be a binding named 'a'"),
-        }
+        let module = typecheck("val a = if (1 < 2) { if (true) 123 } else if (false) 456")?;
+        assert_eq!(Type::Option(Box::new(Type::Int)), module.global_bindings["a"].1);
+
+        Ok(())
     }
 
     #[test]
@@ -6372,83 +6363,79 @@ mod tests {
 
     #[test]
     fn typecheck_invocation() -> TestResult {
-        // let ast = typecheck("func abc() {}\nabc()")?;
-        // let node = ast.get(1).unwrap();
-        //
-        // let expected = TypedAstNode::Invocation(
-        //     Token::LParen(Position::new(2, 4), false),
-        //     TypedInvocationNode {
-        //         typ: Type::Unit,
-        //         target: Box::new(
-        //             identifier!((2, 1), "abc", Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::Unit), is_variadic: false }), 0)
-        //         ),
-        //         args: vec![],
-        //     },
-        // );
-        // assert_eq!(node, &expected);
-        //
-        // let ast = typecheck("\
-        //   func abc(a: Int, b: String): String { b }\n\
-        //   abc(1, \"2\")\
-        // ")?;
-        // let node = ast.get(1).unwrap();
-        //
-        // let expected = TypedAstNode::Invocation(
-        //     Token::LParen(Position::new(2, 4), false),
-        //     TypedInvocationNode {
-        //         typ: Type::String,
-        //         target: Box::new(identifier!(
-        //             (2, 1),
-        //             "abc",
-        //             Type::Fn(FnType {
-        //                 arg_types: vec![("a".to_string(), Type::Int, false), ("b".to_string(), Type::String, false)],
-        //                 type_args: vec![],
-        //                 ret_type: Box::new(Type::String),
-        //                 is_variadic: false
-        //             }),
-        //             0
-        //         )),
-        //         args: vec![
-        //             Some(int_literal!((2, 5), 1)),
-        //             Some(string_literal!((2, 8), "2")),
-        //         ],
-        //     },
-        // );
-        // assert_eq!(node, &expected);
-        //
-        // let ast = typecheck(r#"
-        //   func abc(a: Int, b = "hello"): String { b }
-        //   abc(1)
-        // "#);
-        // assert_eq!(ast.is_ok(), true);
+        let module = typecheck("func abc() {}\nabc()")?;
+        let expected = TypedAstNode::Invocation(
+            Token::LParen(Position::new(2, 4), false),
+            TypedInvocationNode {
+                typ: Type::Unit,
+                target: Box::new(
+                    identifier!((2, 1), "abc", Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::Unit), is_variadic: false }), 0)
+                ),
+                args: vec![],
+            },
+        );
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let ast = typecheck(r#"
+        let module = typecheck("\
+          func abc(a: Int, b: String): String { b }\n\
+          abc(1, \"2\")\
+        ")?;
+        let expected = TypedAstNode::Invocation(
+            Token::LParen(Position::new(2, 4), false),
+            TypedInvocationNode {
+                typ: Type::String,
+                target: Box::new(identifier!(
+                    (2, 1),
+                    "abc",
+                    Type::Fn(FnType {
+                        arg_types: vec![("a".to_string(), Type::Int, false), ("b".to_string(), Type::String, false)],
+                        type_args: vec![],
+                        ret_type: Box::new(Type::String),
+                        is_variadic: false
+                    }),
+                    0
+                )),
+                args: vec![
+                    Some(int_literal!((2, 5), 1)),
+                    Some(string_literal!((2, 8), "2")),
+                ],
+            },
+        );
+        assert_eq!(expected, module.typed_nodes[1]);
+
+        let res = typecheck(r#"
+          func abc(a: Int, b = "hello"): String { b }
+          abc(1)
+        "#);
+        assert_eq!(res.is_ok(), true);
+
+        let res = typecheck(r#"
           func abc(*a: Int[]) {}
           abc()
-          //abc(1)
-          //abc(1, 2, 3, 4)
+          abc(1)
+          abc(1, 2, 3, 4)
           abc(a: [1, 2, 3])
         "#);
-        assert_eq!(ast.is_ok(), true);
+        assert_eq!(res.is_ok(), true);
 
-        let ast = typecheck(r#"
+        let res = typecheck(r#"
           func abc(a: Int, *b: Int[]) {}
           abc(1)
           abc(1)
           abc(1, 2, 3, 4)
           abc(a: 1, b: [2, 3, 4])
         "#);
-        assert_eq!(ast.is_ok(), true);
+        assert_eq!(res.is_ok(), true);
 
         Ok(())
     }
 
     #[test]
     fn typecheck_invocation_instantiation() -> TestResult {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Person { name: String }\n\
           Person(name: \"Ken\")\
-        ");
+        ")?;
         let expected = TypedAstNode::Instantiation(
             Token::LParen(Position::new(2, 7), false),
             TypedInstantiationNode {
@@ -6461,7 +6448,7 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -6471,13 +6458,13 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
         // Test with default parameters
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Person { name: String, age: Int = 0 }\n\
           Person(name: \"Ken\")\
-        ");
+        ")?;
         let expected = TypedAstNode::Instantiation(
             Token::LParen(Position::new(2, 7), false),
             TypedInstantiationNode {
@@ -6491,7 +6478,7 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -6502,7 +6489,7 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
         Ok(())
     }
@@ -6669,7 +6656,7 @@ mod tests {
 
     #[test]
     fn typecheck_while_loop() -> TestResult {
-        let ast = typecheck("while true 1 + 1")?;
+        let module = typecheck("while true 1 + 1")?;
         let expected = TypedAstNode::WhileLoop(
             Token::While(Position::new(1, 1)),
             TypedWhileLoopNode {
@@ -6688,9 +6675,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let ast = typecheck("while true { break }")?;
+        let module = typecheck("while true { break }")?;
         let expected = TypedAstNode::WhileLoop(
             Token::While(Position::new(1, 1)),
             TypedWhileLoopNode {
@@ -6701,9 +6688,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let ast = typecheck("while true {\nval a = 1\na + 1 }")?;
+        let module = typecheck("while true {\nval a = 1\na + 1 }")?;
         let expected = TypedAstNode::WhileLoop(
             Token::While(Position::new(1, 1)),
             TypedWhileLoopNode {
@@ -6731,9 +6718,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let ast = typecheck("while [1, 2][0] { break }")?;
+        let module = typecheck("while [1, 2][0] { break }")?;
         let expected = TypedAstNode::WhileLoop(
             Token::While(Position::new(1, 1)),
             TypedWhileLoopNode {
@@ -6764,12 +6751,12 @@ mod tests {
                 ],
             },
         );
-        Ok(assert_eq!(expected, ast[0]))
+        Ok(assert_eq!(expected, module.typed_nodes[0]))
     }
 
     #[test]
     fn typecheck_while_loop_condition_binding() -> TestResult {
-        let ast = typecheck("while true |v| { v }")?;
+        let module = typecheck("while true |v| { v }")?;
         let expected = TypedAstNode::WhileLoop(
             Token::While(Position::new(1, 1)),
             TypedWhileLoopNode {
@@ -6780,9 +6767,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let ast = typecheck("\
+        let module = typecheck("\
           val item = [1, 2, 3][0]\n\
           while item |item| { item }\
         ")?;
@@ -6798,7 +6785,7 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
         Ok(())
     }
@@ -6833,7 +6820,7 @@ mod tests {
 
     #[test]
     fn typecheck_for_loop() -> TestResult {
-        let ast = typecheck("val arr = [1, 2, 3]\nfor a in arr {\na + 1 }")?;
+        let module = typecheck("val arr = [1, 2, 3]\nfor a in arr {\na + 1 }")?;
         let expected = TypedAstNode::ForLoop(
             Token::For(Position::new(2, 1)),
             TypedForLoopNode {
@@ -6853,9 +6840,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let ast = typecheck("val arr = [1, 2, 3]\nfor a, i in arr {\na + i }")?;
+        let module = typecheck("val arr = [1, 2, 3]\nfor a, i in arr {\na + i }")?;
         let expected = TypedAstNode::ForLoop(
             Token::For(Position::new(2, 1)),
             TypedForLoopNode {
@@ -6875,9 +6862,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let ast = typecheck("val set = #{1, 2, 3}\nfor a, i in set {\na + i }")?;
+        let module = typecheck("val set = #{1, 2, 3}\nfor a, i in set {\na + i }")?;
         let expected = TypedAstNode::ForLoop(
             Token::For(Position::new(2, 1)),
             TypedForLoopNode {
@@ -6897,9 +6884,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let ast = typecheck("val map = {a:1, b:2}\nfor k, v in map {\nk + v }")?;
+        let module = typecheck("val map = {a:1, b:2}\nfor k, v in map {\nk + v }")?;
         let expected = TypedAstNode::ForLoop(
             Token::For(Position::new(2, 1)),
             TypedForLoopNode {
@@ -6919,9 +6906,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let ast = typecheck("\
+        let module = typecheck("\
           val coords = [(1, 2), (3, 4)]\n\
           for (x, y), i in coords {\n\
             x + y\n\
@@ -6952,7 +6939,7 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
         Ok(())
     }
@@ -6977,11 +6964,11 @@ mod tests {
     #[test]
     fn typecheck_accessor_instance() -> TestResult {
         // Getting fields off structs
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Person { name: String }\n\
           val p = Person(name: \"Sam\")\n\
           p.name\n\
-        ");
+        ")?;
         let expected = TypedAstNode::Accessor(
             Token::Dot(Position::new(3, 2)),
             TypedAccessorNode {
@@ -6994,7 +6981,7 @@ mod tests {
                 is_readonly: false,
             },
         );
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
         let expected_typ = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -7004,14 +6991,14 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_typ, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_typ, module.referencable_types["Person"]);
 
         // Getting fields off structs with default field values
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Person { name: String, age: Int = 0 }\n\
           val p = Person(name: \"Sam\")\n\
           p.age\n\
-        ");
+        ")?;
         let expected = TypedAstNode::Accessor(
             Token::Dot(Position::new(3, 2)),
             TypedAccessorNode {
@@ -7024,7 +7011,7 @@ mod tests {
                 is_readonly: false,
             },
         );
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -7035,10 +7022,10 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
         // Getting field of builtin Array type
-        let typed_ast = typecheck("[1, 2, 3].length")?;
+        let module = typecheck("[1, 2, 3].length")?;
         let expected = TypedAstNode::Accessor(
             Token::Dot(Position::new(1, 10)),
             TypedAccessorNode {
@@ -7061,10 +7048,10 @@ mod tests {
                 is_readonly: true,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         // Getting field of builtin String type
-        let typed_ast = typecheck("\"hello\".length")?;
+        let module = typecheck("\"hello\".length")?;
         let expected = TypedAstNode::Accessor(
             Token::Dot(Position::new(1, 8)),
             TypedAccessorNode {
@@ -7077,7 +7064,7 @@ mod tests {
                 is_readonly: true,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         // Test getting readonly field
         let res = typecheck("\
@@ -7093,10 +7080,10 @@ mod tests {
     #[test]
     fn typecheck_accessor_static() -> TestResult {
         // Getting static fields off structs
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Person { func getName(): String = \"Sam\" }\n\
           Person.getName\n\
-        ");
+        ")?;
         let expected = TypedAstNode::Accessor(
             Token::Dot(Position::new(2, 7)),
             TypedAccessorNode {
@@ -7109,7 +7096,7 @@ mod tests {
                 is_readonly: true,
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -7117,18 +7104,18 @@ mod tests {
             static_fields: vec![("getName".to_string(), Type::Fn(FnType { arg_types: vec![], type_args: vec![], ret_type: Box::new(Type::String), is_variadic: false }), true)],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
         Ok(())
     }
 
     #[test]
     fn typecheck_accessor_optional_safe() -> TestResult {
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Person { name: String? = None }\n\
           val p = Person()\n\
           p.name?.length\n\
-        ");
+        ")?;
         let expected = TypedAstNode::Accessor(
             Token::QuestionDot(Position::new(3, 7)),
             TypedAccessorNode {
@@ -7152,7 +7139,7 @@ mod tests {
                 is_readonly: true,
             },
         );
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -7162,14 +7149,14 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
         // Verify that it also works for non-optional fields, converting QuestionDot to just Dot
-        let (typechecker, typed_ast) = typecheck_get_typechecker("\
+        let module = typecheck("\
           type Person { name: String = \"\" }\n\
           val p = Person()\n\
           p?.name\n\
-        ");
+        ")?;
         let expected = TypedAstNode::Accessor(
             Token::Dot(Position::new(3, 2)),
             TypedAccessorNode {
@@ -7182,7 +7169,7 @@ mod tests {
                 is_readonly: false,
             },
         );
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
         let expected_type = Type::Struct(StructType {
             name: "Person".to_string(),
             type_args: vec![],
@@ -7192,7 +7179,7 @@ mod tests {
             static_fields: vec![],
             methods: vec![to_string_method_type()],
         });
-        assert_eq!(expected_type, typechecker.referencable_types["Person"]);
+        assert_eq!(expected_type, module.referencable_types["Person"]);
 
         Ok(())
     }
@@ -7220,7 +7207,7 @@ mod tests {
 
     #[test]
     fn typecheck_lambda() -> TestResult {
-        let typed_ast = typecheck("() => \"hello\"")?;
+        let module = typecheck("() => \"hello\"")?;
         let expected = TypedAstNode::Lambda(
             Token::Arrow(Position::new(1, 4)),
             TypedLambdaNode {
@@ -7230,9 +7217,9 @@ mod tests {
                 orig_node: None,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("a => \"hello\"")?;
+        let module = typecheck("a => \"hello\"")?;
         let expected = TypedAstNode::Lambda(
             Token::Arrow(Position::new(1, 3)),
             TypedLambdaNode {
@@ -7253,9 +7240,9 @@ mod tests {
                 )),
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("(a, b = \"b\") => \"hello\"")?;
+        let module = typecheck("(a, b = \"b\") => \"hello\"")?;
         let expected = TypedAstNode::Lambda(
             Token::Arrow(Position::new(1, 14)),
             TypedLambdaNode {
@@ -7290,9 +7277,9 @@ mod tests {
                 typed_body: None,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
-        let typed_ast = typecheck("(a: String) => \"hello\"")?;
+        let module = typecheck("(a: String) => \"hello\"")?;
         let expected = TypedAstNode::Lambda(
             Token::Arrow(Position::new(1, 13)),
             TypedLambdaNode {
@@ -7306,14 +7293,14 @@ mod tests {
                 orig_node: None,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         Ok(())
     }
 
     #[test]
     fn typecheck_lambda_closure() -> TestResult {
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           func getAdder(x: Int): (Int) => Int {\n\
             y => x + y\n\
           }\
@@ -7358,7 +7345,7 @@ mod tests {
                 is_recursive: false,
             },
         );
-        assert_eq!(expected, typed_ast[0]);
+        assert_eq!(expected, module.typed_nodes[0]);
 
         Ok(())
     }
@@ -7379,7 +7366,7 @@ mod tests {
 
     #[test]
     fn typecheck_lambda_inference() -> TestResult {
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           var fn = (a: String) => a\n\
           fn = a => a\n\
         ")?;
@@ -7409,9 +7396,9 @@ mod tests {
                 )),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           var fn = (a: String) => a\n\
           fn = (a, b = \"a\") => \"hello\"\n\
         ")?;
@@ -7440,17 +7427,17 @@ mod tests {
                 )),
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
-        let typed_ast = typecheck(r#"
+        let res = typecheck(r#"
           var fn = (a: String) => a
           func abc(str: String): String = str
           fn = abc
           fn("abc")
         "#);
-        assert!(typed_ast.is_ok());
+        assert!(res.is_ok());
 
-        let typed_ast = typecheck(r#"
+        let res = typecheck(r#"
           var fn: (String) => String = a => a
           type Person {
             name: String
@@ -7459,20 +7446,20 @@ mod tests {
           fn = Person(name: "Ken").greet
           fn("Hello")
         "#);
-        assert!(typed_ast.is_ok());
+        assert!(res.is_ok());
 
-        let typed_ast = typecheck(r#"
+        let res = typecheck(r#"
           func call(fn: (String) => String, value: String): String = fn(value)
           call((x, b = "hello") => b, "hello")
         "#);
-        assert!(typed_ast.is_ok());
+        assert!(res.is_ok());
 
         // A lambda which returns Unit can accept anything as a response (which will just be thrown out)
-        let typed_ast = typecheck(r#"
+        let res = typecheck(r#"
           func call(fn: (String) => Unit, value: String) = fn(value)
           call((x, b = "hello") => b, "hello")
         "#);
-        assert!(typed_ast.is_ok());
+        assert!(res.is_ok());
 
         Ok(())
     }
@@ -7506,7 +7493,7 @@ mod tests {
     #[test]
     fn typecheck_match_statements() -> TestResult {
         // Verify branches for Int? type
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           val i = [1, 2][2]\n\
           match i {\n\
             Int i => i\n\
@@ -7524,10 +7511,10 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
         // Verify branches for (Int | String)? type
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           val i: (Int | String)? = [1, 2][2]\n\
           match i {\n\
             Int i => i\n\
@@ -7553,10 +7540,10 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[1]);
+        assert_eq!(expected, module.typed_nodes[1]);
 
         // Verify branches for enum type
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           enum Direction { Left, Right, Up, Down }\n\
           val d: Direction = Direction.Left\n\
           match d {\n\
@@ -7604,23 +7591,23 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
 
-        let typed_ast = typecheck("\
+        let res = typecheck("\
           enum Foo { Bar(baz: Int) }\n\
           val f: Foo = Foo.Bar(baz: 24)\n\
           val i: Int = match f {\n\
             Foo.Bar(z) => z\n\
           }
         ");
-        assert!(typed_ast.is_ok());
+        assert!(res.is_ok());
 
         Ok(())
     }
 
     #[test]
     fn typecheck_match_expressions() -> TestResult {
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           val i = [1, 2][2]\n\
           val j = match i {\n\
             Int i => i\n\
@@ -7632,9 +7619,9 @@ mod tests {
           j
         ")?;
         let expected = identifier!((9, 1), "j", Type::Int, 0);
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
 
-        let typed_ast = typecheck("\
+        let module = typecheck("\
           val i: String | Int = 123\n\
           val j = match i {\n\
             Int i => i\n\
@@ -7643,7 +7630,7 @@ mod tests {
           j
         ")?;
         let expected = identifier!((6, 1), "j", Type::Int, 0);
-        assert_eq!(expected, typed_ast[2]);
+        assert_eq!(expected, module.typed_nodes[2]);
 
         Ok(())
     }

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -10,6 +10,7 @@ use crate::builtins::native::{NativeArray, NativeMap, NativeSet, NativeString, d
 use crate::builtins::native_value_trait::NativeTyp;
 use crate::common::util::random_string;
 use crate::builtins::native_fns::NativeFn;
+use crate::typechecker::typechecker::TypedModule;
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -82,7 +83,7 @@ struct JumpHandle {
     instr_slot: usize,
 }
 
-pub fn compile(module_path: String, ast: Vec<TypedAstNode>) -> Result<(Module, Metadata), ()> {
+pub fn compile(module_path: String, module: TypedModule) -> Result<(Module, Metadata), ()> {
     let metadata = Metadata::default();
     let root_scope = Scope { kind: ScopeKind::Root, num_locals: 0, first_local_idx: None };
 
@@ -111,6 +112,7 @@ pub fn compile(module_path: String, ast: Vec<TypedAstNode>) -> Result<(Module, M
         temp_idx: 0,
     };
 
+    let ast = module.typed_nodes;
     compiler.hoist_fn_defs(&ast)?;
 
     let len = ast.len();
@@ -2018,10 +2020,10 @@ mod tests {
     fn compile(input: &str) -> Module {
         let tokens = tokenize(&input.to_string()).unwrap();
         let ast = parse(tokens).unwrap();
-        let (_, typed_ast) = typecheck(ast).unwrap();
+        let module = typecheck(ast).unwrap();
 
         let module_name = "_test.abra".to_string();
-        super::compile(module_name, typed_ast).unwrap().0
+        super::compile(module_name, module).unwrap().0
     }
 
     fn to_string_method() -> (String, Value) {

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -83,7 +83,7 @@ struct JumpHandle {
     instr_slot: usize,
 }
 
-pub fn compile(module_path: String, module: TypedModule) -> Result<(Module, Metadata), ()> {
+pub fn compile(module: TypedModule) -> Result<(Module, Metadata), ()> {
     let metadata = Metadata::default();
     let root_scope = Scope { kind: ScopeKind::Root, num_locals: 0, first_local_idx: None };
 
@@ -94,10 +94,8 @@ pub fn compile(module_path: String, module: TypedModule) -> Result<(Module, Meta
             .collect()
     );
 
-    let module_name = module_path.replace(".abra", "").replace("/", ".");
-
     let mut compiler = Compiler {
-        module_name,
+        module_name: module.module_name,
         code: Vec::new(),
         constants,
         str_constant_indexes: HashMap::new(),
@@ -129,7 +127,7 @@ pub fn compile(module_path: String, module: TypedModule) -> Result<(Module, Meta
     }
     compiler.write_opcode(Opcode::Return, last_line + 1);
 
-    let module = Module { name: module_path, constants: compiler.constants, code: compiler.code };
+    let module = Module { name: compiler.module_name, constants: compiler.constants, code: compiler.code };
     Ok((module, compiler.metadata))
 }
 
@@ -268,7 +266,7 @@ impl Compiler {
                 let const_idx = self.add_constant(Value::Str(const_name.clone()));
                 self.str_constant_indexes.insert(const_name, const_idx);
                 const_idx
-            },
+            }
             Some(const_idx) => *const_idx
         };
         self.write_opcode(Opcode::GStore(const_idx), line);
@@ -2018,12 +2016,12 @@ mod tests {
     }
 
     fn compile(input: &str) -> Module {
+        let module_name = "_test.abra".to_string();
+
         let tokens = tokenize(&input.to_string()).unwrap();
         let ast = parse(tokens).unwrap();
-        let module = typecheck(ast).unwrap();
-
-        let module_name = "_test.abra".to_string();
-        super::compile(module_name, module).unwrap().0
+        let module = typecheck(module_name, ast).unwrap();
+        super::compile(module).unwrap().0
     }
 
     fn to_string_method() -> (String, Value) {
@@ -2039,7 +2037,7 @@ mod tests {
     fn compile_empty() {
         let chunk = compile("");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![Opcode::Return],
             constants: with_prelude_consts(vec![]),
         };
@@ -2050,7 +2048,7 @@ mod tests {
     fn compile_literals() {
         let chunk = compile("1 2.3 4 5.6 \"hello\" true false");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::Pop(1),
@@ -2080,7 +2078,7 @@ mod tests {
     fn compile_unary() {
         let chunk = compile("-5");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Invert,
@@ -2092,7 +2090,7 @@ mod tests {
 
         let chunk = compile("-2.3");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Invert,
@@ -2104,7 +2102,7 @@ mod tests {
 
         let chunk = compile("!false");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::F,
                 Opcode::Negate,
@@ -2119,7 +2117,7 @@ mod tests {
     fn compile_binary_numeric() {
         let chunk = compile("5 + 6");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2133,7 +2131,7 @@ mod tests {
         // Testing i2f and order of ops
         let chunk = compile("1 - -5 * 3.4 / 5");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::I2F,
@@ -2155,7 +2153,7 @@ mod tests {
         // Testing %, along with i2f
         let chunk = compile("3.4 % 2.4 % 5");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2172,7 +2170,7 @@ mod tests {
         // Testing **
         let chunk = compile("3.4 ** 5");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2188,7 +2186,7 @@ mod tests {
     fn compile_binary_grouped() {
         let chunk = compile("(1 + 2) * 3");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -2206,7 +2204,7 @@ mod tests {
     fn compile_binary_str_concat() {
         let chunk = compile("\"abc\" + \"def\"");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2222,7 +2220,7 @@ mod tests {
 
         let chunk = compile("1 + \"a\" + 3.4");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::Constant(with_prelude_const_offset(0)),
@@ -2243,7 +2241,7 @@ mod tests {
     fn compile_binary_boolean() {
         let chunk = compile("true && true || false");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::T,
                 Opcode::JumpIfF(2),
@@ -2263,7 +2261,7 @@ mod tests {
         // Testing xor
         let chunk = compile("true ^ false");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::T,
                 Opcode::F,
@@ -2279,7 +2277,7 @@ mod tests {
     fn compile_binary_comparisons() {
         let chunk = compile("1 <= 5 == 3.4 >= 5.6");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::Constant(with_prelude_const_offset(0)),
@@ -2296,7 +2294,7 @@ mod tests {
 
         let chunk = compile("\"a\" < \"b\" != 4");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2317,7 +2315,7 @@ mod tests {
     fn compile_binary_coalesce() {
         let chunk = compile("[\"a\", \"b\"][2] ?: \"c\"");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2349,7 +2347,7 @@ mod tests {
     fn compile_array_literal() {
         let chunk = compile("[1, 2]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -2362,7 +2360,7 @@ mod tests {
 
         let chunk = compile("[\"a\", \"b\", \"c\"]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2383,7 +2381,7 @@ mod tests {
     fn compile_array_nested() {
         let chunk = compile("[[1, 2], [3, 4, 5]]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -2404,7 +2402,7 @@ mod tests {
     fn compile_set_literal() {
         let chunk = compile("#{1, 2}");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -2417,7 +2415,7 @@ mod tests {
 
         let chunk = compile("#{\"a\", \"b\", \"c\"}");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2438,7 +2436,7 @@ mod tests {
     fn compile_map_literal() {
         let chunk = compile("{ a: 1, b: \"c\", d: true }");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::IConst1,
@@ -2463,7 +2461,7 @@ mod tests {
     fn compile_binding_decl() {
         let chunk = compile("val abc = 123");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::GStore(with_prelude_const_offset(1)),
@@ -2475,7 +2473,7 @@ mod tests {
 
         let chunk = compile("var unset: Bool\nvar set = true");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Nil,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -2492,7 +2490,7 @@ mod tests {
 
         let chunk = compile("val abc = \"a\" + \"b\"\nval def = 5");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::Constant(with_prelude_const_offset(1)),
@@ -2520,7 +2518,7 @@ mod tests {
           val meg = Person(name: \"Meg\")\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -2554,7 +2552,7 @@ mod tests {
           val anAdult = Person(name: \"Some Name\", age: 29)\n\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -2595,7 +2593,7 @@ mod tests {
     fn compile_binding_decl_destructuring_tuples() {
         let chunk = compile("val (a, b) = (1, 2)");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -2625,7 +2623,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -2668,7 +2666,7 @@ mod tests {
     fn compile_binding_decl_destructuring_arrays() {
         let chunk = compile("val [a, b] = [1, 2]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -2698,7 +2696,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -2741,7 +2739,7 @@ mod tests {
     fn compile_binding_decl_destructuring_strings() {
         let chunk = compile("val [a, b] = \"hello\"");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::GStore(with_prelude_const_offset(1)),
@@ -2769,7 +2767,7 @@ mod tests {
     fn compile_ident() {
         let chunk = compile("val abc = 123\nabc");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::GStore(with_prelude_const_offset(1)),
@@ -2785,7 +2783,7 @@ mod tests {
     fn compile_ident_upvalues() {
         let chunk = compile("func a(i: Int) {\nval b = 3\nfunc c(): Int { b + 1 }\n}");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -2843,7 +2841,7 @@ mod tests {
     fn compile_ident_upvalues_skip_level() {
         let chunk = compile("func a(i: Int) {\nval b = 3\nfunc c() { func d(): Int { b + 1 }\n}\n}");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -2924,7 +2922,7 @@ mod tests {
     fn compile_assignment() {
         let chunk = compile("var a = 1\nvar b = 2\nval c = b = a = 3");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 // var a = 1
                 Opcode::IConst1,
@@ -2955,7 +2953,7 @@ mod tests {
 
         let chunk = compile("var a = 1\na = 2\nval b = 3");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 // var a = 1
                 Opcode::IConst1,
@@ -2982,7 +2980,7 @@ mod tests {
     fn compile_assignment_globals() {
         let chunk = compile("var a = 1\nfunc abc(): Int { a = 3 }");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3016,7 +3014,7 @@ mod tests {
     fn compile_assignment_upvalues() {
         let chunk = compile("func outer() {\nvar a = 1\nfunc inner(): Int { a = 3 }\n}");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3073,7 +3071,7 @@ mod tests {
     fn compile_assignment_indexing() {
         let chunk = compile("val a = [1]\na[0] = 0");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::ArrMk(1),
@@ -3092,7 +3090,7 @@ mod tests {
 
         let chunk = compile("val a = {b:1}\na[\"b\"] = 0");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::IConst1,
@@ -3113,7 +3111,7 @@ mod tests {
 
         let chunk = compile("val a = (1, 2)\na[0] = 0");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3140,7 +3138,7 @@ mod tests {
           p.name = \"Meg\"\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3176,7 +3174,7 @@ mod tests {
     fn compile_indexing() {
         let chunk = compile("[1, 2, 3, 4, 5][3 + 1]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3196,7 +3194,7 @@ mod tests {
 
         let chunk = compile("\"some string\"[1 + 1:]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::IConst1,
@@ -3214,7 +3212,7 @@ mod tests {
 
         let chunk = compile("\"some string\"[-1:4]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::IConst1,
@@ -3231,7 +3229,7 @@ mod tests {
 
         let chunk = compile("\"some string\"[:1 + 1]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::IConst0,
@@ -3249,7 +3247,7 @@ mod tests {
 
         let chunk = compile("{ a: 1, b: 2 }[\"a\"]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::IConst1,
@@ -3269,7 +3267,7 @@ mod tests {
 
         let chunk = compile("(1, true, 3)[2]");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::T,
@@ -3288,7 +3286,7 @@ mod tests {
     fn compile_if_else_statements() {
         let chunk = compile("if (1 == 2) 123 else 456");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3307,7 +3305,7 @@ mod tests {
 
         let chunk = compile("if (1 == 2) 123");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3323,7 +3321,7 @@ mod tests {
 
         let chunk = compile("if (1 == 2) { } else { 456 }");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3340,7 +3338,7 @@ mod tests {
 
         let chunk = compile("if (1 == 2) 123 else if (3 < 4) 456 else 789");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3372,7 +3370,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::GStore(with_prelude_const_offset(1)),
@@ -3400,7 +3398,7 @@ mod tests {
     fn compile_if_else_statements_option_condition() {
         let chunk = compile("if ([1, 2][0]) 123 else 456");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3426,7 +3424,7 @@ mod tests {
     fn compile_if_else_statements_with_condition_binding() {
         let chunk = compile("if [1, 2][0] |item| item else 456");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3465,7 +3463,7 @@ mod tests {
           }
         "#);
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3517,7 +3515,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3553,7 +3551,7 @@ mod tests {
     fn compile_function_declaration_default_args() {
         let chunk = compile("func add(a: Int, b = 2): Int = a + b\nadd(1)\nadd(1, 2)");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3609,7 +3607,7 @@ mod tests {
           }
         "#);
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3673,7 +3671,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3726,7 +3724,7 @@ mod tests {
     fn compile_enum_decl_variants() {
         let chunk = compile("enum Status { On, Off }");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3780,7 +3778,7 @@ mod tests {
           val two = inc(number: one)
         "#);
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3825,7 +3823,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3850,7 +3848,7 @@ mod tests {
 
         let chunk = compile("while ([1, 2][0]) { 123 }");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst1,
                 Opcode::IConst2,
@@ -3876,7 +3874,7 @@ mod tests {
     fn compile_while_loop_with_condition_binding() {
         let chunk = compile("while ([1, 2][0]) |item| { item }");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Nil,
                 Opcode::MarkLocal(0),
@@ -3912,7 +3910,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -3948,7 +3946,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::T,
                 Opcode::JumpIfF(5),
@@ -3973,7 +3971,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::T,
                 Opcode::JumpIfF(12),
@@ -4006,7 +4004,7 @@ mod tests {
           }\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 // val msg = "Row: "
                 Opcode::Constant(with_prelude_const_offset(0)),
@@ -4104,7 +4102,7 @@ mod tests {
         "#;
         let chunk = compile(input);
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             constants: with_prelude_consts(vec![
                 Value::Int(5), Value::Int(6), Value::Int(7), Value::Int(8), Value::Int(9), Value::Int(10), Value::Int(11)
             ]),
@@ -4432,7 +4430,7 @@ mod tests {
             .join("\n");
         let chunk = compile(input.as_str());
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             constants: with_prelude_consts(
                 (0..150).into_iter()
                     .flat_map(|i| vec![
@@ -4463,7 +4461,7 @@ mod tests {
           ken.name\n\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -4495,7 +4493,7 @@ mod tests {
         // Accessing fields of structs
         let chunk = compile("\"hello\".length");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::GetField(0),
@@ -4514,7 +4512,7 @@ mod tests {
           val abc = () => println(\"hello\")\
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(1)),
                 Opcode::GStore(with_prelude_const_offset(2)),
@@ -4551,7 +4549,7 @@ mod tests {
           }
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::GStore(with_prelude_const_offset(1)),
@@ -4590,7 +4588,7 @@ mod tests {
           }
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::Constant(with_prelude_const_offset(0)),
                 Opcode::GStore(with_prelude_const_offset(1)),
@@ -4630,7 +4628,7 @@ mod tests {
           }
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -4689,7 +4687,7 @@ mod tests {
           }
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -4763,7 +4761,7 @@ mod tests {
           }
         ");
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),
@@ -4827,7 +4825,7 @@ mod tests {
           }
         "#);
         let expected = Module {
-            name: "_test.abra".to_string(),
+            name: "_test".to_string(),
             code: vec![
                 Opcode::IConst0,
                 Opcode::GStore(with_prelude_const_offset(0)),

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -22,12 +22,12 @@ mod tests {
     }
 
     fn interpret(input: &str) -> Option<Value> {
+        let module_name = "_test.abra".to_string();
+
         let tokens = tokenize(&input.to_string()).unwrap();
         let ast = parse(tokens).unwrap();
-        let module = typecheck(ast).unwrap();
-
-        let module_name = "_test.abra".to_string();
-        let (module, _) = compile(module_name, module).unwrap();
+        let module = typecheck(module_name, ast).unwrap();
+        let (module, _) = compile(module).unwrap();
         let ctx = VMContext::default();
 
         let mut vm = VM::new(module, ctx);

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -24,10 +24,10 @@ mod tests {
     fn interpret(input: &str) -> Option<Value> {
         let tokens = tokenize(&input.to_string()).unwrap();
         let ast = parse(tokens).unwrap();
-        let (_, typed_ast) = typecheck(ast).unwrap();
+        let module = typecheck(ast).unwrap();
 
         let module_name = "_test.abra".to_string();
-        let (module, _) = compile(module_name, typed_ast).unwrap();
+        let (module, _) = compile(module_name, module).unwrap();
         let ctx = VMContext::default();
 
         let mut vm = VM::new(module, ctx);

--- a/abra_lsp/src/backend.rs
+++ b/abra_lsp/src/backend.rs
@@ -16,7 +16,8 @@ impl Backend {
     }
 
     fn get_diagnostics(&self, uri: Url, version: Option<i64>, text: String) -> PublishDiagnosticsParams {
-        let diagnostics = match typecheck(&text) {
+        let module_path = uri.path();
+        let diagnostics = match typecheck(module_path.to_string(), &text) {
             Ok(_) => vec![],
             Err(e) => {
                 let diagnostic = abra_error_to_diagnostic(e, &text);

--- a/abra_lsp/src/utils.rs
+++ b/abra_lsp/src/utils.rs
@@ -1,11 +1,16 @@
 use abra_core::common::display_error::DisplayError;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use abra_core::parser::parse_error::ParseError;
 
 pub fn abra_error_to_diagnostic(e: abra_core::Error, source: &String) -> Diagnostic {
     let range = match &e {
         abra_core::Error::LexerError(e) => e.get_range(),
         abra_core::Error::TypecheckerError(e) => e.get_token().get_range(),
-        abra_core::Error::ParseError(_) => unimplemented!(),
+        abra_core::Error::ParseError(e) => match e {
+            ParseError::UnexpectedEof => unimplemented!(),
+            ParseError::UnexpectedToken(tok) |
+            ParseError::ExpectedToken(_, tok) => tok.get_range()
+        }
         abra_core::Error::InterpretError(_) => unreachable!()
     };
 

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -229,7 +229,8 @@ pub fn disassemble(input: &str) -> JsValue {
 
 #[wasm_bindgen(js_name = typecheck)]
 pub fn typecheck_input(input: &str) -> JsValue {
-    let result = typecheck(&input.to_string())
+    let module_name = "_repl.abra".to_string();
+    let result = typecheck(module_name, &input.to_string())
         .map(|_| ());
     let typecheck_result = TypecheckedResult(result, input.to_string());
     JsValue::from_serde(&typecheck_result)


### PR DESCRIPTION
- The return value from the typechecker now includes types and global
bindings. These will be used later for imports/exports