### PR TITLE
Selfhost: begin work on typechecker

### DIFF
--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -589,7 +589,12 @@ type Array<T> {
 
   func getRange(self, startIndex = 0, endIndex = self.length): T[] {
     val start = if startIndex < 0 startIndex + self.length else startIndex
-    val end = if endIndex > self.length self.length else endIndex
+    val end = if endIndex > self.length
+      self.length
+    else if endIndex < 0
+      endIndex + self.length
+    else
+      endIndex
     val length = end - start
     val subArray: T[] = Array.withCapacity(length)
     subArray.length = length

--- a/abra_llvm/tests/arrays.abra
+++ b/abra_llvm/tests/arrays.abra
@@ -65,8 +65,8 @@
 (() => {
   val arr = [1, 2, 3, 4, 5]
 
-  /// Expect: [2, 3, 4] [2, 3, 4]
-  println(arr[1:4], arr[-4:4])
+  /// Expect: [2, 3, 4] [2, 3, 4] [2, 3, 4]
+  println(arr[1:4], arr[-4:4], arr[1:-1])
 
   /// Expect: []
   println(arr[1:1])

--- a/selfhost/src/parser.abra
+++ b/selfhost/src/parser.abra
@@ -257,7 +257,7 @@ enum ParseErrorKind {
   Unreachable
 }
 
-type ParseError {
+export type ParseError {
   position: Position
   kind: ParseErrorKind
 
@@ -979,7 +979,7 @@ export type Parser {
           nodes.push(node)
         }
         nodes
-      } 
+      }
       TokenKind.Break => if allowTerminators {
         val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
         [node]

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -1,0 +1,134 @@
+import "fs" as fs
+import Lexer, LexerError, Position from "./lexer"
+import Parser, ParsedModule, ParseError from "./parser"
+
+enum TokenizeAndParseError {
+  ReadFileError(path: String)
+  LexerError(inner: LexerError)
+  ParseError(inner: ParseError)
+}
+
+export type ModuleLoader {
+  rootDirPath: String
+
+  // TODO: This of course does nothing right now
+  func resolvePath(self, modulePath: String, relativeTo: String?): String = modulePath
+
+  func tokenizeAndParse(self, modulePath: String): Result<ParsedModule, TokenizeAndParseError> {
+    match fs.readFile(modulePath) {
+      Result.Ok(contents) => {
+        match Lexer.tokenize(contents) {
+          Result.Ok(tokens) => {
+            match Parser.parse(tokens) {
+              Result.Ok(parsedModule) => Result.Ok(parsedModule)
+              Result.Err(error) => Result.Err(TokenizeAndParseError.ParseError(error))
+            }
+          }
+          Result.Err(error) => Result.Err(TokenizeAndParseError.LexerError(error))
+        }
+      }
+      Result.Err => Result.Err(TokenizeAndParseError.ReadFileError(modulePath))
+    }
+  }
+}
+
+type TypedModule {
+  id: Int
+  name: String
+}
+
+export type Project {
+  modules: TypedModule[] = []
+}
+
+type TypecheckerError {
+  modulePath: String
+  kind: TypecheckerErrorKind
+
+  func getMessage(self): String {
+    match self.kind {
+      // TODO: Better error message, once imports are a thing
+      TypecheckerErrorKind.ReadFileError(path) => "Could not read file '$path'"
+      TypecheckerErrorKind.LexerError(inner) => {
+        val contents = match fs.readFile(self.modulePath) {
+          Result.Ok(v) => v
+          Result.Err => return "Could not read file '${self.modulePath}'"
+        }
+        inner.getMessage(self.modulePath, contents)
+      }
+      TypecheckerErrorKind.ParseError(inner) => {
+        val contents = match fs.readFile(self.modulePath) {
+          Result.Ok(v) => v
+          Result.Err => return "Could not read file '${self.modulePath}'"
+        }
+        inner.getMessage(self.modulePath, contents)
+      }
+      TypecheckerErrorKind.TypeError(inner) => {
+        val contents = match fs.readFile(self.modulePath) {
+          Result.Ok(v) => v
+          Result.Err => return "Could not read file '${self.modulePath}'"
+        }
+        inner.getMessage(self.modulePath, contents)
+      }
+    }
+  }
+}
+
+enum TypecheckerErrorKind {
+  ReadFileError(path: String)
+  LexerError(inner: LexerError)
+  ParseError(inner: ParseError)
+  TypeError(inner: TypeError)
+}
+
+type TypeError {
+  position: Position
+  kind: TypeErrorKind
+
+  func getMessage(self, filePath: String, contents: String): String {
+    val lines = ["Error at $filePath:${self.position.line}:${self.position.col}"]
+
+    lines.join("\n")
+  }
+}
+
+enum TypeErrorKind {
+
+}
+
+export type Typechecker {
+  moduleLoader: ModuleLoader
+  project: Project
+
+  func typecheckEntrypoint(self, modulePathAbs: String): Result<Int, TypecheckerError> {
+    self._typecheckModule(modulePathAbs)
+  }
+
+  func _tokenizeAndParse(self, modulePath: String, relativeTo: String? = None): Result<ParsedModule, TypecheckerError> {
+    val absPath = self.moduleLoader.resolvePath(modulePath, relativeTo)
+    match self.moduleLoader.tokenizeAndParse(absPath) {
+      Result.Ok(mod) => Result.Ok(mod)
+      Result.Err(e) => {
+        val kind = match e {
+          TokenizeAndParseError.ReadFileError(path) => TypecheckerErrorKind.ReadFileError(path)
+          TokenizeAndParseError.LexerError(inner) => TypecheckerErrorKind.LexerError(inner)
+          TokenizeAndParseError.ParseError(inner) => TypecheckerErrorKind.ParseError(inner)
+        }
+
+        return Result.Err(TypecheckerError(modulePath: modulePath, kind: kind))
+      }
+    }
+  }
+
+  func _typecheckModule(self, modulePath: String): Result<Int, TypecheckerError> {
+    val moduleId = self.project.modules.length
+
+    val mod = TypedModule(id: moduleId, name: modulePath)
+    self.project.modules.push(mod)
+
+    val parsedModule = match self._tokenizeAndParse(modulePath) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    println(parsedModule)
+
+    Result.Ok(moduleId)
+  }
+}

--- a/selfhost/src/typechecker.test.abra
+++ b/selfhost/src/typechecker.test.abra
@@ -1,0 +1,28 @@
+// When executed directly, this will perform typechecking, starting at the module at the given path
+// and recursively loading and typechecking imported modules. When typechecking is complete, the
+// Project will be filled in with TypedModules, each of which contain a typed AST and other useful
+// data.
+// This is split out into a separate runnable file so that the test-specific code is never compiled into
+// the actual resulting binary; this results in a separate binary being compiled which is only used for
+// testing.
+
+import "fs" as fs
+import getAbsolutePath from "./utils"
+import ModuleLoader, Project, Typechecker from "./typechecker"
+
+if Process.args()[1] |fileName| {
+  val absPathSegs = getAbsolutePath(fileName)
+  val projectRoot = "/" + absPathSegs[:-1].join("/")
+  val filePathAbs = "/" + absPathSegs.join("/")
+
+  val moduleLoader = ModuleLoader(rootDirPath: projectRoot)
+  val project = Project()
+  val typechecker = Typechecker(moduleLoader: moduleLoader, project: project)
+
+  match typechecker.typecheckEntrypoint(filePathAbs) {
+    Result.Ok => println(project)
+    Result.Err(e) => println(e.getMessage())
+  }
+} else {
+  println("Missing required argument <file-name>")
+}

--- a/selfhost/src/utils.abra
+++ b/selfhost/src/utils.abra
@@ -1,3 +1,5 @@
+import "fs" as fs
+
 export func valueIfValidHexDigit(ch: Int): Int? {
   if 48 <= ch && ch <= 57 { // 0-9
     (ch - 48)
@@ -8,4 +10,29 @@ export func valueIfValidHexDigit(ch: Int): Int? {
   } else {
     None
   }
+}
+
+// TODO: Move this elsewhere, probably into std somewhere
+export func getAbsolutePath(fileName: String): String[] {
+  val parts = if fileName[0] == "/" {
+    fileName.split("/")
+  } else {
+    val cwd = fs.getCurrentWorkingDirectory()
+    val path = cwd + "/" + fileName
+    path.split("/")
+  }
+
+  val sanitizedParts: String[] = []
+  for part, idx in parts {
+    if part.isEmpty() continue
+    if part == "." continue
+    if part == ".." {
+      sanitizedParts.pop()
+      continue
+    }
+
+    sanitizedParts.push(part)
+  }
+
+  sanitizedParts
 }

--- a/selfhost/test/typechecker/_lexer_error.abra
+++ b/selfhost/test/typechecker/_lexer_error.abra
@@ -1,0 +1,1 @@
+func ~(a: Int)

--- a/selfhost/test/typechecker/_lexer_error.out
+++ b/selfhost/test/typechecker/_lexer_error.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:1:6
+Unexpected character '~':
+  |  func ~(a: Int)
+          ^

--- a/selfhost/test/typechecker/_parser_error.abra
+++ b/selfhost/test/typechecker/_parser_error.abra
@@ -1,0 +1,1 @@
+func f(a Int) {}

--- a/selfhost/test/typechecker/_parser_error.out
+++ b/selfhost/test/typechecker/_parser_error.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:1:10
+Unexpected token 'identifier', expected one of ',', ')':
+  |  func f(a Int) {}
+              ^

--- a/selfhost_test/src/test_utils.rs
+++ b/selfhost_test/src/test_utils.rs
@@ -32,6 +32,10 @@ impl TestRunner {
         Self::test_runner("parser", "parser.test.abra", "parser_test")
     }
 
+    pub fn typechecker_test_runner() -> Self {
+        Self::test_runner("typechecker", "typechecker.test.abra", "typechecker_test")
+    }
+
     pub fn test_runner(runner_name: &'static str, src_file: &str, output_bin_file: &str) -> Self {
         let selfhost_dir = get_project_root().unwrap().join("selfhost");
         let build_dir = if let Some(test_temp_dir) = std::env::var("TEST_TMP_DIR").ok() {

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -190,3 +190,12 @@ fn parser_tests() {
 
         .run_tests();
 }
+
+#[test]
+fn typechecker_tests() {
+    TestRunner::typechecker_test_runner()
+        // Lexer/Parser error handling
+        .add_test_vs_txt("typechecker/_lexer_error.abra", "typechecker/_lexer_error.out")
+        .add_test_vs_txt("typechecker/_parser_error.abra", "typechecker/_parser_error.out")
+        .run_tests();
+}


### PR DESCRIPTION
This changeset lays out the scaffolding for the selfhosted typechecker. It mimics the ModuleLoader/Project structure of the rust-based reference implementation, although of course it's a lot simpler because I don't have to worry about managing lifetimes. It's also kinda nice to "start over" in a way, since a lot of the stuff I had done regarding the competing `ModuleId` types between the parser and typechecker2 in the reference implementation made things a bit muddy, as well as the confusing uses of paths to denote a module. I'm hoping to simplify things this time around.
Since the typechecker is the thing that loads in the file, and tokenizes and parses it, the `TypecheckerError` is a combination of several different types of errors. The first typechecker test files verify that errors surfaced by the Lexer and Parser bubble up from the Typechecker.