### PR TITLE
Compilation of imports and exports

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,3 +1,26 @@
-import a from .example2
+import Person, addName from .example2
 
-println("a: $a")
+//type Foo {
+//  qux: Int
+//}
+//
+//val f = Foo(qux: 24)
+//println("foo: $f")
+//
+//val names: Int[] = []
+
+//val ken = Person(name: "Ken")
+//addName(ken.name)
+//val brian = Person(name: "Brian")
+//addName(brian.name)
+//println(ken.introduce() + ", and " + brian.introduce())
+
+//names.push(123)
+//println("names: $names")
+
+val ken: Person? = Person(name: "Ken")
+//match ken {
+//  None => println("hmm?")
+//  Person p => println(p)
+//}
+println(ken)

--- a/abra_cli/abra-files/example2.abra
+++ b/abra_cli/abra-files/example2.abra
@@ -1,4 +1,11 @@
-import c from .example4
-import b from .example3
+export type Person {
+  name: String
+  func introduce(self): String = "I am " + self.name
+}
 
-export val a = b + c
+export val names: String[] = []
+
+export func addName(name: String) {
+  names.push(name)
+  println(names)
+}

--- a/abra_core/src/builtins/native/test_utils.rs
+++ b/abra_core/src/builtins/native/test_utils.rs
@@ -39,11 +39,15 @@ pub fn interpret(input: &str) -> Option<Value> {
 pub fn interpret_get_result<S: AsRef<str>>(input: S) -> Result<Option<Value>, Error> {
     let mock_reader = MockModuleReader::default();
     let module_id = ModuleId::from_name("_test");
-    let module = match compile(module_id, &input.as_ref().to_string(), mock_reader) {
-        Ok((module, _)) => module,
+    let modules = match compile(module_id, &input.as_ref().to_string(), mock_reader) {
+        Ok(modules) => modules,
         Err(error) => return Err(error)
     };
 
-    let mut vm = VM::new(module, VMContext::default());
-    vm.run().map_err(|e| Error::InterpretError(e))
+    let mut vm = VM::new(VMContext::default());
+    let mut res = None;
+    for module in modules {
+        res = vm.run(module).map_err(|e| Error::InterpretError(e))?;
+    }
+    Ok(res)
 }

--- a/abra_core/src/builtins/native_fns.rs
+++ b/abra_core/src/builtins/native_fns.rs
@@ -174,17 +174,11 @@ fn read_file(_receiver: Option<Value>, args: Vec<Value>, _vm: &mut VM) -> Option
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::vm::compiler::Module;
     use crate::vm::vm::VMContext;
-
-    fn make_vm() -> VM {
-        let module = Module { name: "_test".to_string(), code: vec![], constants: vec![] };
-        VM::new(module, VMContext::default())
-    }
 
     #[test]
     fn range_returning_int_array() {
-        let mut vm = make_vm();
+        let mut vm = VM::new(VMContext::default());
 
         // Test w/ increment of 1
         let arr = range(None, vec![Value::Int(0), Value::Int(5), Value::Int(1)], &mut vm);
@@ -209,7 +203,7 @@ mod test {
 
     #[test]
     fn range_returning_single_element_int_array() {
-        let mut vm = make_vm();
+        let mut vm = VM::new(VMContext::default());
 
         // Test w/ increment larger than range
         let arr = range(None, vec![Value::Int(0), Value::Int(5), Value::Int(5)], &mut vm);

--- a/abra_core/src/builtins/native_value_trait.rs
+++ b/abra_core/src/builtins/native_value_trait.rs
@@ -10,7 +10,7 @@ pub trait NativeTyp {
 }
 
 pub trait NativeValue: NativeTyp + DynHash + Debug + Downcast {
-    fn construct(type_id: usize, args: Vec<Value>) -> Value where Self: Sized;
+    fn construct(module_idx: usize, type_id: usize, args: Vec<Value>) -> Value where Self: Sized;
     fn get_type_value() -> TypeValue where Self: Sized;
 
     fn is_equal(&self, other: &Box<dyn NativeValue>) -> bool;

--- a/abra_core/src/common/typed_ast_visitor.rs
+++ b/abra_core/src/common/typed_ast_visitor.rs
@@ -1,7 +1,6 @@
 use crate::lexer::tokens::Token;
-use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedBinaryNode, TypedUnaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode, TypedLambdaNode, TypedEnumDeclNode, TypedMatchNode, TypedReturnNode, TypedTupleNode, TypedSetNode};
+use crate::typechecker::typed_ast::{TypedAstNode, TypedLiteralNode, TypedBinaryNode, TypedUnaryNode, TypedArrayNode, TypedBindingDeclNode, TypedAssignmentNode, TypedIndexingNode, TypedGroupedNode, TypedIfNode, TypedFunctionDeclNode, TypedIdentifierNode, TypedInvocationNode, TypedWhileLoopNode, TypedForLoopNode, TypedTypeDeclNode, TypedMapNode, TypedAccessorNode, TypedInstantiationNode, TypedLambdaNode, TypedEnumDeclNode, TypedMatchNode, TypedReturnNode, TypedTupleNode, TypedSetNode, TypedImportNode};
 use crate::typechecker::typed_ast::TypedAstNode::*;
-use crate::parser::ast::ImportNode;
 
 pub trait TypedAstVisitor<V, E> {
     fn visit(&mut self, node: TypedAstNode) -> Result<V, E> {
@@ -65,6 +64,6 @@ pub trait TypedAstVisitor<V, E> {
     fn visit_return(&mut self, token: Token, node: TypedReturnNode) -> Result<V, E>;
     fn visit_match_statement(&mut self, is_stmt: bool, token: Token, node: TypedMatchNode) -> Result<V, E>;
     fn visit_match_expression(&mut self, token: Token, node: TypedMatchNode) -> Result<V, E>;
-    fn visit_import_statement(&mut self, token: Token, node: ImportNode) -> Result<V, E>;
+    fn visit_import_statement(&mut self, token: Token, node: TypedImportNode) -> Result<V, E>;
     fn visit_nil(&mut self, token: Token) -> Result<V, E>;
 }

--- a/abra_core/src/module_loader.rs
+++ b/abra_core/src/module_loader.rs
@@ -3,6 +3,7 @@ use crate::typechecker::typechecker::TypedModule;
 use crate::{Error, typecheck};
 use crate::vm::prelude::Prelude;
 use std::collections::HashMap;
+use crate::vm::compiler::{compile, Module, Metadata};
 
 pub trait ModuleReader {
     fn read_module(&mut self, module_id: &ModuleId) -> Option<String>;
@@ -18,8 +19,13 @@ pub enum ModuleLoaderError {
 pub struct ModuleLoader<R: ModuleReader> {
     module_reader: R,
     typed_module_cache: HashMap<String, Option<TypedModule>>,
+    pub(crate) compiled_modules: Vec<(Module, Option<Metadata>)>,
+    compiled_module_constants: HashMap<ModuleId, HashMap<String, usize>>,
+    compiled_modules_indices: HashMap<ModuleId, usize>,
     pub(crate) ordering: Vec<ModuleId>,
 }
+
+const PRELUDE_MODULE_IDX: usize = 0;
 
 impl<R: ModuleReader> ModuleLoader<R> {
     pub fn new(module_reader: R) -> Self {
@@ -29,7 +35,11 @@ impl<R: ModuleReader> ModuleLoader<R> {
         let ordering = vec![prelude.module_id.clone()];
         cache.insert(prelude.module_id.get_name(), Some(prelude));
 
-        Self { module_reader, typed_module_cache: cache, ordering }
+        let compiled_modules = Vec::new();
+        let compiled_module_constants = HashMap::new();
+        let compiled_modules_indices = HashMap::new();
+
+        Self { module_reader, typed_module_cache: cache, compiled_modules, compiled_module_constants, compiled_modules_indices, ordering }
     }
 
     pub fn load_module(&mut self, module_id: &ModuleId) -> Result<(), ModuleLoaderError> {
@@ -62,5 +72,69 @@ impl<R: ModuleReader> ModuleLoader<R> {
             .expect("It should have been loaded previously")
             .as_ref()
             .expect("It should have completed loading")
+    }
+
+    pub fn add_typed_module(&mut self, typed_module: TypedModule) {
+        self.ordering.push(typed_module.module_id.clone());
+        self.typed_module_cache.insert(typed_module.module_id.get_name(), Some(typed_module));
+    }
+
+    pub fn compile_all(&mut self) {
+        let ordering = self.ordering.clone();
+        for module_id in ordering {
+            if module_id == ModuleId::from_name("prelude") {
+                let (prelude_module, constants_by_idx) = Prelude::compiled_module();
+                self.compiled_modules.push((prelude_module, None));
+                self.compiled_module_constants.insert(module_id.clone(), constants_by_idx);
+
+                let module_idx = self.compiled_modules.len() - 1;
+                debug_assert!(module_idx == PRELUDE_MODULE_IDX);
+                self.compiled_modules_indices.insert(module_id.clone(), module_idx);
+                continue;
+            }
+
+            let typed_module = self.typed_module_cache.get(&module_id.get_name()).unwrap().as_ref().unwrap().clone();
+
+            let module_idx = self.compiled_modules.len();
+            self.compiled_modules_indices.insert(module_id.clone(), module_idx);
+
+            let (module, metadata) = compile(typed_module, module_idx, self).unwrap();
+            self.compiled_modules.push((module, Some(metadata)));
+        }
+    }
+
+    pub fn get_compiled_module(&self, module_id: &ModuleId) -> &Module {
+        self.compiled_modules_indices.get(module_id)
+            .and_then(|idx| self.compiled_modules.get(*idx))
+            .map(|(module, _)| module)
+            .unwrap()
+    }
+
+    fn get_prelude_const_idx(&mut self, const_name: &String) -> Option<(usize, usize)> {
+        let prelude_constants = &self.compiled_module_constants[&ModuleId::from_name("prelude")];
+        prelude_constants.get(const_name).map(|const_idx| (PRELUDE_MODULE_IDX, *const_idx))
+    }
+
+    pub fn get_const_idx(&mut self, module_id: &ModuleId, const_name: &String) -> Option<(usize, usize)> {
+        let module_idx = self.compiled_modules_indices[module_id];
+
+        self.compiled_module_constants.get_mut(module_id)
+            .and_then(|constants| constants.get(const_name).map(|const_idx| (module_idx, *const_idx)))
+            .or_else(|| self.get_prelude_const_idx(const_name))
+    }
+
+    pub fn add_const_idx(&mut self, module_id: &ModuleId, const_name: &String, const_idx: usize) {
+        match self.compiled_module_constants.get_mut(module_id) {
+            Some(constants) => {
+                debug_assert!(!constants.contains_key(const_name));
+                constants.insert(const_name.clone(), const_idx);
+            }
+            None => {
+                let mut constants = HashMap::new();
+                constants.insert(const_name.clone(), const_idx);
+
+                self.compiled_module_constants.insert(module_id.clone(), constants);
+            }
+        }
     }
 }

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -1,5 +1,6 @@
 use crate::lexer::tokens::Token;
 use itertools::Itertools;
+use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AstNode {
@@ -315,8 +316,14 @@ impl ImportNode {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 pub struct ModuleId(pub bool, pub Vec<String>);
+
+impl Display for ModuleId {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.get_name())
+    }
+}
 
 impl ModuleId {
     pub fn get_name(&self) -> String {

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -1,5 +1,5 @@
 use crate::typechecker::types::Type;
-use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode, LambdaNode, TypeIdentifier, BindingPattern, ImportNode};
+use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode, LambdaNode, TypeIdentifier, BindingPattern, ModuleId};
 use crate::lexer::tokens::Token;
 use crate::typechecker::typechecker::Scope;
 
@@ -32,7 +32,7 @@ pub enum TypedAstNode {
     Accessor(Token, TypedAccessorNode),
     MatchStatement(Token, TypedMatchNode),
     MatchExpression(Token, TypedMatchNode),
-    ImportStatement(Token, ImportNode),
+    ImportStatement(Token, TypedImportNode),
     _Nil(Token),
 }
 
@@ -311,6 +311,12 @@ pub struct TypedMatchNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
     pub branches: Vec<(/* match_type: */ Type, /* match_type_ident: */ Option<TypeIdentifier>, /* binding: */ Option<String>, /* body: */ Vec<TypedAstNode>, /* args: */ Option<Vec<BindingPattern>>)>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TypedImportNode {
+    pub imports: Vec<(/* import_name: */ String, /* is_const: */ bool)>,
+    pub module_id: ModuleId,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/vm/disassembler.rs
+++ b/abra_core/src/vm/disassembler.rs
@@ -4,18 +4,7 @@ use crate::vm::value::{Value, FnValue, TypeValue, EnumValue};
 use std::collections::HashMap;
 
 pub fn disassemble(modules: Vec<(Module, Metadata)>) -> String {
-    let mut disassembler = Disassembler {
-        modules,
-        ..Disassembler::default()
-        // current_load: 0,
-        // current_uv_load: 0,
-        // current_uv_store: 0,
-        // current_store: 0,
-        // current_field_get: 0,
-        // current_local_mark: 0,
-        // module,
-        // metadata,
-    };
+    let mut disassembler = Disassembler { modules, ..Disassembler::default() };
     disassembler.disassemble()
 }
 
@@ -27,8 +16,6 @@ struct Disassembler {
     current_store: usize,
     current_field_get: usize,
     current_local_mark: usize,
-    // module: Module,
-    // metadata: Metadata,
     modules: Vec<(Module, Metadata)>,
 }
 

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -1,6 +1,8 @@
+use itertools::Itertools;
+
 #[derive(Clone, Copy, Display, Debug, Hash, PartialEq, Eq)]
 pub enum Opcode {
-    Constant(usize),
+    Constant(/* module_idx: */ usize, /* const_idx: */usize),
     Nil,
     IConst0,
     IConst1,
@@ -47,10 +49,10 @@ pub enum Opcode {
     TupleLoad,
     TupleStore,
     SetMk(usize),
-    GStore(usize),
+    GStore(/* module_id: */ usize, /* const_idx: */ usize),
     LStore(usize),
     UStore(usize),
-    GLoad(usize),
+    GLoad(/* module_id: */ usize, /* const_idx: */ usize),
     LLoad(usize),
     ULoad(usize),
     Jump(usize),
@@ -72,31 +74,31 @@ impl Opcode {
         let base = self.to_string();
 
         let imm = match self {
-            Opcode::Constant(const_idx) => Some(const_idx),
-            Opcode::New(num_fields) => Some(num_fields),
-            Opcode::GetField(field_idx) => Some(field_idx),
-            Opcode::GetMethod(method_idx) => Some(method_idx),
-            Opcode::SetField(field_idx) => Some(field_idx),
+            Opcode::Constant(module_idx, const_idx) => Some(vec![module_idx, const_idx]),
+            Opcode::New(num_fields) => Some(vec![num_fields]),
+            Opcode::GetField(field_idx) => Some(vec![field_idx]),
+            Opcode::GetMethod(method_idx) => Some(vec![method_idx]),
+            Opcode::SetField(field_idx) => Some(vec![field_idx]),
             Opcode::MapMk(size) |
             Opcode::ArrMk(size) |
             Opcode::TupleMk(size) |
-            Opcode::SetMk(size) => Some(size),
-            Opcode::GStore(slot) |
-            Opcode::LStore(slot) => Some(slot),
-            Opcode::UStore(upvalue_idx) => Some(upvalue_idx),
-            Opcode::GLoad(slot) |
-            Opcode::LLoad(slot) => Some(slot),
-            Opcode::ULoad(upvalue_idx) => Some(upvalue_idx),
+            Opcode::SetMk(size) => Some(vec![size]),
+            Opcode::GStore(module_idx, slot) |
+            Opcode::GLoad(module_idx, slot) => Some(vec![module_idx, slot]),
+            Opcode::LStore(slot) |
+            Opcode::LLoad(slot) => Some(vec![slot]),
+            Opcode::UStore(upvalue_idx) |
+            Opcode::ULoad(upvalue_idx) => Some(vec![upvalue_idx]),
             Opcode::Jump(offset) |
             Opcode::JumpIfF(offset) |
-            Opcode::JumpB(offset) => Some(offset),
-            Opcode::Invoke(arity) => Some(arity),
-            Opcode::Pop(num_pops) => Some(num_pops),
-            Opcode::MarkLocal(local_idx) => Some(local_idx),
+            Opcode::JumpB(offset) => Some(vec![offset]),
+            Opcode::Invoke(arity) => Some(vec![arity]),
+            Opcode::Pop(num_pops) => Some(vec![num_pops]),
+            Opcode::MarkLocal(local_idx) => Some(vec![local_idx]),
             _ => None
         };
         match imm {
-            Some(imm) => format!("{} {}", base, imm),
+            Some(imm) => format!("{} {}", base, imm.iter().join(" ")),
             None => base
         }
     }

--- a/abra_core/src/vm/prelude.rs
+++ b/abra_core/src/vm/prelude.rs
@@ -21,28 +21,10 @@ pub static PRELUDE_PRINTLN_INDEX: u8 = 0;
 #[cfg(test)]
 pub static PRELUDE_STRING_INDEX: u8 = 7;
 
-pub struct Prelude {
-    bindings: Vec<PreludeBinding>,
-}
+pub struct Prelude;
 
 impl Prelude {
-    pub(crate) fn typed_module() -> TypedModule {
-        // let prelude = Prelude::new();
-        // let exports = prelude.bindings.into_iter()
-        //     .map(|b| {
-        //         let exported_value = if let Type::Type(_, _, _) = b.typ {
-        //             ExportedValue::Type {
-        //                 reference: None,
-        //                 backing_type: Type::Unit,
-        //                 node: None
-        //             }
-        //         } else {
-        //             ExportedValue::Binding(b.typ)
-        //         };
-        //         (b.name, exported_value)
-        //     })
-        //     .collect();
-
+    pub fn typed_module() -> TypedModule {
         let mut exports = HashMap::new();
 
         for (native_fn_desc, _) in native_fns() {
@@ -78,119 +60,49 @@ impl Prelude {
         }
     }
 
-    pub(crate) fn compiled_module() -> (Module, HashMap<String, usize>) {
+    pub fn compiled_module() -> (Module, HashMap<String, usize>) {
         let mut constants = Vec::new();
-        let mut constant_indexes_by_ident = HashMap::new();
-
-        let prelude = Prelude::new();
-        for PreludeBinding { name, value, .. } in prelude.bindings {
-            constants.push(value);
-            constant_indexes_by_ident.insert(name, constant_indexes_by_ident.len());
-        }
-
-        /*        let mut constants = Vec::new();
-
-                for (_, native_fn) in native_fns() {
-                    constants.push(Value::NativeFn(native_fn));
-                }
-
-                let prelude_types = vec![
-                    ("Int", Some(NativeInt::get_type_value())),
-                    ("Float", Some(NativeFloat::get_type_value())),
-                    ("Bool", None),
-                    ("String", Some(NativeString::get_type_value())),
-                    ("Unit", None),
-                    ("Any", None),
-                    ("Array", Some(NativeArray::get_type_value())),
-                    ("Map", Some(NativeMap::get_type_value())),
-                    ("Set", Some(NativeSet::get_type_value())),
-                    ("Date", Some(NativeDate::get_type_value())),
-                ];
-                for (type_name, type_value) in prelude_types {
-                    let value = match type_value {
-                        Some(type_value) => Value::Type(type_value),
-                        None => Value::Type(TypeValue {
-                            name: type_name.to_string(),
-                            fields: vec![],
-                            constructor: None,
-                            methods: vec![],
-                            static_fields: vec![],
-                        })
-                    };
-                    constants.push(value);
-                }
-        */
-        let module = Module { name: "prelude".to_string(), constants, code: vec![] };
-        (module, constant_indexes_by_ident)
-    }
-
-    fn new() -> Self {
-        let mut bindings = Vec::new();
+        let mut constant_names = Vec::new();
 
         for (native_fn_desc, native_fn) in native_fns() {
             let value = Value::NativeFn(native_fn);
-
             let name = native_fn_desc.name.to_string();
-            let typ = native_fn_desc.get_fn_type();
 
-            bindings.push(PreludeBinding { name, typ, value });
+            constants.push(value);
+            constant_names.push(name);
         }
 
-        // Insert None
-        bindings.push(PreludeBinding { name: "None".to_string(), typ: Type::Option(Box::new(Type::Placeholder)), value: Value::Nil });
+        constants.push(Value::Nil);
+        constant_names.push("None".to_string());
 
         let prelude_types = vec![
-            ("Int", Type::Int, Some(NativeInt::get_type_value())),
-            ("Float", Type::Float, Some(NativeFloat::get_type_value())),
-            ("Bool", Type::Bool, None),
-            ("String", Type::String, Some(NativeString::get_type_value())),
-            ("Unit", Type::Unit, None),
-            ("Any", Type::Any, None),
-            ("Array", Type::Reference("Array".to_string(), vec![Type::Generic("T".to_string())]), Some(NativeArray::get_type_value())),
-            ("Map", Type::Reference("Map".to_string(), vec![Type::Generic("K".to_string()), Type::Generic("V".to_string())]), Some(NativeMap::get_type_value())),
-            ("Set", Type::Reference("Set".to_string(), vec![Type::Generic("T".to_string())]), Some(NativeSet::get_type_value())),
-            ("Date", Type::Reference("Date".to_string(), vec![]), Some(NativeDate::get_type_value())),
+            ("Int", Some(NativeInt::get_type_value())),
+            ("Float", Some(NativeFloat::get_type_value())),
+            ("Bool", None),
+            ("String", Some(NativeString::get_type_value())),
+            ("Unit", None),
+            ("Any", None),
+            ("Array", Some(NativeArray::get_type_value())),
+            ("Map", Some(NativeMap::get_type_value())),
+            ("Set", Some(NativeSet::get_type_value())),
+            ("Date", Some(NativeDate::get_type_value())),
         ];
-        for (type_name, typ, type_value) in prelude_types {
+        for (type_name, type_value) in prelude_types {
             let value = match type_value {
                 Some(type_value) => Value::Type(type_value),
-                None => Value::Type(TypeValue {
-                    name: type_name.to_string(),
-                    fields: vec![],
-                    constructor: None,
-                    methods: vec![],
-                    static_fields: vec![],
-                })
+                None => Value::Type(TypeValue { name: type_name.to_string(), ..TypeValue::default() })
             };
 
-            bindings.push(PreludeBinding {
-                name: type_name.to_string(),
-                typ: Type::Type(type_name.to_string(), Box::new(typ.clone()), false), // TODO: is_enum should not be hard-coded false
-                value,
-            });
+            constants.push(value);
+            constant_names.push(type_name.to_string());
         }
 
-        Self { bindings }
-    }
+        let constant_indexes_by_ident = constant_names.into_iter()
+            .enumerate()
+            .map(|(idx, ident)| (ident, idx))
+            .collect();
 
-    pub fn get_bindings(&self) -> Vec<(String, Value)> {
-        self.bindings.iter()
-            .map(|PreludeBinding { name, value, .. }| (name.clone(), value.clone()))
-            .collect()
-    }
-
-    pub fn get_binding_values(&self) -> Vec<Value> {
-        self.bindings.iter()
-            .map(|PreludeBinding { value, .. }| value.clone())
-            .collect()
-    }
-
-    pub fn num_bindings(&self) -> usize {
-        self.bindings.len()
-    }
-
-    pub fn resolve_ident<S: AsRef<str>>(&self, ident: S) -> Option<Value> {
-        self.bindings.iter()
-            .find_map(|b| if b.name == ident.as_ref() { Some(b.value.clone()) } else { None })
+        let module = Module { name: "prelude".to_string(), constants, code: vec![] };
+        (module, constant_indexes_by_ident)
     }
 }

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -54,7 +54,7 @@ impl Hash for ClosureValue {
     }
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Hash, Eq, PartialEq)]
 pub struct TypeValue {
     pub name: String,
     pub constructor: Option<fn(usize, usize, Vec<Value>) -> Value>,

--- a/abra_core/src/vm/vm.rs
+++ b/abra_core/src/vm/vm.rs
@@ -59,6 +59,7 @@ pub struct Upvalue {
     pub val: Option<Value>,
 }
 
+#[derive(Default)]
 struct CallFrame {
     ip: usize,
     code: Vec<Opcode>,
@@ -87,8 +88,8 @@ impl VMContext {
 
 pub struct VM {
     pub ctx: VMContext,
-    constants: Vec<Value>,
-    type_constant_indexes: HashMap<String, usize>,
+    constants: Vec<Vec<Value>>,
+    type_constant_indexes: HashMap<String, (usize, usize)>,
     call_stack: Vec<CallFrame>,
     stack: Vec<Value>,
     globals: HashMap<String, Value>,
@@ -98,26 +99,12 @@ pub struct VM {
 const STACK_LIMIT: usize = 1024;
 
 impl VM {
-    pub fn new(module: Module, ctx: VMContext) -> Self {
-        let name = "$main".to_string();
-        let Module { code, constants, .. } = module;
-        let root_frame = CallFrame { ip: 0, code, start_stack_idx: 0, name, upvalues: vec![], local_addrs: vec![] };
-
-        let type_constant_indexes = constants.iter().enumerate()
-            .filter_map(|(idx, a)|
-                match a {
-                    Value::Type(TypeValue { name, .. }) |
-                    Value::Enum(EnumValue { name, .. }) => Some((name.clone(), idx)),
-                    _ => None
-                }
-            )
-            .collect();
-
+    pub fn new(ctx: VMContext) -> Self {
         VM {
             ctx,
-            constants,
-            type_constant_indexes,
-            call_stack: vec![root_frame],
+            constants: vec![],
+            type_constant_indexes: HashMap::new(),
+            call_stack: vec![],
             stack: Vec::new(),
             globals: HashMap::new(),
             open_upvalues: HashMap::new(),
@@ -179,23 +166,23 @@ impl VM {
         }
     }
 
-    fn load_constant(&mut self, const_idx: usize) -> Result<(), InterpretError> {
-        let val = self.constants.get(const_idx)
+    fn load_constant(&mut self, (module_idx, const_idx): (usize, usize)) -> Result<(), InterpretError> {
+        let val = self.constants[module_idx].get(const_idx)
             .ok_or(InterpretError::ConstIdxOutOfBounds)?
             .clone();
         self.push(val);
         Ok(())
     }
 
-    pub fn load_type(&self, type_id: usize) -> &TypeValue {
-        if let Some(Value::Type(tv)) = self.constants.get(type_id) {
+    pub fn load_type(&self, (module_idx, type_id): (usize, usize)) -> &TypeValue {
+        if let Some(Value::Type(tv)) = self.constants[module_idx].get(type_id) {
             tv
         } else { panic!("Could not load type for id: {}", type_id) }
     }
 
     pub fn type_id_for_name<S: AsRef<str>>(&self, name: S) -> usize {
         let name = name.as_ref();
-        self.type_constant_indexes[name]
+        self.type_constant_indexes[name].1
     }
 
     fn stack_slot_for_local(&mut self, local_idx: usize) -> usize {
@@ -463,7 +450,30 @@ impl VM {
         }
     }
 
-    pub fn run(&mut self) -> Result<Option<Value>, InterpretError> {
+    pub fn run(&mut self, module: Module) -> Result<Option<Value>, InterpretError> {
+        let module_idx = self.constants.len();
+
+        let Module { name, code, constants, .. } = module;
+
+        let type_constant_indexes = constants.iter().enumerate()
+            .filter_map(|(idx, a)|
+                match a {
+                    Value::Type(TypeValue { name, .. }) |
+                    Value::Enum(EnumValue { name, .. }) => Some((name.clone(), (module_idx, idx))),
+                    _ => None
+                }
+            );
+
+        self.type_constant_indexes.extend(type_constant_indexes);
+        self.constants.push(constants);
+
+        if code.is_empty() {
+            return Ok(None);
+        }
+
+        let frame = CallFrame { code, name, ..CallFrame::default() };
+        self.call_stack.push(frame);
+
         self.run_from_call_stack_depth(1)
     }
 
@@ -476,7 +486,7 @@ impl VM {
             let instr = self.read_instr().ok_or(InterpretError::EndOfBytes)?;
 
             match instr {
-                Opcode::Constant(const_idx) => self.load_constant(const_idx)?,
+                Opcode::Constant(mod_idx, const_idx) => self.load_constant((mod_idx, const_idx))?,
                 Opcode::Nil => self.push(Value::Nil),
                 Opcode::IConst0 => self.push(Value::Int(0)),
                 Opcode::IConst1 => self.push(Value::Int(1)),
@@ -559,7 +569,7 @@ impl VM {
 
                     let type_value = if let Value::Type(tv) = self.pop_expect()? { tv } else { unreachable!() };
                     let type_id = self.type_constant_indexes[&type_value.name];
-                    let inst = type_value.construct(type_id, fields);
+                    let inst = type_value.construct(type_id.0, type_id.1, fields);
 
                     self.push(inst);
                 }
@@ -836,8 +846,8 @@ impl VM {
                     };
                     self.push(value);
                 }
-                Opcode::GStore(const_idx) => {
-                    let global_name = match self.constants.get(const_idx) {
+                Opcode::GStore(module_idx, const_idx) => {
+                    let global_name = match self.constants[module_idx].get(const_idx) {
                         Some(Value::Str(value)) => Ok(value.clone()),
                         None => Err(InterpretError::ConstIdxOutOfBounds),
                         Some(v) => Err(InterpretError::TypeError("String".to_string(), v.to_string()))
@@ -847,8 +857,8 @@ impl VM {
                 }
                 Opcode::LStore(stack_slot) => self.store_local(stack_slot)?,
                 Opcode::UStore(upvalue_idx) => self.store_upvalue(upvalue_idx)?,
-                Opcode::GLoad(const_idx) => {
-                    let global_name = match self.constants.get(const_idx) {
+                Opcode::GLoad(module_idx, const_idx) => {
+                    let global_name = match self.constants[module_idx].get(const_idx) {
                         Some(Value::Str(value)) => Ok(value),
                         None => Err(InterpretError::ConstIdxOutOfBounds),
                         Some(v) => Err(InterpretError::TypeError("String".to_string(), v.to_string()))

--- a/abra_native/src/lib.rs
+++ b/abra_native/src/lib.rs
@@ -894,7 +894,7 @@ fn gen_construct_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
     };
 
     quote! {
-        fn construct(type_id: usize, args: std::vec::Vec<crate::vm::value::Value>) -> crate::vm::value::Value where Self: core::marker::Sized {
+        fn construct(module_idx: usize, type_id: usize, args: std::vec::Vec<crate::vm::value::Value>) -> crate::vm::value::Value where Self: core::marker::Sized {
             #body
         }
     }


### PR DESCRIPTION
- Tons of changes here, I'll start with `ModuleLoader`. The
`ModuleLoader` is now responsible for a bit more - it's the main
orchestrator for typechecking and compilation, keeping track of the
modules that it's typechecked and then compiling those in the necessary
dependency order.
- Compiled constants are also stored in the module loader; this is used
to facilitate imports for Types/Enums, since Type/Enum values can just be
statically referenced as constants and don't need to be loaded from
globals like other bindings.
- The VM now processes multiple modules and persists state across modules.
- Constant/GLoad/GStore opcodes now reference `module_idx` as well as
`constant_idx`, since the VM needs to know which "module" to load the
constant from. I could foresee this being refactored in the future.