### PR TITLE
Supporting generic types in match expressions

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,31 +1,9 @@
-enum Color {
-  Red
-  Green
-  Blue
-  RGB(red: Int, green: Int, blue: Int)
-
-  func white(): Color = Color.RGB(red: 255, green: 255, blue: 255)
-
-  func black(): Color = Color.RGB(red: 0, green: 0, blue: 0)
-
-  func hex(self): String {
-    match self {
-      Color.Red => "0xff0000"
-      Color.Green => "0x00ff00"
-      Color.Blue => "0x0000ff"
-      Color.RGB(red, green, blue) => {
-        val hexes = [red, green, blue].map(c => c.asBase(16).padLeft(2, "0"))
-        "0x" + hexes.join()
-      }
-    }
-  }
+type Foo<T> { bar: T }
+enum LL<T> { Cons(item: T, next: LL<T>), Empty }
+val l: Foo<Int> | LL<Int> = LL.Cons(1, LL.Cons(2, LL.Empty))
+val j = match l {
+  Foo f => f.bar + 1
+  LL.Empty => 0
+  LL.Cons(item, _) => item
 }
-
-[
-  Color.Red,
-  Color.Green,
-  Color.Blue,
-  Color.black(),
-  Color.white(),
-  Color.RGB(red: 128, green: 128, blue: 128)
-].map(c => c.hex())
+j


### PR DESCRIPTION
Addresses #291 

- When materializing a type from its type_ident (when building the match
arms) use placeholder generic values if the parameter is true. This only
is used right now within match expressions/statements, and results in
the type value having instances of `Type::Generic` in its
`Type::Reference` value. When typechecking the match arms, ensure the
underlying possibilities match up against these generics, and also make
sure the proper types are passed into any destructures arguments (in the
case of enums)