### PR TITLE
Imports & exports: additional typechecking

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,26 +1,5 @@
-import Person, addName from .example2
+import ken, Person from .example2
 
-//type Foo {
-//  qux: Int
-//}
-//
-//val f = Foo(qux: 24)
-//println("foo: $f")
-//
-//val names: Int[] = []
+println(ken.name)
 
-//val ken = Person(name: "Ken")
-//addName(ken.name)
-//val brian = Person(name: "Brian")
-//addName(brian.name)
-//println(ken.introduce() + ", and " + brian.introduce())
-
-//names.push(123)
-//println("names: $names")
-
-val ken: Person? = Person(name: "Ken")
-//match ken {
-//  None => println("hmm?")
-//  Person p => println(p)
-//}
-println(ken)
+println(Person(name: "Meg"))

--- a/abra_cli/abra-files/example2.abra
+++ b/abra_cli/abra-files/example2.abra
@@ -1,11 +1,3 @@
-export type Person {
-  name: String
-  func introduce(self): String = "I am " + self.name
-}
+export type Person { name: String }
 
-export val names: String[] = []
-
-export func addName(name: String) {
-  names.push(name)
-  println(names)
-}
+export val ken = Person(name: "Ken")

--- a/abra_core/src/module_loader.rs
+++ b/abra_core/src/module_loader.rs
@@ -4,6 +4,7 @@ use crate::{Error, typecheck};
 use crate::vm::prelude::Prelude;
 use std::collections::HashMap;
 use crate::vm::compiler::{compile, Module, Metadata};
+use crate::typechecker::types::Type;
 
 pub trait ModuleReader {
     fn read_module(&mut self, module_id: &ModuleId) -> Option<String>;
@@ -72,6 +73,16 @@ impl<R: ModuleReader> ModuleLoader<R> {
             .expect("It should have been loaded previously")
             .as_ref()
             .expect("It should have completed loading")
+    }
+
+    pub fn resolve_type(&self, type_name: &String) -> Option<&Type> {
+        let module_name = type_name.split("/").next()
+            .expect("Type name should be properly namespaced");
+        let typed_module = self.typed_module_cache.get(module_name)
+            .expect("It should have been loaded previously")
+            .as_ref()
+            .expect("It should have completed loading");
+        typed_module.referencable_types.get(type_name)
     }
 
     pub fn add_typed_module(&mut self, typed_module: TypedModule) {


### PR DESCRIPTION
- Types referenced indirectly by imports from other modules (which
themselves are _not_ imported) can now be referenced from other modules
- Also ensure that emitted TypedModules only include types defined
within that module; imported types will not be re-exported