### PR TITLE
Allow special statements as block exprs

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,11 +1,14 @@
-val map = {
-  //"foo-bar": "bar",
-  //(1 + "2"): "baz",
-  //(1 + "2"): "baz",
-  ("foo" + "bar"): "bar",
-  ("foo" + "bar"): "bar",
-  foo: "baz",
-  foo: "qux",
-}
+func foo(): String {
+  if true return "asdf"
+  else match None {
+    None => return "zxcv"
+    _ => {
+      while true {
+        if true break
+        else continue
+      }
 
-println(map)
+      "qwer"
+    }
+  }
+}

--- a/abra_core/src/parser/parser.rs
+++ b/abra_core/src/parser/parser.rs
@@ -675,6 +675,9 @@ impl Parser {
                     }
                 }
             }
+            Some(Token::Return(_, _)) |
+            Some(Token::Break(_)) |
+            Some(Token::Continue(_)) => Ok(vec![self.parse_stmt(None)?]),
             _ => Ok(vec![self.parse_expr()?])
         }
     }
@@ -3832,6 +3835,14 @@ mod tests {
             },
         );
         assert_eq!(expected, ast[0]);
+
+        // Test block with special expressions
+        let res = parse("if true return 123");
+        assert!(res.is_ok());
+        let res = parse("if true break");
+        assert!(res.is_ok());
+        let res = parse("if true continue");
+        assert!(res.is_ok());
 
         Ok(())
     }


### PR DESCRIPTION
- To simplify certain statements/expressions which make use of optional
expr/blocks, allow for `return`/`break`/`continue` to be used as an
expression