### PR TITLE
Selfhost: parsing type declarations

### DIFF
--- a/selfhost/src/parser.abra
+++ b/selfhost/src/parser.abra
@@ -176,6 +176,22 @@ type FunctionDeclarationNode {
   body: AstNode[]
 }
 
+type TypeField {
+  name: Label
+  typeAnnotation: TypeIdentifier
+  initializer: AstNode?
+}
+
+type TypeDeclarationNode {
+  decorators: DecoratorNode[]
+  exportToken: Token?
+  name: Label
+  typeParams: Label[]
+  fields: TypeField[]
+  methods: FunctionDeclarationNode[]
+  types: TypeDeclarationNode[]
+}
+
 export type DecoratorNode {
   name: Label
   arguments: InvocationArgument[]
@@ -202,6 +218,7 @@ export enum AstNodeKind {
   For(itemPattern: BindingPattern, indexPattern: BindingPattern?, iterator: AstNode, block: AstNode[])
   BindingDeclaration(value: BindingDeclarationNode)
   FunctionDeclaration(value: FunctionDeclarationNode)
+  TypeDeclaration(value: TypeDeclarationNode)
 
   func isAssignmentExpression(self): Bool {
     match self {
@@ -418,7 +435,7 @@ export type Parser {
         match self._parseDecorator() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
 
         val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.At, TokenKind.Export]
+        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.At, TokenKind.Export]
         if !expected.contains(nextToken.kind) {
           return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
         }
@@ -430,7 +447,7 @@ export type Parser {
         self._advance() // consume 'export' token
 
         val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func]
+        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type]
         if !expected.contains(nextToken.kind) {
           return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
         }
@@ -440,6 +457,7 @@ export type Parser {
       TokenKind.Val => self._parseBindingDeclaration(mutable: false)
       TokenKind.Var => self._parseBindingDeclaration(mutable: true)
       TokenKind.Func => self._parseFunctionDeclaration()
+      TokenKind.Type => self._parseTypeDeclaration()
       TokenKind.While => self._parseWhileLoop()
       TokenKind.For => self._parseForLoop()
       _ => self._parseExpressionStatement()
@@ -563,13 +581,7 @@ export type Parser {
     val typeParams = match nextToken.kind {
       TokenKind.LT => {
         self._advance() // consume '<' token
-        val labels = match self._commaSeparated(end: TokenKind.GT, consumeFinal: false, fn: () => self._expectNextLabel()) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-        if labels.isEmpty() {
-          val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-          return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
-        } else {
-          self._advance() // consume '>' token
-        }
+        val labels = match self._parseTypeParameters() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
         labels
       }
       TokenKind.LParen => []
@@ -619,6 +631,91 @@ export type Parser {
       body: body,
     )
     Result.Ok(AstNode(token: token, kind: AstNodeKind.FunctionDeclaration(node)))
+  }
+
+  func _parseTypeDeclaration(self): Result<AstNode, ParseError> {
+    val decorators = self._seenDecorators
+    self._seenDecorators = []
+
+    val exportToken = self._exportToken
+    self._exportToken = None
+
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val typeName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val typeParams = match nextToken.kind {
+      TokenKind.LT => {
+        self._advance() // consume '<' token
+        val labels = match self._parseTypeParameters() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        labels
+      }
+      TokenKind.LBrace => []
+      _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
+    }
+
+    match self._expectNextTokenKind(TokenKind.LBrace) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+    val fields: TypeField[] = []
+    while self._peek() |nextToken| {
+      match nextToken.kind {
+        TokenKind.Ident => {
+          val name = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          match self._expectNextTokenKind(TokenKind.Colon) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val typeAnnotation = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+          var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val initializer = if nextToken.kind == TokenKind.Eq {
+            self._advance() // consume '=' token
+            val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            expr
+          } else {
+            None
+          }
+
+          nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          if nextToken.kind == TokenKind.Comma {
+            self._advance() // consume ',' token
+          }
+
+          fields.push(TypeField(name: name, typeAnnotation: typeAnnotation, initializer: initializer))
+        }
+        _ => break
+      }
+    }
+
+    val methods: FunctionDeclarationNode[] = []
+    val nestedTypes: TypeDeclarationNode[] = []
+    while self._peek() |nextToken| {
+      if nextToken.kind == TokenKind.RBrace break
+      val nodeRes = match nextToken.kind {
+        TokenKind.RBrace => break
+        TokenKind.At => self._parseStatement()
+        TokenKind.Func => self._parseStatement()
+        TokenKind.Type => self._parseStatement()
+        _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.UnexpectedToken(nextToken)))
+      }
+
+      val node = match nodeRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match node.kind {
+        AstNodeKind.FunctionDeclaration(node) => methods.push(node)
+        AstNodeKind.TypeDeclaration(node) => nestedTypes.push(node)
+        _ => return unreachable()
+      }
+    }
+
+    match self._expectNextTokenKind(TokenKind.RBrace) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+    val node = TypeDeclarationNode(
+      decorators: decorators,
+      exportToken: exportToken,
+      name: typeName,
+      typeParams: typeParams,
+      fields: fields,
+      methods: methods,
+      types: nestedTypes,
+    )
+    Result.Ok(AstNode(token: token, kind: AstNodeKind.TypeDeclaration(node)))
   }
 
   func _parseTypeIdentifier(self): Result<TypeIdentifier, ParseError> {
@@ -734,6 +831,17 @@ export type Parser {
       val param = FunctionParam(label: label, isVariadic: isVariadic, typeAnnotation: typeAnnotation, defaultValue: defaultValue)
       Result.Ok(param)
     })
+  }
+
+  func _parseTypeParameters(self): Result<Label[], ParseError> {
+    val labels = match self._commaSeparated(end: TokenKind.GT, consumeFinal: false, fn: () => self._expectNextLabel()) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    if labels.isEmpty() {
+      val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
+    } else {
+      self._advance() // consume '>' token
+      Result.Ok(labels)
+    }
   }
 
   func _parseBlockOrSingleExpression(self): Result<AstNode[], ParseError> {

--- a/selfhost/src/test_utils.abra
+++ b/selfhost/src/test_utils.abra
@@ -285,7 +285,7 @@ func printAstNodeAsJson(node: AstNode, indentLevelStart: Int, currentIndentLevel
   printTokenAsJson(token: node.token, indentLevelStart: 0, currentIndentLevel: currentIndentLevel + 1)
   print(",\n$fieldsIndent\"kind\": ")
   printAstNodeKindAsJson(kind: node.kind, indentLevelStart: 0, currentIndentLevel: currentIndentLevel + 1)
-  print("$endIndent}")
+  print("\n$endIndent}")
 }
 
 func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentIndentLevel: Int) {
@@ -550,6 +550,7 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
         }
         AssignmentMode.Accessor(node) => {
           printAstNodeKindAsJson(AstNodeKind.Accessor(node), 0, currentIndentLevel + 1)
+          println()
         }
       }
     }
