### PR TITLE
Fixing enums w.r.t. GC

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -1,9 +1,19 @@
 // TODO: This shouldn't stackoverflow
 //println([])
 
-val arr: Int[] = []
-arr.push(1)
-arr
+func foo(i: Int): Result<Int, String> {
+  if i < 0 Result.Err(error: "Less than 0")
+  else Result.Ok(value: i * 10)
+}
 
-//arr.push(1)
-//println(arr)
+enum Color { Red, Blue, Green }
+
+val c = Color.Blue
+
+println(c)
+//for res in results {
+//  match res {
+//    Result.Ok(v) => println("value:", v)
+//    Result.Err(e) => println("error:", e)
+//  }
+//}

--- a/abra_core/src/typechecker/typechecker2_tests.rs
+++ b/abra_core/src/typechecker/typechecker2_tests.rs
@@ -2676,6 +2676,7 @@ fn typecheck_enum_declaration() {
                 EnumVariant { name: "Bar".to_string(), defined_span: Span::new(TEST_MODULE_ID, (2, 1), (2, 3)), kind: EnumVariantKind::Constant },
                 EnumVariant { name: "Baz".to_string(), defined_span: Span::new(TEST_MODULE_ID, (3, 1), (3, 3)), kind: EnumVariantKind::Container(baz_func_id) },
             ],
+            all_variants_constant: false,
             methods: vec![tostring_func_id, hash_func_id, eq_func_id],
             static_methods: vec![],
         }

--- a/selfhost/src/lexer.abra
+++ b/selfhost/src/lexer.abra
@@ -3,19 +3,11 @@ export type Position { line: Int, col: Int }
 export type Token {
   position: Position
   kind: TokenKind
-  intValue: Int = 0
-  strValue: String = ""
 }
 
-// TODO: When tagged union enums are fixed w.r.t. garbage collection, switch back to this implementation
-// export enum TokenKind {
-//   Int(value: Int)
-//   Ident(name: String)
-//   Dot
-// }
 export enum TokenKind {
-  Int,
-  Ident,
+  Int(value: Int)
+  Ident(name: String)
   Dot
 }
 
@@ -103,7 +95,7 @@ export type Lexer {
         ch = self._input._buffer.offset(self._cursor).load().asInt()
       }
 
-      return Token(position: startPos, kind: TokenKind.Int, intValue: num)
+      return Token(position: startPos, kind: TokenKind.Int(num))
     }
 
     // ord('0') = 48
@@ -115,7 +107,7 @@ export type Lexer {
       self._advance()
     }
 
-    Token(position: startPos, kind: TokenKind.Int, intValue: num)
+    Token(position: startPos, kind: TokenKind.Int(num))
   }
 
   func _tokenizeIdent(self, startPos: Position): Token {
@@ -128,6 +120,6 @@ export type Lexer {
     }
 
     val ident = self._input[identStart:self._cursor]
-    Token(position: startPos, kind: TokenKind.Ident, strValue: ident)
+    Token(position: startPos, kind: TokenKind.Ident(ident))
   }
 }

--- a/selfhost/src/lexer.test.abra
+++ b/selfhost/src/lexer.test.abra
@@ -15,7 +15,7 @@ export func printTokensAsJson(tokens: Token[]) {
     println("$indent{")
     println("$indent$indent\"position\": [${token.position.line}, ${token.position.col}],")
     print("$indent$indent\"kind\": ")
-    printTokenKindAsJson(token, "$indent$indent")
+    printTokenKindAsJson(token.kind, "$indent$indent")
     val comma = if idx != tokens.length - 1 "," else ""
     println("${indent}}${comma}")
   }
@@ -23,16 +23,16 @@ export func printTokensAsJson(tokens: Token[]) {
   println("]")
 }
 
-func printTokenKindAsJson(token: Token, indent: String) {
+func printTokenKindAsJson(tokenKind: TokenKind, indent: String) {
   println("{")
-  match token.kind {
-    TokenKind.Int/*(value)*/ => {
+  match tokenKind {
+    TokenKind.Int(value) => {
       println("$indent  \"name\": \"Int\",")
-      println("$indent  \"value\": ${token.intValue}")
+      println("$indent  \"value\": $value")
     }
-    TokenKind.Ident/*(name)*/ => {
+    TokenKind.Ident(name) => {
       println("$indent  \"name\": \"Ident\",")
-      println("$indent  \"value\": \"${token.strValue}\"")
+      println("$indent  \"value\": \"$name\"")
     }
     TokenKind.Dot => {
       println("$indent  \"name\": \"Dot\"")


### PR DESCRIPTION
Enums had been broken ever since I integrated the bdwgc garbage collector into the runtime. This is because of the way I "cleverly" implemented them as being 64-bits which were either an integer for constant variants (just the runtime typeid for comparisons) or a pointer whose upper bits represented the runtime typeid. Because of the fact that the pointer value needed to be masked in order to be recognizable, the garbage collector did not properly mark it and the memory was prematurely freed, leading to weird issues in the selfhosting compiler when attempting to test the lexer. This _should_ be all resolved now.

In addition to this, I also cleaned up the trait value encoding/decoding logic (with even more room for improvement in the future!).