### PR TITLE
Function return value overhaul

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,9 +1,5 @@
-type Foo<T> { bar: T }
-enum LL<T> { Cons(item: T, next: LL<T>), Empty }
-val l: Foo<Int> | LL<Int> = LL.Cons(1, LL.Cons(2, LL.Empty))
-val j = match l {
-  Foo f => f.bar + 1
-  LL.Empty => 0
-  LL.Cons(item, _) => item
-}
-j
+var count = 0
+[1, 2, 3].forEach(i => {
+  count += i
+})
+println(count)

--- a/abra_cli/src/main.rs
+++ b/abra_cli/src/main.rs
@@ -184,14 +184,11 @@ fn compile_and_run(module_id: ModuleId, contents: String, root_dir: PathBuf, vm:
     let mut result = Value::Nil;
     for module in modules {
         match vm.run(module) {
-            Ok(Some(v)) if v != Value::Nil => {
-                result = v;
-            }
+            Ok(v) => result = v,
             Err(e) => {
                 eprintln!("{:?}", e);
                 break;
             }
-            _ => {}
         };
     }
     Ok(result)

--- a/abra_core/src/builtins/common.rs
+++ b/abra_core/src/builtins/common.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 pub fn invoke_fn(vm: &mut VM, fn_obj: &Value, args: Vec<Value>) -> Value {
     let res = vm.invoke_fn(args, fn_obj.clone());
     match res {
-        Ok(v) => v.unwrap_or(Value::Nil),
+        Ok(v) => v,//.unwrap_or(Value::Nil),
         Err(e) => {
             eprintln!("Runtime error: {:?}", e);
             std::process::exit(1);
@@ -13,7 +13,7 @@ pub fn invoke_fn(vm: &mut VM, fn_obj: &Value, args: Vec<Value>) -> Value {
     }
 }
 
-pub fn default_to_string_method(receiver: Option<Value>, _args: Vec<Value>, vm: &mut VM) -> Option<Value> {
+pub fn default_to_string_method(receiver: Option<Value>, _args: Vec<Value>, vm: &mut VM) -> Value {
     let rcv = receiver.unwrap();
     let str_val = match rcv {
         Value::InstanceObj(rcv) => {
@@ -43,7 +43,7 @@ pub fn default_to_string_method(receiver: Option<Value>, _args: Vec<Value>, vm: 
         _ => unimplemented!("The default toString implementation should only ever be attached to instances of types/enums")
     };
 
-    Some(Value::new_string_obj(str_val))
+    Value::new_string_obj(str_val)
 }
 
 pub fn to_string(value: &Value, vm: &mut VM) -> String {

--- a/abra_core/src/builtins/date/native_date.rs
+++ b/abra_core/src/builtins/date/native_date.rs
@@ -128,7 +128,7 @@ mod test {
           Date(year: 2021, month: 3, day: 9).toString()
         "#);
         let expected = new_string_obj("Date(year: 2021, month: 3, day: 9, hour: 0, minute: 0, second: 0)");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -138,7 +138,7 @@ mod test {
           Date.now().toString()
         "#);
         let expected = new_string_obj("Date(year: 0, month: 0, day: 0, hour: 0, minute: 0, second: 0)");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -149,6 +149,6 @@ mod test {
           now.addDays(1).addDays(1).toString()
         "#);
         let expected = new_string_obj("Date(year: 0, month: 0, day: 2, hour: 0, minute: 0, second: 0)");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 }

--- a/abra_core/src/builtins/native/test.abra
+++ b/abra_core/src/builtins/native/test.abra
@@ -10,7 +10,6 @@ export func describe(when: String, tests: () => Unit) {
   currentDescribePath.push(when)
   tests()
   currentDescribePath.pop()
-  return
 }
 
 export func it(should: String, test: () => Unit) {
@@ -39,7 +38,6 @@ type Expectation<T> {
     } else {
       TestResult.Success
     }
-    return
   }
 }
 
@@ -67,7 +65,6 @@ export func runTests(showPassing = false): Int {
     for msg in passMsgs {
       println(msg)
     }
-
   }
 
   if !failMsgs.isEmpty() {
@@ -77,6 +74,7 @@ export func runTests(showPassing = false): Int {
       println()
     }
   }
+
   for msg in failMsgs {
     println(msg)
   }

--- a/abra_core/src/builtins/prelude/index.rs
+++ b/abra_core/src/builtins/prelude/index.rs
@@ -105,19 +105,19 @@ mod test {
     fn test_range() {
         let result = interpret("range(0, 4)");
         let expected = array![Value::Int(0), Value::Int(1), Value::Int(2), Value::Int(3)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("range(0, -4)");
         let expected = array![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("range(0, 10, 2)");
         let expected = array![Value::Int(0), Value::Int(2), Value::Int(4), Value::Int(6), Value::Int(8)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("range(1, 10, 3)");
         let expected = array![Value::Int(1), Value::Int(4), Value::Int(7)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     // TODO: Convert VMContext to a trait to allow for mocked-out testing?

--- a/abra_core/src/builtins/prelude/native_array.rs
+++ b/abra_core/src/builtins/prelude/native_array.rs
@@ -168,6 +168,16 @@ impl NativeArray {
         accumulator
     }
 
+    #[abra_method(signature = "forEach(fn: (T) => Unit)")]
+    fn for_each(&self, mut args: Arguments, vm: &mut VM) {
+        let callback = args.next_value();
+
+        for value in &self._inner {
+            let args = vec![value.clone()];
+            invoke_fn(vm, &callback, args);
+        }
+    }
+
     #[abra_method(signature = "join(joiner?: String): String")]
     fn join(&self, mut args: Arguments, vm: &mut VM) -> Value {
         let joiner = args.next_string_or_default("");
@@ -447,7 +457,7 @@ mod test {
     fn test_array_field_length() {
         let result = interpret("[1, 2, 3, 4, 5].length");
         let expected = Value::Int(5);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         // Setting length should produce an error
         let is_err = interpret_get_result("[1, 2, 3].length = 8").is_err();
@@ -458,73 +468,73 @@ mod test {
     fn test_array_static_fill() {
         let result = interpret("Array.fill(0, 123)");
         let expected = int_array!();
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("Array.fill(5, 12)");
         let expected = int_array!(12, 12, 12, 12, 12);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("Array.fill(6, \"24\")");
         let expected = string_array!("24", "24", "24", "24", "24", "24");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_static_fill_by() {
         let result = interpret("Array.fillBy(0, i => i + 1)");
         let expected = int_array!();
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("Array.fillBy(5, i => i + 1)");
         let expected = int_array!(1, 2, 3, 4, 5);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           func fib(n: Int): Int = if n <= 1 1 else fib(n - 1) + fib(n - 2)
           Array.fillBy(6, fib)
         "#);
         let expected = int_array!(1, 1, 2, 3, 5, 8);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_to_string() {
         let result = interpret("[1, 2, 3].toString()");
         let expected = new_string_obj("[1, 2, 3]");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[[1, 2], [3, 4], [5, 6]].toString()");
         let expected = new_string_obj("[[1, 2], [3, 4], [5, 6]]");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[{ a: 1 }, { b: 3 }].toString()");
         let expected = new_string_obj("[{ a: 1 }, { b: 3 }]");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_is_empty() {
         let result = interpret("[].isEmpty()");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[1, 2, 3].isEmpty()");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_enumerate() {
         let result = interpret("[].enumerate()");
         let expected = Value::new_array_obj(vec![]);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"a\", \"b\"].enumerate()");
         let expected = Value::new_array_obj(vec![
             Value::new_tuple_obj(vec![new_string_obj("a"), Value::Int(0)]),
             Value::new_tuple_obj(vec![new_string_obj("b"), Value::Int(1)]),
         ]);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -536,7 +546,7 @@ mod test {
           arr
         "#);
         let expected = int_array!(1, 2, 3, 4, 5);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = [1, 2, 3]
@@ -544,7 +554,7 @@ mod test {
           arr
         "#);
         let expected = int_array!(1, 2, 3, 4, 5, 6);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -555,14 +565,14 @@ mod test {
           arr.concat([last])
         "#);
         let expected = int_array!(1, 2, 3);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr: Int[] = []
           arr.pop()
         "#);
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -573,14 +583,14 @@ mod test {
           [first].concat(arr)
         "#);
         let expected = int_array!(1, 2, 3);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr: Int[] = []
           arr.popFront()
         "#);
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -593,7 +603,7 @@ mod test {
             int_array!(),
             int_array!(1, 2, 3, 4, 5, 6, 7)
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = [1, 2, 3, 4, 5, 6, 7]
@@ -603,7 +613,7 @@ mod test {
             int_array!(1),
             int_array!(2, 3, 4, 5, 6, 7)
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = [1, 2, 3, 4, 5, 6, 7]
@@ -613,7 +623,7 @@ mod test {
             int_array!(1, 2, 3, 4, 5, 6),
             int_array!(7)
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = [1, 2, 3, 4, 5, 6, 7]
@@ -623,7 +633,7 @@ mod test {
             int_array!(),
             int_array!(1, 2, 3, 4, 5, 6, 7)
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = [1, 2, 3, 4, 5, 6, 7]
@@ -633,7 +643,7 @@ mod test {
             int_array!(1, 2, 3, 4, 5, 6, 7),
             int_array!()
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -644,7 +654,7 @@ mod test {
           arr1.concat(arr2)
         "#);
         let expected = int_array![1, 2, 3, 4, 5, 6];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         // Verify that the original arrays aren't modified
         let result = interpret(r#"
@@ -657,7 +667,7 @@ mod test {
             int_array![1, 2, 3],
             int_array![4, 5, 6]
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         // Verify that the arrays' items are copied by reference
         let result = interpret(r#"
@@ -684,7 +694,7 @@ mod test {
             int_array![0, 1],
             int_array![1, 0, 0, 1]
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -694,7 +704,7 @@ mod test {
           arr.map(i => i * 3)
         "#);
         let expected = int_array![3, 6, 9, 12];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         // Verify closures work
         let result = interpret(r#"
@@ -707,7 +717,7 @@ mod test {
           arr2.concat([total])
         "#);
         let expected = int_array![3, 6, 9, 12, 10];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         // Verify deep call stack initiated from native fn call
         let result = interpret(r#"
@@ -717,7 +727,7 @@ mod test {
           [1, 2].map(i => sameNum(i))
         "#);
         let expected = int_array![1, 2];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -727,7 +737,7 @@ mod test {
           arr.filter(w => w.length < 4)
         "#);
         let expected = string_array!["a", "bc", "def"];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -737,130 +747,141 @@ mod test {
           arr.reduce(0, (acc, i) => acc + i)
         "#);
         let expected = Value::Int(15);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = [1, 2, 3, 4, 5]
           arr.reduce("", (acc, i) => acc + i)
         "#);
         let expected = new_string_obj("12345");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_array_for_each() {
+        let result = interpret(r#"
+          var count = 0
+          [1, 2, 3, 4].forEach(i => count += i)
+          count
+        "#);
+        let expected = Value::Int(10);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_join() {
         let result = interpret("[1, 2, 3, 4, 5].join()");
         let expected = new_string_obj("12345");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"a\", \"b\", \"c\"].join(\", \")");
         let expected = new_string_obj("a, b, c");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_contains() {
         let result = interpret("[].contains(5)");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[1, 2, 3, 4, 5].contains(5)");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[1, 2, 3, 4].contains(6)");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_find() {
         let result = interpret("[1, 2, 3].find(x => x >= 2)");
         let expected = Value::Int(2);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[[1, 2], [3, 4]].find(p => p[0])");
         let expected = array![Value::Int(1), Value::Int(2)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[[1, 2], [3, 4]].find(p => if p[0] |f| f >= 2)");
         let expected = array![Value::Int(3), Value::Int(4)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[1, 2, 3].find(x => x >= 4)");
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_find_index() {
         let result = interpret("[1, 2, 3].findIndex(x => x >= 2)");
         let expected = tuple![Value::Int(2), Value::Int(1)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[[1, 2], [3, 4]].findIndex(p => p[0])");
         let expected = tuple![
             array![Value::Int(1), Value::Int(2)],
             Value::Int(0)
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[1, 2, 3].findIndex(x => x >= 4)");
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_any() {
         let result = interpret("[1, 2, 3, 4, 5].any(x => x > 4)");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[1, 2, 3, 4, 5].any(x => x < 0)");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[[1, 2], [3, 4]].any(p => if p[0] |f| f >= 2)");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_all() {
         let result = interpret("[\"a\", \"bc\", \"def\"].all(w => w.length > 0)");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"a\", \"bc\", \"def\"].all(w => w.length < 3)");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"1\", \"2\", \"24\"].all(w => w.parseInt())");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"a\"].all(w => w.parseInt())");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_none() {
         let result = interpret("[\"a\", \"bc\", \"def\"].none(w => w.length > 0)");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"a\", \"bc\", \"def\"].none(w => w.length < 0)");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"1\", \"2\", \"24\"].none(w => w.parseInt())");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"a\", \"b\"].none(w => w.parseInt())");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -881,7 +902,7 @@ mod test {
           new_string_obj("Meghan"),
           new_string_obj("Kelsey")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\
           [1, 8, 3, 6, 1, 11, 5839, 6].sortBy(fn: i => i, reverse: true)
@@ -896,7 +917,7 @@ mod test {
             Value::Int(1),
             Value::Int(1)
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -907,7 +928,7 @@ mod test {
             new_string_obj("bc"),
             new_string_obj("def")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\
           type Person { name: String }\
@@ -919,7 +940,7 @@ mod test {
             new_string_obj("Ken"),
             new_string_obj("Meg")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -930,7 +951,7 @@ mod test {
             new_string_obj("bc"),
             new_string_obj("def")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[\"a\", \"bc\", \"def\", \"ghi\"].dedupeBy(w => w.length)");
         let expected = array![
@@ -938,7 +959,7 @@ mod test {
             new_string_obj("bc"),
             new_string_obj("def")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -948,7 +969,7 @@ mod test {
             Value::Bool(true) => array![Value::Int(2), Value::Int(4)],
             Value::Bool(false) => array![Value::Int(1), Value::Int(3), Value::Int(5)]
         };
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(
             "[[1, 1], [1, 2], [2, 1], [2, 2], [3, 1], [3, 2]].partition(p => p[0])"
@@ -967,7 +988,7 @@ mod test {
                 array![Value::Int(3), Value::Int(2)]
             ]
         };
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -981,7 +1002,7 @@ mod test {
             Value::Int(3) => Value::Int(2),
             Value::Int(4) => Value::Int(1)
         };
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -993,7 +1014,7 @@ mod test {
         let expected = map! {
             Value::Int(3) => Value::Int(2)
         };
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -1002,25 +1023,25 @@ mod test {
           [1, 2, 3, 4, 3, 2, 1, 2, 1].asSet()\n\
         ");
         let expected = set![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_get_or_default() {
         let result = interpret("[1, 2, 3].getOrDefault(1, 12)");
         let expected = Value::Int(2);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[1, 2, 3].getOrDefault(10, 12)");
         let expected = Value::Int(12);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_array_get_or_else() {
         let result = interpret("[1, 2, 3].getOrElse(1, () => 12)");
         let expected = Value::Int(2);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           var counter = 0
@@ -1031,11 +1052,11 @@ mod test {
           counter
         "#);
         let expected = Value::Int(0);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("[1, 2, 3].getOrElse(10, () => 12)");
         let expected = Value::Int(12);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           var counter = 0
@@ -1046,7 +1067,7 @@ mod test {
           counter
         "#);
         let expected = Value::Int(1);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -1057,7 +1078,7 @@ mod test {
           arr
         "#);
         let expected = array![Value::Int(1), Value::Int(102), Value::Int(3)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = [1, 2, 3]
@@ -1065,6 +1086,6 @@ mod test {
           arr
         "#);
         let expected = array![Value::Int(1), Value::Int(2), Value::Int(3)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 }

--- a/abra_core/src/builtins/prelude/native_float.rs
+++ b/abra_core/src/builtins/prelude/native_float.rs
@@ -57,81 +57,81 @@ mod test {
     fn test_float_to_string() {
         let result = interpret("6.24.toString()");
         let expected = new_string_obj("6.24");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_float_floor() {
         let result = interpret("6.24.floor()");
         let expected = Value::Int(6);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("val f = 6.7\nf.floor()");
         let expected = Value::Int(6);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("val f = -6.7\nf.floor()");
         let expected = Value::Int(-7);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_float_ceil() {
         let result = interpret("6.24.ceil()");
         let expected = Value::Int(7);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("val f = 6.7\nf.ceil()");
         let expected = Value::Int(7);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("val f = -6.7\nf.ceil()");
         let expected = Value::Int(-6);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_float_round() {
         let result = interpret("6.24.round()");
         let expected = Value::Int(6);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("6.75.round()");
         let expected = Value::Int(7);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("(-6.455).round()");
         let expected = Value::Int(-6);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_float_with_precision() {
         let result = interpret("6.12345.withPrecision(0)");
         let expected = Value::Float(6.0);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("6.98765.withPrecision(0)");
         let expected = Value::Float(6.0);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("6.98765.withPrecision(-1)");
         let expected = Value::Float(6.98765);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("1.23456.withPrecision(2)");
         let expected = Value::Float(1.23);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_float_abs() {
         let result = interpret("6.24.abs()");
         let expected = Value::Float(6.24);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("(-6.24).abs()");
         let expected = Value::Float(6.24);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 }

--- a/abra_core/src/builtins/prelude/native_int.rs
+++ b/abra_core/src/builtins/prelude/native_int.rs
@@ -74,105 +74,105 @@ mod test {
     fn test_int_to_string() {
         let result = interpret("24.toString()");
         let expected = new_string_obj("24");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_int_abs() {
         let result = interpret("6.abs()");
         let expected = Value::Int(6);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("(-6).abs()");
         let expected = Value::Int(6);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_int_as_base() {
         let result = interpret("6.asBase(0)");
         let expected = new_string_obj("6");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("6.asBase(1)");
         let expected = new_string_obj("6");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("6.asBase(37)");
         let expected = new_string_obj("6");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("6.asBase(10)");
         let expected = new_string_obj("6");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("24.asBase(8)");
         let expected = new_string_obj("30");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("4040.asBase(16)");
         let expected = new_string_obj("fc8");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("20.asBase(17)");
         let expected = new_string_obj("13");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("24032.asBase(36)");
         let expected = new_string_obj("ijk");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_int_is_even() {
         let result = interpret("0.isEven()");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("6.isEven()");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("(-6).isEven()");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("5.isEven()");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_int_is_odd() {
         let result = interpret("0.isOdd()");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("6.isOdd()");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("(-1).isOdd()");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("1.isOdd()");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_int_is_between() {
         let result = interpret("0.isBetween(0, 5)");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("0.isBetween(lower: 0, upper: 5, inclusive: true)");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("(-1).isBetween(lower: 0, upper: 5, inclusive: true)");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 }

--- a/abra_core/src/builtins/prelude/native_map.rs
+++ b/abra_core/src/builtins/prelude/native_map.rs
@@ -157,11 +157,11 @@ mod test {
     fn test_map_field_size() {
         let result = interpret("{}.size");
         let expected = Value::Int(0);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{ a: 123, b: true }.size");
         let expected = Value::Int(2);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         // Setting size should produce an error
         let is_err = interpret_get_result("{ a: 4 }.size = 8").is_err();
@@ -172,14 +172,14 @@ mod test {
     fn test_map_static_from_pairs() {
         let result = interpret("Map.fromPairs([])");
         let expected = Value::new_map_obj(vec![]);
-        assert_eq!(result, Some(expected));
+        assert_eq!(expected, result);
 
         let result = interpret("Map.fromPairs([(\"a\", 123), (\"b\", 456)])");
         let expected = map! {
             new_string_obj("a") => Value::Int(123),
             new_string_obj("b") => Value::Int(456)
         };
-        assert_eq!(result, Some(expected));
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -189,49 +189,49 @@ mod test {
             new_string_obj("{ a: [1, 2], b: [3, 4] }"),
             new_string_obj("{ b: [3, 4], a: [1, 2] }"),
         ];
-        assert!(expecteds.contains(&result.unwrap()));
+        assert!(expecteds.contains(&result));
 
         let result = interpret("{ a: true, b: false }.toString()");
         let expecteds = vec![
             new_string_obj("{ a: true, b: false }"),
             new_string_obj("{ b: false, a: true }"),
         ];
-        assert!(expecteds.contains(&result.unwrap()));
+        assert!(expecteds.contains(&result));
     }
 
     #[test]
     fn test_map_is_empty() {
         let result = interpret("{}.isEmpty()");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{ a: 123, b: true }.isEmpty()");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_map_enumerate() {
         let result = interpret("{}.enumerate()");
         let expected = Value::new_array_obj(vec![]);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{ a: 123, }.enumerate()");
         let expected = Value::new_array_obj(vec![
             Value::new_tuple_obj(vec![new_string_obj("a"), Value::Int(123)]),
         ]);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_map_keys() {
         let result = interpret("{}.keys()");
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{ a: 123, b: true }.keys()");
         let expected = set![new_string_obj("a"), new_string_obj("b")];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\
           val m: Map<Int[], Int> = {}\
@@ -243,47 +243,47 @@ mod test {
             array![Value::Int(1), Value::Int(2)],
             array![Value::Int(1), Value::Int(2), Value::Int(3)]
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{ a: 123, b: true }.keys()");
         let expected = set![new_string_obj("a"), new_string_obj("b")];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_map_values() {
         let result = interpret("{}.values()");
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{ a: 123, b: true }.values()");
         let expected = set![Value::Int(123), Value::Bool(true)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_map_entries() {
         let result = interpret("{}.entries()");
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{ a: 123, b: true }.entries()");
         let expected = set![
             tuple!(new_string_obj("a"), Value::Int(123)),
             tuple!(new_string_obj("b"), Value::Bool(true))
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_map_contains_key() {
         let result = interpret("{}.containsKey(\"asdf\")");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{ a: 24 }.containsKey(\"a\")");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\
           val m: Map<Int[], String> = {}\
@@ -291,7 +291,7 @@ mod test {
           m.containsKey([1, 2, 3])\
         ");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -303,7 +303,7 @@ mod test {
             new_string_obj("a") => Value::Int(2),
             new_string_obj("b") => Value::Int(3)
         };
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(
             "{ a: 1, b: 2 }.mapValues((k, v) => k + v)"
@@ -312,25 +312,25 @@ mod test {
             new_string_obj("a") => new_string_obj("a1"),
             new_string_obj("b") => new_string_obj("b2")
         };
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_map_get_or_default() {
         let result = interpret("{a:1, b:2}.getOrDefault(\"b\", 12)");
         let expected = Value::Int(2);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{a:1, b:2}.getOrDefault(\"c\", 12)");
         let expected = Value::Int(12);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_map_get_or_else() {
         let result = interpret("{a:1, b:2}.getOrElse(\"b\", () => 12)");
         let expected = Value::Int(2);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           var counter = 0
@@ -341,11 +341,11 @@ mod test {
           counter
         "#);
         let expected = Value::Int(0);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("{a:1, b:2}.getOrElse(\"c\", () => 12)");
         let expected = Value::Int(12);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           var counter = 0
@@ -356,7 +356,7 @@ mod test {
           counter
         "#);
         let expected = Value::Int(1);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -370,7 +370,7 @@ mod test {
           new_string_obj("a") => Value::Int(1),
           new_string_obj("b") => Value::Int(102)
         };
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val map = {a:1, b:2}
@@ -381,6 +381,6 @@ mod test {
           new_string_obj("a") => Value::Int(1),
           new_string_obj("b") => Value::Int(2)
         };
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 }

--- a/abra_core/src/builtins/prelude/native_set.rs
+++ b/abra_core/src/builtins/prelude/native_set.rs
@@ -152,15 +152,15 @@ mod test {
     fn test_set_size() {
         let result = interpret("#{}.size");
         let expected = Value::Int(0);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{0, 1, 2, \"3\"}.size");
         let expected = Value::Int(4);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{0, 1, 2, 1, 0}.size");
         let expected = Value::Int(3);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         // Setting size should produce an error
         let is_err = interpret_get_result("#{1, 2, 3}.size = 8").is_err();
@@ -178,63 +178,63 @@ mod test {
             new_string_obj("#{3, 2, 1}"),
             new_string_obj("#{3, 1, 2}"),
         ];
-        assert!(expecteds.contains(&result.unwrap()));
+        assert!(expecteds.contains(&result));
 
         let result = interpret("#{[1, 2], [3, 4]}.toString()");
         let expecteds = vec![
             new_string_obj("#{[1, 2], [3, 4]}"),
             new_string_obj("#{[3, 4], [1, 2]}"),
         ];
-        assert!(expecteds.contains(&result.unwrap()));
+        assert!(expecteds.contains(&result));
 
         let result = interpret("#{(1, 2), (3, 4)}.toString()");
         let expecteds = vec![
             new_string_obj("#{(1, 2), (3, 4)}"),
             new_string_obj("#{(3, 4), (1, 2)}"),
         ];
-        assert!(expecteds.contains(&result.unwrap()));
+        assert!(expecteds.contains(&result));
     }
 
     #[test]
     fn test_set_is_empty() {
         let result = interpret("#{}.isEmpty()");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{1, 2, \"3\"}.isEmpty()");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_set_enumerate() {
         let result = interpret("#{}.enumerate()");
         let expected = Value::new_array_obj(vec![]);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{\"a\"}.enumerate()");
         let expected = Value::new_array_obj(vec![
             Value::new_tuple_obj(vec![new_string_obj("a"), Value::Int(0)]),
         ]);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_set_contains() {
         let result = interpret("#{}.contains(\"a\")");
         let expected = Value::Bool(false);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{\"a\", \"b\"}.contains(\"a\")");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\
           type Person { name: String }\n\
           #{Person(name: \"Ken\"), Person(name: \"Ken\")}.contains(Person(name: \"Ken\"))\
         ");
         let expected = Value::Bool(true);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -245,7 +245,7 @@ mod test {
           set
         "#);
         let expected = set![Value::Int(1), Value::Int(3)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val set = #{1}
@@ -254,7 +254,7 @@ mod test {
           set
         "#);
         let expected = set![Value::Int(1), Value::Int(3)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod test {
           set
         "#);
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val set: Set<Int> = #{}
@@ -273,53 +273,53 @@ mod test {
           set
         "#);
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_set_map() {
         let result = interpret("#{\"a\", \"b\"}.map(w => w.length)");
         let expected = array![Value::Int(1), Value::Int(1)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_set_filter() {
         let result = interpret("#{1, 2, 3, 4, 5}.filter(n => n.isEven())");
         let expected = set![Value::Int(2), Value::Int(4)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_set_reduce() {
         let result = interpret("#{1, 2, 3, 4, 5}.reduce(0, (acc, n) => acc + n)");
         let expected = Value::Int(15);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_set_as_array() {
         let result = interpret("#{3, 4, 5}.asArray()");
         let expecteds = vec![
-            Some(array![Value::Int(3), Value::Int(4), Value::Int(5)]),
-            Some(array![Value::Int(3), Value::Int(5), Value::Int(4)]),
-            Some(array![Value::Int(4), Value::Int(3), Value::Int(5)]),
-            Some(array![Value::Int(4), Value::Int(5), Value::Int(3)]),
-            Some(array![Value::Int(5), Value::Int(4), Value::Int(3)]),
-            Some(array![Value::Int(5), Value::Int(3), Value::Int(4)]),
+            array![Value::Int(3), Value::Int(4), Value::Int(5)],
+            array![Value::Int(3), Value::Int(5), Value::Int(4)],
+            array![Value::Int(4), Value::Int(3), Value::Int(5)],
+            array![Value::Int(4), Value::Int(5), Value::Int(3)],
+            array![Value::Int(5), Value::Int(4), Value::Int(3)],
+            array![Value::Int(5), Value::Int(3), Value::Int(4)],
         ];
-        assert!(expecteds.contains(&result)); // Sets' order isn't guaranteed :(
+        assert!(expecteds.contains(&result)); // Sets' order aren't guaranteed, so we need to assert this way :/
     }
 
     #[test]
     fn test_set_union() {
         let result = interpret("#{}.union(#{})");
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{1}.union(#{1, 2})");
         let expected = set![Value::Int(1), Value::Int(2)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\
           val s1 = #{1, 3, 5}
@@ -327,36 +327,36 @@ mod test {
           s1.union(s2)
         ");
         let expected = set![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4), Value::Int(5)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_set_difference() {
         let result = interpret("#{}.difference(#{})");
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{1}.difference(#{1, 2})");
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{1, 2}.difference(#{2})");
         let expected = set![Value::Int(1)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_set_intersection() {
         let result = interpret("#{1, 2, 3}.intersection(#{})");
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{1, 2}.intersection(#{3, 4})");
         let expected = set![];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("#{1}.intersection(#{1, 2})");
         let expected = set![Value::Int(1)];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 }

--- a/abra_core/src/builtins/prelude/native_string.rs
+++ b/abra_core/src/builtins/prelude/native_string.rs
@@ -178,7 +178,7 @@ mod test {
     fn test_string_length() {
         let result = interpret("\"asdf qwer\".length");
         let expected = Value::Int(9);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         // Setting length should produce an error
         let is_err = interpret_get_result("\"asdf\".length = 8").is_err();
@@ -189,73 +189,73 @@ mod test {
     fn test_string_to_string() {
         let result = interpret("\"hello\".toString()");
         let expected = new_string_obj("hello");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_to_lower() {
         let result = interpret("\"aSDF qWER\".toLower()");
         let expected = new_string_obj("asdf qwer");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_to_upper() {
         let result = interpret("\"Asdf Qwer\".toUpper()");
         let expected = new_string_obj("ASDF QWER");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_pad_left() {
         let result = interpret("\"asdf\".padLeft(7, \"!\")");
         let expected = new_string_obj("!!!asdf");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"asdf\".padLeft(4, \"!\")");
         let expected = new_string_obj("asdf");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"asdf\".padLeft(-14, \"!\")");
         let expected = new_string_obj("asdf");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_trim() {
         let result = interpret("\"  asdf   \".trim()");
         let expected = new_string_obj("asdf");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_trim_start() {
         let result = interpret("\"  asdf   \".trimStart()");
         let expected = new_string_obj("asdf   ");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"!!asdf   \".trimStart(pattern: \"!\")");
         let expected = new_string_obj("asdf   ");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"!!!asdf   \".trimStart(\"!!\")");
         let expected = new_string_obj("!asdf   ");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_trim_end() {
         let result = interpret("\"  asdf   \".trimEnd()");
         let expected = new_string_obj("  asdf");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"  asdf!!\".trimEnd(pattern: \"!\")");
         let expected = new_string_obj("  asdf");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"  asdf!!!\".trimEnd(\"!!\")");
         let expected = new_string_obj("  asdf!");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -267,7 +267,7 @@ mod test {
           new_string_obj("d"),
           new_string_obj("f")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"  a  b  c d\".split(\"  \")");
         let expected = array![
@@ -276,13 +276,13 @@ mod test {
           new_string_obj("b"),
           new_string_obj("c d")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"asdf\".split(\"qwer\")");
         let expected = array![
           new_string_obj("asdf")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"asdf\".split(\"\")");
         let expected = array![
@@ -291,7 +291,7 @@ mod test {
           new_string_obj("d"),
           new_string_obj("f")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"a\\ns\\nd\\nf\".split(\"\\n\")");
         let expected = array![
@@ -300,7 +300,7 @@ mod test {
           new_string_obj("d"),
           new_string_obj("f")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -313,7 +313,7 @@ mod test {
             new_string_obj(""),
             new_string_obj("hello!")
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = "hello!"
@@ -323,7 +323,7 @@ mod test {
             new_string_obj("h"),
             new_string_obj("ello!")
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = "hello!"
@@ -333,7 +333,7 @@ mod test {
             new_string_obj("hello"),
             new_string_obj("!")
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = "hello!"
@@ -343,7 +343,7 @@ mod test {
             new_string_obj(""),
             new_string_obj("hello!")
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret(r#"
           val arr = "hello!"
@@ -353,7 +353,7 @@ mod test {
             new_string_obj("hello!"),
             new_string_obj("")
         );
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -364,7 +364,7 @@ mod test {
           new_string_obj("qwer"),
           new_string_obj("zxcv")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
@@ -376,75 +376,75 @@ mod test {
           new_string_obj("d"),
           new_string_obj("f")
         ];
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_parse_int() {
         let result = interpret("\"hello\".parseInt()");
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"123 456\".parseInt()");
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"123456.7\".parseInt()");
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"123456\".parseInt()");
         let expected = Value::Int(123456);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"-123456\".parseInt()");
         let expected = Value::Int(-123456);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"ba55\".parseInt(radix: 16)");
         let expected = Value::Int(47701);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_parse_float() {
         let result = interpret("\"hello\".parseFloat()");
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"123 456\".parseFloat()");
         let expected = Value::Nil;
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"123456.7\".parseFloat()");
         let expected = Value::Float(123456.7);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"-123456.7\".parseFloat()");
         let expected = Value::Float(-123456.7);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"123456\".parseFloat()");
         let expected = Value::Float(123456.0);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"-123456\".parseFloat()");
         let expected = Value::Float(-123456.0);
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 
     #[test]
     fn test_string_concat() {
         let result = interpret("\"hello\".concat(\"!\")");
         let expected = new_string_obj("hello!");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"hello\".concat(\" \", \"world\", \"!\")");
         let expected = new_string_obj("hello world!");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
 
         let result = interpret("\"asdf\".concat(true, [1, 2, 3], {a:1})");
         let expected = new_string_obj("asdftrue[1, 2, 3]{ a: 1 }");
-        assert_eq!(Some(expected), result);
+        assert_eq!(expected, result);
     }
 }

--- a/abra_core/src/builtins/test_utils.rs
+++ b/abra_core/src/builtins/test_utils.rs
@@ -32,11 +32,11 @@ macro_rules! string_array {
     ($($i:expr),*) => { Value::new_array_obj(vec![$($i),*].into_iter().map(new_string_obj).collect()) };
 }
 
-pub fn interpret(input: &str) -> Option<Value> {
+pub fn interpret(input: &str) -> Value {
     interpret_get_result(input).unwrap()
 }
 
-pub fn interpret_get_result<S: AsRef<str>>(input: S) -> Result<Option<Value>, Error> {
+pub fn interpret_get_result<S: AsRef<str>>(input: S) -> Result<Value, Error> {
     let mock_reader = MockModuleReader::default();
     let module_id = ModuleId::from_name("_test");
     let modules = match compile(module_id, &input.as_ref().to_string(), mock_reader) {
@@ -45,7 +45,7 @@ pub fn interpret_get_result<S: AsRef<str>>(input: S) -> Result<Option<Value>, Er
     };
 
     let mut vm = VM::new(VMContext::default());
-    let mut res = None;
+    let mut res = Value::Nil;
     for module in modules {
         res = vm.run(module).map_err(|e| Error::InterpretError(e))?;
     }

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -219,10 +219,14 @@ impl Type {
                         return false;
                     }
                 }
-                if !ret.is_equivalent_to(target_ret, resolve_type) {
-                    return false;
+
+                if **target_ret == Unit {
+                    true
+                } else if !ret.is_equivalent_to(target_ret, resolve_type) {
+                    false
+                } else {
+                    true
                 }
-                true
             }
             // TODO
             (Type(_name1, _t1, _is_enum1), Type(_name2, _t2, _is_enum2)) => {

--- a/abra_core/src/vm/value.rs
+++ b/abra_core/src/vm/value.rs
@@ -54,15 +54,13 @@ impl Hash for ClosureValue {
     }
 }
 
-// If a native function's return type is Unit, it should return None
-type NativeAbraFn = fn(Option<Value>, Vec<Value>, &mut VM) -> Option<Value>;
+type NativeAbraFn = fn(Option<Value>, Vec<Value>, &mut VM) -> Value;
 
 #[derive(Clone)]
 pub struct NativeFn {
     pub name: &'static str,
     pub receiver: Option<Box<Value>>,
     pub native_fn: NativeAbraFn,
-    pub has_return: bool,
 }
 
 impl Debug for NativeFn {
@@ -78,7 +76,7 @@ impl PartialEq for NativeFn {
 }
 
 impl NativeFn {
-    pub fn invoke(&self, args: Vec<Value>, vm_ref: &mut VM) -> Option<Value> {
+    pub fn invoke(&self, args: Vec<Value>, vm_ref: &mut VM) -> Value {
         let func = self.native_fn;
         func(self.receiver.as_ref().map(|v| *v.clone()), args, vm_ref)
     }
@@ -292,12 +290,11 @@ impl Hash for Value {
             Value::EnumInstanceObj(o) => (&*o.borrow()).hash(hasher),
             Value::Fn(f) => f.hash(hasher),
             Value::Closure(c) => c.hash(hasher),
-            Value::NativeFn(NativeFn { name, receiver, has_return, .. }) => {
+            Value::NativeFn(NativeFn { name, receiver, .. }) => {
                 name.hash(hasher);
                 if let Some(receiver) = receiver {
                     receiver.hash(hasher);
                 }
-                has_return.hash(hasher);
             }
             Value::Type(tv) => tv.hash(hasher),
             Value::Enum(ev) => ev.hash(hasher),

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -14,28 +14,28 @@ mod tests {
         Value::new_string_obj(string.to_string())
     }
 
-    fn interpret(input: &str) -> Option<Value> {
+    fn interpret(input: &str) -> Value {
         let mock_reader = MockModuleReader::default();
         let module_id = ModuleId::from_name("_test");
         let modules = crate::compile(module_id, &input.to_string(), mock_reader).unwrap();
 
         let ctx = VMContext::default();
         let mut vm = VM::new(ctx);
-        let mut res = None;
+        let mut res = Value::Nil;
         for module in modules {
             res = vm.run(module).unwrap();
         }
         res
     }
 
-    fn interpret_with_modules(input: &str, modules: Vec<(&str, &str)>) -> Option<Value> {
+    fn interpret_with_modules(input: &str, modules: Vec<(&str, &str)>) -> Value {
         let mock_reader = MockModuleReader::new(modules);
         let module_id = ModuleId::from_name("_test");
         let modules = crate::compile(module_id, &input.to_string(), mock_reader).unwrap();
 
         let ctx = VMContext::default();
         let mut vm = VM::new(ctx);
-        let mut res = None;
+        let mut res = Value::Nil;
         for module in modules {
             res = vm.run(module).unwrap();
         }
@@ -44,82 +44,82 @@ mod tests {
 
     #[test]
     fn interpret_nothing() {
-        assert!(interpret("").is_none());
+        assert_eq!(Value::Nil, interpret(""));
     }
 
     #[test]
     fn interpret_constants() {
-        let result = interpret("1").unwrap();
+        let result = interpret("1");
         let expected = Value::Int(1);
         assert_eq!(expected, result);
 
-        let result = interpret("1.23").unwrap();
+        let result = interpret("1.23");
         let expected = Value::Float(1.23);
         assert_eq!(expected, result);
 
-        let result = interpret("true").unwrap();
+        let result = interpret("true");
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
 
-        let result = interpret("false").unwrap();
+        let result = interpret("false");
         let expected = Value::Bool(false);
         assert_eq!(expected, result);
     }
 
     #[test]
     fn interpret_unary() {
-        let result = interpret("-1").unwrap();
+        let result = interpret("-1");
         let expected = Value::Int(-1);
         assert_eq!(expected, result);
 
-        let result = interpret("-1.23").unwrap();
+        let result = interpret("-1.23");
         let expected = Value::Float(-1.23);
         assert_eq!(expected, result);
     }
 
     #[test]
     fn interpret_binary() {
-        let result = interpret("1 + 2 * 3.4 / 5").unwrap();
+        let result = interpret("1 + 2 * 3.4 / 5");
         let expected = Value::Float(2.36);
         assert_eq!(expected, result);
 
-        let result = interpret("7 % 5").unwrap();
+        let result = interpret("7 % 5");
         let expected = Value::Int(2);
         assert_eq!(expected, result);
 
-        let result = interpret("5.25 % 2.5").unwrap();
+        let result = interpret("5.25 % 2.5");
         let expected = Value::Float(0.25);
         assert_eq!(expected, result);
 
-        let result = interpret("\"hello\" +  \" \"+24  + \" world\"").unwrap();
+        let result = interpret("\"hello\" +  \" \"+24  + \" world\"");
         let expected = new_string_obj("hello 24 world");
         assert_eq!(expected, result);
 
-        let result = interpret("2 ** 3 ** 4").unwrap();
+        let result = interpret("2 ** 3 ** 4");
         let expected = Value::Float(4096.0);
         assert_eq!(expected, result);
 
-        let result = interpret("2 ** 3.1").unwrap();
+        let result = interpret("2 ** 3.1");
         let expected = Value::Float(8.574187700290345);
         assert_eq!(expected, result);
     }
 
     #[test]
     fn interpret_binary_boolean() {
-        let result = interpret("true || false").unwrap();
+        let result = interpret("true || false");
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
 
-        let result = interpret("true && false").unwrap();
+        let result = interpret("true && false");
         let expected = Value::Bool(false);
         assert_eq!(expected, result);
 
-        let result = interpret("true && false || true && true").unwrap();
+        let result = interpret("true && false || true && true");
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
 
         for (l, r, res) in vec![(true, true, false), (true, false, true), (false, true, true), (false, false, false)] {
-            let result = interpret(format!("{} ^ {}", l, r).as_str()).unwrap();
+            let result = interpret(format!("{} ^ {}", l, r).as_str());
             let expected = Value::Bool(res);
             assert_eq!(expected, result);
         }
@@ -141,7 +141,7 @@ mod tests {
             res + \" \" + called",
             preface
         );
-        let result = interpret(&input).unwrap();
+        let result = interpret(&input);
         let expected = new_string_obj("true false");
         assert_eq!(expected, result);
 
@@ -151,7 +151,7 @@ mod tests {
             res + \" \" + called",
             preface
         );
-        let result = interpret(&input).unwrap();
+        let result = interpret(&input);
         let expected = new_string_obj("false false");
         assert_eq!(expected, result);
     }
@@ -206,7 +206,7 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            let result = interpret(input).unwrap();
+            let result = interpret(input);
             assert_eq!(Value::Bool(expected), result, "Interpreting {} should be {}", input, expected);
         }
     }
@@ -224,14 +224,14 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            let result = interpret(input).unwrap();
+            let result = interpret(input);
             assert_eq!(expected, result, "Interpreting {} should be {}", input, expected);
         }
     }
 
     #[test]
     fn interpret_array() {
-        let result = interpret("[1, 2, 3]").unwrap();
+        let result = interpret("[1, 2, 3]");
         let expected = Value::new_array_obj(vec![
             Value::Int(1),
             Value::Int(2),
@@ -239,7 +239,7 @@ mod tests {
         ]);
         assert_eq!(expected, result);
 
-        let result = interpret("[0, -1, true, 3.4, \"5\"]").unwrap();
+        let result = interpret("[0, -1, true, 3.4, \"5\"]");
         let expected = Value::new_array_obj(vec![
             Value::Int(0),
             Value::Int(-1),
@@ -249,7 +249,7 @@ mod tests {
         ]);
         assert_eq!(expected, result);
 
-        let result = interpret("[[0, -1], [true, false], [\"a\"]]").unwrap();
+        let result = interpret("[[0, -1], [true, false], [\"a\"]]");
         let expected = Value::new_array_obj(vec![
             Value::new_array_obj(vec![Value::Int(0), Value::Int(-1)]),
             Value::new_array_obj(vec![Value::Bool(true), Value::Bool(false)]),
@@ -260,23 +260,23 @@ mod tests {
 
     #[test]
     fn interpret_array_equality() {
-        let result = interpret("[1, 2] == [1, 2]").unwrap();
+        let result = interpret("[1, 2] == [1, 2]");
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
 
-        let result = interpret("[1, 3] == [1, 2]").unwrap();
+        let result = interpret("[1, 3] == [1, 2]");
         let expected = Value::Bool(false);
         assert_eq!(expected, result);
 
-        let result = interpret("[[0, 1]] == [[1, 2]]").unwrap();
+        let result = interpret("[[0, 1]] == [[1, 2]]");
         let expected = Value::Bool(false);
         assert_eq!(expected, result);
 
-        let result = interpret("[[0, 1], [2, 3]] == [[0, 1], [2, 3]]").unwrap();
+        let result = interpret("[[0, 1], [2, 3]] == [[0, 1], [2, 3]]");
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
 
-        let result = interpret("[1, 2] == \"hello\"").unwrap();
+        let result = interpret("[1, 2] == \"hello\"");
         let expected = Value::Bool(false);
         assert_eq!(expected, result);
     }
@@ -287,7 +287,7 @@ mod tests {
           val a = "def"
           "abc $a ghi"
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("abc def ghi");
         assert_eq!(expected, result);
 
@@ -295,14 +295,14 @@ mod tests {
           func a(): String = "def"
           "$a() ghi"
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("<func a>() ghi");
         assert_eq!(expected, result);
 
         let input = r#"
           "abc $true ghi"
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("abc true ghi");
         assert_eq!(expected, result);
 
@@ -310,7 +310,7 @@ mod tests {
           func a(): String = "def"
           "abc ${a()}"
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("abc def");
         assert_eq!(expected, result);
 
@@ -319,14 +319,14 @@ mod tests {
                    .map(x => x + 2)
                    .join(",")} ghi"
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("abc 3,4,5,6 ghi");
         assert_eq!(expected, result);
 
         let input = r#"
           "${"hello" + " " + "${"world" + "!"}"}"
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("hello world!");
         assert_eq!(expected, result);
     }
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn interpret_map() {
-        let result = interpret("{ a: 1, b: \"hello\", c: true }").unwrap();
+        let result = interpret("{ a: 1, b: \"hello\", c: true }");
         let expected_pairs = vec![
             (new_string_obj("a"), Value::Int(1)),
             (new_string_obj("b"), new_string_obj("hello")),
@@ -354,7 +354,7 @@ mod tests {
         ];
         assert_maps_eq(expected_pairs, result);
 
-        let result = interpret("{ a: { b: \"hello\" }, c: [1, 2] }").unwrap();
+        let result = interpret("{ a: { b: \"hello\" }, c: [1, 2] }");
         let expected_pairs = vec![
             (new_string_obj("a"), Value::new_map_obj(vec![
                 new_string_obj("b"), new_string_obj("hello")
@@ -372,7 +372,7 @@ mod tests {
           var c = a + b > b - a
           c
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
 
@@ -383,7 +383,7 @@ mod tests {
           val a = [a1, a2 + a2, 3 * a3]
           a
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(1),
             Value::Int(4),
@@ -395,7 +395,7 @@ mod tests {
           val (a, b) = (1, 2)
           a + b
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(3);
         assert_eq!(expected, result);
 
@@ -407,7 +407,7 @@ mod tests {
           }
           manhattanDistance((0, 0), (2, 2))
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(4);
         assert_eq!(expected, result);
     }
@@ -420,7 +420,7 @@ mod tests {
           val c = b = a = 3\n\
           a + b + c
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(9);
         assert_eq!(expected, result);
     }
@@ -435,7 +435,7 @@ mod tests {
           m["a"] = 456
           (a[0] ?: 0) + (m["a"] ?: 0)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(579);
         assert_eq!(expected, result);
 
@@ -444,7 +444,7 @@ mod tests {
           a[4] = 123
           a
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(0),
             Value::Nil,
@@ -463,7 +463,7 @@ mod tests {
           p.name = "Ken"
           p.name
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Ken");
         assert_eq!(expected, result);
 
@@ -476,7 +476,7 @@ mod tests {
           n.value = "Ken"
           p.name.value
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Ken");
         assert_eq!(expected, result);
 
@@ -489,7 +489,7 @@ mod tests {
           n.value = "Ken"
           p.name.value
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Ken");
         assert_eq!(expected, result);
     }
@@ -501,17 +501,17 @@ mod tests {
           val item = arr[1]\n
           item
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(2);
         assert_eq!(expected, result);
 
         let input = "[1, 2, 3][-1]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(3);
         assert_eq!(expected, result);
 
         let input = "[][0] == [1, 2][-3]"; // They're both None
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
     }
@@ -519,27 +519,27 @@ mod tests {
     #[test]
     fn interpret_indexing_ranges_arrays() {
         let input = "[1, 2, 3][1:2]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![Value::Int(2)]);
         assert_eq!(expected, result);
 
         let input = "[1, 2, 3][-2:-1]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![Value::Int(2)]);
         assert_eq!(expected, result);
 
         let input = "[1, 2, 3][:1]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![Value::Int(1)]);
         assert_eq!(expected, result);
 
         let input = "[1, 2, 3][1:]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![Value::Int(2), Value::Int(3)]);
         assert_eq!(expected, result);
 
         let input = "[1, 2, 3][-3:]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(1),
             Value::Int(2),
@@ -555,17 +555,17 @@ mod tests {
           val char = str[6]\n
           char
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("w");
         assert_eq!(expected, result);
 
         let input = "\"hello world\"[-3]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("r");
         assert_eq!(expected, result);
 
         let input = "\"hello world\"[100]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Nil;
         assert_eq!(expected, result);
     }
@@ -573,27 +573,27 @@ mod tests {
     #[test]
     fn interpret_indexing_ranges_strings() {
         let input = "\"some string\"[1:2]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("o");
         assert_eq!(expected, result);
 
         let input = "\"some string\"[-2:-1]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("n");
         assert_eq!(expected, result);
 
         let input = "\"some string\"[:4]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("some");
         assert_eq!(expected, result);
 
         let input = "\"some string\"[5:]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("string");
         assert_eq!(expected, result);
 
         let input = "\"some string\"[-6:]";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("string");
         assert_eq!(expected, result);
     }
@@ -605,7 +605,7 @@ mod tests {
           val item = arr[1] ?: 16\n
           item
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(2);
         assert_eq!(expected, result);
 
@@ -614,7 +614,7 @@ mod tests {
           val item = arr[4] ?: 16\n
           item
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(16);
         assert_eq!(expected, result);
     }
@@ -631,7 +631,7 @@ mod tests {
           }
         ";
         let result = interpret(input);
-        assert!(result.is_none());
+        assert_eq!(Value::Nil, result);
 
         let input = "\
           var res = 0\
@@ -643,7 +643,7 @@ mod tests {
           }\
           res
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(123);
         assert_eq!(expected, result);
 
@@ -656,7 +656,7 @@ mod tests {
           }\
           res
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(456);
         assert_eq!(expected, result);
 
@@ -673,7 +673,7 @@ mod tests {
           }\
           res
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(789);
         assert_eq!(expected, result);
 
@@ -691,7 +691,7 @@ mod tests {
           }\
           res
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(246);
         assert_eq!(expected, result);
 
@@ -705,7 +705,7 @@ mod tests {
           val b = a + 3\
           b - 3
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(123);
         assert_eq!(expected, result);
     }
@@ -720,12 +720,12 @@ mod tests {
           }
           abc
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(123);
         assert_eq!(expected, result);
 
         let input = "4 + if (true) { 20 } else { 0 }";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
@@ -739,7 +739,7 @@ mod tests {
           }
           abc()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
     }
@@ -752,7 +752,7 @@ mod tests {
           val def = abc
           def
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Fn(FnValue {
             name: "abc".to_string(),
             code: vec![
@@ -779,14 +779,21 @@ mod tests {
           }\n\
           add(add(a, b), c)\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(6);
         assert_eq!(expected, result);
 
-        // There should be nothing leftover on the stack after a non-returning function executes
+        // There should be nothing leftover on the stack after a Unit-returning function executes
         let input = "println(\"hello\")";
         let result = interpret(input);
-        assert_eq!(None, result);
+        assert_eq!(Value::Nil, result);
+
+        let input = r#"
+          func foo(fn: () => Unit) = fn()
+          foo(() => "hello")
+        "#;
+        let result = interpret(input);
+        assert_eq!(Value::Nil, result);
     }
 
     #[test] // Note: this is like a pseudo-closure test, since the variables are globals...
@@ -800,7 +807,7 @@ mod tests {
           b = 17\n\
           getSum()\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(18);
         assert_eq!(expected, result);
     }
@@ -815,7 +822,7 @@ mod tests {
           }\n\
           getSum()\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(3);
         assert_eq!(expected, result);
     }
@@ -833,7 +840,7 @@ mod tests {
           val results = [tick(), tick(), tick(), tick(), tick()]\n\
           results\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(1),
             Value::Int(2),
@@ -861,7 +868,7 @@ mod tests {
           val results = [tick(), tick(), tick(), tick(), tick()]\n\
           results\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(1),
             Value::Int(2),
@@ -882,7 +889,7 @@ mod tests {
           }
           abc()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
@@ -908,7 +915,7 @@ mod tests {
           abc()
         "#;
 
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
     }
@@ -927,7 +934,7 @@ mod tests {
           val languageName = \"Abra\"\n\
           greet(languageName) + \" \" + greet(languageName)\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Hello, Abra! Hello, Abra!");
         assert_eq!(expected, result);
     }
@@ -950,7 +957,7 @@ mod tests {
           }
           save("Cheerleader") + ", " + save("World")
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Save the Cheerleader, Save the World!");
         assert_eq!(expected, result);
     }
@@ -970,7 +977,7 @@ mod tests {
           \n\
           [fib(0), fib(1), fib(2), fib(3), fib(4), fib(5), fib(6), fib(7), fib(8)]\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(0),
             Value::Int(1),
@@ -1003,7 +1010,7 @@ mod tests {
           \n\
           [fib(0), fib(1), fib(2), fib(3), fib(4), fib(5), fib(6), fib(7), fib(8)]\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(0),
             Value::Int(1),
@@ -1024,7 +1031,7 @@ mod tests {
           func abc(a: Int = 2, b = 3, c = 5): Int { a * b * c }
           [abc(), abc(7), abc(7, 11), abc(7, 11, 13)]
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(30),
             Value::Int(105),
@@ -1046,7 +1053,7 @@ mod tests {
           abc(1)
           called
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Bool(false);
         assert_eq!(expected, result);
 
@@ -1060,7 +1067,7 @@ mod tests {
           abc()
           called
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
     }
@@ -1078,7 +1085,7 @@ mod tests {
           val fn = outer()
           fn()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(4);
         assert_eq!(expected, result);
     }
@@ -1100,7 +1107,7 @@ mod tests {
              start: 17
           )
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(17),
             Value::Int(2),
@@ -1118,7 +1125,7 @@ mod tests {
           func def(): Int = 3
           abc()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(3);
         assert_eq!(expected, result);
 
@@ -1131,7 +1138,7 @@ mod tests {
           }
           abc()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(4);
         assert_eq!(expected, result);
 
@@ -1146,7 +1153,7 @@ mod tests {
           }
           x
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(123);
         assert_eq!(expected, result);
 
@@ -1171,7 +1178,7 @@ mod tests {
           val fn = abc()
           [fn(), fn(), fn(), fn(), fn(), fn(), fn()]
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(1),
             Value::Int(1),
@@ -1195,7 +1202,7 @@ mod tests {
             i * 3
           }).concat([total])
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![Value::Int(3), Value::Int(6), Value::Int(3)]);
         assert_eq!(expected, result);
     }
@@ -1206,7 +1213,7 @@ mod tests {
           func abc(a: Int, *b: Int[]): String = [a].concat(b).join(",")
           [abc(1), abc(1, 2, 3, 4)]
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             new_string_obj("1"),
             new_string_obj("1,2,3,4"),
@@ -1217,7 +1224,7 @@ mod tests {
           func abc(a: Int, *b = [6, 24]): String = [a].concat(b).join(",")
           [abc(1), abc(1, 2, 3, 4)]
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             new_string_obj("1,6,24"),
             new_string_obj("1,2,3,4"),
@@ -1234,7 +1241,7 @@ mod tests {
           }\n\
           a\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(4);
         assert_eq!(expected, result);
     }
@@ -1260,7 +1267,7 @@ mod tests {
           }\n\
           output\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("1,2,F,4,B,F,7,8,F,B,11,F,13,14,Fb,16,17,F,19,B,");
         assert_eq!(expected, result);
     }
@@ -1278,7 +1285,7 @@ mod tests {
           }
           sum
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(22);
         assert_eq!(expected, result);
 
@@ -1293,7 +1300,7 @@ mod tests {
           }
           sum
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(22);
         assert_eq!(expected, result);
     }
@@ -1310,7 +1317,7 @@ mod tests {
           }\n\
           str\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("123");
         assert_eq!(expected, result);
     }
@@ -1331,7 +1338,7 @@ mod tests {
           }\n\
           a\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         // If this returned 3, we'd know that `break` destroyed the outer loop too, but it doesn't
         let expected = Value::Int(5);
         assert_eq!(expected, result);
@@ -1356,7 +1363,7 @@ mod tests {
           }\n\
           output\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("1,2,F,4,B,F,7,8,F,B,11,F,13,14,Fb,16,17,F,19,B,");
         assert_eq!(expected, result);
     }
@@ -1376,7 +1383,7 @@ mod tests {
           }\n\
           output\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("1456, 2456, 3456");
         assert_eq!(expected, result);
     }
@@ -1400,7 +1407,7 @@ mod tests {
           runLoop()\n\
           output\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = "Outer 0 [Inner 0 Inner 1 ], Outer 1 [Inner 0 Inner 1 ], ";
         let expected = new_string_obj(expected);
         assert_eq!(expected, result);
@@ -1413,7 +1420,7 @@ mod tests {
           val ken = Person(name: \"Ken\")\n\
           ken.name\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Ken");
         assert_eq!(expected, result);
 
@@ -1423,7 +1430,7 @@ mod tests {
           val aBaby = Person(name: \"Baby\")\n\
           aBaby.age\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(0);
         assert_eq!(expected, result);
     }
@@ -1439,7 +1446,7 @@ mod tests {
             ("[1, 2, 3, 4].length", Value::Int(4)),
         ];
         for (input, expected) in tests.into_iter() {
-            let result = interpret(input).unwrap();
+            let result = interpret(input);
             assert_eq!(expected, result);
         }
     }
@@ -1452,7 +1459,7 @@ mod tests {
           val ken = Person()\n\
           ken.name?.value?.length\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Nil;
         assert_eq!(expected, result);
 
@@ -1463,7 +1470,7 @@ mod tests {
           val ken = Person(name: Name(value: \"Ken\"))\n\
           1 + (ken.name?.value?.length ?: 0)\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(4);
         assert_eq!(expected, result);
 
@@ -1472,7 +1479,7 @@ mod tests {
           type Person { name: Name? = None }\n\
           \"1\" + Person().name?.value?.length\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("1None");
         assert_eq!(expected, result);
 
@@ -1484,7 +1491,7 @@ mod tests {
             people[1]?.name?.length,\n\
           ]\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(1),
             Value::Nil
@@ -1499,7 +1506,7 @@ mod tests {
           val ken = Person()
           ken.name?.toLower()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Nil;
         assert_eq!(expected, result);
 
@@ -1508,7 +1515,7 @@ mod tests {
           val ken = Person(name: "Ken")
           ken.name?.toLower()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("ken");
         assert_eq!(expected, result);
 
@@ -1520,7 +1527,7 @@ mod tests {
           abc()
           arr
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::new_array_obj(vec![Value::Int(1), Value::Int(2)]),
             Value::new_array_obj(vec![Value::Int(3), Value::Int(4)]),
@@ -1535,7 +1542,7 @@ mod tests {
           abc()
           arr
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::new_array_obj(vec![Value::Int(1), Value::Int(2)]),
             Value::new_array_obj(vec![Value::Int(3), Value::Int(4), Value::Int(5)]),
@@ -1554,7 +1561,7 @@ mod tests {
           val brian = Person(name: \"Brian\")\n\
           ken.introduce() + \", and \" + brian.introduce()\n\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("I am Ken, and I am Brian");
         assert_eq!(expected, result);
     }
@@ -1570,7 +1577,7 @@ mod tests {
           val introduceFn = ken.introduce\n\
           introduceFn()\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("I am Ken");
         assert_eq!(expected, result);
     }
@@ -1585,7 +1592,7 @@ mod tests {
           val ken = Person(name: "Ken")
           Person.introduce(ken.name)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("I am Ken");
         assert_eq!(expected, result);
     }
@@ -1598,7 +1605,7 @@ mod tests {
           val p = Person(name: "Ken")
           p.toString()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Person(name: Ken)");
         assert_eq!(expected, result);
 
@@ -1611,7 +1618,7 @@ mod tests {
           val p = Person(name: "Ken")
           p.toString()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Ken");
         assert_eq!(expected, result);
 
@@ -1624,7 +1631,7 @@ mod tests {
           val p = Person(name: "Ken")
           [p].toString()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("[Ken]");
         assert_eq!(expected, result);
 
@@ -1638,7 +1645,7 @@ mod tests {
           p.name = "Meg"
           toString()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Person(name: Meg)");
         assert_eq!(expected, result);
     }
@@ -1678,7 +1685,7 @@ mod tests {
             Color.RGB(red: 128, green: 128, blue: 128)
           ].map(c => c.hex())
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             new_string_obj("0xff0000"),
             new_string_obj("0x00ff00"),
@@ -1704,7 +1711,7 @@ mod tests {
           }
           Color.Red.hexCode()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("0xff0000");
         assert_eq!(expected, result);
 
@@ -1722,7 +1729,7 @@ mod tests {
             Color.Darken2(Color.Blue), Color.Darken2(Color.Blue, 6.24),
           ].map(c => c.toString())
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             new_string_obj("Color.Darken(Color.Red, 10)"),
             new_string_obj("Color.Darken(Color.Blue, 10)"),
@@ -1743,7 +1750,7 @@ mod tests {
           val l = LL.Cons(1, LL.Cons(2, LL.Empty))
           l.toString()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("LL.Cons(1, LL.Cons(2, LL.Empty))");
         assert_eq!(expected, result);
     }
@@ -1759,7 +1766,7 @@ mod tests {
           }
           f2.toString()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("Foo.Bar(24, 6)");
         assert_eq!(expected, result);
     }
@@ -1791,7 +1798,7 @@ mod tests {
           val node = Node(value: \"a\", next: Node(value: \"b\", next: Node(value: \"c\")))\n\
           node.toString()\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("a, b, c");
         assert_eq!(expected, result);
     }
@@ -1846,7 +1853,7 @@ mod tests {
             .push("d")
             .toString()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = new_string_obj("a, b, c, d");
         assert_eq!(expected, result);
     }
@@ -1857,7 +1864,7 @@ mod tests {
           type List<T> {
             items: T[] = []
 
-            func push(self, item: T): Unit { self.items.push(item) }
+            func push(self, item: T) { self.items.push(item) }
 
             func map<U>(self, fn: (T) => U): U[] {
               val newArr: U[] = []
@@ -1891,7 +1898,7 @@ mod tests {
           })
           sum(nums)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(2497500);
         assert_eq!(expected, result);
     }
@@ -1902,7 +1909,7 @@ mod tests {
           func call(fn: (Int) => Int, value: Int): Int = fn(value)
           call(x => x + 1, 23)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
@@ -1910,7 +1917,7 @@ mod tests {
           func call(fn: (Int) => Int, value: Int): Int = fn(value)
           call((x, y = 1) => x + y + 1, 22)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
@@ -1920,7 +1927,7 @@ mod tests {
           }
           getAdder(20)(1)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
     }
@@ -1938,7 +1945,7 @@ mod tests {
           }\n\
           f()\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
@@ -1951,7 +1958,7 @@ mod tests {
           }\n\
           f()\
         ";
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
     }
@@ -1967,7 +1974,7 @@ mod tests {
           }
           r
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(1);
         assert_eq!(expected, result);
 
@@ -1979,7 +1986,7 @@ mod tests {
           }
           r
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(1);
         assert_eq!(expected, result);
 
@@ -1994,7 +2001,7 @@ mod tests {
           }
           r
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(3);
         assert_eq!(expected, result);
 
@@ -2008,7 +2015,7 @@ mod tests {
           }
           len(12340 + 5)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(5);
         assert_eq!(expected, result);
     }
@@ -2032,7 +2039,7 @@ mod tests {
           }
           abc()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(10);
         assert_eq!(expected, result);
     }
@@ -2062,7 +2069,7 @@ mod tests {
           }
           total
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(396);
         assert_eq!(expected, result);
     }
@@ -2081,7 +2088,7 @@ mod tests {
           val arr = [1, 2, 3, 4]
           contains(arr, 4)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
     }
@@ -2092,7 +2099,7 @@ mod tests {
           val (a, b, c) = (1, 2, 3)
           a + b + c
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(6);
         assert_eq!(expected, result);
 
@@ -2100,7 +2107,7 @@ mod tests {
           val ((a, b), c) = ((1, 2), (3, 4))
           a + b + c[0] + c[1]
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(10);
         assert_eq!(expected, result);
 
@@ -2108,7 +2115,7 @@ mod tests {
           val [(x1, y1), (x2, y2), (x3, y3)] = [(1, 2), (3, 4)]
           [x1, y1, x2, y2, x3, y3]
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![
             Value::Int(1),
             Value::Int(2),
@@ -2123,7 +2130,7 @@ mod tests {
           val [(x1, y1), *mid, (x2, y2)] = [(1, 2), (3, 4), (5, 6), (7, 8)]
           (x1, y1, mid, x2, y2)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_tuple_obj(vec![
             Value::Int(1),
             Value::Int(2),
@@ -2140,7 +2147,7 @@ mod tests {
           val [h1, h2, *mid, t1, t2, t3, t4, t5] = [1, 2, 3, 4, 5, 6]
           (h1, h2, mid, t1, t2, t3, t4, t5)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_tuple_obj(vec![
             Value::Int(1),
             Value::Int(2),
@@ -2157,7 +2164,7 @@ mod tests {
           val [head, *tail] = [1, 2, 3]
           tail
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_array_obj(vec![Value::Int(2), Value::Int(3)]);
         assert_eq!(expected, result);
 
@@ -2165,7 +2172,7 @@ mod tests {
           val [[a], [d], [g, *h]] = ["abc", "def", "ghi"]
           (a, d, g, h)
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::new_tuple_obj(vec![
             new_string_obj("a"),
             new_string_obj("d"),
@@ -2181,7 +2188,7 @@ mod tests {
           }
           wrapper()
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(10);
         assert_eq!(expected, result);
     }
@@ -2196,7 +2203,7 @@ mod tests {
           }
           total
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(24);
         assert_eq!(expected, result);
 
@@ -2208,7 +2215,7 @@ mod tests {
           }
           total
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(6);
         assert_eq!(expected, result);
     }
@@ -2225,7 +2232,7 @@ mod tests {
           }
           s
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(6);
         assert_eq!(expected, result);
     }
@@ -2239,7 +2246,7 @@ mod tests {
           } else { 0 }
           r
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(3);
         assert_eq!(expected, result);
 
@@ -2250,7 +2257,7 @@ mod tests {
           } else { 0 }
           r
         "#;
-        let result = interpret(input).unwrap();
+        let result = interpret(input);
         let expected = Value::Int(4);
         assert_eq!(expected, result);
     }
@@ -2266,7 +2273,7 @@ mod tests {
             (".person", "export type Person { name: String }"),
         ];
         let chunk = interpret_with_modules(mod1, modules);
-        assert_eq!(Some(new_string_obj("Ken")), chunk);
+        assert_eq!(new_string_obj("Ken"), chunk);
 
         // Importing enums
         let mod1 = r#"
@@ -2277,7 +2284,7 @@ mod tests {
             (".direction", "export enum Direction { Up, Down }"),
         ];
         let chunk = interpret_with_modules(mod1, modules);
-        assert_eq!(Some(new_string_obj("Direction.Up")), chunk);
+        assert_eq!(new_string_obj("Direction.Up"), chunk);
 
         // Importing bindings
         let mod1 = r#"
@@ -2288,7 +2295,7 @@ mod tests {
             (".constants", "export val x = 123"),
         ];
         let chunk = interpret_with_modules(mod1, modules);
-        assert_eq!(Some(Value::Int(127)), chunk);
+        assert_eq!(Value::Int(127), chunk);
     }
 
     #[test]
@@ -2310,7 +2317,7 @@ mod tests {
             new_string_obj("Ken"),
             new_string_obj("Meg"),
         ]);
-        assert_eq!(Some(expected), chunk);
+        assert_eq!(expected, chunk);
 
         // Bindings are scoped to modules
         let mod1 = r#"
@@ -2335,7 +2342,7 @@ mod tests {
             ]),
             Value::new_array_obj(vec![])
         ]);
-        assert_eq!(Some(expected), chunk);
+        assert_eq!(expected, chunk);
     }
 
     #[test]
@@ -2347,7 +2354,7 @@ mod tests {
           a + b
         "#);
         let expected = Value::Int(1);
-        assert_eq!(Some(expected), chunk);
+        assert_eq!(expected, chunk);
 
         let chunk = interpret(r#"
           val bools = [true, true, false, true]
@@ -2358,6 +2365,6 @@ mod tests {
           idx
         "#);
         let expected = Value::Int(2);
-        assert_eq!(Some(expected), chunk);
+        assert_eq!(expected, chunk);
     }
 }


### PR DESCRIPTION
- All functions now always return a value. Unit-returning functions will
return a `None` value implicitly, which will always be popped off at
runtime because an expression of type Unit is not assignable to any
variable. This may seem a bit wasteful, but it actually enables lots of
conveniences, like passing values to functions which expect `() =>
Unit`, but actually return some value, eg.
```
var count = 0
[1, 2, 3].forEach(i => count += i)
```
This lambda _returns_ the result of `count += i`, but that result is
popped when being evaluated.
- This also cleans up a lot of function return types internally, which
can now always deal in `Value` rather than `Option<Value>` (since
previously, a Unit-returning function would manifest as a `None`
internally), as well as tons of tests.
- This also adds the `Array#forEach` method, as a proof of concept of
this working correctly.