### PR TITLE
Writing array tests in native abra

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,5 +1,8 @@
-var count = 0
-[1, 2, 3].forEach(i => {
-  count += i
-})
-println(count)
+//val fn: () => Unit = () => {
+//  val a = 4
+//}
+//
+//fn()
+
+val arr = [1, 2, 3]
+arr[-4] = 4

--- a/abra_core/abra_test/array_test.abra
+++ b/abra_core/abra_test/array_test.abra
@@ -1,6 +1,177 @@
 import * from test
 
 describe("Array", () => {
+  // Fields
+  describe(".length", () => {
+    it("should return 0 if the array is empty", () => {
+      val arr: Int[] = []
+      expect(arr.length).toEqual(0)
+    })
+
+    it("should return 1 if the array has 1 item", () => {
+      val arr = [1]
+      expect(arr.length).toEqual(1)
+    })
+  })
+
+  // Static methods
+  describe("::fill", () => {
+    it("should return an empty if given length is 0", () => {
+      val arr = Array.fill(0, "hello")
+      expect(arr.length).toEqual(0)
+      expect(arr).toEqual([])
+    })
+
+    it("should return an array of length N, filled with given items", () => {
+      val arr = Array.fill(5, 0)
+      expect(arr.length).toEqual(5)
+      expect(arr).toEqual([0, 0, 0, 0, 0])
+    })
+
+    it("should fill by reference", () => {
+      val v = [1]
+      val arr = Array.fill(3, v)
+      expect(arr.length).toEqual(3)
+      expect(arr).toEqual([[1], [1], [1]])
+
+      v.push(2)
+      expect(arr).toEqual([[1, 2], [1, 2], [1, 2]])
+    })
+  })
+
+  describe("::fillBy", () => {
+    it("should return an empty if given length is 0", () => {
+      val arr = Array.fillBy(0, _ => "hello")
+      expect(arr.length).toEqual(0)
+      expect(arr).toEqual([])
+    })
+
+    it("should return an array of length N, filled the result of the lambda", () => {
+      val arr = Array.fillBy(5, i => i + 1)
+      expect(arr.length).toEqual(5)
+      expect(arr).toEqual([1, 2, 3, 4, 5])
+    })
+
+    it("should call the function N times", () => {
+      var count = 0
+      val arr = Array.fillBy(3, i => {
+        count += 1
+        i
+      })
+      expect(arr.length).toEqual(3)
+      expect(arr).toEqual([0, 1, 2])
+      expect(count).toEqual(3)
+    })
+  })
+
+  // Operators
+  describe("[]", () => {
+    it("should return the value at index", () => {
+      expect([1, 2, 3][0]).toEqual(1)
+      expect([1, 2, 3][1]).toEqual(2)
+      expect([1, 2, 3][2]).toEqual(3)
+    })
+
+    it("should return the value at negative index", () => {
+      expect([1, 2, 3][-1]).toEqual(3)
+      expect([1, 2, 3][-2]).toEqual(2)
+      expect([1, 2, 3][-3]).toEqual(1)
+    })
+
+    it("should return None if no value exists at index", () => {
+      expect([1, 2, 3][5]).toEqual(None)
+      expect([1, 2, 3][-4]).toEqual(None)
+    })
+  })
+
+  describe("[]=", () => {
+    it("should set the value of self at index to given value", () => {
+      val arr = [1, 2, 3]
+      arr[0] = 4
+      expect(arr).toEqual([4, 2, 3])
+    })
+
+    it("should set the value of self at negative index (within bounds) to given value", () => {
+      val arr = [1, 2, 3]
+      arr[-1] = 4
+      expect(arr).toEqual([1, 2, 4])
+    
+      arr[-2] = 3
+      expect(arr).toEqual([1, 3, 4])
+    
+      arr[-3] = 2
+      expect(arr).toEqual([2, 3, 4])
+    })
+    
+    it("should do nothing if index < -self.length", () => {
+      val arr = [1, 2, 3]
+      arr[-4] = 4
+      expect(arr).toEqual([1, 2, 3])
+    })
+
+    it("should grow array and pad with None values if index is outside range", () => {
+      val arr: Int[] = []
+      arr[2] = 3
+      expect(arr[0]).toEqual(None)
+      expect(arr[1]).toEqual(None)
+      expect(arr[2]).toEqual(3)
+    })
+  })
+
+  describe("[:]", () => {
+    it("should return a sub-array from start (inclusive) to end (exclusive)", () => {
+      val arr = ["a", "b", "c", "d", "e", "f", "g"]
+      expect(arr[1:4]).toEqual(["b", "c", "d"])
+      expect(arr[1:-3]).toEqual(["b", "c", "d"])
+    })
+
+    it("should return a sub-array from 0 to end (exclusive)", () => {
+      val arr = ["a", "b", "c", "d", "e", "f", "g"]
+      expect(arr[:4]).toEqual(["a", "b", "c", "d"])
+      expect(arr[:-3]).toEqual(["a", "b", "c", "d"])
+    })
+
+    it("should return a sub-array from start (inclusive) to self.length (exclusive)", () => {
+      val arr = ["a", "b", "c", "d", "e", "f", "g"]
+      expect(arr[3:]).toEqual(["d", "e", "f", "g"])
+      expect(arr[-2:]).toEqual(["f", "g"])
+    })
+  })
+
+  // Instance methods
+  describe("#toString", () => {
+    it("should return a stringified empty array if self is empty", () => {
+      expect([].toString()).toEqual("[]")
+    })
+
+    it("should return a stringified array", () => {
+      expect([1, 2, 3].toString()).toEqual("[1, 2, 3]")
+      // TODO: #302
+      // expect(["a", "b", "c"].toString()).toEqual("[\"a\", \"b\", \"c\"]")
+    })
+  })
+
+  describe("#isEmpty", () => {
+    it("should return true if self has 0 items", () => {
+      expect([].isEmpty()).toEqual(true)
+    })
+
+    it("should return false if self has items", () => {
+      expect([1].isEmpty()).toEqual(false)
+    })
+  })
+
+  describe("#enumerate", () => {
+    it("should return an empty array if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.enumerate()).toEqual([])
+    })
+
+    it("should return an array of tuples, of the form (item, index)", () => {
+      expect(["a", "b", "c"].enumerate()).toEqual([("a", 0), ("b", 1), ("c", 2)])
+    })
+  })
+
   describe("#push", () => {
     it("should increment .length", () => {
       val arr = [1, 2, 3]
@@ -13,7 +184,527 @@ describe("Array", () => {
     it("should insert the item as the last item", () => {
       val arr = [1, 2, 3]
       arr.push(4)
-      expect(arr[-1]).toEqual(4)
+      expect(arr).toEqual([1, 2, 3, 4])
+    })
+  })
+
+  describe("#pop", () => {
+    it("should decrement .length", () => {
+      val arr = [1, 2, 3]
+      expect(arr.length).toEqual(3)
+
+      arr.pop()
+      expect(arr.length).toEqual(2)
+    })
+
+    it("should remove the last item from self", () => {
+      val arr = [1, 2, 3]
+      arr.pop()
+      expect(arr).toEqual([1, 2])
+    })
+
+    it("should return None, if the array is empty", () => {
+      val arr: Int[] = []
+      val i = arr.pop()
+      expect(i).toEqual(None)
+    })
+  })
+
+  describe("#popFront", () => {
+    it("should decrement .length", () => {
+      val arr = [1, 2, 3]
+      expect(arr.length).toEqual(3)
+
+      arr.popFront()
+      expect(arr.length).toEqual(2)
+    })
+
+    it("should remove the first item from self", () => {
+      val arr = [1, 2, 3]
+      arr.popFront()
+      expect(arr).toEqual([2, 3])
+    })
+
+    it("should return None, if the array is empty", () => {
+      val arr: Int[] = []
+      val i = arr.popFront()
+      expect(i).toEqual(None)
+    })
+  })
+
+  describe("#splitAt", () => {
+    it("should return a tuple of 2 arrays, splitting self at index", () => {
+      val arr = [1, 2, 3, 4, 5]
+      expect(arr.splitAt(1)).toEqual(([1], [2, 3, 4, 5]))
+    })
+
+    it("should return ([], self) if index is 0", () => {
+      val arr = [1, 2, 3, 4, 5]
+      val (s1, s2) = arr.splitAt(0)
+      expect(s1).toEqual([])
+      expect(s2).toEqual(arr)
+    })
+
+    it("should return (self, []) if index is self.length - 1", () => {
+      val arr = [1, 2, 3, 4, 5]
+      val (r1, r2) = arr.splitAt(5)
+      expect(r1).toEqual([1, 2, 3, 4, 5])
+      expect(r2).toEqual([])
+    })
+
+    it("should handle when index < 0", () => {
+      expect([1, 2, 3, 4, 5].splitAt(-1)).toEqual(([1, 2, 3, 4], [5]))
+      expect([1, 2, 3, 4, 5].splitAt(-2)).toEqual(([1, 2, 3], [4, 5]))
+      expect([1, 2, 3, 4, 5].splitAt(-3)).toEqual(([1, 2], [3, 4, 5]))
+      expect([1, 2, 3, 4, 5].splitAt(-4)).toEqual(([1], [2, 3, 4, 5]))
+    })
+
+    it("should handle when index <= self.length", () => {
+      val (a1, a2) = [1, 2, 3, 4, 5].splitAt(-5)
+      expect(a1).toEqual([])
+      expect(a2).toEqual([1, 2, 3, 4, 5])
+
+      val (b1, b2) = [1, 2, 3, 4, 5].splitAt(-6)
+      expect(b1).toEqual([])
+      expect(b2).toEqual([1, 2, 3, 4, 5])
+
+      val (c1, c2) = [1, 2, 3, 4, 5].splitAt(-7)
+      expect(c1).toEqual([])
+      expect(c2).toEqual([1, 2, 3, 4, 5])
+    })
+
+    it("should handle when index >= self.length", () => {
+      val (a1, a2) = [1, 2, 3, 4, 5].splitAt(5)
+      expect(a1).toEqual([1, 2, 3, 4, 5])
+      expect(a2).toEqual([])
+
+      val (b1, b2) = [1, 2, 3, 4, 5].splitAt(6)
+      expect(b1).toEqual([1, 2, 3, 4, 5])
+      expect(b2).toEqual([])
+
+      val (c1, c2) = [1, 2, 3, 4, 5].splitAt(7)
+      expect(c1).toEqual([1, 2, 3, 4, 5])
+      expect(c2).toEqual([])
+    })
+  })
+
+  describe("#concat", () => {
+    it("should return a new array, with argument appended to self", () => {
+      val arr = [1, 2, 3]
+      expect(arr.concat([4, 5, 6])).toEqual([1, 2, 3, 4, 5, 6])
+    })
+
+    it("should not modify self", () => {
+      val arr = [1, 2, 3]
+      arr.concat([4, 5, 6])
+      expect(arr).toEqual([1, 2, 3])
+    })
+  })
+
+  describe("#map", () => {
+    it("should return an empty array if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.map(i => i + 1)).toEqual([])
+    })
+
+    it("should return an array with fn applied to each element of self", () => {
+      val arr = [1, 2, 3]
+      expect(arr.map(i => i + 1)).toEqual([2, 3, 4])
+    })
+  })
+
+  describe("#filter", () => {
+    it("should return an empty array if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.filter(i => i > 1)).toEqual([])
+    })
+
+    it("should return an empty array if predicate never returns true", () => {
+      val arr = [1, 2, 3]
+      expect(arr.filter(i => i == 0)).toEqual([])
+    })
+
+    it("should return an array containing items of self where the predicate is true", () => {
+      val arr = [1, 2, 3]
+      expect(arr.filter(i => i > 1)).toEqual([2, 3])
+    })
+  })
+
+  describe("#reduce", () => {
+    it("should return the initial value if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.reduce(17, (acc, i) => acc + i)).toEqual(17)
+    })
+
+    it("should return accumulated result of applying fn to each item of self", () => {
+      val arr = [1, 2, 3]
+      expect(arr.reduce(18, (acc, i) => acc + i)).toEqual(24)
+    })
+
+    it("should return accumulated result of applying fn to each item of self", () => {
+      val arr = ["a", "b", "c"]
+      expect(arr.reduce("", (acc, n) => acc + n)).toEqual("abc")
+    })
+  })
+
+  describe("#forEach", () => {
+    it("should call the function for each item in self", () => {
+      var str = ""
+      ["a", "b", "c"].forEach(ch => str += ch)
+      expect(str).toEqual("abc")
+    })
+
+    it("should not call the function if self is empty", () => {
+      var called = false
+      val arr: Int[] = []
+      arr.forEach(_ => called = true)
+      expect(called).toEqual(false)
+    })
+  })
+
+  describe("#join", () => {
+    it("should return a string with self's items interleaved with joiner", () => {
+      val str = ["a", "b", "c"].join(",")
+      expect(str).toEqual("a,b,c")
+    })
+
+    it("should return an empty string if self is empty", () => {
+      val str = [].join("|")
+      expect(str).toEqual("")
+    })
+
+    it("should call `toString` on each item in self", () => {
+      val str = [(1, 2), (3, 4), (5, 6)].join(", ")
+      expect(str).toEqual("(1, 2), (3, 4), (5, 6)")
+    })
+  })
+
+  describe("#contains", () => {
+    it("should return true if self contains the item", () => {
+      expect(["a", "b", "c"].contains("b")).toEqual(true)
+    })
+
+    it("should return false if self doesn't contain the item", () => {
+      expect(["a", "b", "c"].contains("e")).toEqual(false)
+    })
+
+    it("should return false if self is empty", () => {
+      expect([].contains("e")).toEqual(false)
+    })
+  })
+
+  describe("#find", () => {
+    it("should return None if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.find(i => i == "e")).toEqual(None)
+    })
+
+    it("should return None if predicate returns false for all items in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.find(i => false)).toEqual(None)
+    })
+
+    it("should return None if predicate returns None for all items in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.find(i => None)).toEqual(None)
+    })
+
+    it("should return the first item in self for which the predicate returns true", () => {
+      val arr = [("a", 1), ("b", 2), ("a", 3)]
+      expect(arr.find(p => p[0] == "a")).toEqual(("a", 1))
+    })
+
+    it("should return the first item in self for which the predicate returns non-None", () => {
+      val arr = [("a", 1), ("b", 2), ("a", 3)]
+      expect(arr.find(p => p[0])).toEqual(("a", 1))
+    })
+  })
+
+  describe("#findIndex", () => {
+    it("should return None if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.findIndex(i => i == "e")).toEqual(None)
+    })
+
+    it("should return None if predicate returns false for all items in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.findIndex(i => false)).toEqual(None)
+    })
+
+    it("should return None if predicate returns None for all items in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.findIndex(i => None)).toEqual(None)
+    })
+
+    it("should return the first item + index in self for which the predicate returns true", () => {
+      val arr = [("a", 1), ("b", 2), ("a", 3)]
+      expect(arr.findIndex(p => p[0] == "a")).toEqual((("a", 1), 0))
+    })
+
+    it("should return the first item + index in self for which the predicate returns non-None", () => {
+      val arr = [("a", 1), ("b", 2), ("a", 3)]
+      expect(arr.findIndex(p => p[0])).toEqual((("a", 1), 0))
+    })
+  })
+
+  describe("#any", () => {
+    it("should return false if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.any(_ => false)).toEqual(false)
+    })
+    
+    it("should return false if predicate returns false for each item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.any(i => false)).toEqual(false)
+    })
+
+    it("should return false if predicate returns None for each item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.any(i => None)).toEqual(false)
+    })
+
+    it("should return true if predicate returns true for one item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.any(i => i > 3)).toEqual(true)
+    })
+
+    it("should return true if predicate returns non-None for one item in self", () => {
+      val arr = [[1, 2], [3, 4]]
+      expect(arr.any(i => i[0])).toEqual(true)
+    })
+  })
+
+  describe("#all", () => {
+    it("should return true if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.all(_ => false)).toEqual(true)
+    })
+
+    it("should return false if predicate returns false for at least 1 item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.all(i => i >= 2)).toEqual(false)
+    })
+
+    it("should return false if predicate returns None for each item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.all(i => None)).toEqual(false)
+    })
+
+    it("should return true if predicate returns true for each item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.all(i => i > 0)).toEqual(true)
+    })
+
+    it("should return true if predicate returns non-None for each item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.all(i => i)).toEqual(true)
+    })
+  })
+
+  describe("#none", () => {
+    it("should return true if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.none(_ => false)).toEqual(true)
+    })
+
+    it("should return false if predicate returns true for at least 1 item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.none(i => i >= 2)).toEqual(false)
+    })
+
+    it("should return false if predicate returns non-None for at least 1 item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.none(i => if i == 1 i else None)).toEqual(false)
+    })
+
+    it("should return true if predicate returns false for each item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.none(i => i < 0)).toEqual(true)
+    })
+
+    it("should return true if predicate returns None for each item in self", () => {
+      val arr = [1, 2, 3, 4]
+      expect(arr.none(i => None)).toEqual(true)
+    })
+  })
+
+  describe("#sortBy", () => {
+    it("should return a new array, sorted using the provided lambda", () => {
+      val arr = ["a", "ghij", "def", "bc"]
+      expect(arr.sortBy(w => w.length)).toEqual(["a", "bc", "def", "ghij"])
+    })
+
+    it("should return a new array, sorted in reverse using the provided lambda", () => {
+      val arr = ["a", "ghij", "def", "bc"]
+      val sorted = arr.sortBy(fn: w => w.length, reverse: true)
+      expect(sorted).toEqual(["ghij", "def", "bc", "a"])
+    })
+
+    it("should only call the lambda once for each item", () => {
+      var count = 0
+      ["a", "ghij", "def", "bc"].sortBy(w => {
+        count += 1
+        w.length
+      })
+      expect(count).toEqual(4)
+    })
+  })
+
+  describe("#dedupe", () => {
+    it("should return a new array, with duplicates removed", () => {
+      expect([1, 1, 2, 3, 2, 4].dedupe()).toEqual([1, 2, 3, 4])
+    })
+
+    it("should not modify self", () => {
+      val arr = [1, 1, 2, 3, 2, 4]
+      arr.dedupe()
+      expect(arr).toEqual([1, 1, 2, 3, 2, 4])
+    })
+  })
+
+  describe("#dedupeBy", () => {
+    it("should return a new array, with duplicates removed as determined by lambda", () => {
+      val arr = ["a", "bc", "de", "f"]
+      expect(arr.dedupeBy(w => w.length)).toEqual(["a", "bc"])
+    })
+
+    it("should only call the lambda once for each item", () => {
+      var count = 0
+      ["a", "bc", "de", "f"].dedupeBy(w => {
+        count += 1
+        w.length
+      })
+      expect(count).toEqual(4)
+    })
+  })
+
+  describe("#partition", () => {
+    it("should return an empty map if self is empty", () => {
+      val arr: Int[] = []
+      val expected: Map<Int, Int[]> = {}
+      expect(arr.partition(_ => 2)).toEqual(expected)
+    })
+
+    it("should return Map of arrays, for each unique return value of the lambda", () => {
+      val arr = ["apple", "bear", "acorn", "coffee"]
+      expect(arr.partition(w => w[0])).toEqual({
+        a: ["apple", "acorn"],
+        b: ["bear"],
+        c: ["coffee"],
+      })
+    })
+  })
+
+  describe("#tally", () => {
+    it("should return an empty map if self is empty", () => {
+      val arr: String[] = []
+      val expected: Map<String, Int> = {}
+      expect(arr.tally()).toEqual(expected)
+    })
+
+    it("should return a Map with counts of each item's occurrence in self, using default comparator", () => {
+      val arr = ["a", "a", "b", "a", "b", "c", "b"]
+      expect(arr.tally()).toEqual({ a: 3, b: 3, c: 1 })
+    })
+  })
+
+  describe("#tallyBy", () => {
+    it("should return an empty Map if self is empty", () => {
+      val arr: String[] = []
+      val expected: Map<Int, Int> = {}
+      expect(arr.tallyBy(_ => 3)).toEqual(expected)
+    })
+
+    it("should return a Map with counts of each item's occurrence in self, using lambda to compare", () => {
+      val arr = [(0, 1), (0, 2), (1, 1), (1, 2), (2, 2)]
+      val expected = Map.fromPairs([(0, 2), (1, 2), (2, 1)])
+      expect(arr.tallyBy(coord => coord[0])).toEqual(expected)
+    })
+  })
+
+  describe("#asSet", () => {
+    it("should return an empty Set if self is empty", () => {
+      val arr: String[] = []
+      val expected: Set<String> = #{}
+      expect(arr.asSet()).toEqual(expected)
+    })
+
+    it("should return a Set containing (deduped) members of self", () => {
+      val arr = ["a", "b", "a", "c"]
+      expect(arr.asSet()).toEqual(#{"a", "b", "c"})
+    })
+  })
+
+  describe("#getOrDefault", () => {
+    it("should return default value if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.getOrDefault(0, 123)).toEqual(123)
+    })
+
+    it("should return item at index if item exists", () => {
+      expect([1, 2, 3].getOrDefault(0, 123)).toEqual(1)
+    })
+
+    it("should return default if no item exists at index in self", () => {
+      expect([1, 2, 3].getOrDefault(7, 123)).toEqual(123)
+    })
+  })
+
+  describe("#getOrElse", () => {
+    it("should return default value from lambda if self is empty", () => {
+      val arr: Int[] = []
+      expect(arr.getOrElse(0, () => 123)).toEqual(123)
+    })
+
+    it("should return item at index if item exists", () => {
+      expect([1, 2, 3].getOrElse(0, () => 123)).toEqual(1)
+    })
+
+    it("should return default if no item exists at index in self", () => {
+      expect([1, 2, 3].getOrElse(7, () => 123)).toEqual(123)
+    })
+
+    it("should only call the lambda if no item exists at index in self", () => {
+      var called = false
+      [1, 2, 3].getOrElse(0, () => {
+        called = true
+        123
+      })
+      expect(called).toEqual(false)
+
+      called = false
+      [1, 2, 3].getOrElse(6, () => {
+        called = true
+        123
+      })
+      expect(called).toEqual(true)
+    })
+  })
+
+  describe("#update", () => {
+    it("should set the item at index in self to the return of lambda", () => {
+      val arr = ["a", "b", "c"]
+      arr.update(0, ch => ch.toUpper())
+      expect(arr).toEqual(["A", "b", "c"])
+    })
+
+    it("should not modify self if no value at index", () => {
+      val arr = ["a", "b", "c"]
+      arr.update(6, ch => ch.toUpper())
+      expect(arr).toEqual(["a", "b", "c"])
+
+      arr.update(-2, ch => ch.toUpper())
+      expect(arr).toEqual(["a", "b", "c"])
+    })
+
+    it("should not call the lambda if no value at index", () => {
+      var called = false
+      val arr = ["a", "b", "c"]
+      arr.update(6, ch => {
+        called = true
+        ch.toUpper()
+      })
+      expect(called).toEqual(false)
     })
   })
 })

