### PR TITLE
Selfhost: typechecking invocation of functions

### DIFF
--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -595,6 +595,35 @@ type Array<T> {
   @Stub func partition<U>(self, fn: (T) => U): Map<U, T[]>
   @Stub func tally(self): Map<T, Int>
   @Stub func tallyBy<U>(self, fn: (T) => U): Map<U, Int>
+
+  func keyBy<U>(self, fn: (T) => U): Map<U, T> {
+    val map: Map<U, T> = Map.new()
+
+    for i in range(0, self.length) {
+      val item = self._buffer.offset(i).load()
+      val key = fn(item)
+      map[key] = item
+    }
+
+    map
+  }
+
+  func indexBy<U>(self, fn: (T) => U): Map<U, T[]> {
+    val map: Map<U, T[]> = Map.new()
+
+    for i in range(0, self.length) {
+      val item = self._buffer.offset(i).load()
+      val key = fn(item)
+      if map[key] |arr| {
+        arr.push(item)
+      } else {
+        map[key] = [item]
+      }
+    }
+
+    map
+  }
+
   @Stub func asSet(self): Set<T>
 
   func get(self, index: Int): T? {

--- a/abra_llvm/src/compiler2.rs
+++ b/abra_llvm/src/compiler2.rs
@@ -2463,6 +2463,31 @@ impl<'a> LLVMCompiler2<'a> {
                             resolved_type_id: *resolved_type_id,
                         }, resolved_generics);
                     }
+                    IndexingMode::Index(idx_expr) if target_struct_id == &self.project.prelude_map_struct_id => {
+                        let map_key_type_id = &target_generics[0];
+                        let map_value_type_id = &target_generics[1];
+                        let (map_get_member_idx, map_get_func_id) = target_ty.find_method_by_name(self.project, "get").unwrap();
+                        let map_get_function = self.project.get_func_by_id(map_get_func_id);
+
+                        return self.visit_expression(&TypedNode::Invocation {
+                            target: Box::new(TypedNode::Accessor {
+                                target: target.clone(),
+                                kind: AccessorKind::Method,
+                                is_opt_safe: false,
+                                member_idx: map_get_member_idx,
+                                member_span: target.span(),
+                                type_id: map_get_function.fn_type_id,
+                                type_arg_ids: vec![],
+                                resolved_type_id: map_get_function.fn_type_id,
+                            }),
+                            arguments: vec![
+                                Some(*idx_expr.clone()),
+                            ],
+                            type_arg_ids: vec![*map_key_type_id, *map_value_type_id],
+                            type_id: *type_id,
+                            resolved_type_id: *resolved_type_id,
+                        }, resolved_generics);
+                    }
                     IndexingMode::Range(start_expr, end_expr) if target_struct_id == &self.project.prelude_array_struct_id => {
                         let array_inner_type_id = &target_generics[0];
                         let (array_get_range_member_idx, array_get_range_func_id) = target_ty.find_method_by_name(self.project, "getRange").unwrap();

--- a/abra_llvm/tests/arrays.abra
+++ b/abra_llvm/tests/arrays.abra
@@ -355,3 +355,25 @@ func printItem(item: Int) = println(item)
   /// Expect: false
   println(strArr.all(s => s == "HELLO"))
 })()
+
+// Array#keyBy
+(() => {
+  val empty: String[] = []
+  /// Expect: {}
+  println(empty.keyBy(s => s.length))
+
+  val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
+  /// Expect: { 3: dog, 4: lazy, 5: brown, 6: jumped }
+  println(strArr.keyBy(s => s.length))
+})()
+
+// Array#indexBy
+(() => {
+  val empty: String[] = []
+  /// Expect: {}
+  println(empty.indexBy(s => s.length))
+
+  val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
+  /// Expect: { 3: [The, fox, the, dog], 4: [over, lazy], 5: [quick, brown], 6: [jumped] }
+  println(strArr.indexBy(s => s.length))
+})()

