### PR TITLE
Selfhost: parse destructuring patterns

### DIFF
--- a/selfhost/src/parser.abra
+++ b/selfhost/src/parser.abra
@@ -117,8 +117,12 @@ export enum TypeIdentifier {
   Function(args: TypeIdentifier[], ret: TypeIdentifier)
 }
 
+export enum BindingPattern {
+  Variable(label: Label)
+}
+
 type BindingDeclarationNode {
-  ident: Label
+  bindingPattern: BindingPattern
   typeAnnotation: TypeIdentifier?
   expr: AstNode?
 }
@@ -308,12 +312,25 @@ export type Parser {
     }
   }
 
+  func _parseBindingPattern(self): Result<BindingPattern, ParseError> {
+    val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val pat = match token.kind {
+      TokenKind.Ident => {
+        val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        BindingPattern.Variable(label)
+      }
+      _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
+    }
+
+    Result.Ok(pat)
+  }
+
   func _parseBindingDeclaration(self, mutable: Bool): Result<AstNode, ParseError> {
     val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
 
     if self._cursor >= self._tokens.length {
-      val node = BindingDeclarationNode(ident: label, typeAnnotation: None, expr: None)
+      val node = BindingDeclarationNode(bindingPattern: pat, typeAnnotation: None, expr: None)
       return Result.Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
     }
 
@@ -327,7 +344,7 @@ export type Parser {
     }
 
     if self._cursor >= self._tokens.length {
-      val node = BindingDeclarationNode(ident: label, typeAnnotation: typeAnnotation, expr: None)
+      val node = BindingDeclarationNode(bindingPattern: pat, typeAnnotation: typeAnnotation, expr: None)
       return Result.Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
     }
 
@@ -340,7 +357,7 @@ export type Parser {
       None
     }
 
-    val node = BindingDeclarationNode(ident: label, typeAnnotation: typeAnnotation, expr: expr)
+    val node = BindingDeclarationNode(bindingPattern: pat, typeAnnotation: typeAnnotation, expr: expr)
     Result.Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
   }
 
@@ -1003,11 +1020,11 @@ export type Parser {
   }
 }
 
-func todo(position: Position): Result<AstNode, ParseError> {
+func todo<V>(position: Position): Result<V, ParseError> {
   Result.Err(ParseError(position: position, kind: ParseErrorKind.NotYetImplemented))
 }
 
-func unreachable(): Result<AstNode, ParseError> {
+func unreachable<V>(): Result<V, ParseError> {
   Result.Err(ParseError(position: Position(line: 0, col: 0), kind: ParseErrorKind.Unreachable))
 }
 

--- a/selfhost/src/test_utils.abra
+++ b/selfhost/src/test_utils.abra
@@ -1,5 +1,5 @@
 import Token, TokenKind from "./lexer"
-import Label, ParsedModule, AstNode, AstNodeKind, LiteralAstNode, IdentifierKind, IndexingMode, TypeIdentifier, AssignmentMode from "./parser"
+import Label, ParsedModule, AstNode, AstNodeKind, LiteralAstNode, IdentifierKind, IndexingMode, TypeIdentifier, AssignmentMode, BindingPattern from "./parser"
 
 export func printTokenAsJson(token: Token, indentLevelStart: Int, currentIndentLevel: Int) {
   val startIndent = "  ".repeat(indentLevelStart)
@@ -185,6 +185,21 @@ func printTypeIdentifierAsJson(typeIdentifier: TypeIdentifier, indentLevelStart:
     }
   }
   print("$endIndent}")
+}
+
+func printBindingPatternAsJson(bindingPattern: BindingPattern, indentLevelStart: Int, currentIndentLevel: Int) {
+  val startIndent = "  ".repeat(indentLevelStart)
+  val fieldsIndent = "  ".repeat(currentIndentLevel + 1)
+  val endIndent = "  ".repeat(currentIndentLevel)
+
+  print("$startIndent{\n$fieldsIndent\"kind\": ")
+  match bindingPattern {
+    BindingPattern.Variable(label) => {
+      print("\"variable\",\n$fieldsIndent\"label\": ")
+      printLabelAsJson(label)
+    }
+  }
+  print("\n$endIndent}")
 }
 
 func printAstNodeAsJson(node: AstNode, indentLevelStart: Int, currentIndentLevel: Int) {
@@ -465,8 +480,8 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
     }
     AstNodeKind.BindingDeclaration(value) => {
       println("$fieldsIndent\"name\": \"bindingDecl\",")
-      print("$fieldsIndent\"ident\": ")
-      printLabelAsJson(value.ident)
+      print("$fieldsIndent\"bindingPattern\": ")
+      printBindingPatternAsJson(value.bindingPattern, 0, currentIndentLevel + 1)
       println(",")
       if value.typeAnnotation |ann| {
         print("$fieldsIndent\"typeAnnotation\": ")

--- a/selfhost/test/parser/bindingdecl.out.json
+++ b/selfhost/test/parser/bindingdecl.out.json
@@ -9,7 +9,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "a", "position": [1, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "a", "position": [1, 5] }
+        },
         "typeAnnotation": null,
         "expr": null
       }
@@ -23,7 +26,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "b", "position": [2, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "b", "position": [2, 5] }
+        },
         "typeAnnotation": null,
         "expr": null
       }
