### PR TITLE
Refactoring enums and enum variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abra"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "abra_core",
  "clap",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "abra_core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "abra_native",
  "downcast-rs",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "abra_wasm"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "abra_core",
  "js-sys",

--- a/abra_cli/Cargo.toml
+++ b/abra_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abra"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Ken Gorab <ken.gorab@gmail.com>"]
 edition = "2018"
 

--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,14 +1,31 @@
-enum LL<T> {
-  Cons(item: T, next: LL<T>)
-  Empty
+enum Color {
+  Red
+  Green
+  Blue
+  RGB(red: Int, green: Int, blue: Int)
 
-  //func getValue(self): T? {
-  //  match self {
-  //    LL.Cons(item, _) => item
-  //    LL.Empty => None
-  //  }
-  //}
+  func white(): Color = Color.RGB(red: 255, green: 255, blue: 255)
+
+  func black(): Color = Color.RGB(red: 0, green: 0, blue: 0)
+
+  func hex(self): String {
+    match self {
+      Color.Red => "0xff0000"
+      Color.Green => "0x00ff00"
+      Color.Blue => "0x0000ff"
+      Color.RGB(red, green, blue) => {
+        val hexes = [red, green, blue].map(c => c.asBase(16).padLeft(2, "0"))
+        "0x" + hexes.join()
+      }
+    }
+  }
 }
 
-val l = LL.Cons(1, LL.Cons("2", LL.Empty))
-l.toString()
+[
+  Color.Red,
+  Color.Green,
+  Color.Blue,
+  Color.black(),
+  Color.white(),
+  Color.RGB(red: 128, green: 128, blue: 128)
+].map(c => c.hex())

--- a/abra_core/Cargo.toml
+++ b/abra_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abra_core"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Ken Gorab <ken.gorab@gmail.com>"]
 edition = "2018"
 

--- a/abra_core/src/builtins/prelude/native_array.rs
+++ b/abra_core/src/builtins/prelude/native_array.rs
@@ -697,7 +697,6 @@ mod test {
         assert_eq!(Some(expected), result);
 
         // Verify closures work
-        // TODO: See #172
         let result = interpret(r#"
           var total = 0
           val arr = [1, 2, 3, 4]

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -1,5 +1,5 @@
 use crate::typechecker::types::Type;
-use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode, LambdaNode, TypeIdentifier, BindingPattern, ModuleId};
+use crate::parser::ast::{UnaryOp, BinaryOp, IndexingMode, LambdaNode, BindingPattern, ModuleId};
 use crate::lexer::tokens::Token;
 use crate::typechecker::typechecker::Scope;
 
@@ -206,7 +206,7 @@ pub struct TypedTypeDeclNode {
 pub struct TypedTypeDeclField {
     pub ident: Token,
     pub typ: Type,
-    pub default_value: Option<TypedAstNode>
+    pub default_value: Option<TypedAstNode>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -220,7 +220,7 @@ pub struct TypedEnumDeclNode {
     // Must be a Token::Ident
     pub name: Token,
     // Tokens represent arg idents, and must be Token::Ident
-    pub variants: Vec<(Token, Type, EnumVariantKind)>,
+    pub variants: Vec<(Token, (Type, Option<Vec<Option<TypedAstNode>>>))>,
     pub static_fields: Vec<(Token, Type, Option<TypedAstNode>)>,
     pub methods: Vec<(String, TypedAstNode)>,
 }
@@ -310,7 +310,15 @@ pub struct TypedAccessorNode {
 pub struct TypedMatchNode {
     pub typ: Type,
     pub target: Box<TypedAstNode>,
-    pub branches: Vec<(/* match_type: */ Type, /* match_type_ident: */ Option<TypeIdentifier>, /* binding: */ Option<String>, /* body: */ Vec<TypedAstNode>, /* args: */ Option<Vec<BindingPattern>>)>,
+    pub branches: Vec<(/* match_kind: */ TypedMatchKind, /* body: */ Vec<TypedAstNode>)>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TypedMatchKind {
+    Wildcard { binding: Option<String> },
+    None { binding: Option<String> },
+    Type { type_name: String, binding: Option<String>, args: Option<Vec<BindingPattern>> },
+    EnumVariant { variant_idx: usize, binding: Option<String>, args: Option<Vec<BindingPattern>> },
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_native/src/lib.rs
+++ b/abra_native/src/lib.rs
@@ -738,7 +738,8 @@ fn gen_rust_type_path(type_repr: &TypeRepr, module_name: &String, type_ref_name:
                     arg_types: vec![ #(#args),* ],
                     type_args: vec![],
                     ret_type: std::boxed::Box::new(#ret),
-                    is_variadic: false
+                    is_variadic: false,
+                    is_enum_constructor: false,
                 })
             }
         }
@@ -806,6 +807,7 @@ fn gen_native_type_code(type_spec: &TypeSpec) -> TokenStream {
                     type_args: vec![],
                     ret_type: Box::new(#return_type),
                     is_variadic: #is_variadic,
+                    is_enum_constructor: false,
                 })
             )
         }
@@ -831,6 +833,7 @@ fn gen_native_type_code(type_spec: &TypeSpec) -> TokenStream {
                     type_args: vec![],
                     ret_type: Box::new(#return_type),
                     is_variadic: #is_variadic,
+                    is_enum_constructor: false,
                 }),
                 true
             )
@@ -852,6 +855,7 @@ fn gen_native_type_code(type_spec: &TypeSpec) -> TokenStream {
                             type_args: vec![],
                             ret_type: std::boxed::Box::new(crate::typechecker::types::Type::String),
                             is_variadic: false,
+                            is_enum_constructor: false,
                         })),
                         #(#methods),*
                     ],
