### PR TITLE
Displaying file name in error messages

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,6 +1,3 @@
-val arr = [1, 2, 3]
-var count = 0
-for item, i in arr {
-  count += if item == 2 { continue } else 1
-}
-count
+import a from .example2
+
+println("$a \uwer")

--- a/abra_cli/abra-files/example2.abra
+++ b/abra_cli/abra-files/example2.abra
@@ -1,3 +1,1 @@
-export type Person { name: String }
-
-export val ken = Person(name: "Ken")
+export val a = "abc "//\qwer"

--- a/abra_cli/src/fs_module_reader.rs
+++ b/abra_cli/src/fs_module_reader.rs
@@ -5,7 +5,7 @@ use abra_core::module_loader::ModuleReader;
 
 #[derive(Debug)]
 pub struct FsModuleReader {
-    project_root: PathBuf,
+    pub(crate) project_root: PathBuf,
 }
 
 impl FsModuleReader {
@@ -16,7 +16,7 @@ impl FsModuleReader {
 
 impl ModuleReader for FsModuleReader {
     fn read_module(&mut self, module_id: &ModuleId) -> Option<String> {
-        let file_path = self.project_root.join(&module_id.get_path("abra"));
+        let file_path = module_id.get_path(Some(&self.project_root));
         match std::fs::read_to_string(file_path) {
             Ok(contents) => Some(contents),
             Err(_) => None

--- a/abra_core/src/common/display_error.rs
+++ b/abra_core/src/common/display_error.rs
@@ -25,10 +25,10 @@ pub trait DisplayError {
         format!("{}|{}{}\n{}", indent, indent, line, underline)
     }
 
-    fn get_message(&self, source: &String) -> String {
+    fn get_message(&self, file_name: &String, source: &String) -> String {
         let lines: Vec<&str> = source.split("\n").collect();
-        self.message_for_error(&lines)
+        self.message_for_error(file_name, &lines)
     }
 
-    fn message_for_error(&self, lines: &Vec<&str>) -> String;
+    fn message_for_error(&self, file_name: &String, lines: &Vec<&str>) -> String;
 }

--- a/abra_core/src/parser/parse_error.rs
+++ b/abra_core/src/parser/parse_error.rs
@@ -1,24 +1,34 @@
 use std::str::FromStr;
 use crate::lexer::tokens::{Token, TokenType, Position, Range};
 use crate::common::display_error::{DisplayError, IND_AMT};
+use crate::parser::ast::ModuleId;
 
 #[derive(Debug, PartialEq)]
-pub enum ParseError {
+pub enum ParseErrorKind {
     UnexpectedEof(Range),
     UnexpectedToken(Token),
     ExpectedToken(TokenType, Token),
 }
 
+#[derive(Debug, PartialEq)]
+pub struct ParseError {
+    pub module_id: ModuleId,
+    pub kind: ParseErrorKind,
+}
+
 impl DisplayError for ParseError {
-    fn message_for_error(&self, lines: &Vec<&str>) -> String {
-        match self {
-            ParseError::UnexpectedToken(token) => {
+    fn message_for_error(&self, file_name: &String, lines: &Vec<&str>) -> String {
+        match &self.kind {
+            ParseErrorKind::UnexpectedToken(token) => {
                 let pos = token.get_position();
                 let message = Self::get_underlined_line(lines, token);
 
-                format!("Unexpected token '{}' ({}:{})\n{}", token.to_string(), pos.line, pos.col, message)
+                format!(
+                    "Error at {}:{}:{}\nUnexpected token '{}'\n{}",
+                    file_name, pos.line, pos.col, token.to_string(), message
+                )
             }
-            ParseError::UnexpectedEof(range) => {
+            ParseErrorKind::UnexpectedEof(range) => {
                 let Position { line, col } = range.end;
                 let last_line = lines.get(line - 1).expect("There should be a last line");
 
@@ -26,16 +36,22 @@ impl DisplayError for ParseError {
                 let indent = Self::indent();
                 let message = format!("{}|{}{}\n{}", indent, indent, last_line, cursor);
 
-                format!("Unexpected end of file ({}:{})\n{}", line, col, message)
+                format!(
+                    "Error at {}:{}:{}\nUnexpected end of file\n{}",
+                    file_name, line, col, message
+                )
             }
-            ParseError::ExpectedToken(expected, actual) => {
+            ParseErrorKind::ExpectedToken(expected, actual) => {
                 let pos = actual.get_position();
                 let message = Self::get_underlined_line(lines, actual);
 
                 // Convert from TokenType to Token, to make use of the #[strum(to_string)] meta,
                 // since strum doesn't apply the #[strum(to_string)] to the discriminants.
                 let expected: Token = Token::from_str(&expected.to_string()).unwrap();
-                format!("Expected token '{}', saw '{}' ({}:{})\n{}", expected.to_string(), actual.to_string(), pos.line, pos.col, message)
+                format!(
+                    "Error at {}:{}:{}\nExpected token '{}', saw '{}'\n{}",
+                    file_name, pos.line, pos.col, expected.to_string(), actual.to_string(), message
+                )
             }
         }
     }
@@ -43,47 +59,55 @@ impl DisplayError for ParseError {
 
 #[cfg(test)]
 mod tests {
-    use super::ParseError;
+    use super::ParseErrorKind;
     use crate::lexer::tokens::{Token, TokenType, Position, Range};
     use crate::common::display_error::DisplayError;
+    use crate::parser::ast::ModuleId;
+    use crate::parser::parse_error::ParseError;
 
     #[test]
     fn test_unexpected_token_error() {
+        let module_id = ModuleId::from_name("test");
         let src = "-+".to_string();
         let token = Token::Plus(Position::new(1, 2));
-        let err = ParseError::UnexpectedToken(token);
+        let err = ParseError { module_id, kind: ParseErrorKind::UnexpectedToken(token) };
 
         let expected = format!("\
-Unexpected token '+' (1:2)
+Error at /tests/test.abra:1:2
+Unexpected token '+'
   |  -+
       ^");
-        assert_eq!(expected, err.get_message(&src));
+        assert_eq!(expected, err.get_message(&"/tests/test.abra".to_string(), &src));
     }
 
     #[test]
     fn test_expected_token_error() {
+        let module_id = ModuleId::from_name("test");
         let src = "val a: = 123".to_string();
-        let err = ParseError::ExpectedToken(
-            TokenType::Ident,
-            Token::Assign(Position::new(1, 8)),
-        );
+        let err = ParseError {
+            module_id,
+            kind: ParseErrorKind::ExpectedToken(TokenType::Ident, Token::Assign(Position::new(1, 8))),
+        };
 
         let expected = format!("\
-Expected token 'identifier', saw '=' (1:8)
+Error at /tests/test.abra:1:8
+Expected token 'identifier', saw '='
   |  val a: = 123
             ^");
-        assert_eq!(expected, err.get_message(&src));
+        assert_eq!(expected, err.get_message(&"/tests/test.abra".to_string(), &src));
     }
 
     #[test]
     fn test_unexpected_eof_error() {
+        let module_id = ModuleId::from_name("test");
         let src = "-".to_string();
-        let err = ParseError::UnexpectedEof(Range::with_length(&Position::new(1, 1), 1));
+        let err = ParseError { module_id, kind: ParseErrorKind::UnexpectedEof(Range::with_length(&Position::new(1, 1), 1)) };
 
         let expected = format!("\
-Unexpected end of file (1:2)
+Error at /tests/test.abra:1:2
+Unexpected end of file
   |  -
       ^");
-        assert_eq!(expected, err.get_message(&src));
+        assert_eq!(expected, err.get_message(&"/tests/test.abra".to_string(), &src));
     }
 }

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -458,7 +458,7 @@ impl Type {
                 }
                 Type::Union(opts)
             }
-            t @ _ => t.clone(),
+            t => t.clone(),
         }
     }
 
@@ -518,7 +518,7 @@ impl Type {
                 let target_opts = target_opts.into_iter().map(|t| t.clone()).collect::<HashSet<Type>>();
                 let opts = match t {
                     Type::Union(opts) => opts.clone(),
-                    t @ _ => vec![t.clone()]
+                    t => vec![t.clone()]
                 }.into_iter().collect::<HashSet<Type>>();
                 let possibilities = opts.difference(&target_opts).map(|t| t.clone()).collect::<Vec<_>>();
                 let typ = if possibilities.is_empty() {
@@ -605,14 +605,15 @@ mod test {
     use crate::typechecker::types::Type::*;
     use crate::parser::parser::{parse, ParseResult};
     use crate::lexer::lexer::tokenize;
-    use crate::parser::ast::{AstNode, BindingDeclNode};
+    use crate::parser::ast::{AstNode, BindingDeclNode, ModuleId};
     use super::*;
 
     fn parse_type_ident_with_types<S: Into<std::string::String>>(input: S, base_types: &HashMap<std::string::String, super::Type>) -> super::Type {
         let type_ident: std::string::String = input.into();
         let val_stmt = format!("val a: {}", type_ident);
-        let tokens = tokenize(&val_stmt).unwrap();
-        let ParseResult { nodes, .. } = parse(tokens).unwrap();
+        let module_id = ModuleId::from_name("test");
+        let tokens = tokenize(&module_id, &val_stmt).unwrap();
+        let ParseResult { nodes, .. } = parse(module_id, tokens).unwrap();
         match nodes.first().unwrap() {
             AstNode::BindingDecl(_, BindingDeclNode { type_ann: Some(type_ann), .. }) => {
                 super::Type::from_type_ident(&type_ann, base_types).unwrap()

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -1764,7 +1764,7 @@ impl<'a, R: ModuleReader> TypedAstVisitor<(), ()> for Compiler<'a, R> {
                             if *is_opt_safe { next = target } else { break; }
                         }
                     }
-                    node @ _ => break unwound_path.push(node)
+                    node => break unwound_path.push(node)
                 }
             }
 

--- a/abra_wasm/js-tests/__tests__/abra-errors.test.ts
+++ b/abra_wasm/js-tests/__tests__/abra-errors.test.ts
@@ -20,7 +20,7 @@ describe('errors', () => {
                         end: [1, 6]
                     }
                 },
-                errorMessage: `Expected token 'identifier', saw 'int' (1:6)
+                errorMessage: `Error at repl.abra:1:6\nExpected token 'identifier', saw 'int'
   |  func 1
           ^`
             }

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -120,7 +120,7 @@ impl Serialize for RunResult {
             Err(error) => {
                 obj.serialize_entry("success", &false)?;
                 obj.serialize_entry("error", &JsWrappedError(&error, &self.1))?;
-                obj.serialize_entry("errorMessage", &error.get_message(&self.1))?;
+                obj.serialize_entry("errorMessage", &error.get_message(&error.module_id().get_path::<&str>(None), &self.1))?;
             }
         };
 
@@ -146,7 +146,7 @@ impl Serialize for TypecheckedResult {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("success", &false)?;
                 obj.serialize_entry("error", &JsWrappedError(error, &self.1))?;
-                obj.serialize_entry("errorMessage", &error.get_message(&self.1))?;
+                obj.serialize_entry("errorMessage", &error.get_message(&"_file".to_string(), &self.1))?;
                 obj.end()
             }
         }
@@ -172,7 +172,7 @@ impl Serialize for DisassembleResult {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("success", &false)?;
                 obj.serialize_entry("error", &JsWrappedError(error, &self.1))?;
-                obj.serialize_entry("errorMessage", &error.get_message(&self.1))?;
+                obj.serialize_entry("errorMessage", &error.get_message(&"_file".to_string(), &self.1))?;
                 obj.end()
             }
         }

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -146,7 +146,9 @@ impl Serialize for TypecheckedResult {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("success", &false)?;
                 obj.serialize_entry("error", &JsWrappedError(error, &self.1))?;
-                obj.serialize_entry("errorMessage", &error.get_message(&"_file".to_string(), &self.1))?;
+
+                let file_name = error.module_id().get_path::<&str>(None);
+                obj.serialize_entry("errorMessage", &error.get_message(&file_name, &self.1))?;
                 obj.end()
             }
         }
@@ -172,7 +174,9 @@ impl Serialize for DisassembleResult {
                 let mut obj = serializer.serialize_map(Some(2))?;
                 obj.serialize_entry("success", &false)?;
                 obj.serialize_entry("error", &JsWrappedError(error, &self.1))?;
-                obj.serialize_entry("errorMessage", &error.get_message(&"_file".to_string(), &self.1))?;
+
+                let file_name = error.module_id().get_path::<&str>(None);
+                obj.serialize_entry("errorMessage", &error.get_message(&file_name, &self.1))?;
                 obj.end()
             }
         }


### PR DESCRIPTION
- Display file name in all error messages.
- Refactor lexer, parser, and typechecker to include the `module_id` in
the error message; this will be used later on to resolve the file name.

- Quick cleanup: change instances of `t @ _ =>` to just `t =>` in match
expressions