@@ -37,7 +43,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "a", "position": [3, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "a", "position": [3, 5] }
+        },
         "typeAnnotation": null,
         "expr": {
           "token": {
@@ -77,7 +86,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "c", "position": [4, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "c", "position": [4, 5] }
+        },
         "typeAnnotation": null,
         "expr": {
           "token": {
@@ -128,7 +140,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "c", "position": [6, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "c", "position": [6, 5] }
+        },
         "typeAnnotation": {
           "kind": "normal",
           "label": { "name": "Int", "position": [6, 8] },
@@ -159,7 +174,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "d", "position": [7, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "d", "position": [7, 5] }
+        },
         "typeAnnotation": {
           "kind": "option",
           "inner": {

--- a/selfhost/test/parser/functiondecl.out.json
+++ b/selfhost/test/parser/functiondecl.out.json
@@ -93,7 +93,10 @@
             },
             "kind": {
               "name": "bindingDecl",
-              "ident": { "name": "x", "position": [4, 7] },
+              "bindingPattern": {
+                "kind": "variable",
+                "label": { "name": "x", "position": [4, 7] }
+              },
               "typeAnnotation": null,
               "expr": {
                 "token": {
@@ -212,7 +215,10 @@
             },
             "kind": {
               "name": "bindingDecl",
-              "ident": { "name": "x", "position": [7, 7] },
+              "bindingPattern": {
+                "kind": "variable",
+                "label": { "name": "x", "position": [7, 7] }
+              },
               "typeAnnotation": null,
               "expr": {
                 "token": {

--- a/selfhost/test/parser/lambdas.out.json
+++ b/selfhost/test/parser/lambdas.out.json
@@ -96,7 +96,10 @@
             },
             "kind": {
               "name": "bindingDecl",
-              "ident": { "name": "x", "position": [4, 7] },
+              "bindingPattern": {
+                "kind": "variable",
+                "label": { "name": "x", "position": [4, 7] }
+              },
               "typeAnnotation": null,
               "expr": {
                 "token": {

--- a/selfhost/test/parser/typeidentifiers.out.json
+++ b/selfhost/test/parser/typeidentifiers.out.json
@@ -9,7 +9,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [1, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [1, 5] }
+        },
         "typeAnnotation": {
           "kind": "normal",
           "label": { "name": "Int", "position": [1, 8] },
@@ -39,7 +42,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [4, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [4, 5] }
+        },
         "typeAnnotation": {
           "kind": "array",
           "inner": {
@@ -63,7 +69,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [5, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [5, 5] }
+        },
         "typeAnnotation": {
           "kind": "option",
           "inner": {
@@ -84,7 +93,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [6, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [6, 5] }
+        },
         "typeAnnotation": {
           "kind": "option",
           "inner": {
@@ -108,7 +120,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [7, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [7, 5] }
+        },
         "typeAnnotation": {
           "kind": "option",
           "inner": {
@@ -132,7 +147,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [8, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [8, 5] }
+        },
         "typeAnnotation": {
           "kind": "array",
           "inner": {
@@ -159,7 +177,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [10, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [10, 5] }
+        },
         "typeAnnotation": {
           "kind": "normal",
           "label": { "name": "Array", "position": [10, 8] },
@@ -183,7 +204,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [11, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [11, 5] }
+        },
         "typeAnnotation": {
           "kind": "normal",
           "label": { "name": "Map", "position": [11, 8] },
@@ -212,7 +236,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [12, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [12, 5] }
+        },
         "typeAnnotation": {
           "kind": "normal",
           "label": { "name": "Foo", "position": [12, 8] },
@@ -244,7 +271,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [13, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [13, 5] }
+        },
         "typeAnnotation": {
           "kind": "normal",
           "label": { "name": "Foo", "position": [13, 8] },
@@ -290,7 +320,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [15, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [15, 5] }
+        },
         "typeAnnotation": {
           "kind": "option",
           "inner": {
@@ -350,7 +383,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [17, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [17, 5] }
+        },
         "typeAnnotation": {
           "kind": "array",
           "inner": {
@@ -371,7 +407,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [18, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [18, 5] }
+        },
         "typeAnnotation": {
           "kind": "normal",
           "label": { "name": "Int", "position": [18, 9] },
@@ -389,7 +428,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [19, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [19, 5] }
+        },
         "typeAnnotation": {
           "kind": "tuple",
           "typeArguments": [
@@ -449,7 +491,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [21, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [21, 5] }
+        },
         "typeAnnotation": {
           "kind": "function",
           "argumentTypes": [
@@ -477,7 +522,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [22, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [22, 5] }
+        },
         "typeAnnotation": {
           "kind": "function",
           "argumentTypes": [
@@ -516,7 +564,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [23, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [23, 5] }
+        },
         "typeAnnotation": {
           "kind": "function",
           "argumentTypes": [
@@ -562,7 +613,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [24, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [24, 5] }
+        },
         "typeAnnotation": {
           "kind": "function",
           "argumentTypes": [],
@@ -584,7 +638,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [25, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [25, 5] }
+        },
         "typeAnnotation": {
           "kind": "function",
           "argumentTypes": [],
@@ -616,7 +673,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [26, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [26, 5] }
+        },
         "typeAnnotation": {
           "kind": "function",
           "argumentTypes": [],
@@ -658,7 +718,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [27, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [27, 5] }
+        },
         "typeAnnotation": {
           "kind": "function",
           "argumentTypes": [],
@@ -683,7 +746,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [28, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [28, 5] }
+        },
         "typeAnnotation": {
           "kind": "array",
           "inner": {
@@ -708,7 +774,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [29, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [29, 5] }
+        },
         "typeAnnotation": {
           "kind": "function",
           "argumentTypes": [],
@@ -733,7 +802,10 @@
       },
       "kind": {
         "name": "bindingDecl",
-        "ident": { "name": "_", "position": [30, 5] },
+        "bindingPattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [30, 5] }
+        },
         "typeAnnotation": {
           "kind": "option",
           "inner": {


### PR DESCRIPTION
For now, simply replace existing binding declarations' identifier fields with a BindingPattern.Variable. I probably won't add the other patterns yet until it becomes necessary, but I did want an abstraction in place for parsing bindings in if-/while-conditions.