### PR TITLE
Enable Optional types' usage in boolean operators

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,4 +1,6 @@
 val bools = [true, false]
-val a = if bools[0] { 1 } else { 0 }
-val b = if bools[1] { 1 } else { 0 }
-a + b
+if bools[1] {
+  println("yup")
+} else {
+  println("nope")
+}

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -1436,7 +1436,7 @@ impl<'a, R: ModuleReader> TypedAstVisitor<(), ()> for Compiler<'a, R> {
         let TypedIfNode { condition, condition_binding, if_block, else_block, .. } = node;
 
         let is_opt = match condition.get_type() {
-            Type::Option(inner) if *inner != Type::Bool => true,
+            Type::Option(inner) => *inner != Type::Bool,
             _ => false
         };
         self.visit(*condition)?;
@@ -1888,7 +1888,7 @@ impl<'a, R: ModuleReader> TypedAstVisitor<(), ()> for Compiler<'a, R> {
 
         self.push_scope(ScopeKind::Loop);
         let is_opt = match condition.get_type() {
-            Type::Option(inner) if *inner != Type::Bool => true,
+            Type::Option(inner) => *inner != Type::Bool,
             _ => false
         };
         if let Some(ident) = &condition_binding {


### PR DESCRIPTION
Addresses #289

- `&&`, `||`, `!`, and `^` now operate on Option types as well as
Boolean values
- Opcodes which operate on boolean values (`JumpIfF`, `Negate`) now work
on "boolish" values (including `None` values for Optional-typed values)
- Remove the `pop_expect_bool!` macro, and replace it with instances of
the `self.pop_expect_boolish()` method (which is inlined)