### PR TITLE
More repl work!

### DIFF
--- a/abra_core/src/module_loader.rs
+++ b/abra_core/src/module_loader.rs
@@ -22,7 +22,7 @@ pub enum ModuleLoaderError {
 pub struct ModuleLoader<'a, R: ModuleReader> {
     module_reader: &'a R,
     native_module_cache: HashMap<String, ModuleSpec>,
-    typed_module_cache: HashMap<String, Option<TypedModule>>,
+    pub typed_module_cache: HashMap<String, Option<TypedModule>>,
     pub(crate) compiled_modules: Vec<(Module, Option<Metadata>)>,
     pub(crate) ordering: Vec<ModuleId>,
 }

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -12,7 +12,7 @@ use std::collections::{HashSet, HashMap};
 use std::iter::FromIterator;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ScopeBinding(/*token:*/ Token, /*type:*/ Type, /*is_mutable:*/ bool);
+pub struct ScopeBinding(pub /*token:*/ Token, pub /*type:*/ Type, pub /*is_mutable:*/ bool);
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScopeKind {


### PR DESCRIPTION
More #318 

- Add support for `.type` command, to display the type information for
any name in the global scope. This is _super_ janky right now, and not
very performant, but it'll do as a first pass.
- Refactor the `type_repr` function and pull it out of the
`TypecheckerError` module. This is much nicer now.