### PR TITLE
Unconstructable types

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,3 +1,8 @@
-import .example2 as e
+//import .example2 as e
+//
+//println(e.Shirt(color: "Blue"))
 
-println(e.Shirt(color: "Blue"))
+//println(Process.args)
+
+enum Foo { Bar }
+val a = Foo()

--- a/abra_core/src/typechecker/typechecker_error.rs
+++ b/abra_core/src/typechecker/typechecker_error.rs
@@ -1436,6 +1436,7 @@ Type Int[] does not have a member with name 'size'"
                 target_type: Type::Struct(StructType {
                     name: "Person".to_string(),
                     type_args: vec![],
+                    constructable: true,
                     fields: vec![
                         StructTypeField { name: "name".to_string(), typ: Type::String, has_default_value: false, readonly: true }
                     ],

--- a/abra_core/src/typechecker/types.rs
+++ b/abra_core/src/typechecker/types.rs
@@ -92,6 +92,7 @@ impl PartialEq for FnType {
 pub struct StructType {
     pub name: String,
     pub type_args: Vec<(String, Type)>,
+    pub constructable: bool,
     pub fields: Vec<StructTypeField>,
     pub static_fields: Vec<(/* name: */ String, /* type: */ Type, /* has_default_value: */ bool)>,
     pub methods: Vec<(String, Type)>,
@@ -738,6 +739,7 @@ mod test {
         let struct_type = StructType {
             name: "List".to_string(),
             type_args: vec![("T".to_string(), Generic("T".to_string()))],
+            constructable: true,
             fields: vec![],
             static_fields: vec![],
             methods: vec![],

--- a/abra_native/src/lib.rs
+++ b/abra_native/src/lib.rs
@@ -841,12 +841,14 @@ fn gen_native_type_code(type_spec: &TypeSpec) -> TokenStream {
     });
 
     let native_type_name_ident = format_ident!("{}", &type_spec.native_type_name);
+    let is_constructable = !type_spec.is_noconstruct;
     let ts = quote! {
         impl crate::builtins::native_value_trait::NativeTyp for #native_type_name_ident {
             fn get_type() -> crate::typechecker::types::StructType where Self: Sized {
                 crate::typechecker::types::StructType {
                     name: #type_name.to_string(),
                     type_args: vec![ #(#type_args),* ],
+                    constructable: #is_constructable,
                     fields: vec![ #(#fields),* ],
                     static_fields: vec![ #(#static_methods),* ],
                     methods: vec![

--- a/abra_wasm/src/js_value/abra_type.rs
+++ b/abra_wasm/src/js_value/abra_type.rs
@@ -103,10 +103,11 @@ impl<'a> Serialize for JsType<'a> {
                 obj.serialize_entry("kind", "Unknown")?;
                 obj.end()
             }
-            Type::Struct(StructType { name, type_args, fields, methods, static_fields }) => {
+            Type::Struct(StructType { name, type_args, constructable, fields, methods, static_fields }) => {
                 let mut obj = serializer.serialize_map(Some(6))?;
                 obj.serialize_entry("kind", "Struct")?;
                 obj.serialize_entry("name", name)?;
+                obj.serialize_entry("constructable", constructable)?;
                 let type_args: Vec<(String, JsType)> = type_args.iter()
                     .map(|(name, typ)| (name.clone(), JsType(typ)))
                     .collect();


### PR DESCRIPTION
- Attempting to construct an "unconstructable" type will now result in a
typechecker error; previously it didn't. This will become useful for the
forthcoming `Process` type, which will hold things like `args`,
`exit()`, etc.