@@ -812,6 +813,88 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
         println("$fieldsIndent]")
       }
     }
+    AstNodeKind.TypeDeclaration(node) => {
+      println("$fieldsIndent\"name\": \"typeDeclaration\",")
+      if node.decorators.isEmpty() {
+        println("$fieldsIndent\"decorators\": [],")
+      } else {
+        println("$fieldsIndent\"decorators\": [")
+        for dec, idx in node.decorators {
+          printDecoratorNodeAsJson(dec, currentIndentLevel + 2, currentIndentLevel + 2)
+          val comma = if idx != node.decorators.length - 1 "," else ""
+          println("$comma")
+        }
+        println("$fieldsIndent],")
+      }
+      if node.exportToken |token| {
+        print("$fieldsIndent\"exportToken\": ")
+        printTokenAsJson(token, 0, currentIndentLevel + 1)
+        println(",")
+      } else {
+        println("$fieldsIndent\"exportToken\": null,")
+      }
+      print("$fieldsIndent\"typeName\": ")
+      printLabelAsJson(node.name)
+
+      if node.typeParams.isEmpty() {
+        println(",\n$fieldsIndent\"typeParams\": [],")
+      } else {
+        println(",\n$fieldsIndent\"typeParams\": [")
+        for label, idx in node.typeParams {
+          print("$fieldsIndent  ")
+          printLabelAsJson(label)
+          val comma = if idx != node.typeParams.length - 1 "," else ""
+          println("$comma")
+        }
+        println("$fieldsIndent],")
+      }
+
+      if node.fields.isEmpty() {
+        println("$fieldsIndent\"fields\": [],")
+      } else {
+        println("$fieldsIndent\"fields\": [")
+        for f, idx in node.fields {
+          println("$fieldsIndent  {")
+          print("$fieldsIndent    \"label\": ")
+          printLabelAsJson(f.name)
+          print(",\n$fieldsIndent    \"typeAnnotation\": ")
+          printTypeIdentifierAsJson(f.typeAnnotation, 0, currentIndentLevel + 3)
+          print(",\n$fieldsIndent    \"initializer\": ")
+          if f.initializer |initializer| {
+            printAstNodeAsJson(initializer, 0, currentIndentLevel + 3)
+          } else {
+            print("null")
+          }
+          val comma = if idx != node.fields.length - 1 "," else ""
+          println("\n$fieldsIndent  }$comma")
+        }
+        println("$fieldsIndent],")
+      }
+
+      if node.methods.isEmpty() {
+        println("$fieldsIndent\"methods\": [],")
+      } else {
+        println("$fieldsIndent\"methods\": [")
+        for method, idx in node.methods {
+          printAstNodeKindAsJson(AstNodeKind.FunctionDeclaration(method), currentIndentLevel + 2, currentIndentLevel + 2)
+          val comma = if idx != node.methods.length - 1 "," else ""
+          println("$comma")
+        }
+        println("$fieldsIndent],")
+      }
+
+      if node.types.isEmpty() {
+        println("$fieldsIndent\"nestedTypes\": []")
+      } else {
+        println("$fieldsIndent\"nestedTypes\": [")
+        for nestedType, idx in node.types {
+          printAstNodeKindAsJson(AstNodeKind.TypeDeclaration(nestedType), currentIndentLevel + 2, currentIndentLevel + 2)
+          val comma = if idx != node.types.length - 1 "," else ""
+          println("$comma")
+        }
+        println("$fieldsIndent]")
+      }
+    }
   }
