### PR TITLE
Large refactor of globals

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,14 +1,41 @@
-func foo(): String {
-  if true return "asdf"
-  else match None {
-    None => return "zxcv"
-    _ => {
-      while true {
-        if true break
-        else continue
-      }
+import b, Shirt, Size from .example2
+import Date from date
 
-      "qwer"
-    }
-  }
+val now = Date.now()
+now.addDays(1)
+now.addDays(1).addDays(1).toString()
+
+println(Size.Custom("foo"))
+
+val arr = Array.fill(10, 1)
+val two = 2
+arr.push(two)
+
+val [first, *_, last] = arr
+println(first, last, b)
+
+println(Date.now())
+
+val shirt = Shirt(color: "Blue", size: Size.M)
+println(shirt)
+
+val huh: Shirt | Date = shirt
+match huh {
+  Shirt => println("ok")
+  Date => println("huh?")
 }
+
+match shirt.size {
+  Size.S => println("small")
+  Size.M => println("medium")
+  Size.L => println("large")
+  Size.XL => println("xl")
+  Size.Custom(s) => println(s.toLower())
+}
+
+type Person {
+  name: String
+}
+
+val p = Person(name: "A")
+println(p)

--- a/abra_cli/abra-files/example2.abra
+++ b/abra_cli/abra-files/example2.abra
@@ -1,1 +1,10 @@
-export val a = "abc "//\qwer"
+val a = [1, 2, 3]
+
+export val b = a.toString()
+
+export enum Size { S, M, L, XL, Custom(size: String) }
+
+export type Shirt {
+  color: String
+  size: Size
+}

--- a/abra_core/src/builtins/common.rs
+++ b/abra_core/src/builtins/common.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 pub fn invoke_fn(vm: &mut VM, fn_obj: &Value, args: Vec<Value>) -> Value {
     let res = vm.invoke_fn(args, fn_obj.clone());
     match res {
-        Ok(v) => v,//.unwrap_or(Value::Nil),
+        Ok(v) => v,
         Err(e) => {
             eprintln!("Runtime error: {:?}", e);
             std::process::exit(1);
@@ -51,7 +51,6 @@ pub fn to_string(value: &Value, vm: &mut VM) -> String {
         Value::Int(val) => format!("{}", val),
         Value::Float(val) => format!("{}", val),
         Value::Bool(val) => format!("{}", val),
-        Value::Str(val) => val.clone(),
         Value::StringObj(o) => {
             let str = &*o.borrow()._inner;
             format!("{}", str)

--- a/abra_core/src/builtins/mod.rs
+++ b/abra_core/src/builtins/mod.rs
@@ -14,4 +14,4 @@ pub mod prelude;
 mod date;
 mod io;
 
-pub use native_modules::load_module;
+pub use native_modules::load_native_module;

--- a/abra_core/src/builtins/native_module_builder.rs
+++ b/abra_core/src/builtins/native_module_builder.rs
@@ -6,10 +6,11 @@ use crate::vm::compiler::Module;
 use crate::parser::ast::ModuleId;
 use std::collections::HashMap;
 
+#[derive(Debug)]
 pub struct ModuleSpec {
     pub(crate) typed_module: TypedModule,
     pub(crate) compiled_module: Module,
-    pub(crate) constant_indexes_by_ident: HashMap<String, usize>,
+    pub(crate) constant_names: Vec<String>,
 }
 
 #[derive(Default)]
@@ -27,16 +28,11 @@ impl ModuleSpecBuilder {
     }
 
     pub fn build(self) -> ModuleSpec {
-        let constant_indexes_by_ident = self.constant_names.into_iter()
-            .enumerate()
-            .map(|(idx, ident)| (ident, idx))
-            .collect();
-
         let module_id = ModuleId::from_name(self.name.as_str());
         ModuleSpec {
             typed_module: TypedModule { module_id, exports: self.exports, referencable_types: self.referencable_types, ..TypedModule::default() },
-            compiled_module: Module { name: self.name, constants: self.constants, code: vec![] },
-            constant_indexes_by_ident,
+            compiled_module: Module { name: self.name, is_native: true, num_globals: self.constants.len(), constants: self.constants,  code: vec![] },
+            constant_names: self.constant_names,
         }
     }
 

--- a/abra_core/src/builtins/native_modules.rs
+++ b/abra_core/src/builtins/native_modules.rs
@@ -1,7 +1,7 @@
 use crate::builtins::native_module_builder::ModuleSpec;
 use crate::builtins::{prelude, date, io};
 
-pub fn load_module(module_name: &str) -> Option<fn() -> ModuleSpec> {
+pub fn load_native_module(module_name: &str) -> Option<fn() -> ModuleSpec> {
     match module_name {
         "prelude" => Some(prelude::load_module),
         "date" => Some(date::load_module),

--- a/abra_core/src/builtins/native_value_trait.rs
+++ b/abra_core/src/builtins/native_value_trait.rs
@@ -10,7 +10,7 @@ pub trait NativeTyp {
 }
 
 pub trait NativeValue: NativeTyp + DynHash + Debug + Downcast {
-    fn construct(module_idx: usize, type_id: usize, args: Vec<Value>) -> Value where Self: Sized;
+    fn construct(type_id: usize, args: Vec<Value>) -> Value where Self: Sized;
     fn get_type_value() -> TypeValue where Self: Sized;
 
     fn is_equal(&self, other: &Box<dyn NativeValue>) -> bool;

--- a/abra_core/src/builtins/prelude/index.rs
+++ b/abra_core/src/builtins/prelude/index.rs
@@ -44,9 +44,11 @@ fn range(mut args: Arguments) -> Value {
 }
 
 #[cfg(test)]
-pub static PRELUDE_PRINTLN_INDEX: u8 = 0;
+pub static PRELUDE_PRINTLN_INDEX: usize = 0;
 #[cfg(test)]
-pub static PRELUDE_STRING_INDEX: u8 = 7;
+pub static PRELUDE_RANGE_INDEX: usize = 2;
+#[cfg(test)]
+pub static PRELUDE_STRING_INDEX: usize = 7;
 
 pub fn load_module() -> ModuleSpec {
     ModuleSpecBuilder::new("prelude")

--- a/abra_core/src/builtins/prelude/mod.rs
+++ b/abra_core/src/builtins/prelude/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-pub use index::{PRELUDE_PRINTLN_INDEX, PRELUDE_STRING_INDEX};
+pub use index::{PRELUDE_PRINTLN_INDEX, PRELUDE_RANGE_INDEX, PRELUDE_STRING_INDEX};
 pub use index::load_module;
 pub use native_array::NativeArray;
 pub use native_float::NativeFloat;

--- a/abra_core/src/module_loader.rs
+++ b/abra_core/src/module_loader.rs
@@ -1,11 +1,12 @@
 use crate::parser::ast::ModuleId;
 use crate::typechecker::typechecker::TypedModule;
 use crate::{Error, typecheck};
-use crate::builtins::{load_module};
+use crate::builtins::{load_native_module};
 use std::collections::HashMap;
 use crate::vm::compiler::{compile, Module, Metadata};
 use crate::typechecker::types::Type;
 use crate::builtins::native::load_native_module_contents;
+use crate::builtins::native_module_builder::ModuleSpec;
 
 pub trait ModuleReader {
     fn read_module(&mut self, module_id: &ModuleId) -> Option<String>;
@@ -20,24 +21,20 @@ pub enum ModuleLoaderError {
 #[derive(Debug)]
 pub struct ModuleLoader<R: ModuleReader> {
     module_reader: R,
+    native_module_cache: HashMap<String, ModuleSpec>,
     typed_module_cache: HashMap<String, Option<TypedModule>>,
     pub(crate) compiled_modules: Vec<(Module, Option<Metadata>)>,
-    compiled_module_constants: HashMap<ModuleId, HashMap<String, usize>>,
-    compiled_modules_indices: HashMap<ModuleId, usize>,
     pub(crate) ordering: Vec<ModuleId>,
 }
-
-const PRELUDE_MODULE_IDX: usize = 0;
 
 impl<R: ModuleReader> ModuleLoader<R> {
     pub fn new(module_reader: R) -> Self {
         let typed_module_cache = HashMap::new();
         let compiled_modules = Vec::new();
-        let compiled_module_constants = HashMap::new();
-        let compiled_modules_indices = HashMap::new();
+        let native_module_cache = HashMap::new();
         let ordering = Vec::new();
 
-        let mut loader = Self { module_reader, typed_module_cache, compiled_modules, compiled_module_constants, compiled_modules_indices, ordering };
+        let mut loader = Self { module_reader, typed_module_cache, compiled_modules, native_module_cache, ordering };
         loader.load_builtin("prelude");
         loader
     }
@@ -73,18 +70,23 @@ impl<R: ModuleReader> ModuleLoader<R> {
     }
 
     fn load_builtin(&mut self, module_name: &str) -> bool {
-        let mod_spec = match load_module(module_name) {
-            None => return false,
-            Some(get_mod_spec) => get_mod_spec()
+        let mod_spec = match self.native_module_cache.get(module_name) {
+            Some(mod_spec) => mod_spec,
+            None => {
+                match load_native_module(module_name) {
+                    None => return false,
+                    Some(mod_spec_fn) => {
+                        self.native_module_cache.insert(module_name.to_string(), mod_spec_fn());
+                        self.native_module_cache.get(module_name).unwrap()
+                    }
+                }
+            }
         };
 
         let module_id = mod_spec.typed_module.module_id.clone();
 
         self.ordering.push(module_id.clone());
-        self.typed_module_cache.insert(module_id.get_name(), Some(mod_spec.typed_module));
-        self.compiled_modules.push((mod_spec.compiled_module, None));
-        self.compiled_module_constants.insert(module_id.clone(), mod_spec.constant_indexes_by_ident);
-        self.compiled_modules_indices.insert(module_id.clone(), self.compiled_modules_indices.len());
+        self.typed_module_cache.insert(module_id.get_name(), Some(mod_spec.typed_module.clone()));
 
         true
     }
@@ -113,57 +115,33 @@ impl<R: ModuleReader> ModuleLoader<R> {
     }
 
     pub fn compile_all(&mut self) {
+        let mut globals = HashMap::<ModuleId, HashMap<String, usize>>::new();
+
         let ordering = self.ordering.clone();
         for module_id in ordering {
             let module_name = module_id.get_name();
 
-            if load_module(&module_name).is_some() {
-                debug_assert!(self.compiled_modules.iter().find(|(m, _)| m.name == module_name).is_some());
+            if let Some(mod_spec) = self.native_module_cache.get(&module_name) {
+                self.compiled_modules.push((mod_spec.compiled_module.clone(), None));
+
+                if !globals.contains_key(&module_id) {
+                    let num_globals: usize = globals.values().map(|m| m.len()).sum();
+                    let map = mod_spec.constant_names.iter().enumerate()
+                        .map(|(idx, g)| (g.clone(), num_globals + idx))
+                        .collect();
+                    globals.insert( module_id.clone(), map);
+                }
+
                 continue;
             }
 
             let typed_module = self.typed_module_cache.get(&module_name).unwrap().as_ref().unwrap().clone();
 
             let module_idx = self.compiled_modules.len();
-            self.compiled_modules_indices.insert(module_id.clone(), module_idx);
 
-            let (module, metadata) = compile(typed_module, module_idx, self).unwrap();
+            globals.insert(module_id.clone(), HashMap::new());
+            let (module, metadata) = compile(typed_module, module_idx, &mut globals).unwrap();
             self.compiled_modules.push((module, Some(metadata)));
-        }
-    }
-
-    pub fn get_compiled_module(&self, module_id: &ModuleId) -> &Module {
-        self.compiled_modules_indices.get(module_id)
-            .and_then(|idx| self.compiled_modules.get(*idx))
-            .map(|(module, _)| module)
-            .unwrap()
-    }
-
-    fn get_prelude_const_idx(&mut self, const_name: &String) -> Option<(usize, usize)> {
-        let prelude_constants = &self.compiled_module_constants[&ModuleId::from_name("prelude")];
-        prelude_constants.get(const_name).map(|const_idx| (PRELUDE_MODULE_IDX, *const_idx))
-    }
-
-    pub fn get_const_idx(&mut self, module_id: &ModuleId, const_name: &String) -> Option<(usize, usize)> {
-        let module_idx = self.compiled_modules_indices[module_id];
-
-        self.compiled_module_constants.get_mut(module_id)
-            .and_then(|constants| constants.get(const_name).map(|const_idx| (module_idx, *const_idx)))
-            .or_else(|| self.get_prelude_const_idx(const_name))
-    }
-
-    pub fn add_const_idx(&mut self, module_id: &ModuleId, const_name: &String, const_idx: usize) {
-        match self.compiled_module_constants.get_mut(module_id) {
-            Some(constants) => {
-                debug_assert!(!constants.contains_key(const_name));
-                constants.insert(const_name.clone(), const_idx);
-            }
-            None => {
-                let mut constants = HashMap::new();
-                constants.insert(const_name.clone(), const_idx);
-
-                self.compiled_module_constants.insert(module_id.clone(), constants);
-            }
         }
     }
 }

--- a/abra_core/src/typechecker/typed_ast.rs
+++ b/abra_core/src/typechecker/typed_ast.rs
@@ -334,7 +334,7 @@ pub enum TypedMatchKind {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TypedImportNode {
-    pub imports: Vec<(/* import_name: */ String, /* is_const: */ bool)>,
+    pub imports: Vec<String>,
     pub module_id: ModuleId,
 }
 

--- a/abra_core/src/vm/opcode.rs
+++ b/abra_core/src/vm/opcode.rs
@@ -34,7 +34,7 @@ pub enum Opcode {
     Eq,
     Neq,
     Xor,
-    New(usize),
+    New(/* type_id: */ usize, /* num_args: */ usize),
     GetField(usize),
     GetMethod(usize),
     SetField(usize),
@@ -49,10 +49,10 @@ pub enum Opcode {
     TupleLoad,
     TupleStore,
     SetMk(usize),
-    GStore(/* module_id: */ usize, /* const_idx: */ usize),
+    GStore(usize),
     LStore(usize),
     UStore(usize),
-    GLoad(/* module_id: */ usize, /* const_idx: */ usize),
+    GLoad(usize),
     LLoad(usize),
     ULoad(usize),
     Jump(usize),
@@ -75,7 +75,7 @@ impl Opcode {
 
         let imm = match self {
             Opcode::Constant(module_idx, const_idx) => Some(vec![module_idx, const_idx]),
-            Opcode::New(num_fields) => Some(vec![num_fields]),
+            Opcode::New(type_global_idx, num_fields) => Some(vec![type_global_idx, num_fields]),
             Opcode::GetField(field_idx) => Some(vec![field_idx]),
             Opcode::GetMethod(method_idx) => Some(vec![method_idx]),
             Opcode::SetField(field_idx) => Some(vec![field_idx]),
@@ -83,8 +83,7 @@ impl Opcode {
             Opcode::ArrMk(size) |
             Opcode::TupleMk(size) |
             Opcode::SetMk(size) => Some(vec![size]),
-            Opcode::GStore(module_idx, slot) |
-            Opcode::GLoad(module_idx, slot) => Some(vec![module_idx, slot]),
+            Opcode::GStore(slot) | Opcode::GLoad(slot) => Some(vec![slot]),
             Opcode::LStore(slot) |
             Opcode::LLoad(slot) => Some(vec![slot]),
             Opcode::UStore(upvalue_idx) |

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -756,13 +756,12 @@ mod tests {
         let expected = Value::Fn(FnValue {
             name: "abc".to_string(),
             code: vec![
-                Opcode::Constant(1, 3),
+                Opcode::Constant(1, 1),
                 Opcode::LStore(0),
                 Opcode::Return
             ],
             upvalues: vec![],
             receiver: None,
-            has_return: true,
         });
         assert_eq!(expected, result);
     }

--- a/abra_native/src/lib.rs
+++ b/abra_native/src/lib.rs
@@ -900,7 +900,7 @@ fn gen_construct_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
             let constructor_fn_name_ident = format_ident!("{}", &constructor_fn_name);
             quote! {
                 let inst = Self::#constructor_fn_name_ident(args);
-                crate::vm::value::Value::new_native_instance_obj(module_idx, type_id, std::boxed::Box::new(inst))
+                crate::vm::value::Value::new_native_instance_obj(type_id, std::boxed::Box::new(inst))
             }
         }
         None => {
@@ -912,7 +912,7 @@ fn gen_construct_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
     };
 
     quote! {
-        fn construct(module_idx: usize, type_id: usize, args: std::vec::Vec<crate::vm::value::Value>) -> crate::vm::value::Value where Self: core::marker::Sized {
+        fn construct(type_id: usize, args: std::vec::Vec<crate::vm::value::Value>) -> crate::vm::value::Value where Self: core::marker::Sized {
             #body
         }
     }
@@ -968,9 +968,8 @@ fn gen_get_type_value_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStr
                         None => {
                             quote! {
                                 let inst = inst.#native_name_ident(#arguments);
-                                let (module_idx, type_id) = vm.type_id_for_name(#fully_qualified_type_name);
+                                let type_id = vm.type_id_for_name(#fully_qualified_type_name);
                                 crate::vm::value::Value::new_native_instance_obj(
-                                    module_idx,
                                     type_id,
                                     std::boxed::Box::new(inst)
                                 )
@@ -1074,9 +1073,8 @@ fn gen_get_type_value_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStr
                     if let TypeRepr::SelfType(_) = &static_method.return_type {
                         quote! {
                             let inst = Self::#native_name_ident(#arguments);
-                            let (module_idx, type_id) = vm.type_id_for_name(#fully_qualified_type_name);
+                            let type_id = vm.type_id_for_name(#fully_qualified_type_name);
                             crate::vm::value::Value::new_native_instance_obj(
-                                module_idx,
                                 type_id,
                                 std::boxed::Box::new(inst)
                             )

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -31,7 +31,6 @@ impl Serialize for RunResultValue {
             Value::Int(val) => serializer.serialize_i64(*val),
             Value::Float(val) => serializer.serialize_f64(*val),
             Value::Bool(val) => serializer.serialize_bool(*val),
-            Value::Str(val) => serializer.serialize_str(val),
             Value::StringObj(o) => {
                 serializer.serialize_str(&*o.borrow()._inner)
             }


### PR DESCRIPTION
- Previously, globals were kind of a mess. Within the VM, globals was a
hashmap from name->value, and the name was a `Value::Str` that needed to
be referenced in the runtime `constants` array. Now, we keep track of
globals during compilation and we're able to reference globals by index
at runtime. This saves a few steps during runtime (good!) and also
allows us to remove the `Value::Str` variant entirely (awesome!).
- This also cleans up a lot of things with `constants` as well; in
addition to no longer having many unnecessary `Value::Str` constant
values, native modules' imports are now able to be referenced by global
index rather than by constant index. This allows for the cleanup
of #306, and it also helps pave the way for garbage collection (as well
as supporting potentially mutable imports).
- Also, now that types are referenced by their global index, we can
streamline the instantiation process. The `Opcode::New` instruction
contains a direct reference to the global index corresponding to the
Type being instantiated, so this saves an instruction (previously we'd
need to push the global/constant onto the stack first).
- This _also_ simplifies construction of native types (as well as
`type_id` representations in general), since the `module_idx` is no
longer needed. We can also remove a lot of the code in the ModuleLoader,
since it doesn't need to be responsible for keeping track of as many
things anymore.