@@ -1333,6 +1337,7 @@ fn generate_function_code(static_method: MethodSpec) -> proc_macro2::TokenStream
                 type_args: vec![],
                 ret_type: Box::new(#return_type),
                 is_variadic: #is_variadic,
+                is_enum_constructor: false,
             })
         }
     };

--- a/abra_wasm/Cargo.toml
+++ b/abra_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abra_wasm"
-version = "0.6.9"
+version = "0.6.10"
 authors = ["Ken Gorab <ken.gorab@gmail.com>"]
 edition = "2018"
 

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -79,7 +79,7 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("innerType", &JsType(inner_type))?;
                 obj.end()
             }
-            Type::Fn(FnType { arg_types, type_args, ret_type, is_variadic }) => {
+            Type::Fn(FnType { arg_types, type_args, ret_type, is_variadic, is_enum_constructor }) => {
                 let mut obj = serializer.serialize_map(Some(3))?;
                 obj.serialize_entry("kind", "Fn")?;
                 let args: Vec<(String, JsType)> = arg_types.iter()
@@ -89,6 +89,7 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("typeArgs", &type_args)?;
                 obj.serialize_entry("returnType", &JsType(ret_type))?;
                 obj.serialize_entry("isVariadic", is_variadic)?;
+                obj.serialize_entry("isEnumConstructor", is_enum_constructor)?;
                 obj.end()
             }
             Type::Type(name, _, _) => {
@@ -133,7 +134,7 @@ impl<'a> Serialize for JsType<'a> {
                     .collect();
                 obj.serialize_entry("typeArgs", &type_args)?;
                 let variants: Vec<String> = variants.iter()
-                    .map(|variant| variant.name.clone())
+                    .map(|(name, _)| name.clone())
                     .collect();
                 obj.serialize_entry("variants", &variants)?;
                 let static_fields: Vec<(String, JsType)> = static_fields.iter()
@@ -144,14 +145,6 @@ impl<'a> Serialize for JsType<'a> {
                     .map(|(name, typ)| (name.clone(), JsType(typ)))
                     .collect();
                 obj.serialize_entry("methods", &methods)?;
-                obj.end()
-            }
-            Type::EnumVariant(enum_type, variant, _) => {
-                let mut obj = serializer.serialize_map(Some(3))?;
-                obj.serialize_entry("kind", "EnumVariant")?;
-                obj.serialize_entry("enumType", &JsType(enum_type))?;
-                obj.serialize_entry("variantName", &variant.name)?;
-                obj.serialize_entry("index", &variant.variant_idx)?;
                 obj.end()
             }
             Type::Placeholder => {

--- a/abra_wasm/src/js_value/error.rs
+++ b/abra_wasm/src/js_value/error.rs
@@ -524,21 +524,29 @@ impl<'a> Serialize for JsWrappedError<'a> {
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
-                TypecheckerError::InvalidMatchCaseDestructuring { token, typ } => {
+                TypecheckerError::InvalidMatchCaseDestructuring { token, typ , enum_variant } => {
                     let mut obj = serializer.serialize_map(Some(5))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "invalidDestructuring")?;
                     obj.serialize_entry("token", &JsToken(token))?;
-                    obj.serialize_entry("type", &JsType(typ))?;
+                    if let Some(typ) = typ {
+                        obj.serialize_entry("type", &JsType(typ))?;
+                    }
+                    if let Some(variant_name) = enum_variant {
+                        obj.serialize_entry("variantName", variant_name)?;
+                    }
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;
                     obj.end()
                 }
-                TypecheckerError::InvalidMatchCaseDestructuringArity { token, typ, expected, actual } => {
+                TypecheckerError::InvalidMatchCaseDestructuringArity { token, typ, enum_variant, expected, actual } => {
                     let mut obj = serializer.serialize_map(Some(7))?;
                     obj.serialize_entry("kind", "typecheckerError")?;
                     obj.serialize_entry("subKind", "invalidDestructuring")?;
                     obj.serialize_entry("token", &JsToken(token))?;
                     obj.serialize_entry("type", &JsType(typ))?;
+                    if let Some(variant_name) = enum_variant {
+                        obj.serialize_entry("variantName", variant_name)?;
+                    }
                     obj.serialize_entry("expected", expected)?;
                     obj.serialize_entry("actual", actual)?;
                     obj.serialize_entry("range", &JsRange(&typechecker_error.get_token().get_range()))?;

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -95,7 +95,7 @@ impl Serialize for RunResultValue {
 
                 arr.end()
             }
-            Value::EnumVariantObj(o) => serializer.serialize_str(&*o.borrow().name),
+            Value::EnumInstanceObj(o) => serializer.serialize_u32((&*o.borrow()).idx as u32),
             Value::Fn(FnValue { name, .. }) => serializer.serialize_str(name),
             Value::Closure(ClosureValue { name, .. }) => serializer.serialize_str(name),
             Value::NativeFn(NativeFn { name, .. }) => serializer.serialize_str(name),


### PR DESCRIPTION
- Don't eagerly pre-bind methods to enum instance objects
- Remove special `Type::EnumVariant` type; instead, static enum variants
are typed as instances of the enum, and constructor enums are typed as
functions which return the enum
  - Programmatically generate a `Value::Fn` at compile-time for this
    function
- Clean up / address some lingering TODO comments
- Improve some error messages around enums (and add additional tests for
them)
- Refactor match expressions/statements to be _much_ cleaner, hopefully
helping to pave the way for generic types in match conditions