-  println("$endIndent}")
+  print("$endIndent}")
 }

--- a/selfhost/test/parser/decorator_error_before_expr.out
+++ b/selfhost/test/parser/decorator_error_before_expr.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:2:1
-Unexpected token 'identifier', expected one of 'val', 'var', 'func', '@', 'export':
+Unexpected token 'identifier', expected one of 'val', 'var', 'func', 'type', '@', 'export':
   |  abc()
      ^

--- a/selfhost/test/parser/decorator_error_before_invalid_stmt.out
+++ b/selfhost/test/parser/decorator_error_before_invalid_stmt.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:2:1
-Unexpected token 'while', expected one of 'val', 'var', 'func', '@', 'export':
+Unexpected token 'while', expected one of 'val', 'var', 'func', 'type', '@', 'export':
   |  while true { }
      ^

--- a/selfhost/test/parser/export_error_before_expr.out
+++ b/selfhost/test/parser/export_error_before_expr.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:1:8
-Unexpected token 'identifier', expected one of 'val', 'var', 'func':
+Unexpected token 'identifier', expected one of 'val', 'var', 'func', 'type':
   |  export a + 1
             ^

--- a/selfhost/test/parser/export_error_before_invalid_statement.out
+++ b/selfhost/test/parser/export_error_before_invalid_statement.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:1:8
-Unexpected token 'while', expected one of 'val', 'var', 'func':
+Unexpected token 'while', expected one of 'val', 'var', 'func', 'type':
   |  export while true {}
             ^

--- a/selfhost/test/parser/typedecl.abra
+++ b/selfhost/test/parser/typedecl.abra
@@ -1,0 +1,50 @@
+type Foo { }
+type Foo<A, B> { }
+type Foo<A> { a: A, b: Bool }
+type Foo {
+  a: Int
+  b: Bool = true
+}
+
+type FooBar123 {
+  func foo(self, b: String) {}
+}
+
+type FooBar123 {
+  a: Int
+
+  func foo(self, b: String): X<Y> = 123
+  func bar(self, b = true) { self.a + b }
+}
+
+type FooBar123 {
+  a: Int
+
+  func foo(self, b: String): X<Y> = 123
+
+  @Foo
+  func bar(self, b = true) { self.a + b }
+}
+
+type Outer {
+  a: Int
+
+  func foo(self, b: String): X<Y> { 123 }
+
+  type Inner {
+    a: Int
+
+    func bar(self, b = true) { self.a + b }
+  }
+}
+
+@Bar("a")
+export type Outer {
+  a: Int
+
+  @Bar("b")
+  func foo(self, b: String): X<Y> { 123 }
+
+  @Bar("c")
+  type Inner { a: Int }
+}