--- a/selfhost/src/parser.abra
+++ b/selfhost/src/parser.abra
@@ -102,9 +102,11 @@ type AccessorAstNode {
 type InvocationArgument {
   label: Label?
   value: AstNode
+
+  func position(self): Position = self.label?.position ?: self.value.token.position
 }
 
-type InvocationAstNode {
+export type InvocationAstNode {
   invokee: AstNode
   typeArguments: TypeIdentifier[]
   arguments: InvocationArgument[]

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -1,6 +1,6 @@
 import "fs" as fs
 import Lexer, LexerError, Token, TokenKind, Position from "./lexer"
-import Parser, ParsedModule, ParseError, AstNode, AstNodeKind, LiteralAstNode, UnaryAstNode, UnaryOp, BindingDeclarationNode, BindingPattern, TypeIdentifier, Label, IdentifierKind, FunctionDeclarationNode from "./parser"
+import Parser, ParsedModule, ParseError, AstNode, AstNodeKind, LiteralAstNode, UnaryAstNode, UnaryOp, BindingDeclarationNode, BindingPattern, TypeIdentifier, Label, IdentifierKind, FunctionDeclarationNode, InvocationAstNode from "./parser"
 
 enum TokenizeAndParseError {
   ReadFileError(path: String)
@@ -222,6 +222,7 @@ export enum TypedAstNodeKind {
   // Binary(...)
   Grouped(inner: TypedAstNode)
   Identifier(kind: IdentifierKind)
+  Invocation(invokee: TypedAstNode, arguments: TypedAstNode?[])
   Array(items: TypedAstNode[])
   If(isStatement: Bool, typedCondition: TypedAstNode, conditionBinding: (BindingPattern, Variable[])?, typedIfBlock: TypedAstNode[], typedElseBlock: TypedAstNode[])
   While(typedCondition: TypedAstNode, conditionBinding: (BindingPattern, Variable[])?, block: TypedAstNode[])
@@ -426,6 +427,43 @@ type TypeError {
         lines.push(self._getCursorLine(self.position, contents))
         lines.push("Control flow exits before this code is reached")
       }
+      TypeErrorKind.WrongInvocationArity(expected, given) => {
+        val argumentsStr = if expected == 1 "argument" else "arguments"
+        val verbStr = if given == 1 "was" else "were"
+
+        if given > expected {
+          lines.push("Too many arguments for invocation")
+          lines.push(self._getCursorLine(self.position, contents))
+          lines.push("Expected no more than $expected $argumentsStr, but $given $verbStr passed")
+        } else {
+          lines.push("Not enough arguments for invocation")
+          lines.push(self._getCursorLine(self.position, contents))
+          lines.push("$expected $argumentsStr required, but $given $verbStr passed")
+        }
+      }
+      TypeErrorKind.ParameterLabelMismatch(expected, given) => {
+        lines.push("Incorrect label for parameter")
+        lines.push(self._getCursorLine(self.position, contents))
+        lines.push("The parameter's name is '$expected', but instead found '$given'")
+      }
+      TypeErrorKind.MixedArgumentType(label) => {
+        lines.push("Cannot mix labeled and positional optional arguments")
+        lines.push(self._getCursorLine(self.position, contents))
+        lines.push("This argument requires a label because a prior optional parameter has been labeled:")
+        lines.push(self._getCursorLine(label.position, contents))
+        lines.push("(Optional parameters may be listed positionally until a label is encountered. After that point, parameter values cannot be unambiguously determined without labels)")
+      }
+      TypeErrorKind.UnknownParameterName(name) => {
+        lines.push("Unknown parameter label")
+        lines.push(self._getCursorLine(self.position, contents))
+        lines.push("This function doesn't have a parameter named '$name'")
+      }
+      TypeErrorKind.ParameterTypeMismatch(name, expected, given) => {
+        lines.push("Type mismatch for parameter '$name'")
+        lines.push(self._getCursorLine(self.position, contents))
+        lines.push("Expected: ${expected.repr()}")
+        lines.push("but instead found: ${given.repr()}")
+      }
     }
 
     lines.join("\n")
@@ -463,6 +501,11 @@ enum TypeErrorKind {
   ReturnTypeMismatch(fnName: String?, expected: Type, received: Type?)
   InvalidTerminatorPosition(terminator: String)
   UnreachableCode
+  WrongInvocationArity(expected: Int, given: Int)
+  ParameterLabelMismatch(expected: String, given: String)
+  MixedArgumentType(label: Label)
+  UnknownParameterName(name: String)
+  ParameterTypeMismatch(name: String, expected: Type, given: Type)
 }
 
 export type Typechecker {
@@ -1127,7 +1170,7 @@ export type Typechecker {
       }
       AstNodeKind.Identifier(kind) => self._typecheckIdentifier(token, kind, typeHint)
       AstNodeKind.Accessor(value) => todo(node.token.position, "accessor expression")
-      AstNodeKind.Invocation(value) => todo(node.token.position, "invocation expression")
+      AstNodeKind.Invocation(node) => self._typecheckInvocation(token, node)
       AstNodeKind.Array(items) => self._typecheckArray(token, items, typeHint)
       AstNodeKind.Set(items) => todo(node.token.position, "set expression")
       AstNodeKind.Map(items) => todo(node.token.position, "map expression")
@@ -1199,6 +1242,80 @@ export type Typechecker {
     }
 
     Result.Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Identifier(kind)))
+  }
+
+  func _typecheckInvocation(self, token: Token, node: InvocationAstNode): Result<TypedAstNode, TypeError> {
+    val invokee = match self._typecheckExpression(node.invokee, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+    val fn = match invokee.kind {
+      TypedAstNodeKind.Identifier(identKind) => match identKind {
+        IdentifierKind.Named(name) => {
+          // todo: create TypedIdentifierKind with TypedIdentifiefKind.Named(name: String, variable: Variable) to save from doing this lookup twice
+          val variable = if self._resolveIdentifier(name) |v| v else {
+            return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName(name, "variable")))
+          }
+          val fn = match variable.alias {
+            VariableAlias.Function(fn) => fn
+            _ => return todo(invokee.token.position, "other types of variable aliases for identifier invocation")
+          }
+          fn
+        }
+        _ => return todo(invokee.token.position, "other types of identifier targets for invocation")
+      }
+      _ => return todo(invokee.token.position, "other types of target expressions for invocation")
+    }
+
+    // Function invocation is position-based for required parameters, with optional parameter labels to express call-site intent (ie. for Bool params), and it's
+    // an error if a positional parameter's label is incorrect. Once we reach any optional parameters in the argument list, parameters can either be positional
+    // OR labeled, but once a labeled optional parameter is seen, all subsequent arguments in the argument list must also be labeled.
+    val paramsByName = fn.params.keyBy(p => p.label.name)
+    val typedArgumentsByName: Map<String, TypedAstNode> = {}
+    var hasBegunOptionalParams = false
+    var mostRecentLabeledOptionalParam: Label? = None
+    for arg, idx in node.arguments {
+      var param = if fn.params[idx] |param| param else {
+        return Result.Err(TypeError(position: arg.position(), kind: TypeErrorKind.WrongInvocationArity(expected: fn.params.length, given: node.arguments.length)))
+      }
+      if param.defaultValue { hasBegunOptionalParams = true }
+      if param.isVariadic { return todo(arg.position(), "variadic parameters") }
+
+      if arg.label |label| {
+        if label.name != param.label.name {
+          if !hasBegunOptionalParams {
+            return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.ParameterLabelMismatch(expected: param.label.name, given: label.name)))
+          }
+
+          param = if paramsByName[label.name] |p| p else {
+            return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownParameterName(label.name)))
+          }
+        }
+        if hasBegunOptionalParams && !mostRecentLabeledOptionalParam {
+          mostRecentLabeledOptionalParam = label
+        }
+      } else if mostRecentLabeledOptionalParam |label| {
+        return Result.Err(TypeError(position: arg.position(), kind: TypeErrorKind.MixedArgumentType(label)))
+      }
+
+      val typedArg = match self._typecheckExpression(arg.value, param.ty) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      if !self._typeSatisfiesRequired(ty: typedArg.ty, required: param.ty) {
+        return Result.Err(TypeError(position: typedArg.token.position, kind: TypeErrorKind.ParameterTypeMismatch(param.label.name, param.ty, typedArg.ty)))
+      }
+      typedArgumentsByName[param.label.name] = typedArg
+    }
+
+    val typedArguments: TypedAstNode?[] = []
+    for param in fn.params {
+      if typedArgumentsByName[param.label.name] |argValue| {
+        typedArguments.push(argValue)
+      } else if param.defaultValue {
+        typedArguments.push(None)
+      } else {
+        val numRequired = fn.params.filter(p => !p.defaultValue).length
+        return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.WrongInvocationArity(expected: numRequired, given: node.arguments.length)))
+      }
+    }
+
+    Result.Ok(TypedAstNode(token: token, ty: fn.returnType, kind: TypedAstNodeKind.Invocation(invokee, typedArguments)))
   }
 
   func _typecheckArray(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {

--- a/selfhost/src/typechecker_test_utils.abra
+++ b/selfhost/src/typechecker_test_utils.abra
@@ -136,6 +136,17 @@ export type Jsonifier {
         self.print("\"name\": \"$name\"")
         println()
       }
+      TypedAstNodeKind.Invocation(invokee, arguments) => {
+        self.println("\"kind\": \"invocation\",")
+
+        self.print("\"invokee\": ")
+        self.printNode(invokee)
+        println(",")
+
+        self.print("\"arguments\": ")
+        self.array(arguments, n => self.opt(n, n => self.printNode(n)))
+        println()
+      }
       TypedAstNodeKind.Array(items) => {
         self.println("\"kind\": \"array\",")
 

--- a/selfhost/test/typechecker/invocation.1.abra
+++ b/selfhost/test/typechecker/invocation.1.abra
@@ -1,0 +1,3 @@
+func foo(a: Int): Int = a
+
+val _: Int = foo(123)

--- a/selfhost/test/typechecker/invocation.1.out.json
+++ b/selfhost/test/typechecker/invocation.1.out.json
@@ -1,0 +1,173 @@
+{
+  "id": 1,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "foo", "position": [1, 6] },
+          "scope": {
+            "name": "$root::module_1::foo",
+            "variables": [
+              {
+                "label": { "name": "a", "position": [1, 10] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              }
+            ],
+            "functions": []
+          },
+          "parameters": [
+            {
+              "label": { "name": "a", "position": [1, 10] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            }
+          ],
+          "returnType": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "body": [
+            {
+              "token": {
+                "position": [1, 25],
+                "kind": {
+                  "name": "Ident",
+                  "value": "a"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "a"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [3, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [3, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [3, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [3, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [3, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [3, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/selfhost/test/typechecker/invocation.2.abra
+++ b/selfhost/test/typechecker/invocation.2.abra
@@ -1,0 +1,4 @@
+// Test calling function with optional labels for positional arguments
+func foo(a: Int, b: Bool, c: Float): Int = a
+
+val _: Int = foo(123, b: true, 1.23)

--- a/selfhost/test/typechecker/invocation.2.out.json
+++ b/selfhost/test/typechecker/invocation.2.out.json
@@ -1,0 +1,257 @@
+{
+  "id": 1,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [2, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "foo", "position": [2, 6] },
+          "scope": {
+            "name": "$root::module_1::foo",
+            "variables": [
+              {
+                "label": { "name": "a", "position": [2, 10] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              {
+                "label": { "name": "b", "position": [2, 18] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                }
+              },
+              {
+                "label": { "name": "c", "position": [2, 27] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                }
+              }
+            ],
+            "functions": []
+          },
+          "parameters": [
+            {
+              "label": { "name": "a", "position": [2, 10] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            },
+            {
+              "label": { "name": "b", "position": [2, 18] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            },
+            {
+              "label": { "name": "c", "position": [2, 27] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Float"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            }
+          ],
+          "returnType": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "body": [
+            {
+              "token": {
+                "position": [2, 44],
+                "kind": {
+                  "name": "Ident",
+                  "value": "a"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "a"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [4, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [4, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [4, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [4, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [4, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [4, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [4, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              {
+                "token": {
+                  "position": [4, 32],
+                  "kind": {
+                    "name": "Float",
+                    "value": 1.23
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 1.23
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/selfhost/test/typechecker/invocation.3.abra
+++ b/selfhost/test/typechecker/invocation.3.abra
@@ -1,0 +1,11 @@
+// Test calling function which has an optional parameter
+func foo(a: Int, b: Bool, c = 1.23): Int = a
+
+// Don't pass value for optional parameter
+val _: Int = foo(123, b: true)
+
+// Pass value positionally for optional parameter
+val _: Int = foo(123, b: true, 4.56)
+
+// Pass labeled value for optional parameter
+val _: Int = foo(123, b: true, c: 4.56)

--- a/selfhost/test/typechecker/invocation.3.out.json
+++ b/selfhost/test/typechecker/invocation.3.out.json
@@ -1,0 +1,541 @@
+{
+  "id": 1,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [2, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "foo", "position": [2, 6] },
+          "scope": {
+            "name": "$root::module_1::foo",
+            "variables": [
+              {
+                "label": { "name": "a", "position": [2, 10] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              {
+                "label": { "name": "b", "position": [2, 18] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                }
+              },
+              {
+                "label": { "name": "c", "position": [2, 27] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                }
+              }
+            ],
+            "functions": []
+          },
+          "parameters": [
+            {
+              "label": { "name": "a", "position": [2, 10] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            },
+            {
+              "label": { "name": "b", "position": [2, 18] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            },
+            {
+              "label": { "name": "c", "position": [2, 27] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Float"
+              },
+              "defaultValue": {
+                "token": {
+                  "position": [2, 31],
+                  "kind": {
+                    "name": "Float",
+                    "value": 1.23
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 1.23
+                }
+              },
+              "isVariadic": false
+            }
+          ],
+          "returnType": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "body": [
+            {
+              "token": {
+                "position": [2, 44],
+                "kind": {
+                  "name": "Ident",
+                  "value": "a"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "a"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [5, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [5, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [5, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [5, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [5, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [5, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [5, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              null
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [8, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [8, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [8, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [8, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [8, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [8, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [8, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              {
+                "token": {
+                  "position": [8, 32],
+                  "kind": {
+                    "name": "Float",
+                    "value": 4.56
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 4.56
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [11, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [11, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [11, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [11, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [11, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [11, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [11, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              {
+                "token": {
+                  "position": [11, 35],
+                  "kind": {
+                    "name": "Float",
+                    "value": 4.56
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 4.56
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/selfhost/test/typechecker/invocation.4.abra
+++ b/selfhost/test/typechecker/invocation.4.abra
@@ -1,0 +1,17 @@
+// Test calling function which has multiple optional parameters
+func foo(a: Int, b: Bool, c = 1.23, d = "abc"): Int = a
+
+// Don't pass value for any optional parameters
+val _: Int = foo(123, b: true)
+
+// Pass value positionally for first optional parameter, no value for second
+val _: Int = foo(123, b: true, 4.56)
+
+// Pass labeled value for first optional parameter, no value for second
+val _: Int = foo(123, b: true, c: 4.56)
+
+// Pass labeled value for second optional parameter, no value for first
+val _: Int = foo(123, b: true, d: "foo")
+
+// Pass labeled value for first and second optional parameters, but out of order
+val _: Int = foo(123, b: true, d: "foo", c: 4.56)

--- a/selfhost/test/typechecker/invocation.4.out.json
+++ b/selfhost/test/typechecker/invocation.4.out.json
@@ -1,0 +1,908 @@
+{
+  "id": 1,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [2, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "foo", "position": [2, 6] },
+          "scope": {
+            "name": "$root::module_1::foo",
+            "variables": [
+              {
+                "label": { "name": "a", "position": [2, 10] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              {
+                "label": { "name": "b", "position": [2, 18] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                }
+              },
+              {
+                "label": { "name": "c", "position": [2, 27] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                }
+              },
+              {
+                "label": { "name": "d", "position": [2, 37] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "String"
+                }
+              }
+            ],
+            "functions": []
+          },
+          "parameters": [
+            {
+              "label": { "name": "a", "position": [2, 10] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            },
+            {
+              "label": { "name": "b", "position": [2, 18] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            },
+            {
+              "label": { "name": "c", "position": [2, 27] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Float"
+              },
+              "defaultValue": {
+                "token": {
+                  "position": [2, 31],
+                  "kind": {
+                    "name": "Float",
+                    "value": 1.23
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 1.23
+                }
+              },
+              "isVariadic": false
+            },
+            {
+              "label": { "name": "d", "position": [2, 37] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "String"
+              },
+              "defaultValue": {
+                "token": {
+                  "position": [2, 41],
+                  "kind": {
+                    "name": "String",
+                    "value": "abc"
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": "abc"
+                }
+              },
+              "isVariadic": false
+            }
+          ],
+          "returnType": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "body": [
+            {
+              "token": {
+                "position": [2, 55],
+                "kind": {
+                  "name": "Ident",
+                  "value": "a"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "a"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [5, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [5, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [5, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [5, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [5, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [5, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [5, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              null,
+              null
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [8, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [8, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [8, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [8, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [8, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [8, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [8, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              {
+                "token": {
+                  "position": [8, 32],
+                  "kind": {
+                    "name": "Float",
+                    "value": 4.56
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 4.56
+                }
+              },
+              null
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [11, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [11, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [11, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [11, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [11, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [11, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [11, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              {
+                "token": {
+                  "position": [11, 35],
+                  "kind": {
+                    "name": "Float",
+                    "value": 4.56
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 4.56
+                }
+              },
+              null
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [14, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [14, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [14, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [14, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [14, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [14, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [14, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              null,
+              {
+                "token": {
+                  "position": [14, 35],
+                  "kind": {
+                    "name": "String",
+                    "value": "foo"
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": "foo"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [17, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [17, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [17, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [17, 17],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [17, 14],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "function",
+                "paramTypes": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Float"
+                  },
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ],
+                "returnType": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [17, 18],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
+                }
+              },
+              {
+                "token": {
+                  "position": [17, 26],
+                  "kind": {
+                    "name": "Bool",
+                    "value": true
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": true
+                }
+              },
+              {
+                "token": {
+                  "position": [17, 45],
+                  "kind": {
+                    "name": "Float",
+                    "value": 4.56
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Float"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 4.56
+                }
+              },
+              {
+                "token": {
+                  "position": [17, 35],
+                  "kind": {
+                    "name": "String",
+                    "value": "foo"
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": "foo"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/selfhost/test/typechecker/invocation.5.abra
+++ b/selfhost/test/typechecker/invocation.5.abra
@@ -1,0 +1,5 @@
+// Test calling function which has multiple optional parameters
+func foo(a: Int[], b: Bool?) {}
+
+foo(a: [], b: true)
+foo(a: [1, 2], b: None)

--- a/selfhost/test/typechecker/invocation.5.out.json
+++ b/selfhost/test/typechecker/invocation.5.out.json
@@ -1,0 +1,329 @@
+{
+  "id": 1,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [2, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "foo", "position": [2, 6] },
+          "scope": {
+            "name": "$root::module_1::foo",
+            "variables": [
+              {
+                "label": { "name": "a", "position": [2, 10] },
+                "mutable": false,
+                "type": {
+                  "nullable": false,
+                  "kind": "instance",
+                  "struct": { "moduleId": 0, "name": "Array" },
+                  "typeParams": [
+                    {
+                      "nullable": false,
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    }
+                  ]
+                }
+              },
+              {
+                "label": { "name": "b", "position": [2, 20] },
+                "mutable": false,
+                "type": {
+                  "nullable": true,
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                }
+              }
+            ],
+            "functions": []
+          },
+          "parameters": [
+            {
+              "label": { "name": "a", "position": [2, 10] },
+              "type": {
+                "nullable": false,
+                "kind": "instance",
+                "struct": { "moduleId": 0, "name": "Array" },
+                "typeParams": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                ]
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            },
+            {
+              "label": { "name": "b", "position": [2, 20] },
+              "type": {
+                "nullable": true,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            }
+          ],
+          "returnType": {
+            "nullable": false,
+            "kind": "primitive",
+            "primitive": "Unit"
+          },
+          "body": []
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [4, 4],
+        "kind": {
+          "name": "LParen"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "invocation",
+        "invokee": {
+          "token": {
+            "position": [4, 1],
+            "kind": {
+              "name": "Ident",
+              "value": "foo"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "function",
+            "paramTypes": [
+              {
+                "nullable": false,
+                "kind": "instance",
+                "struct": { "moduleId": 0, "name": "Array" },
+                "typeParams": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                ]
+              },
+              {
+                "nullable": true,
+                "kind": "primitive",
+                "primitive": "Bool"
+              }
+            ],
+            "returnType": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Unit"
+            }
+          },
+          "node": {
+            "kind": "identifier",
+            "name": "foo"
+          }
+        },
+        "arguments": [
+          {
+            "token": {
+              "position": [4, 8],
+              "kind": {
+                "name": "LBrack"
+              }
+            },
+            "type": {
+              "nullable": false,
+              "kind": "instance",
+              "struct": { "moduleId": 0, "name": "Array" },
+              "typeParams": [
+                {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              ]
+            },
+            "node": {
+              "kind": "array",
+              "items": []
+            }
+          },
+          {
+            "token": {
+              "position": [4, 15],
+              "kind": {
+                "name": "Bool",
+                "value": true
+              }
+            },
+            "type": {
+              "nullable": true,
+              "kind": "primitive",
+              "primitive": "Bool"
+            },
+            "node": {
+              "kind": "literal",
+              "value": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "token": {
+        "position": [5, 4],
+        "kind": {
+          "name": "LParen"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "invocation",
+        "invokee": {
+          "token": {
+            "position": [5, 1],
+            "kind": {
+              "name": "Ident",
+              "value": "foo"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "function",
+            "paramTypes": [
+              {
+                "nullable": false,
+                "kind": "instance",
+                "struct": { "moduleId": 0, "name": "Array" },
+                "typeParams": [
+                  {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                ]
+              },
+              {
+                "nullable": true,
+                "kind": "primitive",
+                "primitive": "Bool"
+              }
+            ],
+            "returnType": {
+              "nullable": false,
+              "kind": "primitive",
+              "primitive": "Unit"
+            }
+          },
+          "node": {
+            "kind": "identifier",
+            "name": "foo"
+          }
+        },
+        "arguments": [
+          {
+            "token": {
+              "position": [5, 8],
+              "kind": {
+                "name": "LBrack"
+              }
+            },
+            "type": {
+              "nullable": false,
+              "kind": "instance",
+              "struct": { "moduleId": 0, "name": "Array" },
+              "typeParams": [
+                {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              ]
+            },
+            "node": {
+              "kind": "array",
+              "items": [
+                {
+                  "token": {
+                    "position": [5, 9],
+                    "kind": {
+                      "name": "Int",
+                      "value": 1
+                    }
+                  },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": 1
+                  }
+                },
+                {
+                  "token": {
+                    "position": [5, 12],
+                    "kind": {
+                      "name": "Int",
+                      "value": 2
+                    }
+                  },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "token": {
+              "position": [5, 19],
+              "kind": {
+                "name": "None"
+              }
+            },
+            "type": {
+              "nullable": true,
+              "kind": "primitive",
+              "primitive": "Bool"
+            },
+            "node": {
+              "kind": "identifier",
+              "name": "None"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/selfhost/test/typechecker/invocation_error_incorrect_label.abra
+++ b/selfhost/test/typechecker/invocation_error_incorrect_label.abra
@@ -1,0 +1,2 @@
+func foo(a: Int): Int = 123
+foo(abc: 123)

--- a/selfhost/test/typechecker/invocation_error_incorrect_label.out
+++ b/selfhost/test/typechecker/invocation_error_incorrect_label.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:2:5
+Incorrect label for parameter
+  |  foo(abc: 123)
+         ^
+The parameter's name is 'a', but instead found 'abc'

--- a/selfhost/test/typechecker/invocation_error_mixed_label_optional.abra
+++ b/selfhost/test/typechecker/invocation_error_mixed_label_optional.abra
@@ -1,0 +1,2 @@
+func foo(a: Int, b = 123, c = true, d = "abcd"): Int = 123
+foo(1, c: false, "hello")

--- a/selfhost/test/typechecker/invocation_error_mixed_label_optional.out
+++ b/selfhost/test/typechecker/invocation_error_mixed_label_optional.out
@@ -1,0 +1,8 @@
+Error at %FILE_NAME%:2:18
+Cannot mix labeled and positional optional arguments
+  |  foo(1, c: false, "hello")
+                      ^
+This argument requires a label because a prior optional parameter has been labeled:
+  |  foo(1, c: false, "hello")
+            ^
+(Optional parameters may be listed positionally until a label is encountered. After that point, parameter values cannot be unambiguously determined without labels)

--- a/selfhost/test/typechecker/invocation_error_optional_param_type_mismatch.abra
+++ b/selfhost/test/typechecker/invocation_error_optional_param_type_mismatch.abra
@@ -1,0 +1,2 @@
+func foo(a: Int, b = 123, c = true, d = "abcd"): Int = 123
+foo(1, false, "hello")

--- a/selfhost/test/typechecker/invocation_error_optional_param_type_mismatch.out
+++ b/selfhost/test/typechecker/invocation_error_optional_param_type_mismatch.out
@@ -1,0 +1,6 @@
+Error at %FILE_NAME%:2:8
+Type mismatch for parameter 'b'
+  |  foo(1, false, "hello")
+            ^
+Expected: Int
+but instead found: Bool

--- a/selfhost/test/typechecker/invocation_error_optional_param_unknown.abra
+++ b/selfhost/test/typechecker/invocation_error_optional_param_unknown.abra
@@ -1,0 +1,2 @@
+func foo(a: Int, b = 123, c = true, d = "abcd"): Int = 123
+foo(1, x: 123)

--- a/selfhost/test/typechecker/invocation_error_optional_param_unknown.out
+++ b/selfhost/test/typechecker/invocation_error_optional_param_unknown.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:2:8
+Unknown parameter label
+  |  foo(1, x: 123)
+            ^
+This function doesn't have a parameter named 'x'

--- a/selfhost/test/typechecker/invocation_error_too_few_args.abra
+++ b/selfhost/test/typechecker/invocation_error_too_few_args.abra
@@ -1,0 +1,2 @@
+func foo(a: Int, b: Int): Int = 123
+foo()

--- a/selfhost/test/typechecker/invocation_error_too_few_args.out
+++ b/selfhost/test/typechecker/invocation_error_too_few_args.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:2:4
+Not enough arguments for invocation
+  |  foo()
+        ^
+2 arguments required, but 0 were passed

--- a/selfhost/test/typechecker/invocation_error_too_many_args.abra
+++ b/selfhost/test/typechecker/invocation_error_too_many_args.abra
@@ -1,0 +1,2 @@
+func foo(): Int = 123
+foo(1, 2)

--- a/selfhost/test/typechecker/invocation_error_too_many_args.out
+++ b/selfhost/test/typechecker/invocation_error_too_many_args.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:2:5
+Too many arguments for invocation
+  |  foo(1, 2)
+         ^
+Expected no more than 0 arguments, but 2 were passed

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -234,6 +234,20 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/if_error_unfilled_holes_bindingdecl.4.abra", "typechecker/if_error_unfilled_holes_bindingdecl.4.out")
         .add_test_vs_txt("typechecker/if_expr.abra", "typechecker/if_expr.out.json")
         .add_test_vs_txt("typechecker/if_stmt.abra", "typechecker/if_stmt.out.json")
+        // Invocation
+        .add_test_vs_txt("typechecker/invocation.1.abra", "typechecker/invocation.1.out.json")
+        .add_test_vs_txt("typechecker/invocation.2.abra", "typechecker/invocation.2.out.json")
+        .add_test_vs_txt("typechecker/invocation.3.abra", "typechecker/invocation.3.out.json")
+        .add_test_vs_txt("typechecker/invocation.4.abra", "typechecker/invocation.4.out.json")
+        .add_test_vs_txt("typechecker/invocation.5.abra", "typechecker/invocation.5.out.json")
+        .add_test_vs_txt("typechecker/invocation_error_incorrect_label.abra", "typechecker/invocation_error_incorrect_label.out")
+        .add_test_vs_txt("typechecker/invocation_error_mixed_label_optional.abra", "typechecker/invocation_error_mixed_label_optional.out")
+        .add_test_vs_txt("typechecker/invocation_error_optional_param_type_mismatch.abra", "typechecker/invocation_error_optional_param_type_mismatch.out")
+        .add_test_vs_txt("typechecker/invocation_error_optional_param_unknown.abra", "typechecker/invocation_error_optional_param_unknown.out")
+        .add_test_vs_txt("typechecker/invocation_error_too_few_args.abra", "typechecker/invocation_error_too_few_args.out")
+        .add_test_vs_txt("typechecker/invocation_error_too_many_args.abra", "typechecker/invocation_error_too_many_args.out")
+
+
         // Break
         .add_test_vs_txt("typechecker/break_as_expr.abra", "typechecker/break_as_expr.out.json")
         .add_test_vs_txt("typechecker/break_error_location_module.abra", "typechecker/break_error_location_module.out")
@@ -259,8 +273,6 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/for_error_bad_iterator.abra", "typechecker/for_error_bad_iterator.out")
         .add_test_vs_txt("typechecker/for_error_bad_iterator_unfilled_hole.abra", "typechecker/for_error_bad_iterator_unfilled_hole.out")
         .add_test_vs_txt("typechecker/for_error_duplicate_ident.abra", "typechecker/for_error_duplicate_ident.out")
-
-
         // Binding declaration
         .add_test_vs_txt("typechecker/bindingdecl.abra", "typechecker/bindingdecl.out.json")
         .add_test_vs_txt("typechecker/bindingdecl_error_bare_var.abra", "typechecker/bindingdecl_error_bare_var.out")


### PR DESCRIPTION
This is the first portion of the work to typecheck function invocation. Once methods are implemented, I will expand upon this work, as well as invocation of arbitrary expressions as functions.

This also adds two new methods to the `Array` type in the `prelude` module: `Array#keyBy` and `Array#indexBy`. I only use `#keyBy` in the selfhosted typechecker, but I thought it made sense to add `#indexBy` while I was at it.