--- a/abra_lsp/src/utils.rs
+++ b/abra_lsp/src/utils.rs
@@ -7,7 +7,19 @@ pub fn abra_error_to_diagnostic(e: abra_core::Error, source: &String) -> Diagnos
         abra_core::Error::LexerError(e) => e.get_range(),
         abra_core::Error::TypecheckerError(e) => e.get_token().get_range(),
         abra_core::Error::ParseError(e) => match e {
-            ParseError::UnexpectedEof => unimplemented!(),
+            ParseError::UnexpectedEof => {
+                // TODO: Fix janky implementation
+                let range = Range {
+                    start: Position { line: u64::max_value(), character: u64::max_value() },
+                    end: Position { line: u64::max_value(), character: u64::max_value() },
+                };
+                return Diagnostic {
+                    severity: Some(DiagnosticSeverity::Error),
+                    range,
+                    message: e.get_message(&source),
+                    ..Diagnostic::default()
+                };
+            },
             ParseError::UnexpectedToken(tok) |
             ParseError::ExpectedToken(_, tok) => tok.get_range()
         }


### PR DESCRIPTION
Contributes to #303 

- Fully flesh out the `array_test.abra` test suite with unit tests for
every field, operator, static method, and instance method for arrays.
- To support this, I found a bug related to the previous change; when a
`return` statement is used in a Unit-returning function, we need to
manually push a `Value::Nil` onto the stack so it'll be returned. Also,
let's just go ahead and make sure that Unit-returning lambdas _also_
work correctly.
- Add temporary code to the LSP module to get
`ParseError::UnexpectedEof` to work; this should be fixed in a future
changeset.