--- a/selfhost/test/parser/typedecl.out.json
+++ b/selfhost/test/parser/typedecl.out.json
@@ -1,0 +1,868 @@
+{
+  "imports": [],
+  "nodes": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "exportToken": null,
+        "typeName": { "name": "Foo", "position": [1, 6] },
+        "typeParams": [],
+        "fields": [],
+        "methods": [],
+        "nestedTypes": []
+      }
+    },
+    {
+      "token": {
+        "position": [2, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "exportToken": null,
+        "typeName": { "name": "Foo", "position": [2, 6] },
+        "typeParams": [
+          { "name": "A", "position": [2, 10] },
+          { "name": "B", "position": [2, 13] }
+        ],
+        "fields": [],
+        "methods": [],
+        "nestedTypes": []
+      }
+    },
+    {
+      "token": {
+        "position": [3, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "exportToken": null,
+        "typeName": { "name": "Foo", "position": [3, 6] },
+        "typeParams": [
+          { "name": "A", "position": [3, 10] }
+        ],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [3, 15] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "A", "position": [3, 18] },
+              "typeArguments": []
+            },
+            "initializer": null
+          },
+          {
+            "label": { "name": "b", "position": [3, 21] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Bool", "position": [3, 24] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [],
+        "nestedTypes": []
+      }
+    },
+    {
+      "token": {
+        "position": [4, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "exportToken": null,
+        "typeName": { "name": "Foo", "position": [4, 6] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [5, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [5, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          },
+          {
+            "label": { "name": "b", "position": [6, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Bool", "position": [6, 6] },
+              "typeArguments": []
+            },
+            "initializer": {
+              "token": {
+                "position": [6, 13],
+                "kind": {
+                  "name": "Bool",
+                  "value": true
+                }
+              },
+              "kind": {
+                "name": "literal",
+                "type": "bool",
+                "value": true
+              }
+            }
+          }
+        ],
+        "methods": [],
+        "nestedTypes": []
+      }
+    },
+    {
+      "token": {
+        "position": [9, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "exportToken": null,
+        "typeName": { "name": "FooBar123", "position": [9, 6] },
+        "typeParams": [],
+        "fields": [],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [],
+            "exportToken": null,
+            "ident": { "name": "foo", "position": [10, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [10, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [10, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [10, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": []
+          }
+        ],
+        "nestedTypes": []
+      }
+    },
+    {
+      "token": {
+        "position": [13, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "exportToken": null,
+        "typeName": { "name": "FooBar123", "position": [13, 6] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [14, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [14, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [],
+            "exportToken": null,
+            "ident": { "name": "foo", "position": [16, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [16, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [16, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [16, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [16, 37],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 123
+                }
+              }
+            ]
+          },
+          {
+            "name": "function",
+            "decorators": [],
+            "exportToken": null,
+            "ident": { "name": "bar", "position": [17, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [17, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [17, 18] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": {
+                  "token": {
+                    "position": [17, 22],
+                    "kind": {
+                      "name": "Bool",
+                      "value": true
+                    }
+                  },
+                  "kind": {
+                    "name": "literal",
+                    "type": "bool",
+                    "value": true
+                  }
+                }
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [17, 37],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "kind": {
+                  "name": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [17, 34],
+                      "kind": {
+                        "name": "Dot"
+                      }
+                    },
+                    "kind": {
+                      "name": "accessor",
+                      "root": {
+                        "token": {
+                          "position": [17, 30],
+                          "kind": {
+                            "name": "Self"
+                          }
+                        },
+                        "kind": {
+                          "name": "identifier",
+                          "ident": "self"
+                        }
+                      },
+                      "path": [
+                        {
+                          "dotToken": {
+                            "position": [17, 34],
+                            "kind": {
+                              "name": "Dot"
+                            }
+                          },
+                          "ident": "a",
+                          "position": [17, 35]
+                        }
+                      ]
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [17, 39],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "b"
+                      }
+                    },
+                    "kind": {
+                      "name": "identifier",
+                      "ident": "b"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "nestedTypes": []
+      }
+    },
+    {
+      "token": {
+        "position": [20, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "exportToken": null,
+        "typeName": { "name": "FooBar123", "position": [20, 6] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [21, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [21, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [],
+            "exportToken": null,
+            "ident": { "name": "foo", "position": [23, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [23, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [23, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [23, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [23, 37],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 123
+                }
+              }
+            ]
+          },
+          {
+            "name": "function",
+            "decorators": [
+              {
+                "name": { "name": "Foo", "position": [25, 4] },
+                "arguments": []
+              }
+            ],
+            "exportToken": null,
+            "ident": { "name": "bar", "position": [26, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [26, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [26, 18] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": {
+                  "token": {
+                    "position": [26, 22],
+                    "kind": {
+                      "name": "Bool",
+                      "value": true
+                    }
+                  },
+                  "kind": {
+                    "name": "literal",
+                    "type": "bool",
+                    "value": true
+                  }
+                }
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [26, 37],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "kind": {
+                  "name": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [26, 34],
+                      "kind": {
+                        "name": "Dot"
+                      }
+                    },
+                    "kind": {
+                      "name": "accessor",
+                      "root": {
+                        "token": {
+                          "position": [26, 30],
+                          "kind": {
+                            "name": "Self"
+                          }
+                        },
+                        "kind": {
+                          "name": "identifier",
+                          "ident": "self"
+                        }
+                      },
+                      "path": [
+                        {
+                          "dotToken": {
+                            "position": [26, 34],
+                            "kind": {
+                              "name": "Dot"
+                            }
+                          },
+                          "ident": "a",
+                          "position": [26, 35]
+                        }
+                      ]
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [26, 39],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "b"
+                      }
+                    },
+                    "kind": {
+                      "name": "identifier",
+                      "ident": "b"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "nestedTypes": []
+      }
+    },
+    {
+      "token": {
+        "position": [29, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "exportToken": null,
+        "typeName": { "name": "Outer", "position": [29, 6] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [30, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [30, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [],
+            "exportToken": null,
+            "ident": { "name": "foo", "position": [32, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [32, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [32, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [32, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [32, 37],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 123
+                }
+              }
+            ]
+          }
+        ],
+        "nestedTypes": [
+          {
+            "name": "typeDeclaration",
+            "decorators": [],
+            "exportToken": null,
+            "typeName": { "name": "Inner", "position": [34, 8] },
+            "typeParams": [],
+            "fields": [
+              {
+                "label": { "name": "a", "position": [35, 5] },
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "Int", "position": [35, 8] },
+                  "typeArguments": []
+                },
+                "initializer": null
+              }
+            ],
+            "methods": [
+              {
+                "name": "function",
+                "decorators": [],
+                "exportToken": null,
+                "ident": { "name": "bar", "position": [37, 10] },
+                "typeParams": [],
+                "params": [
+                  {
+                    "label": { "name": "self", "position": [37, 14] },
+                    "isVariadic": false,
+                    "typeAnnotation": null,
+                    "defaultValue": null
+                  },
+                  {
+                    "label": { "name": "b", "position": [37, 20] },
+                    "isVariadic": false,
+                    "typeAnnotation": null,
+                    "defaultValue": {
+                      "token": {
+                        "position": [37, 24],
+                        "kind": {
+                          "name": "Bool",
+                          "value": true
+                        }
+                      },
+                      "kind": {
+                        "name": "literal",
+                        "type": "bool",
+                        "value": true
+                      }
+                    }
+                  }
+                ],
+                "body": [
+                  {
+                    "token": {
+                      "position": [37, 39],
+                      "kind": {
+                        "name": "Plus"
+                      }
+                    },
+                    "kind": {
+                      "name": "binary",
+                      "op": "BinaryOp.Add",
+                      "left": {
+                        "token": {
+                          "position": [37, 36],
+                          "kind": {
+                            "name": "Dot"
+                          }
+                        },
+                        "kind": {
+                          "name": "accessor",
+                          "root": {
+                            "token": {
+                              "position": [37, 32],
+                              "kind": {
+                                "name": "Self"
+                              }
+                            },
+                            "kind": {
+                              "name": "identifier",
+                              "ident": "self"
+                            }
+                          },
+                          "path": [
+                            {
+                              "dotToken": {
+                                "position": [37, 36],
+                                "kind": {
+                                  "name": "Dot"
+                                }
+                              },
+                              "ident": "a",
+                              "position": [37, 37]
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [37, 41],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "b"
+                          }
+                        },
+                        "kind": {
+                          "name": "identifier",
+                          "ident": "b"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "nestedTypes": []
+          }
+        ]
+      }
+    },
+    {
+      "token": {
+        "position": [42, 8],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [
+          {
+            "name": { "name": "Bar", "position": [41, 2] },
+            "arguments": [
+              {
+                "label": null,
+                "value": {
+                  "token": {
+                    "position": [41, 6],
+                    "kind": {
+                      "name": "String",
+                      "value": "a"
+                    }
+                  },
+                  "kind": {
+                    "name": "literal",
+                    "type": "string",
+                    "value": "a"
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "exportToken": {
+          "position": [42, 1],
+          "kind": {
+            "name": "Export"
+          }
+        },
+        "typeName": { "name": "Outer", "position": [42, 13] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [43, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [43, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [
+              {
+                "name": { "name": "Bar", "position": [45, 4] },
+                "arguments": [
+                  {
+                    "label": null,
+                    "value": {
+                      "token": {
+                        "position": [45, 8],
+                        "kind": {
+                          "name": "String",
+                          "value": "b"
+                        }
+                      },
+                      "kind": {
+                        "name": "literal",
+                        "type": "string",
+                        "value": "b"
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "exportToken": null,
+            "ident": { "name": "foo", "position": [46, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [46, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [46, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [46, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [46, 37],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 123
+                }
+              }
+            ]
+          }
+        ],
+        "nestedTypes": [
+          {
+            "name": "typeDeclaration",
+            "decorators": [
+              {
+                "name": { "name": "Bar", "position": [48, 4] },
+                "arguments": [
+                  {
+                    "label": null,
+                    "value": {
+                      "token": {
+                        "position": [48, 8],
+                        "kind": {
+                          "name": "String",
+                          "value": "c"
+                        }
+                      },
+                      "kind": {
+                        "name": "literal",
+                        "type": "string",
+                        "value": "c"
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "exportToken": null,
+            "typeName": { "name": "Inner", "position": [49, 8] },
+            "typeParams": [],
+            "fields": [
+              {
+                "label": { "name": "a", "position": [49, 16] },
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "Int", "position": [49, 19] },
+                  "typeArguments": []
+                },
+                "initializer": null
+              }
+            ],
+            "methods": [],
+            "nestedTypes": []
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/selfhost/test/parser/typedecl_error_exporting_method.abra
+++ b/selfhost/test/parser/typedecl_error_exporting_method.abra
@@ -1,0 +1,3 @@
+type FooBar123 {
+  export func foo(self, b: String) {}
+}

--- a/selfhost/test/parser/typedecl_error_exporting_method.out
+++ b/selfhost/test/parser/typedecl_error_exporting_method.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:2:3
+Unexpected token 'export':
+  |    export func foo(self, b: String) {}
+       ^

--- a/selfhost/test/parser/typedecl_error_field_after_method.abra
+++ b/selfhost/test/parser/typedecl_error_field_after_method.abra
@@ -1,0 +1,5 @@
+type FooBar123 {
+  a: Int
+  func foo(self) {}
+  b: Int
+}

--- a/selfhost/test/parser/typedecl_error_field_after_method.out
+++ b/selfhost/test/parser/typedecl_error_field_after_method.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:4:3
+Unexpected token 'identifier':
+  |    b: Int
+       ^

--- a/selfhost/test/parser/typedecl_error_illegal_body_part.abra
+++ b/selfhost/test/parser/typedecl_error_illegal_body_part.abra
@@ -1,0 +1,3 @@
+type FooBar123 {
+  while true { }
+}

--- a/selfhost/test/parser/typedecl_error_illegal_body_part.out
+++ b/selfhost/test/parser/typedecl_error_illegal_body_part.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:2:3
+Unexpected token 'while':
+  |    while true { }
+       ^

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -121,7 +121,6 @@ fn parser_tests() {
         .add_test_vs_txt("parser/match_error_case_no_case.abra", "parser/match_error_case_no_case.out")
         .add_test_vs_txt("parser/match_error_no_expr.abra", "parser/match_error_no_expr.out")
         .add_test_vs_txt("parser/match_error_no_lbrace.abra", "parser/match_error_no_lbrace.out")
-
         // Decorators
         .add_test_vs_txt("parser/decorator_error_bad_ident.abra", "parser/decorator_error_bad_ident.out")
         .add_test_vs_txt("parser/decorator_error_before_expr.abra", "parser/decorator_error_before_expr.out")
@@ -144,12 +143,18 @@ fn parser_tests() {
         .add_test_vs_txt("parser/import_error_list_no_comma.abra", "parser/import_error_list_no_comma.out")
         .add_test_vs_txt("parser/import_error_list_no_from.abra", "parser/import_error_list_no_from.out")
         .add_test_vs_txt("parser/import_error_list_no_module_eof.abra", "parser/import_error_list_no_module_eof.out")
-
         // Exports
         .add_test_vs_txt("parser/export.abra", "parser/export.out.json")
         .add_test_vs_txt("parser/export_error_before_expr.abra", "parser/export_error_before_expr.out")
         .add_test_vs_txt("parser/export_error_before_invalid_statement.abra", "parser/export_error_before_invalid_statement.out")
 
+        // While
+        .add_test_vs_txt("parser/while.abra", "parser/while.out.json")
+        .add_test_vs_txt("parser/while_error_as_expr.abra", "parser/while_error_as_expr.out")
+        // For
+        .add_test_vs_txt("parser/for.abra", "parser/for.out.json")
+        .add_test_vs_txt("parser/for_error_no_in.abra", "parser/for_error_no_in.out")
+        .add_test_vs_txt("parser/for_error_no_iterator.abra", "parser/for_error_no_iterator.out")
         // Type identifiers
         .add_test_vs_txt("parser/typeidentifiers.abra", "parser/typeidentifiers.out.json")
         .add_test_vs_txt("parser/typeidentifiers_error_empty_typeargs.abra", "parser/typeidentifiers_error_empty_typeargs.out")
@@ -170,12 +175,10 @@ fn parser_tests() {
         .add_test_vs_txt("parser/functiondecl_error_empty_typeparams.abra", "parser/functiondecl_error_empty_typeparams.out")
         .add_test_vs_txt("parser/functiondecl_error_typeparam_invalid.abra", "parser/functiondecl_error_typeparam_invalid.out")
         .add_test_vs_txt("parser/functiondecl_error_no_body.abra", "parser/functiondecl_error_no_body.out")
-        // While
-        .add_test_vs_txt("parser/while.abra", "parser/while.out.json")
-        .add_test_vs_txt("parser/while_error_as_expr.abra", "parser/while_error_as_expr.out")
-        // For
-        .add_test_vs_txt("parser/for.abra", "parser/for.out.json")
-        .add_test_vs_txt("parser/for_error_no_in.abra", "parser/for_error_no_in.out")
-        .add_test_vs_txt("parser/for_error_no_iterator.abra", "parser/for_error_no_iterator.out")
+        // Type declaration
+        .add_test_vs_txt("parser/typedecl.abra", "parser/typedecl.out.json")
+        .add_test_vs_txt("parser/typedecl_error_exporting_method.abra", "parser/typedecl_error_exporting_method.out")
+        .add_test_vs_txt("parser/typedecl_error_field_after_method.abra", "parser/typedecl_error_field_after_method.out")
+        .add_test_vs_txt("parser/typedecl_error_illegal_body_part.abra", "parser/typedecl_error_illegal_body_part.out")
         .run_tests();
 }


### PR DESCRIPTION
Adding parsing of type declarations to the selfhosted parser. This also adds an additional feature which had been missing from the reference implementation: nested types. This will come in handy in a lot of places.