### PR TITLE
Add `Result<V, E>` enum

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,6 +1,46 @@
-val x: Int? = 0
-val i = match x {
-  None(z) => 0
-  _ => 1
+func foo(): Result<Int, String> {
+  Result.Err("123")
 }
-println(i)
+
+val results = [
+  Result.Ok("a"),
+  Result.Err(1),
+  Result.Ok("1"),
+]
+
+println(Result.all(results))
+
+val f = foo()
+  .map(v => v * 2)
+  .mapErr(e => e + "!!!")
+
+if f.getValue() |f| println(f)
+else println("no value :(")
+
+/*
+
+func bar(): Result<Int, Int> {
+  //val f = foo()!
+
+  val r: Result<Int, Int>? = a?.foo()
+  match r {
+    Ok(v) => {}
+    Err(e) => {}
+    None => {}
+  }
+
+  val r: Result<Int, String> = a.foo()
+  val r: Result<Int, Int> = a.foo().mapErr(str => str.length)
+  match r {
+    Ok(v) => {}
+    Err(e) => {}
+  }
+
+  val r: Int = try a.foo().mapErr(str => str.length)
+    val r = match a.foo().mapErr(str => str.length) {
+      Ok(v) => v
+      Err e => return e
+    }
+  }
+}
+*/

--- a/abra_core/src/builtins/common.rs
+++ b/abra_core/src/builtins/common.rs
@@ -119,6 +119,12 @@ pub fn to_string(value: &Value, vm: &mut VM) -> String {
             let ret = &*ret.as_string().borrow();
             ret._inner.clone()
         }
+        Value::NativeEnumInstanceObj(o) => {
+            let i = &*o.borrow();
+            let v = i.inst.method_to_string(vm);
+            let v = &*v.as_string().borrow();
+            v._inner.clone()
+        }
         Value::Fn(FnValue { name, .. }) |
         Value::Closure(ClosureValue { name, .. }) => format!("<func {}>", name),
         Value::NativeFn(NativeFn { name, .. }) => format!("<func {}>", name),

--- a/abra_core/src/builtins/native_value_trait.rs
+++ b/abra_core/src/builtins/native_value_trait.rs
@@ -1,17 +1,19 @@
-use crate::vm::value::{Value, TypeValue};
-use crate::typechecker::types::StructType;
+use crate::vm::value::Value;
+use crate::typechecker::types::{StructType, EnumType};
 use std::fmt::Debug;
 use downcast_rs::Downcast;
 use std::hash::{Hash, Hasher};
 use crate::vm::vm::VM;
 
 pub trait NativeTyp {
-    fn get_type() -> StructType where Self: Sized;
+    fn is_struct() -> bool where Self: Sized;
+    fn get_struct_type() -> StructType where Self: Sized;
+    fn get_enum_type() -> EnumType where Self: Sized;
 }
 
 pub trait NativeValue: NativeTyp + DynHash + Debug + Downcast {
     fn construct(type_id: usize, args: Vec<Value>) -> Value where Self: Sized;
-    fn get_type_value() -> TypeValue where Self: Sized;
+    fn get_type_value() -> Value where Self: Sized;
 
     fn is_equal(&self, other: &Box<dyn NativeValue>) -> bool;
     fn method_to_string(&self, vm: &mut VM) -> Value;

--- a/abra_core/src/builtins/prelude/index.rs
+++ b/abra_core/src/builtins/prelude/index.rs
@@ -7,6 +7,7 @@ use crate::vm::value::Value;
 use crate::builtins::arguments::Arguments;
 use crate::vm::vm::VM;
 use itertools::Itertools;
+use crate::builtins::prelude::native_result::NativeResult;
 
 #[abra_function(signature = "println(*items: Any[])")]
 fn println(args: Arguments, vm: &mut VM) {
@@ -50,7 +51,7 @@ pub static PRELUDE_RANGE_INDEX: usize = 2;
 #[cfg(test)]
 pub static PRELUDE_STRING_INDEX: usize = 8;
 #[cfg(test)]
-pub static NUM_PRELUDE_BINDINGS: usize = 15;
+pub static NUM_PRELUDE_BINDINGS: usize = 16;
 
 pub static PRELUDE_PROCESS_INDEX: usize = 4;
 
@@ -92,6 +93,7 @@ pub fn load_module() -> ModuleSpec {
                 .with_native_value::<NativeSet>()
         )
         .add_type_impl::<Process>()
+        .add_type_impl::<NativeResult>()
         .build()
 }
 
@@ -102,7 +104,7 @@ mod test {
 
     #[test]
     fn test_importing_module_explicitly_fails() {
-        let imports = &["println", "print", "range", "Int", "Float", "Bool", "String", "Unit", "Any", "Array", "Map", "Set", "Process", "process"];
+        let imports = &["println", "print", "range", "Int", "Float", "Bool", "String", "Unit", "Any", "Array", "Map", "Set", "Process", "process", "Result"];
         for import in imports {
             let result = interpret_get_result(format!("import {} from prelude", import));
             assert!(result.is_err());

--- a/abra_core/src/builtins/prelude/mod.rs
+++ b/abra_core/src/builtins/prelude/mod.rs
@@ -15,6 +15,7 @@ mod native_array;
 mod native_float;
 mod native_int;
 mod native_map;
+mod native_result;
 mod native_set;
 mod native_string;
 mod process;

--- a/abra_core/src/builtins/prelude/native_result.rs
+++ b/abra_core/src/builtins/prelude/native_result.rs
@@ -1,0 +1,223 @@
+use abra_native::{AbraType, abra_methods};
+use std::fmt::Debug;
+use std::hash::Hash;
+use crate::builtins::arguments::Arguments;
+use crate::vm::value::Value;
+use crate::vm::vm::VM;
+use crate::builtins::common::invoke_fn;
+
+#[derive(AbraType, Debug, Clone, Eq, Hash, PartialEq)]
+#[abra_type(module = "prelude", signature = "Result<V, E>", is_enum = true)]
+pub struct NativeResult {
+    value: Value,
+    is_ok: bool,
+}
+
+#[abra_methods]
+impl NativeResult {
+    #[abra_enum_variant(signature = "Ok(value: V)", return_type = "Result<V, Placeholder>")]
+    fn ok(mut args: Arguments) -> Self {
+        let value = args.next_value();
+        Self { value, is_ok: true }
+    }
+
+    #[abra_enum_variant(signature = "Err(error: E)", return_type = "Result<Placeholder, E>")]
+    fn err(mut args: Arguments) -> Self {
+        let value = args.next_value();
+        Self { value, is_ok: false }
+    }
+
+    #[abra_enum_variant_data]
+    fn variant_data(&self) -> (usize, Vec<&Value>) {
+        let idx = if self.is_ok { 0 } else { 1 };
+        (idx, vec![&self.value])
+    }
+
+    #[abra_static_method(signature = "all<V1, E1>(results: Result<V1, E1>[]): Result<V1[], E1>")]
+    fn all(mut args: Arguments) -> Self {
+        let results = args.next_array();
+
+        let mut value = Vec::new();
+        for r in results {
+            if let Value::NativeEnumInstanceObj(o) = r {
+                let rcv = &*o.borrow();
+                let inst: &Self = rcv.inst.downcast_ref::<Self>().unwrap();
+                if inst.is_ok {
+                    value.push(inst.value.clone());
+                } else {
+                    return Self { value: inst.value.clone(), is_ok: false };
+                }
+            } else { unreachable!() }
+        }
+
+        Self { value: Value::new_array_obj(value), is_ok: true }
+    }
+
+    #[abra_method(signature = "getValue(): V?")]
+    fn get_value(&self) -> Value {
+        if !self.is_ok {
+            return Value::Nil;
+        }
+
+        self.value.clone()
+    }
+
+    #[abra_method(signature = "map<T>(fn: (V) => T): Result<T, E>")]
+    fn map(&self, mut args: Arguments, vm: &mut VM) -> Self {
+        let callback = args.next_value();
+
+        if !self.is_ok {
+            return self.clone();
+        }
+
+        let value = invoke_fn(vm, &callback, vec![self.value.clone()]);
+        Self { value, is_ok: true }
+    }
+
+    #[abra_method(signature = "mapErr<T>(fn: (E) => T): Result<V, T>")]
+    fn map_err(&self, mut args: Arguments, vm: &mut VM) -> Self {
+        let callback = args.next_value();
+
+        if self.is_ok {
+            return self.clone();
+        }
+
+        let value = invoke_fn(vm, &callback, vec![self.value.clone()]);
+        Self { value, is_ok: false }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::builtins::test_utils::{interpret, new_string_obj};
+    use crate::vm::value::Value;
+    use crate::builtins::prelude::native_result::NativeResult;
+
+    #[test]
+    fn test_result_ok_variant() {
+        let result = interpret("Result.Ok(\"asdf\")");
+        if let Value::NativeEnumInstanceObj(o) = result {
+            let expected = NativeResult { value: new_string_obj("asdf"), is_ok: true };
+            assert_eq!(o.borrow().inst.downcast_ref::<NativeResult>().unwrap(), &expected);
+        } else {
+            panic!("fail")
+        }
+    }
+
+    #[test]
+    fn test_result_err_variant() {
+        let result = interpret("Result.Err(\"asdf\")");
+        if let Value::NativeEnumInstanceObj(o) = result {
+            let expected = NativeResult { value: new_string_obj("asdf"), is_ok: false };
+            assert_eq!(o.borrow().inst.downcast_ref::<NativeResult>().unwrap(), &expected);
+        } else {
+            panic!("fail")
+        }
+    }
+
+    #[test]
+    fn test_result_matching() {
+        let result = interpret(r#"
+          val r = Result.Ok("asdf")
+          val s = match r {
+            Result.Ok(v) => v.toUpper(),
+            Result.Err(e) => "hmmm"
+          }
+          s
+        "#);
+        assert_eq!(new_string_obj("ASDF"), result);
+
+        let result = interpret(r#"
+          val r = Result.Err("qwer")
+          val s = match r {
+            Result.Ok(v) => "hmmm"
+            Result.Err(e) => e.toUpper()
+          }
+          s
+        "#);
+        assert_eq!(new_string_obj("QWER"), result);
+    }
+
+    #[test]
+    fn test_result_static_all() {
+        let result = interpret(r#"
+          val results = [Result.Ok("asdf"), Result.Ok("qwer")]
+          Result.all(results).getValue()
+        "#);
+        assert_eq!(array![new_string_obj("asdf"), new_string_obj("qwer")], result);
+
+        let result = interpret(r#"
+          val results = [Result.Ok("asdf"), Result.Ok("qwer"), Result.Err(123), Result.Ok("zxcv")]
+          Result.all(results)
+        "#);
+        if let Value::NativeEnumInstanceObj(o) = result {
+            let expected = NativeResult { value: Value::Int(123), is_ok: false };
+            assert_eq!(o.borrow().inst.downcast_ref::<NativeResult>().unwrap(), &expected);
+        } else {
+            panic!("fail")
+        }
+    }
+
+    #[test]
+    fn test_result_get_value() {
+        let result = interpret("Result.Ok(\"asdf\").getValue()");
+        assert_eq!(new_string_obj("asdf"), result);
+
+        let result = interpret("Result.Err(\"asdf\").getValue()");
+        assert_eq!(Value::Nil, result);
+    }
+
+    #[test]
+    fn test_result_map() {
+        // Verify `map` transforms Ok value
+        let result = interpret(r#"
+          val r = Result.Ok("asdf")
+          r.map(v => v.toUpper())
+        "#);
+        if let Value::NativeEnumInstanceObj(o) = result {
+            let expected = NativeResult { value: new_string_obj("ASDF"), is_ok: true };
+            assert_eq!(o.borrow().inst.downcast_ref::<NativeResult>().unwrap(), &expected);
+        } else {
+            panic!("fail")
+        }
+
+        // Verify `map` does nothing to Err value
+        let result = interpret(r#"
+          val r = Result.Err("asdf")
+          r.map(v => "hmm")
+        "#);
+        if let Value::NativeEnumInstanceObj(o) = result {
+            let expected = NativeResult { value: new_string_obj("asdf"), is_ok: false };
+            assert_eq!(o.borrow().inst.downcast_ref::<NativeResult>().unwrap(), &expected);
+        } else {
+            panic!("fail")
+        }
+    }
+
+    #[test]
+    fn test_result_map_err() {
+        // Verify `mapErr` transforms Err value
+        let result = interpret(r#"
+          val r = Result.Err("asdf")
+          r.mapErr(v => v.toUpper())
+        "#);
+        if let Value::NativeEnumInstanceObj(o) = result {
+            let expected = NativeResult { value: new_string_obj("ASDF"), is_ok: false };
+            assert_eq!(o.borrow().inst.downcast_ref::<NativeResult>().unwrap(), &expected);
+        } else {
+            panic!("fail")
+        }
+
+        // Verify `mapErr` does nothing to Ok value
+        let result = interpret(r#"
+          val r = Result.Ok("asdf")
+          r.mapErr(v => "hmm")
+        "#);
+        if let Value::NativeEnumInstanceObj(o) = result {
+            let expected = NativeResult { value: new_string_obj("asdf"), is_ok: true };
+            assert_eq!(o.borrow().inst.downcast_ref::<NativeResult>().unwrap(), &expected);
+        } else {
+            panic!("fail")
+        }
+    }
+}

--- a/abra_core/src/typechecker/typechecker.rs
+++ b/abra_core/src/typechecker/typechecker.rs
@@ -1533,7 +1533,7 @@ impl<'a, R: ModuleReader> AstVisitor<TypedAstNode, TypecheckerErrorKind> for Typ
                 .nth(0)
                 .expect("We know the size is 1")
         } else if !item_types.is_empty() {
-            Type::Union(item_types.into_iter().collect())
+            Type::flatten(item_types.into_iter().collect())
         } else {
             Type::Unknown
         };
@@ -3016,17 +3016,17 @@ impl<'a, R: ModuleReader> AstVisitor<TypedAstNode, TypecheckerErrorKind> for Typ
                         });
                     Ok((field_data, generics))
                 }
-                Type::String => Ok((NativeString::get_type().get_field_or_method(&field_name), HashMap::new())),
-                Type::Float => Ok((NativeFloat::get_type().get_field_or_method(&field_name), HashMap::new())),
-                Type::Int => Ok((NativeInt::get_type().get_field_or_method(&field_name), HashMap::new())),
+                Type::String => Ok((NativeString::get_struct_type().get_field_or_method(&field_name), HashMap::new())),
+                Type::Float => Ok((NativeFloat::get_struct_type().get_field_or_method(&field_name), HashMap::new())),
+                Type::Int => Ok((NativeInt::get_struct_type().get_field_or_method(&field_name), HashMap::new())),
                 Type::Array(inner_type) => {
                     let generics = vec![("T".to_string(), *inner_type.clone())].into_iter().collect::<HashMap<String, Type>>();
-                    let field_data = NativeArray::get_type().get_field_or_method(field_name);
+                    let field_data = NativeArray::get_struct_type().get_field_or_method(field_name);
                     Ok((field_data, generics))
                 }
                 Type::Set(inner_type) => {
                     let generics = vec![("T".to_string(), *inner_type.clone())].into_iter().collect::<HashMap<String, Type>>();
-                    let field_data = NativeSet::get_type().get_field_or_method(field_name);
+                    let field_data = NativeSet::get_struct_type().get_field_or_method(field_name);
                     Ok((field_data, generics))
                 }
                 Type::Map(key_type, value_type) => {
@@ -3034,7 +3034,7 @@ impl<'a, R: ModuleReader> AstVisitor<TypedAstNode, TypecheckerErrorKind> for Typ
                         ("K".to_string(), *key_type.clone()),
                         ("V".to_string(), *value_type.clone()),
                     ].into_iter().collect::<HashMap<String, Type>>();
-                    let field_data = NativeMap::get_type().get_field_or_method(field_name);
+                    let field_data = NativeMap::get_struct_type().get_field_or_method(field_name);
                     Ok((field_data, generics))
                 }
                 Type::Type(_, typ, _) => match zelf.resolve_ref_type(&*typ) {
@@ -3062,11 +3062,11 @@ impl<'a, R: ModuleReader> AstVisitor<TypedAstNode, TypecheckerErrorKind> for Typ
                         Ok((field_data, HashMap::new()))
                     }
                     Type::Array(_) => {
-                        let field_data = NativeArray::get_type().get_static_field_or_method(field_name);
+                        let field_data = NativeArray::get_struct_type().get_static_field_or_method(field_name);
                         Ok((field_data, HashMap::new()))
                     }
                     Type::Map(_, _) => {
-                        let field_data = NativeMap::get_type().get_static_field_or_method(field_name);
+                        let field_data = NativeMap::get_struct_type().get_static_field_or_method(field_name);
                         Ok((field_data, HashMap::new()))
                     }
                     _ => unimplemented!()

--- a/abra_core/src/vm/compiler.rs
+++ b/abra_core/src/vm/compiler.rs
@@ -846,9 +846,9 @@ impl<'a> Compiler<'a> {
                         // number of elements in the destructuring pattern following the `*splat`. From the example above:
                         //   $temp_0[1:].splitAt(-2)
                         let split_at_method_idx = if is_string {
-                            NativeString::get_type().get_method_idx("splitAt").expect("String is missing required splitAt method")
+                            NativeString::get_struct_type().get_method_idx("splitAt").expect("String is missing required splitAt method")
                         } else {
-                            NativeArray::get_type().get_method_idx("splitAt").expect("Array is missing required splitAt method")
+                            NativeArray::get_struct_type().get_method_idx("splitAt").expect("Array is missing required splitAt method")
                         };
                         self.write_opcode(Opcode::GetMethod(split_at_method_idx), line);
                         self.metadata.field_gets.push("splitAt".to_string());
@@ -1924,9 +1924,9 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
         // $iter = <iterator>.enumerate()
         self.visit(*iterator)?;
         let enumerate_method_idx = match iterator_type {
-            Type::Array(_) => NativeArray::get_type().get_method_idx("enumerate").expect("Array is missing required enumerate method"),
-            Type::Set(_) => NativeSet::get_type().get_method_idx("enumerate").expect("Set is missing required enumerate method"),
-            Type::Map(_, _) => NativeMap::get_type().get_method_idx("enumerate").expect("Map is missing required enumerate method"),
+            Type::Array(_) => NativeArray::get_struct_type().get_method_idx("enumerate").expect("Array is missing required enumerate method"),
+            Type::Set(_) => NativeSet::get_struct_type().get_method_idx("enumerate").expect("Set is missing required enumerate method"),
+            Type::Map(_, _) => NativeMap::get_struct_type().get_method_idx("enumerate").expect("Map is missing required enumerate method"),
             _ => unreachable!("Should have been caught during typechecking")
         };
         self.write_opcode(Opcode::GetMethod(enumerate_method_idx), line);
@@ -1953,7 +1953,7 @@ impl<'a> TypedAstVisitor<(), ()> for Compiler<'a> {
         // Essentially: if $idx >= $iter.length { break }
         load_intrinsic(self, "$idx", line);
         load_intrinsic(self, "$iter", line);
-        let length_idx = NativeArray::get_type().get_field_idx("length").expect("Array is missing required length field");
+        let length_idx = NativeArray::get_struct_type().get_field_idx("length").expect("Array is missing required length field");
         self.write_opcode(Opcode::GetField(length_idx), line);
         self.metadata.field_gets.push("length".to_string());
         self.write_opcode(Opcode::LT, line);

--- a/abra_native/src/abra_function/gen.rs
+++ b/abra_native/src/abra_function/gen.rs
@@ -1,0 +1,64 @@
+use quote::{quote, format_ident};
+use crate::signature::{TypeRepr, MethodArgSpec};
+use crate::type_utils::gen_rust_type_path;
+use crate::abra_methods::parsing::MethodSpec;
+
+pub fn generate_function_code(static_method: MethodSpec) -> proc_macro2::TokenStream {
+    let name = &static_method.name;
+    let num_args = static_method.args.len();
+    let native_name_ident = format_ident!("{}", &static_method.native_method_name);
+    let native_method_arity = static_method.native_method_arity;
+
+    let arguments = match native_method_arity {
+        0 => quote! {},
+        1 => quote! { crate::builtins::arguments::Arguments::new(#name, #num_args, args) },
+        2 => quote! { crate::builtins::arguments::Arguments::new(#name, #num_args, args), vm },
+        _ => unreachable!()
+    };
+
+    let body = if static_method.return_type != TypeRepr::Unit {
+        quote! { #native_name_ident(#arguments) }
+    } else {
+        quote! {
+            #native_name_ident(#arguments);
+            crate::vm::value::Value::Nil
+        }
+    };
+
+    let fn_type = {
+        let args = static_method.args.iter().map(|arg| {
+            let MethodArgSpec { name, typ, is_optional, .. } = arg;
+            let typ = gen_rust_type_path(typ, &"BOGUS".to_string(), &"BOGUS".to_string());
+
+            quote! { (#name.to_string(), #typ, #is_optional) }
+        });
+
+        let return_type = gen_rust_type_path(&static_method.return_type, &"BOGUS".to_string(), &"BOGUS".to_string());
+        let is_variadic = &static_method.is_variadic;
+
+        quote! {
+            crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
+                arg_types: vec![#(#args),*],
+                type_args: vec![],
+                ret_type: Box::new(#return_type),
+                is_variadic: #is_variadic,
+                is_enum_constructor: false,
+            })
+        }
+    };
+
+    let native_value = quote! {
+        crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
+            name: #name,
+            receiver: None,
+            native_fn: |rcv, args, vm| { #body },
+        })
+    };
+
+    let gen_fn_name = format_ident!("{}__gen_spec", static_method.native_method_name);
+    quote! {
+        fn #gen_fn_name() -> (std::string::String, crate::typechecker::types::Type, crate::vm::value::Value) {
+            (#name.to_string(), #fn_type, #native_value)
+        }
+    }
+}

--- a/abra_native/src/abra_function/mod.rs
+++ b/abra_native/src/abra_function/mod.rs
@@ -1,0 +1,5 @@
+mod gen;
+mod parsing;
+
+pub use gen::generate_function_code;
+pub use parsing::parse_function;

--- a/abra_native/src/abra_function/parsing.rs
+++ b/abra_native/src/abra_function/parsing.rs
@@ -1,0 +1,53 @@
+use syn::FnArg;
+use std::collections::HashMap;
+use proc_macro2::Span;
+use syn::spanned::Spanned;
+use crate::signature::{TypeRepr, parse_fn_signature, Signature};
+use crate::abra_methods::parsing::MethodSpec;
+
+pub fn parse_function(attr_args: HashMap<String, String>, function: &syn::ItemFn) -> Result<MethodSpec, syn::Error> {
+    if let Some(FnArg::Receiver(_)) = function.sig.inputs.first() {
+        let msg = format!("The function bound via #[abra_function] must not receive self");
+        return Err(syn::Error::new(function.span(), msg));
+    }
+    let native_method_arity = function.sig.inputs.len();
+    if native_method_arity > 2 {
+        let msg = format!("The function bound via #[abra_function] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
+        return Err(syn::Error::new(function.sig.inputs.span(), msg));
+    }
+
+    let signature = match attr_args.get("signature") {
+        Some(signature) => match parse_fn_signature(None, &vec![], signature) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("Invalid signature provided to #[abra_function]: {}", e);
+                return Err(syn::Error::new(Span::call_site(), msg));
+            }
+        }
+        None => {
+            let msg = "Missing required parameter `signature` in #[abra_function] attribute".to_string();
+            return Err(syn::Error::new(Span::call_site(), msg));
+        }
+    };
+    let Signature { func_name, args, return_type } = signature;
+
+    if return_type == TypeRepr::Unit && function.sig.output != syn::ReturnType::Default {
+        let msg = format!("The function bound via #[abra_function] has no return type in its signature, and therefore must not have a return value");
+        return Err(syn::Error::new(function.sig.output.span(), msg));
+    }
+
+    let is_variadic = args.iter().any(|arg| arg.is_variadic);
+
+    let method_name = function.sig.ident.to_string();
+    Ok(MethodSpec {
+        native_method_name: method_name.clone(),
+        native_method_arity,
+        name: func_name,
+        args,
+        return_type,
+        is_static: true,
+        is_mut: false,
+        is_variadic,
+        is_pseudomethod: false,
+    })
+}

--- a/abra_native/src/abra_methods/gen.rs
+++ b/abra_native/src/abra_methods/gen.rs
@@ -1,0 +1,709 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use crate::signature::{MethodArgSpec, TypeRepr};
+use crate::type_utils::gen_rust_type_path;
+use crate::abra_methods::parsing::{ConstructorSpec, MethodSpec, EnumVariantSpec, EnumVariantDataSpec};
+use crate::abra_type::parsing::FieldSpec;
+
+#[derive(Debug)]
+pub struct TypeSpec {
+    pub(crate) native_type_name: String,
+    pub(crate) name: String,
+    pub(crate) module_name: String,
+    pub(crate) type_args: Vec<String>,
+    pub(crate) constructor: Option<ConstructorSpec>,
+    pub(crate) to_string_method: Option<String>,
+    pub(crate) fields: Vec<FieldSpec>,
+    pub(crate) methods: Vec<MethodSpec>,
+    pub(crate) pseudo_methods: Vec<MethodSpec>,
+    pub(crate) static_methods: Vec<MethodSpec>,
+    pub(crate) is_pseudotype: bool,
+    pub(crate) is_noconstruct: bool,
+    pub(crate) value_variant: Option<String>,
+    pub(crate) is_enum: bool,
+    pub(crate) enum_variants: Vec<EnumVariantSpec>,
+    pub(crate) enum_variant_data: Option<EnumVariantDataSpec>,
+}
+
+pub fn gen_native_type_code(type_spec: &TypeSpec) -> TokenStream {
+    let type_name = &type_spec.name;
+    let module_name = &type_spec.module_name;
+
+    let type_args = type_spec.type_args.iter().map(|type_arg_name| {
+        quote! {
+            (#type_arg_name.to_string(), crate::typechecker::types::Type::Generic(#type_arg_name.to_string()))
+        }
+    });
+
+    let fields = type_spec.fields.iter().map(|field| {
+        let FieldSpec { name, typ, has_default, readonly, .. } = field;
+        let typ = gen_rust_type_path(typ, module_name, type_name);
+
+        quote! {
+            crate::typechecker::types::StructTypeField {
+                name: #name.to_string(),
+                typ: #typ,
+                has_default_value: #has_default,
+                readonly: #readonly,
+            }
+        }
+    });
+
+    let all_methods = type_spec.methods.iter().chain(type_spec.pseudo_methods.iter());
+    let methods = all_methods.map(|method| {
+        let MethodSpec { name, args, return_type, is_variadic, .. } = method;
+
+        let args = args.iter().map(|arg| {
+            let MethodArgSpec { name, typ, is_optional, .. } = arg;
+            let typ = gen_rust_type_path(typ, module_name, type_name);
+
+            quote! { (#name.to_string(), #typ, #is_optional) }
+        });
+
+        let return_type = gen_rust_type_path(return_type, module_name, type_name);
+
+        quote! {
+            (
+                #name.to_string(),
+                crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
+                    arg_types: vec![#(#args),*],
+                    type_args: vec![],
+                    ret_type: Box::new(#return_type),
+                    is_variadic: #is_variadic,
+                    is_enum_constructor: false,
+                })
+            )
+        }
+    });
+
+    let static_methods = type_spec.static_methods.iter().map(|static_method| {
+        let MethodSpec { name, args, return_type, is_variadic, .. } = static_method;
+
+        let args = args.iter().map(|arg| {
+            let MethodArgSpec { name, typ, is_optional, .. } = arg;
+            let typ = gen_rust_type_path(typ, module_name, type_name);
+
+            quote! { (#name.to_string(), #typ, #is_optional) }
+        });
+
+        let return_type = gen_rust_type_path(return_type, module_name, type_name);
+
+        quote! {
+            (
+                #name.to_string(),
+                crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
+                    arg_types: vec![#(#args),*],
+                    type_args: vec![],
+                    ret_type: Box::new(#return_type),
+                    is_variadic: #is_variadic,
+                    is_enum_constructor: false,
+                }),
+                true
+            )
+        }
+    });
+
+    let native_type_name_ident = format_ident!("{}", &type_spec.native_type_name);
+    let is_constructable = !type_spec.is_noconstruct;
+    let ts = if !type_spec.is_enum {
+        quote! {
+            impl crate::builtins::native_value_trait::NativeTyp for #native_type_name_ident {
+                fn is_struct() -> bool { true }
+                fn get_struct_type() -> crate::typechecker::types::StructType where Self: Sized {
+                    crate::typechecker::types::StructType {
+                        name: #type_name.to_string(),
+                        type_args: vec![ #(#type_args),* ],
+                        constructable: #is_constructable,
+                        fields: vec![ #(#fields),* ],
+                        static_fields: vec![ #(#static_methods),* ],
+                        methods: vec![
+                            ("toString".to_string(), crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
+                                arg_types: vec![],
+                                type_args: vec![],
+                                ret_type: std::boxed::Box::new(crate::typechecker::types::Type::String),
+                                is_variadic: false,
+                                is_enum_constructor: false,
+                            })),
+                            #(#methods),*
+                        ],
+                    }
+                }
+                fn get_enum_type() -> crate::typechecker::types::EnumType where Self: Sized {
+                    unreachable!("This is not an enum type");
+                }
+            }
+        }
+    } else {
+        let variants = type_spec.enum_variants.iter().map(|variant| {
+            let EnumVariantSpec { name, args, return_type, .. } = variant;
+
+            let args = args.iter().map(|arg| {
+                let MethodArgSpec { name, typ, is_optional, .. } = arg;
+                let typ = gen_rust_type_path(typ, module_name, type_name);
+
+                quote! { (#name.to_string(), #typ, #is_optional) }
+            });
+            let return_type = gen_rust_type_path(return_type, module_name, type_name);
+
+            quote! {
+                (
+                    #name.to_string(),
+                    crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
+                        arg_types: vec![ #(#args),* ],
+                        type_args: vec![],
+                        ret_type: std::boxed::Box::new(#return_type),
+                        is_variadic: false,
+                        is_enum_constructor: true,
+                    })
+                )
+            }
+        });
+
+        quote! {
+            impl crate::builtins::native_value_trait::NativeTyp for #native_type_name_ident {
+                fn is_struct() -> bool { false }
+                fn get_struct_type() -> crate::typechecker::types::StructType where Self: Sized {
+                    unreachable!("This is not a struct type");
+                }
+                fn get_enum_type() -> crate::typechecker::types::EnumType where Self: Sized {
+                    crate::typechecker::types::EnumType {
+                        name: "Result".to_string(),
+                        type_args: vec![ #(#type_args),* ],
+                        variants: vec![ #(#variants),* ],
+                        static_fields: vec![ #(#static_methods),* ],
+                        methods: vec![
+                            ("toString".to_string(), crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
+                                arg_types: vec![],
+                                type_args: vec![],
+                                ret_type: std::boxed::Box::new(crate::typechecker::types::Type::String),
+                                is_variadic: false,
+                                is_enum_constructor: false,
+                            })),
+                            #(#methods),*
+                        ],
+                    }
+                }
+            }
+        }
+    };
+
+    ts.into()
+}
+
+pub fn gen_native_value_code(type_spec: &TypeSpec) -> TokenStream {
+    let construct_method_code = gen_construct_code(type_spec);
+    let get_type_value_method_code = gen_get_type_value_method_code(type_spec);
+    let to_string_method_code = gen_to_string_method_code(type_spec);
+    let get_field_values_method_code = gen_get_field_values_method_code(type_spec);
+    let get_field_value_method_code = gen_get_field_value_method_code(type_spec);
+    let set_field_value_method_code = gen_set_field_value_method_code(type_spec);
+
+    let native_type_name_ident = format_ident!("{}", &type_spec.native_type_name);
+    let ts = quote! {
+        impl crate::builtins::native_value_trait::NativeValue for #native_type_name_ident {
+            #construct_method_code
+            #get_type_value_method_code
+            fn is_equal(&self, other: &std::boxed::Box<dyn crate::builtins::native_value_trait::NativeValue>) -> bool {
+                let other = other.downcast_ref::<Self>();
+                other.map_or(false, |o| o.eq(&self))
+            }
+            #to_string_method_code
+            #get_field_values_method_code
+            #get_field_value_method_code
+            #set_field_value_method_code
+        }
+    };
+    ts.into()
+}
+
+fn gen_construct_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
+    let body = match &type_spec.constructor {
+        Some(spec) => {
+            let constructor_fn_name = &spec.native_fn_name;
+            let constructor_fn_name_ident = format_ident!("{}", &constructor_fn_name);
+            quote! {
+                let inst = Self::#constructor_fn_name_ident(args);
+                crate::vm::value::Value::new_native_instance_obj(type_id, std::boxed::Box::new(inst))
+            }
+        }
+        None => {
+            quote! { unreachable!("The type bound to #type_name has not bound a function via #[abra_constructor]. You were probably never intended to construct this type") }
+        }
+    };
+
+    quote! {
+        fn construct(type_id: usize, args: std::vec::Vec<crate::vm::value::Value>) -> crate::vm::value::Value where Self: core::marker::Sized {
+            #body
+        }
+    }
+}
+
+fn gen_get_type_value_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
+    let type_name = &type_spec.name;
+    let module_name = &type_spec.module_name;
+    let fully_qualified_type_name = format!("{}/{}", module_name, type_name);
+
+    let fields = type_spec.fields.iter().map(|field| {
+        let name = &field.name;
+        quote! { #name.to_string() }
+    });
+
+    let all_methods = type_spec.methods.iter().chain(type_spec.pseudo_methods.iter());
+    let methods = all_methods.map(|method| {
+        let name = &method.name;
+        let num_args = method.args.len();
+        let native_name_ident = format_ident!("{}", &method.native_method_name);
+        let native_method_arity = method.native_method_arity;
+
+        let arguments = match native_method_arity {
+            0 => quote! {},
+            1 => quote! {
+                crate::builtins::arguments::Arguments::new(#name, #num_args, args)
+            },
+            2 => quote! {
+                crate::builtins::arguments::Arguments::new(#name, #num_args, args), vm
+            },
+            _ => unreachable!()
+        };
+
+        let body = if method.is_pseudomethod {
+            if type_spec.value_variant.is_some() {
+                quote! { Self::#native_name_ident }
+            } else {
+                quote! { |rcv, args, vm| Self::#native_name_ident(rcv.unwrap(), #arguments) }
+            }
+        } else {
+            let body_return = if method.return_type != TypeRepr::Unit {
+                if let TypeRepr::SelfType(_) = &method.return_type {
+                    match &type_spec.value_variant {
+                        Some(variant) => {
+                            let variant = format_ident!("{}", variant);
+                            quote! {
+                                let inst = inst.#native_name_ident(#arguments);
+                                crate::vm::value::Value::#variant(
+                                    std::sync::Arc::new(std::cell::RefCell::new(inst))
+                                )
+                            }
+                        }
+                        None => {
+                            if type_spec.is_enum {
+                                let enum_variant_data_fn_spec = &type_spec.enum_variant_data.as_ref().unwrap();
+                                let fn_name = &enum_variant_data_fn_spec.native_method_name;
+                                let fn_name_ident = format_ident!("{}", &fn_name);
+
+                                quote! {
+                                    let inst = inst.#native_name_ident(#arguments);
+                                    let type_id = vm.type_id_for_name(#fully_qualified_type_name);
+                                    let (variant_idx, _) = inst.#fn_name_ident();
+                                    crate::vm::value::Value::new_native_enum_instance_obj(
+                                        type_id,
+                                        variant_idx,
+                                        std::boxed::Box::new(inst)
+                                    )
+                                }
+                            } else {
+                                quote! {
+                                    let inst = inst.#native_name_ident(#arguments);
+                                    let type_id = vm.type_id_for_name(#fully_qualified_type_name);
+                                    crate::vm::value::Value::new_native_instance_obj(
+                                        type_id,
+                                        std::boxed::Box::new(inst)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    quote! { inst.#native_name_ident(#arguments) }
+                }
+            } else {
+                quote! {
+                    inst.#native_name_ident(#arguments);
+                    crate::vm::value::Value::Nil
+                }
+            };
+            let invocation = if method.is_mut {
+                if type_spec.value_variant.is_some() {
+                    quote! {
+                        let inst = &mut *rcv_obj.borrow_mut();
+                        #body_return
+                    }
+                } else {
+                    quote! {
+                        let mut rcv = &mut *rcv_obj.borrow_mut();
+                        let mut inst = rcv.inst.downcast_mut::<Self>().unwrap();
+                        #body_return
+                    }
+                }
+            } else {
+                if type_spec.value_variant.is_some() {
+                    quote! {
+                        let inst = &*rcv_obj.borrow();
+                        #body_return
+                    }
+                } else {
+                    quote! {
+                        let rcv = &*rcv_obj.borrow();
+                        let mut inst = rcv.inst.downcast_ref::<Self>().unwrap();
+                        #body_return
+                    }
+                }
+            };
+
+            let b = match &type_spec.value_variant {
+                Some(variant) => {
+                    let variant = format_ident!("{}", variant);
+                    quote! {
+                        if let Some(crate::vm::value::Value::#variant(rcv_obj)) = rcv { #invocation } else { unreachable!() }
+                    }
+                }
+                None => {
+                    let t = if type_spec.is_enum {
+                        quote! { crate::vm::value::Value::NativeEnumInstanceObj }
+                    } else {
+                        quote! { crate::vm::value::Value::NativeInstanceObj }
+                    };
+
+                    quote! {
+                        if let Some(#t(rcv_obj)) = rcv { #invocation } else { unreachable!() }
+                    }
+                }
+            };
+
+            quote! {
+                |rcv, args, vm| #b
+            }
+        };
+
+        quote! {
+            (#name.to_string(), crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
+                name: #name,
+                receiver: None,
+                native_fn: #body,
+            }))
+        }
+    });
+
+    let static_methods = type_spec.static_methods.iter().map(|static_method| {
+        let name = &static_method.name;
+        let num_args = static_method.args.len();
+        let native_name_ident = format_ident!("{}", &static_method.native_method_name);
+        let native_method_arity = static_method.native_method_arity;
+
+        let arguments = match native_method_arity {
+            0 => quote! {},
+            1 => quote! {
+                crate::builtins::arguments::Arguments::new(#name, #num_args, args)
+            },
+            2 => quote! {
+                crate::builtins::arguments::Arguments::new(#name, #num_args, args), vm
+            },
+            _ => unreachable!()
+        };
+
+        let body = if static_method.return_type != TypeRepr::Unit {
+            match &type_spec.value_variant {
+                Some(variant) => {
+                    let variant = format_ident!("{}", variant);
+                    quote! {
+                        let inst = Self::#native_name_ident(#arguments);
+                        crate::vm::value::Value::#variant(
+                            std::sync::Arc::new(std::cell::RefCell::new(inst))
+                        )
+                    }
+                }
+                None => {
+                    if let TypeRepr::SelfType(_) = &static_method.return_type {
+                        if type_spec.is_enum {
+                            let enum_variant_data_fn_spec = &type_spec.enum_variant_data.as_ref().unwrap();
+                            let fn_name = &enum_variant_data_fn_spec.native_method_name;
+                            let fn_name_ident = format_ident!("{}", &fn_name);
+
+                            quote! {
+                                let inst = Self::#native_name_ident(#arguments);
+                                let type_id = vm.type_id_for_name(#fully_qualified_type_name);
+                                let (variant_idx, _) = inst.#fn_name_ident();
+                                crate::vm::value::Value::new_native_enum_instance_obj(
+                                    type_id,
+                                    variant_idx,
+                                    std::boxed::Box::new(inst)
+                                )
+                            }
+                        } else {
+                            quote! {
+                                let inst = Self::#native_name_ident(#arguments);
+                                let type_id = vm.type_id_for_name(#fully_qualified_type_name);
+                                crate::vm::value::Value::new_native_instance_obj(
+                                    type_id,
+                                    std::boxed::Box::new(inst)
+                                )
+                            }
+                        }
+                    } else {
+                        quote! { Self::#native_name_ident(#arguments) }
+                    }
+                }
+            }
+        } else {
+            quote! {
+                Self::#native_name_ident(#arguments);
+                crate::vm::value::Value::Nil
+            }
+        };
+
+        quote! {
+            (#name.to_string(), crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
+                name: #name,
+                receiver: None,
+                native_fn: |rcv, args, vm| { #body },
+            }))
+        }
+    });
+
+    let to_string_method_code = if type_spec.is_pseudotype || type_spec.value_variant.is_some() {
+        quote! {
+            ("toString".to_string(), crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
+                name: "toString",
+                receiver: None,
+                native_fn: |rcv, _args, vm| {
+                    Value::new_string_obj(
+                        crate::builtins::common::to_string(&rcv.unwrap(), vm)
+                    )
+                },
+            })),
+        }
+    } else {
+        let t = if type_spec.is_enum {
+            quote! { crate::vm::value::Value::NativeEnumInstanceObj }
+        } else {
+            quote! { crate::vm::value::Value::NativeInstanceObj }
+        };
+
+        quote! {
+            ("toString".to_string(), crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
+                name: "toString",
+                receiver: None,
+                native_fn: |rcv, _args, vm| {
+                    if let Some(#t(rcv_obj)) = rcv {
+                        let rcv = &*rcv_obj.borrow();
+                        let mut inst = rcv.inst.downcast_ref::<Self>().unwrap();
+                        rcv.inst.method_to_string(vm)
+                    } else { unreachable!() }
+                },
+            })),
+        }
+    };
+
+    if !type_spec.is_enum {
+        quote! {
+            fn get_type_value() -> crate::vm::value::Value where Self: core::marker::Sized {
+                crate::vm::value::Value::Type(crate::vm::value::TypeValue {
+                    name: #type_name.to_string(),
+                    module_name: #module_name.to_string(),
+                    fields: vec![ #(#fields),* ],
+                    constructor: Some(Self::construct),
+                    methods: vec![
+                        #to_string_method_code
+                        #(#methods),*
+                    ],
+                    static_fields: vec![ #(#static_methods),* ],
+                })
+            }
+        }
+    } else {
+        let variants = type_spec.enum_variants.iter().enumerate().map(|(idx, variant)| {
+            let EnumVariantSpec { native_method_name, native_method_arity, name, args, .. } = variant;
+
+            let num_args = args.len();
+            let native_name_ident = format_ident!("{}", &native_method_name);
+
+            let arguments = match native_method_arity {
+                0 => quote! {},
+                1 => quote! {
+                crate::builtins::arguments::Arguments::new(#name, #num_args, args)
+            },
+                2 => quote! {
+                crate::builtins::arguments::Arguments::new(#name, #num_args, args), vm
+            },
+                _ => unreachable!()
+            };
+
+            quote! {
+                (
+                    #name.to_string(),
+                    crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
+                        name: #name,
+                        receiver: None,
+                        native_fn: |_rcv, args, vm| {
+                            let type_id = vm.type_id_for_name(#fully_qualified_type_name);
+                            let inst = Self::#native_name_ident(#arguments);
+                            crate::vm::value::Value::new_native_enum_instance_obj(type_id, #idx, Box::new(inst))
+                        },
+                    })
+                )
+            }
+        });
+
+        quote! {
+            fn get_type_value() -> crate::vm::value::Value where Self: core::marker::Sized {
+                crate::vm::value::Value::Enum(crate::vm::value::EnumValue {
+                    name: #type_name.to_string(),
+                    module_name: #module_name.to_string(),
+                    variants: vec![ #(#variants),* ],
+                    methods: vec![
+                        #to_string_method_code
+                        #(#methods),*
+                    ],
+                    static_fields: vec![ #(#static_methods),* ],
+                })
+            }
+        }
+    }
+}
+
+fn gen_to_string_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
+    match &type_spec.to_string_method {
+        Some(method_name) => {
+            let method_name_ident = format_ident!("{}", method_name);
+            quote! {
+                fn method_to_string(&self, vm: &mut crate::vm::vm::VM) -> crate::vm::value::Value {
+                    crate::vm::value::Value::new_string_obj(self.#method_name_ident(vm))
+                }
+            }
+        }
+        None => {
+            if !type_spec.is_enum {
+                let mut format_str = vec![format!("{}(", type_spec.name)];
+                let mut fields_code = Vec::new();
+                let num_fields = type_spec.fields.len();
+                for (idx, field) in type_spec.fields.iter().enumerate() {
+                    format_str.push(format!(
+                        "{}{}: {{}}{}",
+                        if idx > 0 { ", " } else { "" },
+                        &field.name,
+                        if idx == num_fields - 1 { ")" } else { "" }
+                    ));
+
+                    let getter_name = &field.getter.as_ref().unwrap().native_method_name;
+                    let method_name_ident = format_ident!("{}", getter_name);
+                    fields_code.push(quote! { self.#method_name_ident() });
+                }
+                let format_str = format_str.join("");
+
+                quote! {
+                    fn method_to_string(&self, vm: &mut crate::vm::vm::VM) -> crate::vm::value::Value {
+                        crate::vm::value::Value::new_string_obj(format!(#format_str, #(#fields_code),*))
+                    }
+                }
+            } else {
+                let enum_variant_data_fn_spec = &type_spec.enum_variant_data.as_ref().unwrap();
+                let fn_name = &enum_variant_data_fn_spec.native_method_name;
+                let fn_name_ident = format_ident!("{}", &fn_name);
+
+                let variant_str_branches = type_spec.enum_variants.iter().enumerate().map(|(idx, variant)| {
+                    let variant_name = format!("{}.{}(", type_spec.name, variant.name);
+                    quote! {
+                        #idx => #variant_name
+                    }
+                });
+
+                quote! {
+                    fn method_to_string(&self, vm: &mut crate::vm::vm::VM) -> crate::vm::value::Value {
+                        use itertools::Itertools;
+
+                        let (idx, values) = self.#fn_name_ident();
+                        let prefix = match idx {
+                            #(#variant_str_branches,)*
+                            _ => unreachable!(),
+                        };
+                        let values = values.iter().map(|v| v.to_string()).join(", ");
+                        crate::vm::value::Value::new_string_obj(format!("{}{})", prefix, values))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn gen_get_field_values_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
+    if type_spec.is_enum {
+        let enum_variant_data_fn_spec = &type_spec.enum_variant_data.as_ref().unwrap();
+        let fn_name = &enum_variant_data_fn_spec.native_method_name;
+        let fn_name_ident = format_ident!("{}", &fn_name);
+
+        return quote! {
+            fn get_field_values(&self) -> std::vec::Vec<crate::vm::value::Value> {
+                self.#fn_name_ident().1.iter().map(|v| (*v).clone()).collect()
+            }
+        };
+    }
+
+    let code = type_spec.fields.iter().map(|field| {
+        let getter_name = &field.getter.as_ref().unwrap().native_method_name;
+        let method_name_ident = format_ident!("{}", getter_name);
+        quote! { self.#method_name_ident() }
+    });
+
+    quote! {
+        fn get_field_values(&self) -> std::vec::Vec<crate::vm::value::Value> {
+            vec![ #(#code),* ]
+        }
+    }
+}
+
+fn gen_get_field_value_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
+    if type_spec.is_enum {
+        let enum_variant_data_fn_spec = &type_spec.enum_variant_data.as_ref().unwrap();
+        let fn_name = &enum_variant_data_fn_spec.native_method_name;
+        let fn_name_ident = format_ident!("{}", &fn_name);
+
+        return quote! {
+            fn get_field_value(&self, field_idx: usize) -> crate::vm::value::Value {
+                let (_, values) = self.#fn_name_ident();
+                values[field_idx].clone()
+            }
+        };
+    }
+
+    let code = type_spec.fields.iter().enumerate().map(|(idx, field)| {
+        let method_name = &field.getter.as_ref().unwrap().native_method_name;
+        let method_name_ident = format_ident!("{}", method_name);
+
+        quote! { #idx => self.#method_name_ident() }
+    });
+
+    quote! {
+        fn get_field_value(&self, field_idx: usize) -> crate::vm::value::Value {
+            match field_idx {
+                #(#code,)*
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+fn gen_set_field_value_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
+    if type_spec.is_enum {
+        return quote! {
+            fn set_field_value(&mut self, _field_idx: usize, _value: crate::vm::value::Value) {
+                unreachable!("Enum variant fields cannot be directly set");
+            }
+        };
+    }
+
+    let code = type_spec.fields.iter().enumerate().filter_map(|(idx, field)| {
+        field.setter.as_ref().map(|setter| {
+            let method_name_ident = format_ident!("{}", setter.native_method_name);
+            quote! { #idx => self.#method_name_ident(value) }
+        })
+    });
+
+    quote! {
+        fn set_field_value(&mut self, field_idx: usize, value: crate::vm::value::Value) {
+            match field_idx {
+                #(#code,)*
+                _ => unreachable!(),
+            }
+        }
+    }
+}

--- a/abra_native/src/abra_methods/mod.rs
+++ b/abra_native/src/abra_methods/mod.rs
@@ -1,0 +1,2 @@
+pub mod parsing;
+pub mod gen;

--- a/abra_native/src/abra_methods/parsing.rs
+++ b/abra_native/src/abra_methods/parsing.rs
@@ -1,0 +1,428 @@
+use syn::{FnArg, ReturnType};
+use syn::spanned::Spanned;
+use crate::signature::{TypeRepr, MethodArgSpec, parse_fn_signature, Signature, parse_type};
+use crate::parsing_common::{find_attr, parse_attr};
+
+#[derive(Debug)]
+pub struct GetterSpec {
+    pub(crate) native_method_name: String,
+}
+
+#[derive(Debug)]
+pub struct SetterSpec {
+    pub(crate) native_method_name: String,
+}
+
+pub fn parse_getter(method: &mut syn::ImplItemMethod) -> Result<Option<(String, GetterSpec)>, syn::Error> {
+    let method_name = method.sig.ident.to_string();
+
+    let (idx, abra_getter_attr) = match find_attr(&method.attrs, "abra_getter") {
+        Some(attr) => attr,
+        None => return Ok(None)
+    };
+    let attr_span = abra_getter_attr.span();
+    let attr = parse_attr(abra_getter_attr);
+    method.attrs.remove(idx);
+
+    let field = match attr.get("field") {
+        Some(field) => field.clone(),
+        None => {
+            let msg = format!("Missing required parameter `field` in `abra_getter` attribute");
+            return Err(syn::Error::new(attr_span, msg));
+        }
+    };
+
+    Ok(Some((field, GetterSpec { native_method_name: method_name })))
+}
+
+pub fn parse_setter(method: &mut syn::ImplItemMethod) -> Result<Option<(String, SetterSpec)>, syn::Error> {
+    let method_name = method.sig.ident.to_string();
+
+    let (idx, abra_setter_attr) = match find_attr(&method.attrs, "abra_setter") {
+        Some(attr) => attr,
+        None => return Ok(None)
+    };
+    let attr_span = abra_setter_attr.span();
+    let attr = parse_attr(abra_setter_attr);
+    method.attrs.remove(idx);
+
+    let field = match attr.get("field") {
+        Some(field) => field.clone(),
+        None => {
+            let msg = format!("Missing required parameter `field` in `abra_setter` attribute");
+            return Err(syn::Error::new(attr_span, msg));
+        }
+    };
+
+    Ok(Some((field, SetterSpec { native_method_name: method_name })))
+}
+
+#[derive(Debug)]
+pub struct MethodSpec {
+    pub(crate) native_method_name: String,
+    pub(crate) native_method_arity: usize,
+    pub(crate) name: String,
+    pub(crate) args: Vec<MethodArgSpec>,
+    pub(crate) return_type: TypeRepr,
+    pub(crate) is_static: bool,
+    pub(crate) is_mut: bool,
+    pub(crate) is_variadic: bool,
+    pub(crate) is_pseudomethod: bool,
+}
+
+pub fn parse_method(type_name: &String, type_args: &Vec<String>, method: &mut syn::ImplItemMethod) -> Result<Option<MethodSpec>, syn::Error> {
+    let (idx, abra_method_attr) = match find_attr(&method.attrs, "abra_method") {
+        Some(attr) => attr,
+        None => return Ok(None)
+    };
+    let attr_span = abra_method_attr.span();
+    let attr = parse_attr(abra_method_attr);
+    method.attrs.remove(idx);
+
+    let signature = match attr.get("signature") {
+        Some(signature) => match parse_fn_signature(Some(type_name), type_args, signature) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("Invalid signature provided to #[abra_method]: {}", e);
+                return Err(syn::Error::new(attr_span, msg));
+            }
+        }
+        None => {
+            let msg = "Missing required parameter `signature` in #[abra_method] attribute".to_string();
+            return Err(syn::Error::new(attr_span, msg));
+        }
+    };
+
+    let is_mut = match method.sig.inputs.first() {
+        Some(FnArg::Typed(_)) | None => {
+            let msg = format!("The function bound via #[abra_method] must receive self");
+            return Err(syn::Error::new(method.span(), msg));
+        }
+        Some(FnArg::Receiver(rcv)) => {
+            if !rcv.reference.is_some() {
+                let msg = format!("The function bound via #[abra_method] must receive a reference to self");
+                return Err(syn::Error::new(rcv.span(), msg));
+            }
+            rcv.mutability.is_some()
+        }
+    };
+    let native_method_arity = method.sig.inputs.len() - 1; // -1 to account for &self
+    if native_method_arity > 2 {
+        let msg = format!("The function bound via #[abra_method] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
+        return Err(syn::Error::new(method.sig.inputs.span(), msg));
+    }
+
+    if signature.return_type == TypeRepr::Unit && method.sig.output != syn::ReturnType::Default {
+        let msg = format!("The function bound via #[abra_method] has no return type in its signature, and therefore must not have a return value");
+        return Err(syn::Error::new(method.sig.output.span(), msg));
+    }
+    if let TypeRepr::SelfType(_) = &signature.return_type {
+        let is_invalid = if let ReturnType::Type(_, t) = &method.sig.output {
+            if let syn::Type::Path(type_path) = &**t {
+                if let Some(seg) = type_path.path.segments.last() {
+                    seg.ident.to_string() != "Self"
+                } else { unreachable!() }
+            } else { true }
+        } else { true };
+        if is_invalid {
+            let msg = format!("The function bound via #[abra_method] has a signature which returns '{}', so it must return Self", type_name);
+            return Err(syn::Error::new(method.sig.span(), msg));
+        }
+    }
+
+    let is_variadic = signature.args.iter().any(|arg| arg.is_variadic);
+
+    let method_name = method.sig.ident.to_string();
+    Ok(Some(MethodSpec {
+        native_method_name: method_name.clone(),
+        native_method_arity,
+        name: signature.func_name,
+        args: signature.args,
+        return_type: signature.return_type,
+        is_static: false,
+        is_mut,
+        is_variadic,
+        is_pseudomethod: false,
+    }))
+}
+
+pub fn parse_pseudomethod(type_args: &Vec<String>, method: &mut syn::ImplItemMethod) -> Result<Option<MethodSpec>, syn::Error> {
+    let (idx, abra_method_attr) = match find_attr(&method.attrs, "abra_pseudomethod") {
+        Some(attr) => attr,
+        None => return Ok(None)
+    };
+    let attr_span = abra_method_attr.span();
+    let attr = parse_attr(abra_method_attr);
+    method.attrs.remove(idx);
+
+    let signature = match attr.get("signature") {
+        Some(signature) => match parse_fn_signature(None, type_args, signature) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("Invalid signature provided to #[abra_pseudomethod]: {}", e);
+                return Err(syn::Error::new(attr_span, msg));
+            }
+        }
+        None => {
+            let msg = "Missing required parameter `signature` in #[abra_pseudomethod] attribute".to_string();
+            return Err(syn::Error::new(attr_span, msg));
+        }
+    };
+
+    if let Some(FnArg::Receiver(_)) = method.sig.inputs.first() {
+        let msg = format!("The function bound via #[abra_pseudomethod] must not receive self");
+        return Err(syn::Error::new(method.span(), msg));
+    }
+    let native_method_arity = method.sig.inputs.len() - 1; // -1 to account for rcv
+    if native_method_arity > 2 {
+        let msg = format!("The function bound via #[abra_pseudomethod] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
+        return Err(syn::Error::new(method.sig.inputs.span(), msg));
+    }
+
+    if signature.return_type == TypeRepr::Unit && method.sig.output != syn::ReturnType::Default {
+        let msg = format!("The function bound via #[abra_pseudomethod] has no return type in its signature, and therefore must not have a return value");
+        return Err(syn::Error::new(method.sig.output.span(), msg));
+    }
+
+    let is_variadic = signature.args.iter().any(|arg| arg.is_variadic);
+
+    let method_name = method.sig.ident.to_string();
+    Ok(Some(MethodSpec {
+        native_method_name: method_name.clone(),
+        native_method_arity,
+        name: signature.func_name,
+        args: signature.args,
+        return_type: signature.return_type,
+        is_static: false,
+        is_mut: false,
+        is_variadic,
+        is_pseudomethod: true,
+    }))
+}
+
+pub fn parse_static_method(type_name: &String, type_args: &Vec<String>, method: &mut syn::ImplItemMethod) -> Result<Option<MethodSpec>, syn::Error> {
+    let (idx, abra_method_attr) = match find_attr(&method.attrs, "abra_static_method") {
+        Some(attr) => attr,
+        None => return Ok(None)
+    };
+    let attr_span = abra_method_attr.span();
+    let attr = parse_attr(abra_method_attr);
+    method.attrs.remove(idx);
+
+    if let Some(FnArg::Receiver(_)) = method.sig.inputs.first() {
+        let msg = format!("The function bound via #[abra_static_method] must not receive self");
+        return Err(syn::Error::new(method.span(), msg));
+    }
+    let native_method_arity = method.sig.inputs.len();
+    if native_method_arity > 2 {
+        let msg = format!("The function bound via #[abra_static_method] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
+        return Err(syn::Error::new(method.sig.inputs.span(), msg));
+    }
+
+    let signature = match attr.get("signature") {
+        Some(signature) => match parse_fn_signature(Some(type_name), type_args, signature) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("Invalid signature provided to #[abra_static_method]: {}", e);
+                return Err(syn::Error::new(attr_span, msg));
+            }
+        }
+        None => {
+            let msg = "Missing required parameter `signature` in #[abra_static_method] attribute".to_string();
+            return Err(syn::Error::new(attr_span, msg));
+        }
+    };
+    let Signature { func_name, args, return_type } = signature;
+
+    if return_type == TypeRepr::Unit && method.sig.output != syn::ReturnType::Default {
+        let msg = format!("The function bound via #[abra_static_method] has no return type in its signature, and therefore must not have a return value");
+        return Err(syn::Error::new(method.sig.output.span(), msg));
+    }
+    if let TypeRepr::SelfType(_) = &return_type {
+        let is_invalid = if let ReturnType::Type(_, t) = &method.sig.output {
+            if let syn::Type::Path(type_path) = &**t {
+                if let Some(seg) = type_path.path.segments.last() {
+                    seg.ident.to_string() != "Self"
+                } else { unreachable!() }
+            } else { true }
+        } else { true };
+        if is_invalid {
+            let msg = format!("The function bound via #[abra_static_method] has a signature which returns '{}', so it must return Self", type_name);
+            return Err(syn::Error::new(method.sig.span(), msg));
+        }
+    }
+
+    let is_variadic = args.iter().any(|arg| arg.is_variadic);
+
+    let method_name = method.sig.ident.to_string();
+    Ok(Some(MethodSpec {
+        native_method_name: method_name.clone(),
+        native_method_arity,
+        name: func_name,
+        args,
+        return_type,
+        is_static: true,
+        is_mut: false,
+        is_variadic,
+        is_pseudomethod: false,
+    }))
+}
+
+#[derive(Debug)]
+pub struct ConstructorSpec {
+    pub(crate) native_fn_name: String,
+}
+
+pub fn parse_constructor(method: &mut syn::ImplItemMethod) -> Result<Option<ConstructorSpec>, syn::Error> {
+    let abra_constructor_attr = find_attr(&method.attrs, "abra_constructor");
+    match abra_constructor_attr {
+        Some((idx, _)) => method.attrs.remove(idx),
+        _ => return Ok(None)
+    };
+    let method_name = method.sig.ident.to_string();
+    if let Some(FnArg::Receiver(_)) = method.sig.inputs.first() {
+        let msg = format!("The function bound via #[abra_constructor] must not receive self");
+        return Err(syn::Error::new(method.span(), msg));
+    }
+
+    Ok(Some(ConstructorSpec { native_fn_name: method_name }))
+}
+
+pub fn parse_to_string_method(method: &mut syn::ImplItemMethod) -> Result<Option<String>, syn::Error> {
+    let abra_constructor_attr = find_attr(&method.attrs, "abra_to_string");
+    match abra_constructor_attr {
+        Some((idx, _)) => method.attrs.remove(idx),
+        _ => return Ok(None)
+    };
+    let method_name = method.sig.ident.to_string();
+    if let ReturnType::Type(_, t) = &method.sig.output {
+        if let syn::Type::Path(type_path) = &**t {
+            if let Some(seg) = type_path.path.segments.last() {
+                if seg.ident.to_string() != "String" {
+                    let msg = "The function bound via #[abra_to_string] must return String".to_string();
+                    return Err(syn::Error::new(method.sig.output.span(), msg));
+                }
+            }
+        }
+    }
+
+    Ok(Some(method_name))
+}
+
+#[derive(Debug)]
+pub struct EnumVariantSpec {
+    pub(crate) native_method_name: String,
+    pub(crate) native_method_arity: usize,
+    pub(crate) name: String,
+    pub(crate) args: Vec<MethodArgSpec>,
+    pub(crate) return_type: TypeRepr,
+}
+
+pub fn parse_enum_variant(type_name: &String, type_args: &Vec<String>, method: &mut syn::ImplItemMethod) -> Result<Option<EnumVariantSpec>, syn::Error> {
+    let (idx, abra_method_attr) = match find_attr(&method.attrs, "abra_enum_variant") {
+        Some(attr) => attr,
+        None => return Ok(None)
+    };
+    let attr_span = abra_method_attr.span();
+    let attr = parse_attr(abra_method_attr);
+    method.attrs.remove(idx);
+
+    if let Some(FnArg::Receiver(_)) = method.sig.inputs.first() {
+        let msg = format!("The function bound via #[abra_enum_variant] must not receive self");
+        return Err(syn::Error::new(method.span(), msg));
+    }
+    let native_method_arity = method.sig.inputs.len();
+    if native_method_arity > 2 {
+        let msg = format!("The function bound via #[abra_enum_variant] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
+        return Err(syn::Error::new(method.sig.inputs.span(), msg));
+    }
+
+    let signature = match attr.get("signature") {
+        Some(signature) => match parse_fn_signature(Some(type_name), type_args, signature) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("Invalid `signature` provided to #[abra_enum_variant]: {}", e);
+                return Err(syn::Error::new(attr_span, msg));
+            }
+        }
+        None => {
+            let msg = "Missing required parameter `signature` in #[abra_enum_variant] attribute".to_string();
+            return Err(syn::Error::new(attr_span, msg));
+        }
+    };
+    let return_type = match attr.get("return_type") {
+        Some(signature) => match parse_type(Some(type_name), type_args, signature) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("Invalid `return_type` provided to #[abra_enum_variant]: {}", e);
+                return Err(syn::Error::new(attr_span, msg));
+            }
+        }
+        None => {
+            let msg = "Missing required parameter `return_type` in #[abra_enum_variant] attribute".to_string();
+            return Err(syn::Error::new(attr_span, msg));
+        }
+    };
+    let Signature { func_name, args, .. } = signature;
+
+    if return_type == TypeRepr::Unit && method.sig.output != syn::ReturnType::Default {
+        let msg = format!("The function bound via #[abra_enum_variant] has no return type in its signature, and therefore must not have a return value");
+        return Err(syn::Error::new(method.sig.output.span(), msg));
+    }
+    if let TypeRepr::SelfType(_) = &return_type {
+        let is_invalid = if let ReturnType::Type(_, t) = &method.sig.output {
+            if let syn::Type::Path(type_path) = &**t {
+                if let Some(seg) = type_path.path.segments.last() {
+                    seg.ident.to_string() != "Self"
+                } else { unreachable!() }
+            } else { true }
+        } else { true };
+        if is_invalid {
+            let msg = format!("The function bound via #[abra_enum_variant] has a signature which returns '{}', so it must return Self", type_name);
+            return Err(syn::Error::new(method.sig.span(), msg));
+        }
+    }
+
+    let method_name = method.sig.ident.to_string();
+    Ok(Some(EnumVariantSpec {
+        native_method_name: method_name,
+        native_method_arity,
+        name: func_name,
+        args,
+        return_type,
+    }))
+}
+
+#[derive(Debug)]
+pub struct EnumVariantDataSpec {
+    pub(crate) native_method_name: String,
+    pub(crate) native_method_arity: usize,
+}
+
+pub fn parse_enum_variant_data(method: &mut syn::ImplItemMethod) -> Result<Option<EnumVariantDataSpec>, syn::Error> {
+    let (idx, _) = match find_attr(&method.attrs, "abra_enum_variant_data") {
+        Some(attr) => attr,
+        None => return Ok(None)
+    };
+    method.attrs.remove(idx);
+
+    match method.sig.inputs.first() {
+        Some(FnArg::Typed(_)) | None => {
+            let msg = format!("The function bound via #[abra_enum_variant_data] must receive self");
+            return Err(syn::Error::new(method.span(), msg));
+        }
+        Some(FnArg::Receiver(rcv)) if !rcv.reference.is_some() => {
+            let msg = format!("The function bound via #[abra_enum_variant_data] must receive a reference to self");
+            return Err(syn::Error::new(rcv.span(), msg));
+        }
+        _ => {}
+    }
+    let native_method_arity = method.sig.inputs.len();
+    if native_method_arity != 1 {
+        let msg = format!("The function bound via #[abra_enum_variant_data] receives too many parameters; bound functions can only receive 1 parameter (self)");
+        return Err(syn::Error::new(method.sig.inputs.span(), msg));
+    }
+
+    let method_name = method.sig.ident.to_string();
+    Ok(Some(EnumVariantDataSpec { native_method_name: method_name, native_method_arity }))
+}

--- a/abra_native/src/abra_type/mod.rs
+++ b/abra_native/src/abra_type/mod.rs
@@ -1,0 +1,1 @@
+pub mod parsing;

--- a/abra_native/src/abra_type/parsing.rs
+++ b/abra_native/src/abra_type/parsing.rs
@@ -1,0 +1,129 @@
+use crate::abra_methods::parsing::{GetterSpec, SetterSpec};
+use crate::parsing_common::{find_attr, parse_attr};
+use proc_macro2::Span;
+use syn::spanned::Spanned;
+use crate::signature::{TypeRepr, parse_type};
+
+#[derive(Debug)]
+pub struct ParsedTypeAttr {
+    pub(crate) type_name: String,
+    pub(crate) module_name: String,
+    pub(crate) type_args: Vec<String>,
+    pub(crate) is_pseudotype: bool,
+    pub(crate) is_noconstruct: bool,
+    pub(crate) value_variant: Option<String>,
+    pub(crate) is_enum: bool,
+}
+
+pub fn parse_abra_type_attr(attrs: &Vec<syn::Attribute>) -> Result<ParsedTypeAttr, syn::Error> {
+    match find_attr(attrs, "abra_type") {
+        Some((_, attr)) => {
+            let attr_span = attr.span();
+            let attr = parse_attr(attr);
+            let is_pseudotype = attr.get("pseudotype").map(|v| v == "true").unwrap_or(false);
+            let is_noconstruct = attr.get("noconstruct").map(|v| v == "true").unwrap_or(false);
+            let value_variant = attr.get("variant").map(|v| v.clone());
+            let is_enum = attr.get("is_enum").map(|v| v == "true").unwrap_or(false);
+
+            let module_name = match attr.get("module") {
+                Some(module_name) => module_name.clone(),
+                None => {
+                    let msg = "Missing required parameter `module` in #[abra_type] attribute".to_string();
+                    return Err(syn::Error::new(attr_span, msg));
+                }
+            };
+
+            match attr.get("signature") {
+                Some(signature) => match parse_type(None, &vec![], signature) {
+                    Ok(repr) => match repr {
+                        TypeRepr::Ident(type_name, type_args) => {
+                            let type_args = type_args.into_iter()
+                                .map(|t| match t {
+                                    TypeRepr::Ident(n, _) => n,
+                                    r => unreachable!(format!("Unexpected type {:?}", r))
+                                })
+                                .collect();
+                            let parsed = ParsedTypeAttr {
+                                type_name,
+                                module_name,
+                                type_args,
+                                is_pseudotype,
+                                is_noconstruct,
+                                value_variant,
+                                is_enum,
+                            };
+                            Ok(parsed)
+                        }
+                        r => unreachable!(format!("Unexpected type {:?}", r))
+                    },
+                    Err(e) => {
+                        let msg = format!("Invalid signature provided to #[abra_type]: {}", e);
+                        Err(syn::Error::new(attr_span, msg))
+                    }
+                }
+                None => {
+                    let msg = "Missing required parameter `signature` in #[abra_type] attribute".to_string();
+                    Err(syn::Error::new(attr_span, msg))
+                }
+            }
+        }
+        None => {
+            let msg = "Missing required attribute `#[abra_type]`".to_string();
+            Err(syn::Error::new(Span::call_site(), msg))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FieldSpec {
+    pub(crate) native_field_name: String,
+    pub(crate) name: String,
+    pub(crate) typ: TypeRepr,
+    pub(crate) has_default: bool,
+    pub(crate) readonly: bool,
+    pub(crate) getter: Option<GetterSpec>,
+    pub(crate) setter: Option<SetterSpec>,
+}
+
+pub fn parse_abra_field_attr(type_name: &String, struct_item: &syn::ItemStruct, type_args: &Vec<String>, field: &syn::Field) -> Result<Option<FieldSpec>, syn::Error> {
+    let (_, attr) = match find_attr(&field.attrs, "abra_field") {
+        Some(attr) => attr,
+        _ => return Ok(None)
+    };
+    let field_attr = parse_attr(attr);
+
+    let field_ident = field.ident.as_ref();
+    let name = match field_ident {
+        Some(name) => name.to_string(),
+        None => {
+            let msg = format!("A struct which derives AbraType must have named fields");
+            return Err(syn::Error::new(struct_item.span(), msg));
+        }
+    };
+
+    let typ = match field_attr.get("field_type") {
+        Some(typ) => {
+            match parse_type(Some(type_name), type_args, typ) {
+                Ok(t) => t,
+                Err(e) => {
+                    let msg = format!("Invalid `field_type` provided to #[abra_field]: {}", e);
+                    return Err(syn::Error::new(attr.span(), msg));
+                }
+            }
+        }
+        None => {
+            let msg = format!("Missing required parameter `field_type` for field `{}`", name);
+            return Err(syn::Error::new(attr.span(), msg));
+        }
+    };
+
+    Ok(Some(FieldSpec {
+        native_field_name: name.clone(),
+        name: field_attr.get("name").unwrap_or(&name).clone(),
+        typ,
+        has_default: field_attr.get("has_default").map_or(false, |f| f == "true"),
+        readonly: field_attr.get("readonly").map_or(false, |f| f == "true"),
+        getter: None, // <
+        setter: None, // < For now, will be set later when parsing methods
+    }))
+}

--- a/abra_native/src/lib.rs
+++ b/abra_native/src/lib.rs
@@ -1,69 +1,22 @@
 use proc_macro::TokenStream;
-use quote::{quote, format_ident};
-use syn::{parse_macro_input, NestedMeta, ImplItem, Type, FnArg, ReturnType};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use proc_macro2::Span;
+use quote::quote;
+use syn::{ImplItem, parse_macro_input, Type};
 use syn::spanned::Spanned;
-use crate::signature::{TypeRepr, MethodArgSpec, parse_type, parse_fn_signature, Signature};
+use crate::abra_function::{generate_function_code, parse_function};
+use crate::parsing_common::{parse_attr_meta, find_attr};
+use crate::abra_methods::parsing::{ConstructorSpec, parse_constructor, parse_static_method, parse_to_string_method, parse_getter, parse_setter, parse_pseudomethod, parse_method, parse_enum_variant, parse_enum_variant_data, EnumVariantDataSpec};
+use crate::abra_type::parsing::{FieldSpec, ParsedTypeAttr, parse_abra_type_attr, parse_abra_field_attr};
+use crate::abra_methods::gen::{gen_native_type_code, gen_native_value_code, TypeSpec};
 
+mod abra_function;
+mod abra_methods;
+mod abra_type;
 mod signature;
-
-#[derive(Debug)]
-struct TypeSpec {
-    native_type_name: String,
-    name: String,
-    module_name: String,
-    type_args: Vec<String>,
-    constructor: Option<ConstructorSpec>,
-    to_string_method: Option<String>,
-    fields: Vec<FieldSpec>,
-    methods: Vec<MethodSpec>,
-    pseudo_methods: Vec<MethodSpec>,
-    static_methods: Vec<MethodSpec>,
-    is_pseudotype: bool,
-    is_noconstruct: bool,
-    value_variant: Option<String>,
-}
-
-#[derive(Debug)]
-struct ConstructorSpec {
-    native_fn_name: String,
-}
-
-#[derive(Debug)]
-struct FieldSpec {
-    native_field_name: String,
-    name: String,
-    typ: TypeRepr,
-    has_default: bool,
-    readonly: bool,
-    getter: Option<GetterSpec>,
-    setter: Option<SetterSpec>,
-}
-
-#[derive(Debug)]
-struct MethodSpec {
-    native_method_name: String,
-    native_method_arity: usize,
-    name: String,
-    args: Vec<MethodArgSpec>,
-    return_type: TypeRepr,
-    is_static: bool,
-    is_mut: bool,
-    is_variadic: bool,
-    is_pseudomethod: bool,
-}
-
-#[derive(Debug)]
-struct GetterSpec {
-    native_method_name: String,
-}
-
-#[derive(Debug)]
-struct SetterSpec {
-    native_method_name: String,
-}
+mod type_utils;
+mod parsing_common;
 
 #[derive(Debug)]
 struct FirstPass {
@@ -74,6 +27,7 @@ struct FirstPass {
     is_pseudotype: bool,
     is_noconstruct: bool,
     value_variant: Option<String>,
+    is_enum: bool,
 }
 
 thread_local! {
@@ -85,10 +39,19 @@ pub fn abra_type(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::ItemStruct);
     let native_type_name = input.ident.to_string();
 
-    let (type_name, module_name, type_args, is_pseudotype, is_noconstruct, value_variant) = match parse_abra_type_attr(&input.attrs) {
+    let parsed_type_attr = match parse_abra_type_attr(&input.attrs) {
         Ok(res) => res,
         Err(e) => return e.to_compile_error().into()
     };
+    let ParsedTypeAttr {
+        type_name,
+        module_name,
+        type_args,
+        is_pseudotype,
+        is_noconstruct,
+        value_variant ,
+        is_enum,
+    } = parsed_type_attr;
 
     let field_specs = input.fields.iter()
         .map(|f| parse_abra_field_attr(&type_name, &input, &type_args, f))
@@ -100,104 +63,12 @@ pub fn abra_type(input: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into()
     };
 
-    let first_pass = FirstPass { type_name, module_name, type_args, field_specs, is_pseudotype, is_noconstruct, value_variant };
+    let first_pass = FirstPass { type_name, module_name, type_args, field_specs, is_pseudotype, is_noconstruct, value_variant, is_enum };
     TYPES.with(|types| {
         types.borrow_mut().insert(native_type_name, first_pass)
     });
 
     (quote! {}).into()
-}
-
-fn parse_abra_field_attr(type_name: &String, struct_item: &syn::ItemStruct, type_args: &Vec<String>, field: &syn::Field) -> Result<Option<FieldSpec>, syn::Error> {
-    let (_, attr) = match find_attr(&field.attrs, "abra_field") {
-        Some(attr) => attr,
-        _ => return Ok(None)
-    };
-    let field_attr = parse_attr(attr);
-
-    let field_ident = field.ident.as_ref();
-    let name = match field_ident {
-        Some(name) => name.to_string(),
-        None => {
-            let msg = format!("A struct which derives AbraType must have named fields");
-            return Err(syn::Error::new(struct_item.span(), msg));
-        }
-    };
-
-    let typ = match field_attr.get("field_type") {
-        Some(typ) => {
-            match parse_type(Some(type_name), type_args, typ) {
-                Ok(t) => t,
-                Err(e) => {
-                    let msg = format!("Invalid `field_type` provided to #[abra_field]: {}", e);
-                    return Err(syn::Error::new(attr.span(), msg));
-                }
-            }
-        }
-        None => {
-            let msg = format!("Missing required parameter `field_type` for field `{}`", name);
-            return Err(syn::Error::new(attr.span(), msg));
-        }
-    };
-
-    Ok(Some(FieldSpec {
-        native_field_name: name.clone(),
-        name: field_attr.get("name").unwrap_or(&name).clone(),
-        typ,
-        has_default: field_attr.get("has_default").map_or(false, |f| f == "true"),
-        readonly: field_attr.get("readonly").map_or(false, |f| f == "true"),
-        getter: None, // <
-        setter: None, // < For now, will be set later when parsing methods
-    }))
-}
-
-fn parse_abra_type_attr(attrs: &Vec<syn::Attribute>) -> Result<(String, String, Vec<String>, bool, bool, Option<String>), syn::Error> {
-    match find_attr(attrs, "abra_type") {
-        Some((_, attr)) => {
-            let attr_span = attr.span();
-            let attr = parse_attr(attr);
-            let is_pseudotype = attr.get("pseudotype").map(|v| v == "true").unwrap_or(false);
-            let is_noconstruct = attr.get("noconstruct").map(|v| v == "true").unwrap_or(false);
-            let value_variant = attr.get("variant").map(|v| v.clone());
-
-            let module_name = match attr.get("module") {
-                Some(module_name) => module_name.clone(),
-                None => {
-                    let msg = "Missing required parameter `module` in #[abra_type] attribute".to_string();
-                    return Err(syn::Error::new(attr_span, msg));
-                }
-            };
-
-            match attr.get("signature") {
-                Some(signature) => match parse_type(None, &vec![], signature) {
-                    Ok(repr) => match repr {
-                        TypeRepr::Ident(type_name, type_args) => {
-                            let type_args = type_args.into_iter()
-                                .map(|t| match t {
-                                    TypeRepr::Ident(n, _) => n,
-                                    r => unreachable!(format!("Unexpected type {:?}", r))
-                                })
-                                .collect();
-                            Ok((type_name, module_name, type_args, is_pseudotype, is_noconstruct, value_variant))
-                        }
-                        r => unreachable!(format!("Unexpected type {:?}", r))
-                    },
-                    Err(e) => {
-                        let msg = format!("Invalid signature provided to #[abra_type]: {}", e);
-                        Err(syn::Error::new(attr_span, msg))
-                    }
-                }
-                None => {
-                    let msg = "Missing required parameter `signature` in #[abra_type] attribute".to_string();
-                    Err(syn::Error::new(attr_span, msg))
-                }
-            }
-        }
-        None => {
-            let msg = "Missing required attribute `#[abra_type]`".to_string();
-            Err(syn::Error::new(Span::call_site(), msg))
-        }
-    }
 }
 
 #[proc_macro_attribute]
@@ -219,122 +90,139 @@ pub fn abra_methods(_args: TokenStream, input: TokenStream) -> TokenStream {
         let msg = format!("Cannot implement methods for struct {}, which does not derive AbraType", native_type_name);
         return syn::Error::new(Span::call_site(), msg).to_compile_error().into();
     };
-    let FirstPass { type_name, module_name, type_args, mut field_specs, is_pseudotype, is_noconstruct, value_variant } = first_pass_data;
+    let FirstPass { type_name, module_name, type_args, mut field_specs, is_pseudotype, is_noconstruct, value_variant, is_enum } = first_pass_data;
 
     let mut methods = Vec::new();
     let mut static_methods = Vec::new();
+    let mut enum_variants = Vec::new();
     let mut pseudo_methods = Vec::new();
     let mut constructor: Option<ConstructorSpec> = None;
+    let mut enum_variant_data: Option<EnumVariantDataSpec> = None;
     let mut to_string_method_name: Option<String> = None;
     for item in &mut input.items {
         match item {
             ImplItem::Method(ref mut m) => {
-                match find_attr(&m.attrs, "abra_constructor") {
-                    None => {}
-                    Some((_, attr)) => {
-                        if is_noconstruct {
-                            let msg = format!("This type has `noconstruct = true` in its #[abra_type] attribute, and cannot have a function bound via #[abra_constructor]");
-                            return syn::Error::new(attr.span(), msg).to_compile_error().into();
-                        }
+                if let Some((_, attr)) = find_attr(&m.attrs, "abra_constructor") {
+                    if is_noconstruct {
+                        let msg = format!("This type has `noconstruct = true` in its #[abra_type] attribute, and cannot have a function bound via #[abra_constructor]");
+                        return syn::Error::new(attr.span(), msg).to_compile_error().into();
+                    }
 
-                        if constructor.is_some() {
-                            let msg = format!("Duplicate constructor function. A type may only have 1 function with the #[abra_constructor] attribute");
-                            return syn::Error::new(attr.span(), msg).to_compile_error().into();
-                        }
-                        constructor = match parse_constructor(m) {
-                            Ok(c) => c,
-                            Err(e) => return e.to_compile_error().into()
-                        };
-                        continue;
+                    if is_enum {
+                        let msg = format!("This type has `is_enum = true` in its #[abra_type] attribute, and cannot have a function bound via #[abra_constructor]");
+                        return syn::Error::new(attr.span(), msg).to_compile_error().into();
+                    }
+
+                    if constructor.is_some() {
+                        let msg = format!("Duplicate constructor function. A type may only have 1 function with the #[abra_constructor] attribute");
+                        return syn::Error::new(attr.span(), msg).to_compile_error().into();
+                    }
+                    constructor = match parse_constructor(m) {
+                        Ok(c) => c,
+                        Err(e) => return e.to_compile_error().into()
+                    };
+                    continue;
+                }
+
+                if let Some((_, attr)) = find_attr(&m.attrs, "abra_enum_variant") {
+                    let attr_span = attr.span();
+                    if !is_enum {
+                        let msg = format!("Cannot use #[abra_enum_variant] in non-enum type. Did you forget to add `is_enum = true` to #[abra_type]?");
+                        return syn::Error::new(attr_span, msg).to_compile_error().into();
+                    }
+
+                    match parse_enum_variant(&type_name, &type_args, m) {
+                        Ok(Some(m)) => enum_variants.push(m),
+                        Err(e) => return e.to_compile_error().into(),
+                        _ => continue
                     }
                 }
 
-                match find_attr(&m.attrs, "abra_static_method") {
-                    None => {}
-                    Some(_) => {
-                        match parse_static_method(&type_name, &type_args, m) {
-                            Ok(Some(m)) => static_methods.push(m),
-                            Err(e) => return e.to_compile_error().into(),
-                            _ => continue
-                        }
+                if let Some((_, attr)) = find_attr(&m.attrs, "abra_enum_variant_data") {
+                    let attr_span = attr.span();
+                    if !is_enum {
+                        let msg = format!("Cannot use #[abra_enum_variant_data] in non-enum type. Did you forget to add `is_enum = true` to #[abra_type]?");
+                        return syn::Error::new(attr_span, msg).to_compile_error().into();
+                    }
+
+                    match parse_enum_variant_data(m) {
+                        Ok(Some(m)) => enum_variant_data = Some(m),
+                        Err(e) => return e.to_compile_error().into(),
+                        _ => continue
                     }
                 }
 
-                match find_attr(&m.attrs, "abra_to_string") {
-                    None => {}
-                    Some((_, attr)) => {
-                        let attr_span = attr.span();
-                        match parse_to_string_method(m) {
-                            Ok(m) => {
-                                if to_string_method_name.is_some() {
-                                    let msg = format!("Duplicate to-string function. A type may only have 1 function with the #[abra_to_string] attribute");
+                if let Some(_) = find_attr(&m.attrs, "abra_static_method") {
+                    match parse_static_method(&type_name, &type_args, m) {
+                        Ok(Some(m)) => static_methods.push(m),
+                        Err(e) => return e.to_compile_error().into(),
+                        _ => continue
+                    }
+                }
+
+                if let Some((_, attr)) = find_attr(&m.attrs, "abra_to_string") {
+                    let attr_span = attr.span();
+                    match parse_to_string_method(m) {
+                        Ok(m) => {
+                            if to_string_method_name.is_some() {
+                                let msg = format!("Duplicate to-string function. A type may only have 1 function with the #[abra_to_string] attribute");
+                                return syn::Error::new(attr_span, msg).to_compile_error().into();
+                            }
+                            to_string_method_name = m;
+                            continue;
+                        }
+                        Err(e) => return e.to_compile_error().into()
+                    }
+                }
+
+                if let Some((_, attr)) = find_attr(&m.attrs, "abra_getter") {
+                    let attr_span = attr.span();
+                    match parse_getter(m) {
+                        Err(e) => return e.to_compile_error().into(),
+                        Ok(Some((field_name, getter))) => {
+                            let field = field_specs.iter_mut().find(|f| f.name == field_name);
+                            match field {
+                                Some(field) => field.getter = Some(getter),
+                                None => {
+                                    let msg = format!("Cannot bind getter for field {}; struct {} has no such field", field_name, type_name);
                                     return syn::Error::new(attr_span, msg).to_compile_error().into();
                                 }
-                                to_string_method_name = m;
-                                continue;
                             }
-                            Err(e) => return e.to_compile_error().into()
                         }
+                        _ => {}
                     }
+                    continue;
                 }
 
-                match find_attr(&m.attrs, "abra_getter") {
-                    None => {}
-                    Some((_, attr)) => {
-                        let attr_span = attr.span();
-                        match parse_getter(m) {
-                            Err(e) => return e.to_compile_error().into(),
-                            Ok(Some((field_name, getter))) => {
-                                let field = field_specs.iter_mut().find(|f| f.name == field_name);
-                                match field {
-                                    Some(field) => field.getter = Some(getter),
-                                    None => {
-                                        let msg = format!("Cannot bind getter for field {}; struct {} has no such field", field_name, type_name);
-                                        return syn::Error::new(attr_span, msg).to_compile_error().into();
-                                    }
+                if let Some((_, attr)) = find_attr(&m.attrs, "abra_setter") {
+                    let attr_span = attr.span();
+                    match parse_setter(m) {
+                        Err(e) => return e.to_compile_error().into(),
+                        Ok(Some((field_name, setter))) => {
+                            let field = field_specs.iter_mut().find(|f| f.name == field_name);
+                            match field {
+                                Some(field) => field.setter = Some(setter),
+                                None => {
+                                    let msg = format!("Cannot bind setter for field {}; struct {} has no such field", field_name, type_name);
+                                    return syn::Error::new(attr_span, msg).to_compile_error().into();
                                 }
                             }
-                            _ => {}
                         }
-                        continue;
+                        _ => {}
                     }
+                    continue;
                 }
 
-                match find_attr(&m.attrs, "abra_setter") {
-                    None => {}
-                    Some((_, attr)) => {
-                        let attr_span = attr.span();
-                        match parse_setter(m) {
-                            Err(e) => return e.to_compile_error().into(),
-                            Ok(Some((field_name, setter))) => {
-                                let field = field_specs.iter_mut().find(|f| f.name == field_name);
-                                match field {
-                                    Some(field) => field.setter = Some(setter),
-                                    None => {
-                                        let msg = format!("Cannot bind setter for field {}; struct {} has no such field", field_name, type_name);
-                                        return syn::Error::new(attr_span, msg).to_compile_error().into();
-                                    }
-                                }
-                            }
-                            _ => {}
-                        }
-                        continue;
+                if let Some((_, attr)) = find_attr(&m.attrs, "abra_pseudomethod") {
+                    if !is_pseudotype {
+                        let msg = "Pseudomethods not allowed unless pseudotype = true in #[abra_type] attribute".to_string();
+                        return syn::Error::new(attr.span(), msg).to_compile_error().into();
                     }
-                }
 
-                match find_attr(&m.attrs, "abra_pseudomethod") {
-                    None => {}
-                    Some((_, attr)) => {
-                        if !is_pseudotype {
-                            let msg = "Pseudomethods not allowed unless pseudotype = true in #[abra_type] attribute".to_string();
-                            return syn::Error::new(attr.span(), msg).to_compile_error().into();
-                        }
-
-                        match parse_pseudomethod(&type_args, m) {
-                            Ok(Some(m)) => pseudo_methods.push(m),
-                            Err(e) => return e.to_compile_error().into(),
-                            _ => continue
-                        }
+                    match parse_pseudomethod(&type_args, m) {
+                        Ok(Some(m)) => pseudo_methods.push(m),
+                        Err(e) => return e.to_compile_error().into(),
+                        _ => continue
                     }
                 }
 
@@ -348,11 +236,20 @@ pub fn abra_methods(_args: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
 
-    if constructor.is_none() && !is_noconstruct {
+    if constructor.is_none() && !(is_noconstruct || is_enum) {
         let msg = format!(
             "Missing required constructor function binding for struct {}.\n\
             Please add the #[abra_constructor] attribute to a function of type (Vec<Value>) -> Self.\n\
-            You can also add `noconstruct = true` to the #[abra_type] attribute if you don't want to provide an explicit constructor",
+            You can also add `noconstruct = true` to the #[abra_type] attribute if you don't want to \n\
+            provide an explicit constructor, or `is_enum = true` if you intended for this type to be an enum.",
+            type_name
+        );
+        return syn::Error::new(Span::call_site(), msg).to_compile_error().into();
+    }
+    if enum_variant_data.is_none() && is_enum {
+        let msg = format!(
+            "Missing required enum variant data function binding for enum {}.\n\
+            Please add the #[abra_enum_variant_data] attribute to a function of type (Self) -> (usize, Vec<&Value>).",
             type_name
         );
         return syn::Error::new(Span::call_site(), msg).to_compile_error().into();
@@ -386,6 +283,9 @@ pub fn abra_methods(_args: TokenStream, input: TokenStream) -> TokenStream {
         is_pseudotype,
         is_noconstruct,
         value_variant,
+        is_enum,
+        enum_variants,
+        enum_variant_data,
     };
 
     let native_type_code = gen_native_type_code(&type_spec);
@@ -398,860 +298,6 @@ pub fn abra_methods(_args: TokenStream, input: TokenStream) -> TokenStream {
     ts.into()
 }
 
-fn parse_method(type_name: &String, type_args: &Vec<String>, method: &mut syn::ImplItemMethod) -> Result<Option<MethodSpec>, syn::Error> {
-    let (idx, abra_method_attr) = match find_attr(&method.attrs, "abra_method") {
-        Some(attr) => attr,
-        None => return Ok(None)
-    };
-    let attr_span = abra_method_attr.span();
-    let attr = parse_attr(abra_method_attr);
-    method.attrs.remove(idx);
-
-    let signature = match attr.get("signature") {
-        Some(signature) => match parse_fn_signature(Some(type_name), type_args, signature) {
-            Ok(s) => s,
-            Err(e) => {
-                let msg = format!("Invalid signature provided to #[abra_method]: {}", e);
-                return Err(syn::Error::new(attr_span, msg));
-            }
-        }
-        None => {
-            let msg = "Missing required parameter `signature` in #[abra_method] attribute".to_string();
-            return Err(syn::Error::new(attr_span, msg));
-        }
-    };
-
-    let is_mut = match method.sig.inputs.first() {
-        Some(FnArg::Typed(_)) | None => {
-            let msg = format!("The function bound via #[abra_method] must receive self");
-            return Err(syn::Error::new(method.span(), msg));
-        }
-        Some(FnArg::Receiver(rcv)) => {
-            if !rcv.reference.is_some() {
-                let msg = format!("The function bound via #[abra_method] must receive a reference to self");
-                return Err(syn::Error::new(rcv.span(), msg));
-            }
-            rcv.mutability.is_some()
-        }
-    };
-    let native_method_arity = method.sig.inputs.len() - 1; // -1 to account for &self
-    if native_method_arity > 2 {
-        let msg = format!("The function bound via #[abra_method] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
-        return Err(syn::Error::new(method.sig.inputs.span(), msg));
-    }
-
-    if signature.return_type == TypeRepr::Unit && method.sig.output != syn::ReturnType::Default {
-        let msg = format!("The function bound via #[abra_method] has no return type in its signature, and therefore must not have a return value");
-        return Err(syn::Error::new(method.sig.output.span(), msg));
-    }
-    if let TypeRepr::SelfType(_) = &signature.return_type {
-        let is_invalid = if let ReturnType::Type(_, t) = &method.sig.output {
-            if let syn::Type::Path(type_path) = &**t {
-                if let Some(seg) = type_path.path.segments.last() {
-                    seg.ident.to_string() != "Self"
-                } else { unreachable!() }
-            } else { true }
-        } else { true };
-        if is_invalid {
-            let msg = format!("The function bound via #[abra_method] has a signature which returns '{}', so it must return Self", type_name);
-            return Err(syn::Error::new(method.sig.span(), msg));
-        }
-    }
-
-    let is_variadic = signature.args.iter().any(|arg| arg.is_variadic);
-
-    let method_name = method.sig.ident.to_string();
-    Ok(Some(MethodSpec {
-        native_method_name: method_name.clone(),
-        native_method_arity,
-        name: signature.func_name,
-        args: signature.args,
-        return_type: signature.return_type,
-        is_static: false,
-        is_mut,
-        is_variadic,
-        is_pseudomethod: false,
-    }))
-}
-
-fn parse_pseudomethod(type_args: &Vec<String>, method: &mut syn::ImplItemMethod) -> Result<Option<MethodSpec>, syn::Error> {
-    let (idx, abra_method_attr) = match find_attr(&method.attrs, "abra_pseudomethod") {
-        Some(attr) => attr,
-        None => return Ok(None)
-    };
-    let attr_span = abra_method_attr.span();
-    let attr = parse_attr(abra_method_attr);
-    method.attrs.remove(idx);
-
-    let signature = match attr.get("signature") {
-        Some(signature) => match parse_fn_signature(None, type_args, signature) {
-            Ok(s) => s,
-            Err(e) => {
-                let msg = format!("Invalid signature provided to #[abra_pseudomethod]: {}", e);
-                return Err(syn::Error::new(attr_span, msg));
-            }
-        }
-        None => {
-            let msg = "Missing required parameter `signature` in #[abra_pseudomethod] attribute".to_string();
-            return Err(syn::Error::new(attr_span, msg));
-        }
-    };
-
-    if let Some(FnArg::Receiver(_)) = method.sig.inputs.first() {
-        let msg = format!("The function bound via #[abra_pseudomethod] must not receive self");
-        return Err(syn::Error::new(method.span(), msg));
-    }
-    let native_method_arity = method.sig.inputs.len() - 1; // -1 to account for rcv
-    if native_method_arity > 2 {
-        let msg = format!("The function bound via #[abra_pseudomethod] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
-        return Err(syn::Error::new(method.sig.inputs.span(), msg));
-    }
-
-    if signature.return_type == TypeRepr::Unit && method.sig.output != syn::ReturnType::Default {
-        let msg = format!("The function bound via #[abra_pseudomethod] has no return type in its signature, and therefore must not have a return value");
-        return Err(syn::Error::new(method.sig.output.span(), msg));
-    }
-
-    let is_variadic = signature.args.iter().any(|arg| arg.is_variadic);
-
-    let method_name = method.sig.ident.to_string();
-    Ok(Some(MethodSpec {
-        native_method_name: method_name.clone(),
-        native_method_arity,
-        name: signature.func_name,
-        args: signature.args,
-        return_type: signature.return_type,
-        is_static: false,
-        is_mut: false,
-        is_variadic,
-        is_pseudomethod: true,
-    }))
-}
-
-fn parse_static_method(type_name: &String, type_args: &Vec<String>, method: &mut syn::ImplItemMethod) -> Result<Option<MethodSpec>, syn::Error> {
-    let (idx, abra_method_attr) = match find_attr(&method.attrs, "abra_static_method") {
-        Some(attr) => attr,
-        None => return Ok(None)
-    };
-    let attr_span = abra_method_attr.span();
-    let attr = parse_attr(abra_method_attr);
-    method.attrs.remove(idx);
-
-    if let Some(FnArg::Receiver(_)) = method.sig.inputs.first() {
-        let msg = format!("The function bound via #[abra_static_method] must not receive self");
-        return Err(syn::Error::new(method.span(), msg));
-    }
-    let native_method_arity = method.sig.inputs.len();
-    if native_method_arity > 2 {
-        let msg = format!("The function bound via #[abra_static_method] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
-        return Err(syn::Error::new(method.sig.inputs.span(), msg));
-    }
-
-    let signature = match attr.get("signature") {
-        Some(signature) => match parse_fn_signature(Some(type_name), type_args, signature) {
-            Ok(s) => s,
-            Err(e) => {
-                let msg = format!("Invalid signature provided to #[abra_static_method]: {}", e);
-                return Err(syn::Error::new(attr_span, msg));
-            }
-        }
-        None => {
-            let msg = "Missing required parameter `signature` in #[abra_static_method] attribute".to_string();
-            return Err(syn::Error::new(attr_span, msg));
-        }
-    };
-    let Signature { func_name, args, return_type } = signature;
-
-    if return_type == TypeRepr::Unit && method.sig.output != syn::ReturnType::Default {
-        let msg = format!("The function bound via #[abra_static_method] has no return type in its signature, and therefore must not have a return value");
-        return Err(syn::Error::new(method.sig.output.span(), msg));
-    }
-    if let TypeRepr::SelfType(_) = &return_type {
-        let is_invalid = if let ReturnType::Type(_, t) = &method.sig.output {
-            if let syn::Type::Path(type_path) = &**t {
-                if let Some(seg) = type_path.path.segments.last() {
-                    seg.ident.to_string() != "Self"
-                } else { unreachable!() }
-            } else { true }
-        } else { true };
-        if is_invalid {
-            let msg = format!("The function bound via #[abra_static_method] has a signature which returns '{}', so it must return Self", type_name);
-            return Err(syn::Error::new(method.sig.span(), msg));
-        }
-    }
-
-    let is_variadic = args.iter().any(|arg| arg.is_variadic);
-
-    let method_name = method.sig.ident.to_string();
-    Ok(Some(MethodSpec {
-        native_method_name: method_name.clone(),
-        native_method_arity,
-        name: func_name,
-        args,
-        return_type,
-        is_static: true,
-        is_mut: false,
-        is_variadic,
-        is_pseudomethod: false,
-    }))
-}
-
-fn parse_constructor(method: &mut syn::ImplItemMethod) -> Result<Option<ConstructorSpec>, syn::Error> {
-    let abra_constructor_attr = find_attr(&method.attrs, "abra_constructor");
-    match abra_constructor_attr {
-        Some((idx, _)) => method.attrs.remove(idx),
-        _ => return Ok(None)
-    };
-    let method_name = method.sig.ident.to_string();
-    if let Some(FnArg::Receiver(_)) = method.sig.inputs.first() {
-        let msg = format!("The function bound via #[abra_constructor] must not receive self");
-        return Err(syn::Error::new(method.span(), msg));
-    }
-
-    Ok(Some(ConstructorSpec { native_fn_name: method_name }))
-}
-
-fn parse_to_string_method(method: &mut syn::ImplItemMethod) -> Result<Option<String>, syn::Error> {
-    let abra_constructor_attr = find_attr(&method.attrs, "abra_to_string");
-    match abra_constructor_attr {
-        Some((idx, _)) => method.attrs.remove(idx),
-        _ => return Ok(None)
-    };
-    let method_name = method.sig.ident.to_string();
-    if let ReturnType::Type(_, t) = &method.sig.output {
-        if let syn::Type::Path(type_path) = &**t {
-            if let Some(seg) = type_path.path.segments.last() {
-                if seg.ident.to_string() != "String" {
-                    let msg = "The function bound via #[abra_to_string] must return String".to_string();
-                    return Err(syn::Error::new(method.sig.output.span(), msg));
-                }
-            }
-        }
-    }
-
-    Ok(Some(method_name))
-}
-
-fn parse_getter(method: &mut syn::ImplItemMethod) -> Result<Option<(String, GetterSpec)>, syn::Error> {
-    let method_name = method.sig.ident.to_string();
-
-    let (idx, abra_getter_attr) = match find_attr(&method.attrs, "abra_getter") {
-        Some(attr) => attr,
-        None => return Ok(None)
-    };
-    let attr_span = abra_getter_attr.span();
-    let attr = parse_attr(abra_getter_attr);
-    method.attrs.remove(idx);
-
-    let field = match attr.get("field") {
-        Some(field) => field.clone(),
-        None => {
-            let msg = format!("Missing required parameter `field` in `abra_getter` attribute");
-            return Err(syn::Error::new(attr_span, msg));
-        }
-    };
-
-    Ok(Some((field, GetterSpec { native_method_name: method_name })))
-}
-
-fn parse_setter(method: &mut syn::ImplItemMethod) -> Result<Option<(String, SetterSpec)>, syn::Error> {
-    let method_name = method.sig.ident.to_string();
-
-    let (idx, abra_setter_attr) = match find_attr(&method.attrs, "abra_setter") {
-        Some(attr) => attr,
-        None => return Ok(None)
-    };
-    let attr_span = abra_setter_attr.span();
-    let attr = parse_attr(abra_setter_attr);
-    method.attrs.remove(idx);
-
-    let field = match attr.get("field") {
-        Some(field) => field.clone(),
-        None => {
-            let msg = format!("Missing required parameter `field` in `abra_setter` attribute");
-            return Err(syn::Error::new(attr_span, msg));
-        }
-    };
-
-    Ok(Some((field, SetterSpec { native_method_name: method_name })))
-}
-
-fn gen_rust_type_path(type_repr: &TypeRepr, module_name: &String, type_ref_name: &String) -> proc_macro2::TokenStream {
-    match type_repr {
-        TypeRepr::SelfType(type_args) => {
-            if type_ref_name == "Array" {
-                let arr_type_repr = TypeRepr::Array(Box::new(type_args[0].clone()));
-                gen_rust_type_path(&arr_type_repr, module_name, type_ref_name)
-            } else if type_ref_name == "String" {
-                quote! { crate::typechecker::types::Type::String }
-            } else if type_ref_name == "Set" {
-                let inner_type = type_args.get(0).expect("Sets require T value");
-                let inner_type_repr = gen_rust_type_path(inner_type, module_name, type_ref_name);
-
-                quote! { crate::typechecker::types::Type::Set(std::boxed::Box::new(#inner_type_repr)) }
-            } else if type_ref_name == "Map" {
-                let key_type = type_args.get(0).expect("Maps require K value");
-                let key_type_repr = gen_rust_type_path(key_type, module_name, type_ref_name);
-                let val_type = type_args.get(1).expect("Maps require V value");
-                let val_type_repr = gen_rust_type_path(val_type, module_name, type_ref_name);
-
-                quote! {
-                    crate::typechecker::types::Type::Map(
-                        std::boxed::Box::new(#key_type_repr),
-                        std::boxed::Box::new(#val_type_repr)
-                    )
-                }
-            } else {
-                let type_args = type_args.iter().map(|type_arg| {
-                    gen_rust_type_path(type_arg, module_name, type_ref_name)
-                });
-
-                quote! { crate::typechecker::types::Type::Reference(#type_ref_name.to_string(), vec![ #(#type_args),* ]) }
-            }
-        }
-        TypeRepr::Generic(g) => quote! { crate::typechecker::types::Type::Generic(#g.to_string()) },
-        TypeRepr::Unit => quote! { crate::typechecker::types::Type::Unit },
-        TypeRepr::Ident(i, type_args) => {
-            match i.as_str() {
-                "Unit" | "Any" | "Int" | "Float" | "String" | "Bool" => {
-                    let typ = format_ident!("{}", i);
-                    quote! { crate::typechecker::types::Type::#typ }
-                }
-                "Set" => {
-                    let inner_type = type_args.get(0).expect("Sets require T value");
-                    let inner_type_repr = gen_rust_type_path(inner_type, module_name, type_ref_name);
-
-                    quote! { crate::typechecker::types::Type::Set(std::boxed::Box::new(#inner_type_repr)) }
-                }
-                "Map" => {
-                    let key_type = type_args.get(0).expect("Maps require K value");
-                    let key_type_repr = gen_rust_type_path(key_type, module_name, type_ref_name);
-                    let val_type = type_args.get(1).expect("Maps require V value");
-                    let val_type_repr = gen_rust_type_path(val_type, module_name, type_ref_name);
-
-                    quote! {
-                        crate::typechecker::types::Type::Map(
-                            std::boxed::Box::new(#key_type_repr),
-                            std::boxed::Box::new(#val_type_repr)
-                        )
-                    }
-                }
-                i => {
-                    let type_args = type_args.iter().map(|type_arg| {
-                        gen_rust_type_path(type_arg, module_name, type_ref_name)
-                    });
-
-                    quote! { crate::typechecker::types::Type::Reference(#i.to_string(), vec![ #(#type_args),* ]) }
-                }
-            }
-        }
-        TypeRepr::Fn(args, ret) => {
-            let args = args.iter().map(|arg| {
-                let arg_type = gen_rust_type_path(arg, module_name, type_ref_name);
-                quote! { ("_".to_string(), #arg_type, false) }
-            });
-            let ret = gen_rust_type_path(ret, module_name, type_ref_name);
-
-            quote! {
-                crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
-                    arg_types: vec![ #(#args),* ],
-                    type_args: vec![],
-                    ret_type: std::boxed::Box::new(#ret),
-                    is_variadic: false,
-                    is_enum_constructor: false,
-                })
-            }
-        }
-        TypeRepr::Tuple(types) => {
-            let types = types.iter().map(|t| gen_rust_type_path(t, module_name, type_ref_name));
-            quote! { crate::typechecker::types::Type::Tuple(vec![ #(#types),* ]) }
-        }
-        TypeRepr::Union(types) => {
-            let types = types.iter().map(|t| gen_rust_type_path(t, module_name, type_ref_name));
-            quote! { crate::typechecker::types::Type::Union(vec![ #(#types),* ]) }
-        }
-        TypeRepr::Array(t) => {
-            let t = gen_rust_type_path(t, module_name, type_ref_name);
-            quote! { crate::typechecker::types::Type::Array(std::boxed::Box::new(#t)) }
-        }
-        TypeRepr::Opt(t) => {
-            let t = gen_rust_type_path(t, module_name, type_ref_name);
-            quote! { crate::typechecker::types::Type::Option(std::boxed::Box::new(#t)) }
-        }
-    }
-}
-
-fn gen_native_type_code(type_spec: &TypeSpec) -> TokenStream {
-    let type_name = &type_spec.name;
-    let module_name = &type_spec.module_name;
-
-    let type_args = type_spec.type_args.iter().map(|type_arg_name| {
-        quote! {
-            (#type_arg_name.to_string(), crate::typechecker::types::Type::Generic(#type_arg_name.to_string()))
-        }
-    });
-
-    let fields = type_spec.fields.iter().map(|field| {
-        let FieldSpec { name, typ, has_default, readonly, .. } = field;
-        let typ = gen_rust_type_path(typ, module_name, type_name);
-
-        quote! {
-            crate::typechecker::types::StructTypeField {
-                name: #name.to_string(),
-                typ: #typ,
-                has_default_value: #has_default,
-                readonly: #readonly,
-            }
-        }
-    });
-
-    let all_methods = type_spec.methods.iter().chain(type_spec.pseudo_methods.iter());
-    let methods = all_methods.map(|method| {
-        let MethodSpec { name, args, return_type, is_variadic, .. } = method;
-
-        let args = args.iter().map(|arg| {
-            let MethodArgSpec { name, typ, is_optional, .. } = arg;
-            let typ = gen_rust_type_path(typ, module_name, type_name);
-
-            quote! { (#name.to_string(), #typ, #is_optional) }
-        });
-
-        let return_type = gen_rust_type_path(return_type, module_name, type_name);
-
-        quote! {
-            (
-                #name.to_string(),
-                crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
-                    arg_types: vec![#(#args),*],
-                    type_args: vec![],
-                    ret_type: Box::new(#return_type),
-                    is_variadic: #is_variadic,
-                    is_enum_constructor: false,
-                })
-            )
-        }
-    });
-
-    let static_methods = type_spec.static_methods.iter().map(|static_method| {
-        let MethodSpec { name, args, return_type, is_variadic, .. } = static_method;
-
-        let args = args.iter().map(|arg| {
-            let MethodArgSpec { name, typ, is_optional, .. } = arg;
-            let typ = gen_rust_type_path(typ, module_name, type_name);
-
-            quote! { (#name.to_string(), #typ, #is_optional) }
-        });
-
-        let return_type = gen_rust_type_path(return_type, module_name, type_name);
-
-        quote! {
-            (
-                #name.to_string(),
-                crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
-                    arg_types: vec![#(#args),*],
-                    type_args: vec![],
-                    ret_type: Box::new(#return_type),
-                    is_variadic: #is_variadic,
-                    is_enum_constructor: false,
-                }),
-                true
-            )
-        }
-    });
-
-    let native_type_name_ident = format_ident!("{}", &type_spec.native_type_name);
-    let is_constructable = !type_spec.is_noconstruct;
-    let ts = quote! {
-        impl crate::builtins::native_value_trait::NativeTyp for #native_type_name_ident {
-            fn get_type() -> crate::typechecker::types::StructType where Self: Sized {
-                crate::typechecker::types::StructType {
-                    name: #type_name.to_string(),
-                    type_args: vec![ #(#type_args),* ],
-                    constructable: #is_constructable,
-                    fields: vec![ #(#fields),* ],
-                    static_fields: vec![ #(#static_methods),* ],
-                    methods: vec![
-                        ("toString".to_string(), crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
-                            arg_types: vec![],
-                            type_args: vec![],
-                            ret_type: std::boxed::Box::new(crate::typechecker::types::Type::String),
-                            is_variadic: false,
-                            is_enum_constructor: false,
-                        })),
-                        #(#methods),*
-                    ],
-                }
-            }
-        }
-    };
-
-    ts.into()
-}
-
-fn gen_native_value_code(type_spec: &TypeSpec) -> TokenStream {
-    let construct_method_code = gen_construct_code(type_spec);
-    let get_type_value_method_code = gen_get_type_value_method_code(type_spec);
-    let to_string_method_code = gen_to_string_method_code(type_spec);
-    let get_field_values_method_code = gen_get_field_values_method_code(type_spec);
-    let get_field_value_method_code = gen_get_field_value_method_code(type_spec);
-    let set_field_value_method_code = gen_set_field_value_method_code(type_spec);
-
-    let native_type_name_ident = format_ident!("{}", &type_spec.native_type_name);
-    let ts = quote! {
-        impl crate::builtins::native_value_trait::NativeValue for #native_type_name_ident {
-            #construct_method_code
-            #get_type_value_method_code
-            fn is_equal(&self, other: &std::boxed::Box<dyn crate::builtins::native_value_trait::NativeValue>) -> bool {
-                let other = other.downcast_ref::<Self>();
-                other.map_or(false, |o| o.eq(&self))
-            }
-            #to_string_method_code
-            #get_field_values_method_code
-            #get_field_value_method_code
-            #set_field_value_method_code
-        }
-    };
-    ts.into()
-}
-
-fn gen_construct_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
-    let body = match &type_spec.constructor {
-        Some(spec) => {
-            let constructor_fn_name = &spec.native_fn_name;
-            let constructor_fn_name_ident = format_ident!("{}", &constructor_fn_name);
-            quote! {
-                let inst = Self::#constructor_fn_name_ident(args);
-                crate::vm::value::Value::new_native_instance_obj(type_id, std::boxed::Box::new(inst))
-            }
-        }
-        None => {
-            quote! {
-                unreachable!("The type bound to #type_name has not bound a function via #[abra_constructor]. \
-                You were probably never intended to construct this type")
-            }
-        }
-    };
-
-    quote! {
-        fn construct(type_id: usize, args: std::vec::Vec<crate::vm::value::Value>) -> crate::vm::value::Value where Self: core::marker::Sized {
-            #body
-        }
-    }
-}
-
-fn gen_get_type_value_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
-    let type_name = &type_spec.name;
-    let module_name = &type_spec.module_name;
-    let fully_qualified_type_name = format!("{}/{}", module_name, type_name);
-
-    let fields = type_spec.fields.iter().map(|field| {
-        let name = &field.name;
-        quote! { #name.to_string() }
-    });
-
-    let all_methods = type_spec.methods.iter().chain(type_spec.pseudo_methods.iter());
-    let methods = all_methods.map(|method| {
-        let name = &method.name;
-        let num_args = method.args.len();
-        let native_name_ident = format_ident!("{}", &method.native_method_name);
-        let native_method_arity = method.native_method_arity;
-
-        let arguments = match native_method_arity {
-            0 => quote! {},
-            1 => quote! {
-                crate::builtins::arguments::Arguments::new(#name, #num_args, args)
-            },
-            2 => quote! {
-                crate::builtins::arguments::Arguments::new(#name, #num_args, args), vm
-            },
-            _ => unreachable!()
-        };
-
-        let body = if method.is_pseudomethod {
-            if type_spec.value_variant.is_some() {
-                quote! { Self::#native_name_ident }
-            } else {
-                quote! { |rcv, args, vm| Self::#native_name_ident(rcv.unwrap(), #arguments) }
-            }
-        } else {
-            let body_return = if method.return_type != TypeRepr::Unit {
-                if let TypeRepr::SelfType(_) = &method.return_type {
-                    match &type_spec.value_variant {
-                        Some(variant) => {
-                            let variant = format_ident!("{}", variant);
-                            quote! {
-                                let inst = inst.#native_name_ident(#arguments);
-                                crate::vm::value::Value::#variant(
-                                    std::sync::Arc::new(std::cell::RefCell::new(inst))
-                                )
-                            }
-                        }
-                        None => {
-                            quote! {
-                                let inst = inst.#native_name_ident(#arguments);
-                                let type_id = vm.type_id_for_name(#fully_qualified_type_name);
-                                crate::vm::value::Value::new_native_instance_obj(
-                                    type_id,
-                                    std::boxed::Box::new(inst)
-                                )
-                            }
-                        }
-                    }
-                } else {
-                    quote! { inst.#native_name_ident(#arguments) }
-                }
-            } else {
-                quote! {
-                    inst.#native_name_ident(#arguments);
-                    crate::vm::value::Value::Nil
-                }
-            };
-            let invocation = if method.is_mut {
-                if type_spec.value_variant.is_some() {
-                    quote! {
-                        let inst = &mut *rcv_obj.borrow_mut();
-                        #body_return
-                    }
-                } else {
-                    quote! {
-                        let mut rcv = &mut *rcv_obj.borrow_mut();
-                        let mut inst = rcv.inst.downcast_mut::<Self>().unwrap();
-                        #body_return
-                    }
-                }
-            } else {
-                if type_spec.value_variant.is_some() {
-                    quote! {
-                        let inst = &*rcv_obj.borrow();
-                        #body_return
-                    }
-                } else {
-                    quote! {
-                        let rcv = &*rcv_obj.borrow();
-                        let mut inst = rcv.inst.downcast_ref::<Self>().unwrap();
-                        #body_return
-                    }
-                }
-            };
-
-            let b = match &type_spec.value_variant {
-                Some(variant) => {
-                    let variant = format_ident!("{}", variant);
-                    quote! {
-                        if let Some(crate::vm::value::Value::#variant(rcv_obj)) = rcv { #invocation } else { unreachable!() }
-                    }
-                }
-                None => {
-                    quote! {
-                        if let Some(crate::vm::value::Value::NativeInstanceObj(rcv_obj)) = rcv { #invocation } else { unreachable!() }
-                    }
-                }
-            };
-
-            quote! {
-                |rcv, args, vm| #b
-            }
-        };
-
-        quote! {
-            (#name.to_string(), crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
-                name: #name,
-                receiver: None,
-                native_fn: #body,
-            }))
-        }
-    });
-
-    let static_methods = type_spec.static_methods.iter().map(|static_method| {
-        let name = &static_method.name;
-        let num_args = static_method.args.len();
-        let native_name_ident = format_ident!("{}", &static_method.native_method_name);
-        let native_method_arity = static_method.native_method_arity;
-
-        let arguments = match native_method_arity {
-            0 => quote! {},
-            1 => quote! {
-                crate::builtins::arguments::Arguments::new(#name, #num_args, args)
-            },
-            2 => quote! {
-                crate::builtins::arguments::Arguments::new(#name, #num_args, args), vm
-            },
-            _ => unreachable!()
-        };
-
-        let body = if static_method.return_type != TypeRepr::Unit {
-            match &type_spec.value_variant {
-                Some(variant) => {
-                    let variant = format_ident!("{}", variant);
-                    quote! {
-                        let inst = Self::#native_name_ident(#arguments);
-                        crate::vm::value::Value::#variant(
-                            std::sync::Arc::new(std::cell::RefCell::new(inst))
-                        )
-                    }
-                }
-                None => {
-                    if let TypeRepr::SelfType(_) = &static_method.return_type {
-                        quote! {
-                            let inst = Self::#native_name_ident(#arguments);
-                            let type_id = vm.type_id_for_name(#fully_qualified_type_name);
-                            crate::vm::value::Value::new_native_instance_obj(
-                                type_id,
-                                std::boxed::Box::new(inst)
-                            )
-                        }
-                    } else {
-                        quote! { Self::#native_name_ident(#arguments) }
-                    }
-                }
-            }
-        } else {
-            quote! {
-                Self::#native_name_ident(#arguments);
-                crate::vm::value::Value::Nil
-            }
-        };
-
-        quote! {
-            (#name.to_string(), crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
-                name: #name,
-                receiver: None,
-                native_fn: |rcv, args, vm| { #body },
-            }))
-        }
-    });
-
-    let to_string_method_code = if type_spec.is_pseudotype || type_spec.value_variant.is_some() {
-        quote! {
-            ("toString".to_string(), crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
-                name: "toString",
-                receiver: None,
-                native_fn: |rcv, _args, vm| {
-                    Value::new_string_obj(
-                        crate::builtins::common::to_string(&rcv.unwrap(), vm)
-                    )
-                },
-            })),
-        }
-    } else {
-        quote! {
-            ("toString".to_string(), crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
-                name: "toString",
-                receiver: None,
-                native_fn: |rcv, _args, vm| {
-                    if let Some(crate::vm::value::Value::NativeInstanceObj(rcv_obj)) = rcv {
-                        let rcv = &*rcv_obj.borrow();
-                        let mut inst = rcv.inst.downcast_ref::<Self>().unwrap();
-                        rcv.inst.method_to_string(vm)
-                    } else { unreachable!() }
-                },
-            })),
-        }
-    };
-
-    quote! {
-        fn get_type_value() -> crate::vm::value::TypeValue where Self: core::marker::Sized {
-            crate::vm::value::TypeValue {
-                name: #type_name.to_string(),
-                module_name: #module_name.to_string(),
-                fields: vec![ #(#fields),* ],
-                constructor: Some(Self::construct),
-                methods: vec![
-                    #to_string_method_code
-                    #(#methods),*
-                ],
-                static_fields: vec![ #(#static_methods),* ],
-            }
-        }
-    }
-}
-
-fn gen_to_string_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
-    match &type_spec.to_string_method {
-        Some(method_name) => {
-            let method_name_ident = format_ident!("{}", method_name);
-            quote! {
-                fn method_to_string(&self, vm: &mut crate::vm::vm::VM) -> crate::vm::value::Value {
-                    crate::vm::value::Value::new_string_obj(self.#method_name_ident(vm))
-                }
-            }
-        }
-        None => {
-            let mut format_str = vec![format!("{}(", type_spec.name)];
-            let mut fields_code = Vec::new();
-            let num_fields = type_spec.fields.len();
-            for (idx, field) in type_spec.fields.iter().enumerate() {
-                format_str.push(format!(
-                    "{}{}: {{}}{}",
-                    if idx > 0 { ", " } else { "" },
-                    &field.name,
-                    if idx == num_fields - 1 { ")" } else { "" }
-                ));
-
-                let getter_name = &field.getter.as_ref().unwrap().native_method_name;
-                let method_name_ident = format_ident!("{}", getter_name);
-                fields_code.push(quote!{ self.#method_name_ident() });
-            }
-            let format_str = format_str.join("");
-
-            quote! {
-                fn method_to_string(&self, vm: &mut crate::vm::vm::VM) -> crate::vm::value::Value {
-                    crate::vm::value::Value::new_string_obj(format!(#format_str, #(#fields_code),*))
-                }
-            }
-        }
-    }
-}
-
-fn gen_get_field_values_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
-    let code = type_spec.fields.iter().map(|field| {
-        let getter_name = &field.getter.as_ref().unwrap().native_method_name;
-        let method_name_ident = format_ident!("{}", getter_name);
-        quote! { self.#method_name_ident() }
-    });
-
-    quote! {
-        fn get_field_values(&self) -> std::vec::Vec<crate::vm::value::Value> {
-            vec![ #(#code),* ]
-        }
-    }
-}
-
-fn gen_get_field_value_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
-    let code = type_spec.fields.iter().enumerate().map(|(idx, field)| {
-        let method_name = &field.getter.as_ref().unwrap().native_method_name;
-        let method_name_ident = format_ident!("{}", method_name);
-
-        quote! { #idx => self.#method_name_ident() }
-    });
-
-    quote! {
-        fn get_field_value(&self, field_idx: usize) -> crate::vm::value::Value {
-            match field_idx {
-                #(#code,)*
-                _ => unreachable!(),
-            }
-        }
-    }
-}
-
-fn gen_set_field_value_method_code(type_spec: &TypeSpec) -> proc_macro2::TokenStream {
-    let code = type_spec.fields.iter().enumerate().filter_map(|(idx, field)| {
-        field.setter.as_ref().map(|setter| {
-            let method_name_ident = format_ident!("{}", setter.native_method_name);
-            quote! { #idx => self.#method_name_ident(value) }
-        })
-    });
-
-    quote! {
-        fn set_field_value(&mut self, field_idx: usize, value: crate::vm::value::Value) {
-            match field_idx {
-                #(#code,)*
-                _ => unreachable!(),
-            }
-        }
-    }
-}
 
 #[proc_macro_attribute]
 pub fn abra_function(attr: TokenStream, input: TokenStream) -> TokenStream {
@@ -1272,156 +318,4 @@ pub fn abra_function(attr: TokenStream, input: TokenStream) -> TokenStream {
         #gen_spec_method_code
     };
     ts.into()
-}
-
-fn parse_function(attr_args: HashMap<String, String>, function: &syn::ItemFn) -> Result<MethodSpec, syn::Error> {
-    if let Some(FnArg::Receiver(_)) = function.sig.inputs.first() {
-        let msg = format!("The function bound via #[abra_function] must not receive self");
-        return Err(syn::Error::new(function.span(), msg));
-    }
-    let native_method_arity = function.sig.inputs.len();
-    if native_method_arity > 2 {
-        let msg = format!("The function bound via #[abra_function] receives too many parameters; bound functions can only receive up to 2 parameters (Arguments and VM)");
-        return Err(syn::Error::new(function.sig.inputs.span(), msg));
-    }
-
-    let signature = match attr_args.get("signature") {
-        Some(signature) => match parse_fn_signature(None, &vec![], signature) {
-            Ok(s) => s,
-            Err(e) => {
-                let msg = format!("Invalid signature provided to #[abra_function]: {}", e);
-                return Err(syn::Error::new(Span::call_site(), msg));
-            }
-        }
-        None => {
-            let msg = "Missing required parameter `signature` in #[abra_function] attribute".to_string();
-            return Err(syn::Error::new(Span::call_site(), msg));
-        }
-    };
-    let Signature { func_name, args, return_type } = signature;
-
-    if return_type == TypeRepr::Unit && function.sig.output != syn::ReturnType::Default {
-        let msg = format!("The function bound via #[abra_function] has no return type in its signature, and therefore must not have a return value");
-        return Err(syn::Error::new(function.sig.output.span(), msg));
-    }
-
-    let is_variadic = args.iter().any(|arg| arg.is_variadic);
-
-    let method_name = function.sig.ident.to_string();
-    Ok(MethodSpec {
-        native_method_name: method_name.clone(),
-        native_method_arity,
-        name: func_name,
-        args,
-        return_type,
-        is_static: true,
-        is_mut: false,
-        is_variadic,
-        is_pseudomethod: false,
-    })
-}
-
-fn generate_function_code(static_method: MethodSpec) -> proc_macro2::TokenStream {
-    let name = &static_method.name;
-    let num_args = static_method.args.len();
-    let native_name_ident = format_ident!("{}", &static_method.native_method_name);
-    let native_method_arity = static_method.native_method_arity;
-
-    let arguments = match native_method_arity {
-        0 => quote! {},
-        1 => quote! { crate::builtins::arguments::Arguments::new(#name, #num_args, args) },
-        2 => quote! { crate::builtins::arguments::Arguments::new(#name, #num_args, args), vm },
-        _ => unreachable!()
-    };
-
-    let body = if static_method.return_type != TypeRepr::Unit {
-        quote! { #native_name_ident(#arguments) }
-    } else {
-        quote! {
-            #native_name_ident(#arguments);
-            crate::vm::value::Value::Nil
-        }
-    };
-
-    let fn_type = {
-        let args = static_method.args.iter().map(|arg| {
-            let MethodArgSpec { name, typ, is_optional, .. } = arg;
-            let typ = gen_rust_type_path(typ, &"BOGUS".to_string(), &"BOGUS".to_string());
-
-            quote! { (#name.to_string(), #typ, #is_optional) }
-        });
-
-        let return_type = gen_rust_type_path(&static_method.return_type, &"BOGUS".to_string(), &"BOGUS".to_string());
-        let is_variadic = &static_method.is_variadic;
-
-        quote! {
-            crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
-                arg_types: vec![#(#args),*],
-                type_args: vec![],
-                ret_type: Box::new(#return_type),
-                is_variadic: #is_variadic,
-                is_enum_constructor: false,
-            })
-        }
-    };
-
-    let native_value = quote! {
-        crate::vm::value::Value::NativeFn(crate::vm::value::NativeFn {
-            name: #name,
-            receiver: None,
-            native_fn: |rcv, args, vm| { #body },
-        })
-    };
-
-    let gen_fn_name = format_ident!("{}__gen_spec", static_method.native_method_name);
-    quote! {
-        fn #gen_fn_name() -> (std::string::String, crate::typechecker::types::Type, crate::vm::value::Value) {
-            (#name.to_string(), #fn_type, #native_value)
-        }
-    }
-}
-
-fn find_attr<'a>(attrs: &'a Vec<syn::Attribute>, name: &str) -> Option<(usize, &'a syn::Attribute)> {
-    attrs.into_iter().enumerate().find(|(_, attr)| {
-        attr.path.segments.first().map_or(false, |s| {
-            s.ident.to_string() == name.to_string()
-        })
-    })
-}
-
-fn parse_attr(attr: &syn::Attribute) -> HashMap<String, String> {
-    let mut map = HashMap::new();
-
-    match attr.parse_meta() {
-        Err(e) => eprintln!("{:#?}", e),
-        Ok(syn::Meta::List(meta)) => {
-            for nested in meta.nested {
-                if let Some((arg, val)) = parse_attr_meta(nested) {
-                    map.insert(arg, val);
-                }
-            }
-        }
-        _ => {}
-    }
-
-    map
-}
-
-fn parse_attr_meta(nested: syn::NestedMeta) -> Option<(String, String)> {
-    match nested {
-        NestedMeta::Meta(syn::Meta::NameValue(nv)) => {
-            let arg = nv.path.segments[0].ident.to_string();
-            let val = match nv.lit {
-                syn::Lit::Str(s) => s.value(),
-                syn::Lit::Bool(b) => b.value.to_string(),
-                _ => unreachable!()
-            };
-            Some((arg, val))
-        }
-        NestedMeta::Meta(syn::Meta::Path(path)) => {
-            let bool_arg = path.segments[0].ident.to_string();
-            Some((bool_arg, "true".to_string()))
-        }
-        _ => None
-    }
 }

--- a/abra_native/src/parsing_common.rs
+++ b/abra_native/src/parsing_common.rs
@@ -1,0 +1,47 @@
+use syn::NestedMeta;
+use std::collections::HashMap;
+
+pub fn find_attr<'a>(attrs: &'a Vec<syn::Attribute>, name: &str) -> Option<(usize, &'a syn::Attribute)> {
+    attrs.into_iter().enumerate().find(|(_, attr)| {
+        attr.path.segments.first().map_or(false, |s| {
+            s.ident.to_string() == name.to_string()
+        })
+    })
+}
+
+pub fn parse_attr(attr: &syn::Attribute) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+
+    match attr.parse_meta() {
+        Err(e) => eprintln!("{:#?}", e),
+        Ok(syn::Meta::List(meta)) => {
+            for nested in meta.nested {
+                if let Some((arg, val)) = parse_attr_meta(nested) {
+                    map.insert(arg, val);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    map
+}
+
+pub fn parse_attr_meta(nested: syn::NestedMeta) -> Option<(String, String)> {
+    match nested {
+        NestedMeta::Meta(syn::Meta::NameValue(nv)) => {
+            let arg = nv.path.segments[0].ident.to_string();
+            let val = match nv.lit {
+                syn::Lit::Str(s) => s.value(),
+                syn::Lit::Bool(b) => b.value.to_string(),
+                _ => unreachable!()
+            };
+            Some((arg, val))
+        }
+        NestedMeta::Meta(syn::Meta::Path(path)) => {
+            let bool_arg = path.segments[0].ident.to_string();
+            Some((bool_arg, "true".to_string()))
+        }
+        _ => None
+    }
+}

--- a/abra_native/src/type_utils.rs
+++ b/abra_native/src/type_utils.rs
@@ -1,0 +1,107 @@
+use crate::signature::TypeRepr;
+use quote::{quote, format_ident};
+
+pub fn gen_rust_type_path(type_repr: &TypeRepr, module_name: &String, type_ref_name: &String) -> proc_macro2::TokenStream {
+    match type_repr {
+        TypeRepr::SelfType(type_args) => {
+            if type_ref_name == "Array" {
+                let arr_type_repr = TypeRepr::Array(Box::new(type_args[0].clone()));
+                gen_rust_type_path(&arr_type_repr, module_name, type_ref_name)
+            } else if type_ref_name == "String" {
+                quote! { crate::typechecker::types::Type::String }
+            } else if type_ref_name == "Set" {
+                let inner_type = type_args.get(0).expect("Sets require T value");
+                let inner_type_repr = gen_rust_type_path(inner_type, module_name, type_ref_name);
+
+                quote! { crate::typechecker::types::Type::Set(std::boxed::Box::new(#inner_type_repr)) }
+            } else if type_ref_name == "Map" {
+                let key_type = type_args.get(0).expect("Maps require K value");
+                let key_type_repr = gen_rust_type_path(key_type, module_name, type_ref_name);
+                let val_type = type_args.get(1).expect("Maps require V value");
+                let val_type_repr = gen_rust_type_path(val_type, module_name, type_ref_name);
+
+                quote! {
+                    crate::typechecker::types::Type::Map(
+                        std::boxed::Box::new(#key_type_repr),
+                        std::boxed::Box::new(#val_type_repr)
+                    )
+                }
+            } else {
+                let type_args = type_args.iter().map(|type_arg| {
+                    gen_rust_type_path(type_arg, module_name, type_ref_name)
+                });
+
+                quote! { crate::typechecker::types::Type::Reference(#type_ref_name.to_string(), vec![ #(#type_args),* ]) }
+            }
+        }
+        TypeRepr::Generic(g) => quote! { crate::typechecker::types::Type::Generic(#g.to_string()) },
+        TypeRepr::Unit => quote! { crate::typechecker::types::Type::Unit },
+        TypeRepr::Ident(i, type_args) => {
+            match i.as_str() {
+                "Unit" | "Any" | "Int" | "Float" | "String" | "Bool" | "Placeholder" => {
+                    let typ = format_ident!("{}", i);
+                    quote! { crate::typechecker::types::Type::#typ }
+                }
+                "Set" => {
+                    let inner_type = type_args.get(0).expect("Sets require T value");
+                    let inner_type_repr = gen_rust_type_path(inner_type, module_name, type_ref_name);
+
+                    quote! { crate::typechecker::types::Type::Set(std::boxed::Box::new(#inner_type_repr)) }
+                }
+                "Map" => {
+                    let key_type = type_args.get(0).expect("Maps require K value");
+                    let key_type_repr = gen_rust_type_path(key_type, module_name, type_ref_name);
+                    let val_type = type_args.get(1).expect("Maps require V value");
+                    let val_type_repr = gen_rust_type_path(val_type, module_name, type_ref_name);
+
+                    quote! {
+                        crate::typechecker::types::Type::Map(
+                            std::boxed::Box::new(#key_type_repr),
+                            std::boxed::Box::new(#val_type_repr)
+                        )
+                    }
+                }
+                i => {
+                    let type_args = type_args.iter().map(|type_arg| {
+                        gen_rust_type_path(type_arg, module_name, type_ref_name)
+                    });
+
+                    quote! { crate::typechecker::types::Type::Reference(#i.to_string(), vec![ #(#type_args),* ]) }
+                }
+            }
+        }
+        TypeRepr::Fn(args, ret) => {
+            let args = args.iter().map(|arg| {
+                let arg_type = gen_rust_type_path(arg, module_name, type_ref_name);
+                quote! { ("_".to_string(), #arg_type, false) }
+            });
+            let ret = gen_rust_type_path(ret, module_name, type_ref_name);
+
+            quote! {
+                crate::typechecker::types::Type::Fn(crate::typechecker::types::FnType {
+                    arg_types: vec![ #(#args),* ],
+                    type_args: vec![],
+                    ret_type: std::boxed::Box::new(#ret),
+                    is_variadic: false,
+                    is_enum_constructor: false,
+                })
+            }
+        }
+        TypeRepr::Tuple(types) => {
+            let types = types.iter().map(|t| gen_rust_type_path(t, module_name, type_ref_name));
+            quote! { crate::typechecker::types::Type::Tuple(vec![ #(#types),* ]) }
+        }
+        TypeRepr::Union(types) => {
+            let types = types.iter().map(|t| gen_rust_type_path(t, module_name, type_ref_name));
+            quote! { crate::typechecker::types::Type::Union(vec![ #(#types),* ]) }
+        }
+        TypeRepr::Array(t) => {
+            let t = gen_rust_type_path(t, module_name, type_ref_name);
+            quote! { crate::typechecker::types::Type::Array(std::boxed::Box::new(#t)) }
+        }
+        TypeRepr::Opt(t) => {
+            let t = gen_rust_type_path(t, module_name, type_ref_name);
+            quote! { crate::typechecker::types::Type::Option(std::boxed::Box::new(#t)) }
+        }
+    }
+}

--- a/abra_wasm/src/lib.rs
+++ b/abra_wasm/src/lib.rs
@@ -91,6 +91,7 @@ impl Serialize for RunResultValue {
                 arr.end()
             }
             Value::EnumInstanceObj(o) => serializer.serialize_u32((&*o.borrow()).idx as u32),
+            Value::NativeEnumInstanceObj(o) => serializer.serialize_u32((&*o.borrow()).idx as u32),
             Value::Fn(FnValue { name, .. }) => serializer.serialize_str(name),
             Value::Closure(ClosureValue { name, .. }) => serializer.serialize_str(name),
             Value::NativeFn(NativeFn { name, .. }) => serializer.serialize_str(name),


### PR DESCRIPTION
- Add native `Result<V, E>` enum type in `prelude`!
- Refactor abra_native module to support creating enum types using the
existing proc macros. It's still in its pretty early stages, but all the
main pieces are in place.
- Add `Type::flatten` function to handle cases like
```
val results = [Result.Ok("asdf"), Result.Err(123)]
```
Previously, the type of `results` would be
`(Result<String, _> | Result<_, Int>)[]`, but now it gets flattened to a
much more reasonable representation: `Result<String, Int>[]`. This will
_defintely_ need to be iterated on, as it only works for `Placeholder`
types in `Reference` types at the moment.