### PR TITLE
Fixing returns

### DIFF
--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -2210,6 +2210,61 @@ mod tests {
         let result = interpret(input);
         let expected = Value::Bool(true);
         assert_eq!(expected, result);
+
+        let input = r#"
+          func f(): Int {
+            if true {
+              val x = 12
+              return 24
+            }
+            return 6
+          }
+          f()
+        "#;
+        let result = interpret(input);
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = r#"
+          func f(): Int {
+            while true {
+              val x = 12
+              return 24
+            }
+          }
+          f()
+        "#;
+        let result = interpret(input);
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = r#"
+          func f(): Int {
+            for _ in [1, 2, 3] {
+              val x = 12
+              return 24
+            }
+          }
+          f()
+        "#;
+        let result = interpret(input);
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
+
+        let input = r#"
+          func f(): Int {
+            match "a" {
+              _ => {
+                val x = 12
+                return 24
+              }
+            }
+          }
+          f()
+        "#;
+        let result = interpret(input);
+        let expected = Value::Int(24);
+        assert_eq!(expected, result);
     }
 
     #[test]


### PR DESCRIPTION
- Right now, returning from a block within a function does not properly
pop that scope's locals, leaving garbage on top of the stack. This is
because the `first_local_idx` value that's being used during
`visit_return` is not w.r.t. the function scope, but rather the
enclosing for/while/match/if scope. To fix this, we can actually just
always emit `LStore 0` to store the return valueinto the return local slot.