### PR TITLE
Add try-expressions!

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,46 +1,42 @@
-func foo(): Result<Int, String> {
-  Result.Err("123")
-}
+func f(): Int {
+  //if true {
+  //  val x = 12
+  //  return 24
+  //}
+  //return 6
 
-val results = [
-  Result.Ok("a"),
-  Result.Err(1),
-  Result.Ok("1"),
-]
+  //while true {
+  //  val x = 12
+  //  return 24
+  //}
 
-println(Result.all(results))
+  //for _ in [1, 2, 3] {
+  //  val x = 12
+  //  return 24
+  //}
 
-val f = foo()
-  .map(v => v * 2)
-  .mapErr(e => e + "!!!")
-
-if f.getValue() |f| println(f)
-else println("no value :(")
-
-/*
-
-func bar(): Result<Int, Int> {
-  //val f = foo()!
-
-  val r: Result<Int, Int>? = a?.foo()
-  match r {
-    Ok(v) => {}
-    Err(e) => {}
-    None => {}
-  }
-
-  val r: Result<Int, String> = a.foo()
-  val r: Result<Int, Int> = a.foo().mapErr(str => str.length)
-  match r {
-    Ok(v) => {}
-    Err(e) => {}
-  }
-
-  val r: Int = try a.foo().mapErr(str => str.length)
-    val r = match a.foo().mapErr(str => str.length) {
-      Ok(v) => v
-      Err e => return e
+  match "a" {
+    _ => {
+      val x = 12
+      return 24
     }
   }
 }
-*/
+//println(f())
+
+//type List<T> { items: T[] }
+
+func doSomething(): Result<Int, String> =
+  Result.Ok(123)
+  //Result.Err("asdf")
+
+func foo(): Result<Int, String> {
+  val i = try doSomething()
+  //val i = match doSomething() {
+  //  Result.Ok(v) => v
+  //  Result.Err e => return e
+  //}
+  Result.Ok(i + 1)
+}
+
+println(foo())

--- a/abra_core/src/builtins/prelude/mod.rs
+++ b/abra_core/src/builtins/prelude/mod.rs
@@ -6,6 +6,7 @@ pub use native_array::NativeArray;
 pub use native_float::NativeFloat;
 pub use native_int::NativeInt;
 pub use native_map::NativeMap;
+pub use native_result::NativeResult;
 pub use native_set::NativeSet;
 pub use native_string::NativeString;
 pub use process::Process;

--- a/abra_core/src/builtins/prelude/native_result.rs
+++ b/abra_core/src/builtins/prelude/native_result.rs
@@ -62,6 +62,15 @@ impl NativeResult {
         self.value.clone()
     }
 
+    #[abra_method(signature = "getError(): E?")]
+    fn get_error(&self) -> Value {
+        if self.is_ok {
+            return Value::Nil;
+        }
+
+        self.value.clone()
+    }
+
     #[abra_method(signature = "map<T>(fn: (V) => T): Result<T, E>")]
     fn map(&self, mut args: Arguments, vm: &mut VM) -> Self {
         let callback = args.next_value();
@@ -165,6 +174,15 @@ mod test {
 
         let result = interpret("Result.Err(\"asdf\").getValue()");
         assert_eq!(Value::Nil, result);
+    }
+
+    #[test]
+    fn test_result_get_error() {
+        let result = interpret("Result.Ok(\"asdf\").getError()");
+        assert_eq!(Value::Nil, result);
+
+        let result = interpret("Result.Err(\"asdf\").getError()");
+        assert_eq!(new_string_obj("asdf"), result);
     }
 
     #[test]

--- a/abra_core/src/common/ast_visitor.rs
+++ b/abra_core/src/common/ast_visitor.rs
@@ -1,4 +1,4 @@
-use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode, LambdaNode, TypeIdentifier, EnumDeclNode, MatchNode, SetNode, ImportNode};
+use crate::parser::ast::{AstNode, AstLiteralNode, UnaryNode, BinaryNode, ArrayNode, BindingDeclNode, AssignmentNode, IndexingNode, GroupedNode, IfNode, FunctionDeclNode, InvocationNode, WhileLoopNode, ForLoopNode, TypeDeclNode, MapNode, AccessorNode, LambdaNode, TypeIdentifier, EnumDeclNode, MatchNode, SetNode, ImportNode, TryNode};
 use crate::parser::ast::AstNode::*;
 use crate::lexer::tokens::Token;
 use crate::typechecker::types::Type;
@@ -33,6 +33,7 @@ pub trait AstVisitor<V, E> {
             ImportStatement(tok, node) => self.visit_import(tok, node),
             ForLoop(tok, node) => self.visit_for_loop(tok, node),
             Accessor(tok, node) => self.visit_accessor(tok, node),
+            Try(tok, node) => self.visit_try(tok, node),
             Lambda(tok, node) => self.visit_lambda(tok, node, None),
             Tuple(tok, nodes) => self.visit_tuple(tok, nodes),
         }
@@ -64,6 +65,7 @@ pub trait AstVisitor<V, E> {
     fn visit_return(&mut self, token: Token, node: Option<Box<AstNode>>) -> Result<V, E>;
     fn visit_import(&mut self, token: Token, node: ImportNode) -> Result<V, E>;
     fn visit_accessor(&mut self, token: Token, node: AccessorNode) -> Result<V, E>;
+    fn visit_try(&mut self, token: Token, node: TryNode) -> Result<V, E>;
     fn visit_lambda(&mut self, token: Token, node: LambdaNode, args_override: Option<Vec<(Token, Type, Option<TypedAstNode>)>>) -> Result<V, E>;
     fn visit_tuple(&mut self, token: Token, nodes: Vec<AstNode>) -> Result<V, E>;
 }

--- a/abra_core/src/lexer/lexer.rs
+++ b/abra_core/src/lexer/lexer.rs
@@ -294,6 +294,7 @@ impl<'a> Lexer<'a> {
                 "export" => Token::Export(pos),
                 "from" => Token::From(pos),
                 "as" => Token::As(pos),
+                "try" => Token::Try(pos),
                 "None" => Token::None(pos),
                 s => Token::Ident(pos, s.to_string())
             };
@@ -788,7 +789,7 @@ mod tests {
     #[test]
     fn test_tokenize_keywords() {
         let input = "true false val var if else func while break for in \
-        type enum self match readonly import export from as continue";
+        type enum self match readonly import export from as try continue";
         let tokens = tokenize(input).unwrap();
         let expected = vec![
             Token::Bool(Position::new(1, 1), true),
@@ -811,7 +812,8 @@ mod tests {
             Token::Export(Position::new(1, 89)),
             Token::From(Position::new(1, 96)),
             Token::As(Position::new(1, 101)),
-            Token::Continue(Position::new(1, 104)),
+            Token::Try(Position::new(1, 104)),
+            Token::Continue(Position::new(1, 108)),
         ];
         assert_eq!(expected, tokens);
     }

--- a/abra_core/src/lexer/tokens.rs
+++ b/abra_core/src/lexer/tokens.rs
@@ -54,6 +54,7 @@ pub enum Token {
     #[strum(to_string = "export", serialize = "Export")] Export(Position),
     #[strum(to_string = "from", serialize = "From")] From(Position),
     #[strum(to_string = "as", serialize = "As")] As(Position),
+    #[strum(to_string = "try", serialize = "Try")] Try(Position),
 
     // Identifiers
     #[strum(to_string = "identifier", serialize = "Ident")] Ident(Position, String),
@@ -133,6 +134,7 @@ impl Token {
             Token::Export(pos) |
             Token::From(pos) |
             Token::As(pos) |
+            Token::Try(pos) |
 
             Token::Ident(pos, _) |
             Token::Self_(pos) |
@@ -215,6 +217,7 @@ impl Token {
             Token::Export(pos) => Range::with_length(pos, 5),
             Token::From(pos) => Range::with_length(pos, 3),
             Token::As(pos) => Range::with_length(pos, 1),
+            Token::Try(pos) => Range::with_length(pos, 2),
 
             Token::Ident(pos, i) => Range::with_length(pos, i.len() - 1),
             Token::Self_(pos) => Range::with_length(pos, 3),

--- a/abra_core/src/parser/ast.rs
+++ b/abra_core/src/parser/ast.rs
@@ -28,6 +28,7 @@ pub enum AstNode {
     Break(Token),
     Continue(Token),
     Accessor(Token, AccessorNode),
+    Try(Token, TryNode),
     Lambda(Token, LambdaNode),
     MatchStatement(Token, MatchNode),
     MatchExpression(Token, MatchNode),
@@ -65,6 +66,7 @@ impl AstNode {
             AstNode::ReturnStatement(token, _) |
             AstNode::ImportStatement(token, _) |
             AstNode::Accessor(token, _) |
+            AstNode::Try(token, _) |
             AstNode::MatchStatement(token, _) |
             AstNode::MatchExpression(token, _) => token,
         }
@@ -288,6 +290,11 @@ pub struct AccessorNode {
     // Must be an AstNode::Identifier
     pub field: Box<AstNode>,
     pub is_opt_safe: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TryNode {
+    pub expr: Box<AstNode>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/abra_core/src/vm/vm_test.rs
+++ b/abra_core/src/vm/vm_test.rs
@@ -2570,4 +2570,31 @@ mod tests {
         let expected = Value::Int(2);
         assert_eq!(expected, chunk);
     }
+
+    #[test]
+    fn interpret_try_expression() {
+        // Test with Ok value
+        let chunk = interpret(r#"
+          func foo(): Result<Int, String> = Result.Ok(23)
+          func bar(): Result<Int, String> {
+            val i = try foo()
+            Result.Ok(i + 1)
+          }
+          bar().getValue()
+        "#);
+        let expected = Value::Int(24);
+        assert_eq!(expected, chunk);
+
+        // Test with Err value
+        let chunk = interpret(r#"
+          func foo(): Result<Int, String> = Result.Err("asdf")
+          func bar(): Result<Int, String> {
+            val i = try foo()
+            Result.Ok(i + 1)
+          }
+          bar().getError()
+        "#);
+        let expected = new_string_obj("asdf");
+        assert_eq!(expected, chunk);
+    }
 }


### PR DESCRIPTION
- Add try-expressions. These take the form `try <expr>` and attempt to
"unwrap" the value of the expression to which it's applied (as a prefix
operator). If this value is some "successful" value, the function flow
proceeds as normal; if it's some "failure" value, the failure value is
returned and the function terminates. (This is very similar to, and
largely inspired by, how Rust's `?` operator works).
- After typechecking is performed to ensure the types line up (in a very
hacky and one-off implementation, since the only tryable type for now is
the `Result<V, E>` type (though there's no reason why it has to be, it
could change when "interfaces" are added)), a match expression is
emitted which handles the logic. For example, the following code:
```
func foo(): Result<Int, String> = ...
func bar(): Result<Int, String> {
  val a = try foo()
  Result.Ok(a + 0.1)
}
```
After transformation, this gets emitted:
```
func foo(): Result<Int, String> = ...
func bar(): Result<Int, String> {
  val a = match foo() {
    Result.Ok(v) => v
    Result.Err e => return e
  }
  Result.Ok(a + 0.1)
}
```