### PR TITLE
Add `process` builtin

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,8 +1,1 @@
-//import .example2 as e
-//
-//println(e.Shirt(color: "Blue"))
-
-//println(Process.args)
-
-enum Foo { Bar }
-val a = Foo()
+println(process.args)

--- a/abra_cli/src/main.rs
+++ b/abra_cli/src/main.rs
@@ -29,11 +29,16 @@ enum SubCommand {
 
 #[derive(Clap)]
 struct RunOpts {
-    file_path: String
+    #[clap(help = "Path to an abra file to run")]
+    file_path: String,
+
+    #[clap(last = true, help = "Arguments to pass to the abra program")]
+    args: Vec<String>,
 }
 
 #[derive(Clap)]
 struct DisassembleOpts {
+    #[clap(help = "Path to an abra file to disassemble")]
     file_path: String,
 
     #[clap(short = "o", help = "Where to write bytecode to (default: stdout)")]
@@ -69,7 +74,8 @@ fn cmd_compile_and_run(opts: RunOpts) -> Result<(), ()> {
 
     let module_id = ModuleId::from_path(&opts.file_path);
 
-    let mut vm = VM::new(VMContext::default());
+    let env = std::env::vars().collect();
+    let mut vm = VM::new(VMContext::new(opts.args, env));
     let result = compile_and_run(module_id, contents, current_path, &mut vm)?;
     if result != Value::Nil {
         println!("{}", to_string(&result, &mut vm));

--- a/abra_core/src/builtins/native_module_builder.rs
+++ b/abra_core/src/builtins/native_module_builder.rs
@@ -31,7 +31,7 @@ impl ModuleSpecBuilder {
         let module_id = ModuleId::from_name(self.name.as_str());
         ModuleSpec {
             typed_module: TypedModule { module_id, exports: self.exports, referencable_types: self.referencable_types, ..TypedModule::default() },
-            compiled_module: Module { name: self.name, is_native: true, num_globals: self.constants.len(), constants: self.constants,  code: vec![] },
+            compiled_module: Module { name: self.name, is_native: true, num_globals: self.constants.len(), constants: self.constants, code: vec![] },
             constant_names: self.constant_names,
         }
     }

--- a/abra_core/src/builtins/prelude/index.rs
+++ b/abra_core/src/builtins/prelude/index.rs
@@ -1,6 +1,6 @@
 use abra_native::abra_function;
 use crate::typechecker::types::Type;
-use crate::builtins::prelude::{NativeInt, NativeSet, NativeFloat, NativeString, NativeArray, NativeMap};
+use crate::builtins::prelude::{NativeInt, NativeSet, NativeFloat, NativeString, NativeArray, NativeMap, Process};
 use crate::builtins::common::to_string;
 use crate::builtins::native_module_builder::{ModuleSpec, TypeSpec, ModuleSpecBuilder};
 use crate::vm::value::Value;
@@ -48,7 +48,11 @@ pub static PRELUDE_PRINTLN_INDEX: usize = 0;
 #[cfg(test)]
 pub static PRELUDE_RANGE_INDEX: usize = 2;
 #[cfg(test)]
-pub static PRELUDE_STRING_INDEX: usize = 7;
+pub static PRELUDE_STRING_INDEX: usize = 8;
+#[cfg(test)]
+pub static NUM_PRELUDE_BINDINGS: usize = 15;
+
+pub static PRELUDE_PROCESS_INDEX: usize = 4;
 
 pub fn load_module() -> ModuleSpec {
     ModuleSpecBuilder::new("prelude")
@@ -56,6 +60,7 @@ pub fn load_module() -> ModuleSpec {
         .add_function(print__gen_spec)
         .add_function(range__gen_spec)
         .add_binding("None", Type::Option(Box::new(Type::Placeholder)), Value::Nil)
+        .add_binding("process", Type::Reference("prelude/Process".to_string(), vec![]), Value::Nil)
         .add_type(
             TypeSpec::builder("Int", Type::Int)
                 .with_native_value::<NativeInt>()
@@ -86,6 +91,7 @@ pub fn load_module() -> ModuleSpec {
                 .with_typeref()
                 .with_native_value::<NativeSet>()
         )
+        .add_type_impl::<Process>()
         .build()
 }
 
@@ -96,7 +102,7 @@ mod test {
 
     #[test]
     fn test_importing_module_explicitly_fails() {
-        let imports = &["println", "print", "range", "Int", "Float", "Bool", "String", "Unit", "Any", "Array", "Map", "Set"];
+        let imports = &["println", "print", "range", "Int", "Float", "Bool", "String", "Unit", "Any", "Array", "Map", "Set", "Process", "process"];
         for import in imports {
             let result = interpret_get_result(format!("import {} from prelude", import));
             assert!(result.is_err());

--- a/abra_core/src/builtins/prelude/mod.rs
+++ b/abra_core/src/builtins/prelude/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
-pub use index::{PRELUDE_PRINTLN_INDEX, PRELUDE_RANGE_INDEX, PRELUDE_STRING_INDEX};
+pub use index::{PRELUDE_PRINTLN_INDEX, PRELUDE_RANGE_INDEX, PRELUDE_STRING_INDEX, NUM_PRELUDE_BINDINGS};
+pub use index::PRELUDE_PROCESS_INDEX;
 pub use index::load_module;
 pub use native_array::NativeArray;
 pub use native_float::NativeFloat;
@@ -7,6 +8,7 @@ pub use native_int::NativeInt;
 pub use native_map::NativeMap;
 pub use native_set::NativeSet;
 pub use native_string::NativeString;
+pub use process::Process;
 
 mod index;
 mod native_array;
@@ -15,3 +17,4 @@ mod native_int;
 mod native_map;
 mod native_set;
 mod native_string;
+mod process;

--- a/abra_core/src/builtins/prelude/process.rs
+++ b/abra_core/src/builtins/prelude/process.rs
@@ -1,0 +1,97 @@
+use abra_native::{AbraType, abra_methods};
+use crate::vm::value::Value;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+use std::collections::HashMap;
+use crate::vm::vm::VM;
+
+#[derive(AbraType, Debug, Clone, Eq, PartialEq)]
+#[abra_type(module = "prelude", signature = "Process", noconstruct = true)]
+pub struct Process {
+    #[abra_field(name = "args", field_type = "String[]", readonly)]
+    args: Vec<String>,
+
+    #[abra_field(name = "env", field_type = "Map<String, String>", readonly)]
+    env: HashMap<String, String>,
+}
+
+#[abra_methods]
+impl Process {
+    pub(crate) fn init(vm: &VM) -> Self {
+        Self {
+            args: vm.ctx.args.clone(),
+            env: vm.ctx.env.clone(),
+        }
+    }
+
+    #[abra_getter(field = "args")]
+    fn get_args(&self) -> Value {
+        let args = self.args.iter()
+            .map(|a| Value::new_string_obj(a.clone()))
+            .collect();
+        Value::new_array_obj(args)
+    }
+
+    #[abra_getter(field = "env")]
+    fn get_env(&self) -> Value {
+        let env_values = self.env.iter()
+            .flat_map(|(key, val)| vec![
+                Value::new_string_obj(key.clone()),
+                Value::new_string_obj(val.clone()),
+            ])
+            .collect();
+        Value::new_map_obj(env_values)
+    }
+}
+
+impl Hash for Process {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        for arg in &self.args {
+            arg.hash(hasher);
+        }
+
+        for (k, v) in &self.env {
+            k.hash(hasher);
+            v.hash(hasher);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::builtins::test_utils::{interpret, interpret_get_result};
+    use crate::vm::value::Value;
+
+    #[test]
+    fn test_process_singleton_instance_() {
+        let result = interpret(r#"
+          val args: String[] | Int = process.args
+          val r = match args {
+            Int => false
+            _ => true
+          }
+          r
+        "#);
+        let expected = Value::Bool(true);
+        assert_eq!(expected, result);
+
+        let result = interpret(r#"
+          val env: Map<String, String> | Int = process.env
+          val r = match env {
+            Int => false
+            _ => true
+          }
+          r
+        "#);
+        let expected = Value::Bool(true);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_instantiation_fails() {
+        let result = interpret_get_result(r#"
+          val p = Process()
+        "#);
+        assert!(result.is_err());
+    }
+}

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -1879,7 +1879,7 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
 
             self.visit(if_node)?;
 
-            return Ok(())
+            return Ok(());
         }
 
         let TypedAccessorNode { target, field_ident, field_idx, is_method, .. } = node;
@@ -1890,7 +1890,7 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
             let global_idx = *global_idx.expect(&format!("There should be a designated global slot for name {}", field_name));
             self.write_opcode(Opcode::GLoad(global_idx), line);
 
-            return Ok(())
+            return Ok(());
         }
 
         self.visit(*target)?;
@@ -2169,7 +2169,7 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
             self.add_and_write_constant(Value::Module(module_id), line);
             self.write_store_global_instr(alias_name, line);
 
-            return Ok(())
+            return Ok(());
         }
 
         for import_name in imports {
@@ -2187,7 +2187,7 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::builtins::prelude::{PRELUDE_PRINTLN_INDEX, PRELUDE_STRING_INDEX, PRELUDE_RANGE_INDEX};
+    use crate::builtins::prelude::{PRELUDE_PRINTLN_INDEX, PRELUDE_STRING_INDEX, PRELUDE_RANGE_INDEX, NUM_PRELUDE_BINDINGS};
     use crate::common::test_utils::MockModuleReader;
     use crate::parser::ast::ModuleId;
     use itertools::Itertools;
@@ -2224,10 +2224,8 @@ mod tests {
         }))
     }
 
-    const PRELUDE_OFFSET: usize = 13;
-
     fn global_idx(idx: usize) -> usize {
-        PRELUDE_OFFSET + idx
+        NUM_PRELUDE_BINDINGS + idx
     }
 
     #[test]

--- a/abra_native/src/lib.rs
+++ b/abra_native/src/lib.rs
@@ -717,6 +717,25 @@ fn gen_rust_type_path(type_repr: &TypeRepr, module_name: &String, type_ref_name:
                     let typ = format_ident!("{}", i);
                     quote! { crate::typechecker::types::Type::#typ }
                 }
+                "Set" => {
+                    let inner_type = type_args.get(0).expect("Sets require T value");
+                    let inner_type_repr = gen_rust_type_path(inner_type, module_name, type_ref_name);
+
+                    quote! { crate::typechecker::types::Type::Set(std::boxed::Box::new(#inner_type_repr)) }
+                }
+                "Map" => {
+                    let key_type = type_args.get(0).expect("Maps require K value");
+                    let key_type_repr = gen_rust_type_path(key_type, module_name, type_ref_name);
+                    let val_type = type_args.get(1).expect("Maps require V value");
+                    let val_type_repr = gen_rust_type_path(val_type, module_name, type_ref_name);
+
+                    quote! {
+                        crate::typechecker::types::Type::Map(
+                            std::boxed::Box::new(#key_type_repr),
+                            std::boxed::Box::new(#val_type_repr)
+                        )
+                    }
+                }
                 i => {
                     let type_args = type_args.iter().map(|type_arg| {
                         gen_rust_type_path(type_arg, module_name, type_ref_name)

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -297,7 +297,8 @@ pub fn run(input: &str, js_bridge: Option<AbraContext>) -> JsValue {
             }),
             None => Box::new(|input| console_log(input))
         },
-        prompt: Box::new(|_prompt| unimplemented!())
+        prompt: Box::new(|_prompt| unimplemented!()),
+        ..VMContext::default()
     };
 
     let module_reader = UnimplementedModuleReader;
@@ -321,7 +322,8 @@ pub fn run_module(module_name: &str, module_reader: JsModuleReader, js_bridge: O
             }),
             None => Box::new(|input| console_log(input))
         },
-        prompt: Box::new(|_prompt| unimplemented!())
+        prompt: Box::new(|_prompt| unimplemented!()),
+        ..VMContext::default()
     };
 
     let input = match module_reader._read_module(module_name) {


### PR DESCRIPTION
- The `process` top-level builtin variable is an instance of the
`Process` type (this type cannot be directly instantiated, the only
possible instance is the builtin). This instance currently contains 2
fields:
  - `args`: the arguments supplied to the cli program (`abra run <file> -- <args`)
  - `env`: a Map of the environment variables that the program is running in
- Both of these values with be empty when run in a wasm context