### PR TITLE
Selfhost: typechecking enum declarations

### DIFF
--- a/selfhost/src/parser.abra
+++ b/selfhost/src/parser.abra
@@ -225,7 +225,7 @@ export enum EnumVariant {
   Container(label: Label, fields: TypeField[])
 }
 
-type EnumDeclarationNode {
+export type EnumDeclarationNode {
   decorators: DecoratorNode[]
   exportToken: Token?
   name: Label

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -94,7 +94,7 @@ export type Scope {
   func makeChild(self, name: String, kind: ScopeKind): Scope = Scope(name: "${self.name}::$name", kind: kind, parent: self)
 }
 
-type Field {
+export type Field {
   name: Label
   ty: Type
   initializer: TypedAstNode?
@@ -134,6 +134,11 @@ export type Enum {
 
   // Override eq method since default implementation recurses infinitely (scope -> variables -> TypeKind.Enum)
   func eq(self, other: Enum): Bool = self.moduleId == other.moduleId && self.label == other.label
+}
+
+enum Instantiatable {
+  Struct(struct: Struct)
+  EnumContainerVariant(enum_: Enum, variant: TypedEnumVariant, fields: Field[])
 }
 
 
@@ -255,6 +260,10 @@ export type Type {
         val substTypeArgs = typeArgs.map(ty => ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown))
         Type(kind: TypeKind.Instance(struct, substTypeArgs))
       }
+      TypeKind.EnumInstance(enum_, typeArgs) => {
+        val substTypeArgs = typeArgs.map(ty => ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown))
+        Type(kind: TypeKind.EnumInstance(enum_, substTypeArgs))
+      }
       TypeKind.Tuple(typeArgs) => {
         val substTypeArgs = typeArgs.map(ty => ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown))
         Type(kind: TypeKind.Tuple(substTypeArgs))
@@ -368,6 +377,23 @@ export type Function {
     Function(label: struct.label, scope: fnScope, kind: FunctionKind.Standalone, typeParams: structTypeParams, params: params, returnType: returnType, body: [], isGenerated: true)
   }
 
+  func forEnumVariant(
+    scope: Scope,
+    enum_: Enum,
+    variantLabel: Label,
+    variantFields: Field[],
+  ): Function {
+    val bogusPosition = Position(line: 0, col: 0)
+
+    val fnScope = scope.makeChild("${enum_.label.name}.${variantLabel.name}", ScopeKind.Func)
+    val typeParams = enum_.typeParams.map(t => (Type(kind: TypeKind.Generic(t)), Label(name: t, position: bogusPosition)))
+    val params = variantFields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer))
+    val typeArgs = enum_.typeParams.map(t => Type(kind: TypeKind.Generic(t)))
+    val returnType = Type(kind: TypeKind.EnumInstance(enum_, typeArgs))
+
+    Function(label: variantLabel, scope: fnScope, kind: FunctionKind.Standalone, typeParams: typeParams, params: params, returnType: returnType, body: [], isGenerated: true)
+  }
+
   func getType(self): Type = Type(kind: TypeKind.Func(paramTypes: self.params.map(p => (p.ty, !p.defaultValue)), returnType: self.returnType))
 
   func withSubstitutedGenerics(self, resolvedGenerics: Map<String, Type>, retainUnknown: Bool): Function {
@@ -393,6 +419,7 @@ export type Function {
 export enum TypedInvokee {
   Struct(struct: Struct)
   Expr(expr: TypedAstNode)
+  EnumVariant(enum_: Enum, variant: TypedEnumVariant)
 }
 
 export enum TypedIndexingNode {
@@ -746,7 +773,10 @@ type TypeError {
       TypeErrorKind.IllegalCallableType(ty) => {
         lines.push("Cannot invoke target as function")
         lines.push(self._getCursorLine(self.position, contents))
-        lines.push("Type '${ty.repr()}' is not callable")
+        match ty.kind {
+          TypeKind.EnumInstance => lines.push("This is a constant enum variant, and it accepts no arguments")
+          _ => lines.push("Type '${ty.repr()}' is not callable")
+        }
       }
       TypeErrorKind.WrongTypeArgumentArity(expected, given) => {
         val verbStr = if given == 1 "was" else "were"
@@ -1161,6 +1191,20 @@ export type Typechecker {
         }
         _ => false
       }
+      TypeKind.EnumInstance(reqEnum, reqTypeArgs) => match ty.kind {
+        TypeKind.EnumInstance(enum_, typeArgs) => {
+          if reqEnum.moduleId != enum_.moduleId || reqEnum.label != enum_.label return false
+
+          if reqTypeArgs.length != typeArgs.length return false
+          for reqTypeArg, i in reqTypeArgs {
+            val typeArg = if typeArgs[i] |t| t else { return true }
+            if !self._typeSatisfiesRequired(ty: typeArg, required: reqTypeArg) return false
+          }
+
+          true
+        }
+        _ => false
+      }
       TypeKind.Tuple(reqTypes) => match ty.kind {
         TypeKind.Tuple(types) => {
           if reqTypes.length != types.length return false
@@ -1183,6 +1227,7 @@ export type Typechecker {
     match ty.kind {
       TypeKind.Generic(name) => true
       TypeKind.Instance(_, typeArgs) => typeArgs.any(t => self._containsGenerics(t))
+      TypeKind.EnumInstance(_, typeArgs) => typeArgs.any(t => self._containsGenerics(t))
       TypeKind.Tuple(typeArgs) => typeArgs.any(t => self._containsGenerics(t))
       TypeKind.Func(paramTypes, returnType) => {
         if self._containsGenerics(returnType) return true
@@ -1201,6 +1246,25 @@ export type Typechecker {
       TypeKind.Instance(_, templateTypeArgs) => {
         match source.kind {
           TypeKind.Instance(_, sourceTypeArgs) => {
+            if templateTypeArgs.length != sourceTypeArgs.length {
+              // There's currently no notion of asserts, but this will show up in output files and fail tests so it won't go unnoticed.
+              println("templateTypeArgs.length != sourceTypeArgs.length")
+              return
+            }
+            for tplTypeArg, idx in templateTypeArgs {
+              val srcTypeArg = if sourceTypeArgs[idx] |t| t else {
+                println("templateTypeArgs.length != sourceTypeArgs.length")
+                return
+              }
+              self.__extractGenerics(template: tplTypeArg, source: srcTypeArg, extracted: extracted)
+            }
+          }
+          _ => {}
+        }
+      }
+      TypeKind.EnumInstance(_, templateTypeArgs) => {
+        match source.kind {
+          TypeKind.EnumInstance(_, sourceTypeArgs) => {
             if templateTypeArgs.length != sourceTypeArgs.length {
               // There's currently no notion of asserts, but this will show up in output files and fail tests so it won't go unnoticed.
               println("templateTypeArgs.length != sourceTypeArgs.length")
@@ -2793,7 +2857,7 @@ export type Typechecker {
             VariableAlias.Function(fn) => self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint)
             VariableAlias.Struct(struct) => {
               val initializerFn = Function.initializer(self.currentScope, struct)
-              self._typecheckInvocationOfFunction(token, invokee, initializerFn, node, typeHint, struct)
+              self._typecheckInvocationOfFunction(token, invokee, initializerFn, node, typeHint, Instantiatable.Struct(struct))
             }
             VariableAlias.Enum(enum_) => return Result.Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))))))
             None => self._typecheckInvocationOfExpression(token, invokee, invokee.token.position, node)
@@ -2804,7 +2868,16 @@ export type Typechecker {
       }
       TypedAstNodeKind.Accessor(_, _, tail) => {
         match tail {
-          AccessorPathSegment.EnumVariant(_, enum_, variant) => return todo(token.position, "invocation of enum variants")
+          AccessorPathSegment.EnumVariant(label, enum_, variant) => {
+            val fields = match variant.kind {
+              EnumVariantKind.Constant => return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalCallableType(invokee.ty)))
+              EnumVariantKind.Container(fields) => fields
+            }
+
+            val enumVariantAsFn = Function.forEnumVariant(self.currentScope, enum_, variant.label, fields)
+
+            self._typecheckInvocationOfFunction(token, invokee, enumVariantAsFn, node, typeHint, Instantiatable.EnumContainerVariant(enum_, variant, fields))
+          }
           AccessorPathSegment.Method(_, fn) => self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint)
           AccessorPathSegment.Field(label) => self._typecheckInvocationOfExpression(token, invokee, label.position, node)
         }
@@ -2852,7 +2925,7 @@ export type Typechecker {
     Result.Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Invocation(typedInvokee, typedArguments)))
   }
 
-  func _typecheckInvocationOfFunction(self, token: Token, invokee: TypedAstNode, fn: Function, invocationNode: InvocationAstNode, typeHint: Type?, instantiationOf: Struct? = None): Result<TypedAstNode, TypeError> {
+  func _typecheckInvocationOfFunction(self, token: Token, invokee: TypedAstNode, fn: Function, invocationNode: InvocationAstNode, typeHint: Type?, instantiationOf: Instantiatable? = None): Result<TypedAstNode, TypeError> {
     // Function invocation is position-based for required parameters, with optional parameter labels to express call-site intent (ie. for Bool params), and it's
     // an error if a positional parameter's label is incorrect. Once we reach any optional parameters in the argument list, parameters can either be positional
     // OR labeled, but once a labeled optional parameter is seen, all subsequent arguments in the argument list must also be labeled.
@@ -2978,10 +3051,19 @@ export type Typechecker {
       } else if param.defaultValue {
         typedArguments.push(None)
       } else {
-        val errorKind = if instantiationOf |struct| {
-          val missing = struct.fields
-            .filter(f => !f.initializer && !typedArgumentsByName.containsKey(f.name.name))
-            .map(f => f.name.name)
+        val errorKind = if instantiationOf |i| {
+          val missing = match i {
+            Instantiatable.Struct(struct) => {
+              struct.fields
+                .filter(f => !f.initializer && !typedArgumentsByName.containsKey(f.name.name))
+                .map(f => f.name.name)
+            }
+            Instantiatable.EnumContainerVariant(_, _, fields) => {
+              fields
+                .filter(f => !f.initializer && !typedArgumentsByName.containsKey(f.name.name))
+                .map(f => f.name.name)
+            }
+          }
           TypeErrorKind.MissingRequiredFields(missing)
         } else {
           val numRequired = fn.params.filter(p => !p.defaultValue).length
@@ -2996,8 +3078,12 @@ export type Typechecker {
       fn.returnType.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false)
     } else fn.returnType
 
-    val typedInvokee = if instantiationOf |struct| {
-      TypedInvokee.Struct(struct)
+    val typedInvokee = if instantiationOf |i| {
+      val v = match i {
+        Instantiatable.Struct(struct) => TypedInvokee.Struct(struct)
+        Instantiatable.EnumContainerVariant(enum_, variant, _) => TypedInvokee.EnumVariant(enum_, variant)
+      }
+      v
     } else {
       TypedInvokee.Expr(invokee)
     }

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -1,6 +1,6 @@
 import "fs" as fs
 import Lexer, LexerError, Token, TokenKind, Position from "./lexer"
-import Parser, ParsedModule, ParseError, AstNode, AstNodeKind, LiteralAstNode, UnaryAstNode, UnaryOp, BinaryAstNode, BinaryOp, BindingDeclarationNode, BindingPattern, TypeIdentifier, Label, IdentifierKind, FunctionDeclarationNode, FunctionParam, InvocationAstNode, InvocationArgument, TypeDeclarationNode, AccessorAstNode, IndexingMode, AssignOp, AssignmentMode from "./parser"
+import Parser, ParsedModule, ParseError, AstNode, AstNodeKind, LiteralAstNode, UnaryAstNode, UnaryOp, BinaryAstNode, BinaryOp, BindingDeclarationNode, BindingPattern, TypeIdentifier, Label, IdentifierKind, FunctionDeclarationNode, FunctionParam, InvocationAstNode, InvocationArgument, TypeDeclarationNode, EnumDeclarationNode, EnumVariant, AccessorAstNode, IndexingMode, AssignOp, AssignmentMode from "./parser"
 
 enum TokenizeAndParseError {
   ReadFileError(path: String)
@@ -42,6 +42,7 @@ export type TypedModule {
 export enum VariableAlias {
   Function(fn: Function)
   Struct(struct: Struct)
+  Enum(enum_: Enum)
 }
 
 export type Variable {
@@ -85,6 +86,7 @@ export type Scope {
   functions: Function[] = []
   types: Type[] = []
   structs: Struct[] = []
+  enums: Enum[] = []
   kind: ScopeKind = ScopeKind.Root
   parent: Scope? = None
   terminator: Terminator? = None
@@ -110,6 +112,30 @@ export type Struct {
   // Override eq method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
   func eq(self, other: Struct): Bool = self.moduleId == other.moduleId && self.label == other.label
 }
+
+export type TypedEnumVariant {
+  label: Label
+  kind: EnumVariantKind
+}
+
+export enum EnumVariantKind {
+  Constant
+  Container(fields: Field[])
+}
+
+export type Enum {
+  moduleId: Int
+  label: Label
+  scope: Scope
+  typeParams: String[]
+  variants: TypedEnumVariant[] = []
+  instanceMethods: Function[] = []
+  staticMethods: Function[] = []
+
+  // Override eq method since default implementation recurses infinitely (scope -> variables -> TypeKind.Enum)
+  func eq(self, other: Enum): Bool = self.moduleId == other.moduleId && self.label == other.label
+}
+
 
 export type Project {
   modules: TypedModule[] = []
@@ -145,6 +171,13 @@ export type Type {
           "${struct.label.name}$genericsRepr"
         }
       }
+      TypeKind.EnumInstance(enum_, typeParams) => {
+        val genericsRepr = if typeParams.isEmpty() "" else {
+          val reprs = typeParams.map(t => t.repr()).join(", ")
+          "<$reprs>"
+        }
+        "${enum_.label.name}$genericsRepr"
+      }
       TypeKind.Tuple(types) => "(${types.map(t => t.repr()).join(", ")})"
       TypeKind.Func(paramTypes, returnType) => {
         val paramsRepr = paramTypes.filter(p => p[1]).map(p => p[0].repr()).join(", ")
@@ -154,7 +187,10 @@ export type Type {
         if self.nullable return "($repr)?"
         repr
       }
-      TypeKind.Struct(struct) => "<#type ${struct.label.name}>"
+      TypeKind.Type(structOrEnum) => match structOrEnum {
+        StructOrEnum.Struct(struct) => "<#type ${struct.label.name}>"
+        StructOrEnum.Enum(enum_) => "<#enum ${enum_.label.name}>"
+      }
       TypeKind.Hole => "<unknown>"
     }
 
@@ -170,9 +206,10 @@ export type Type {
     TypeKind.Never => false
     TypeKind.Generic => false
     TypeKind.Instance(_, generics) => generics.any(t => t.hasUnfilledHoles())
+    TypeKind.EnumInstance(_, generics) => generics.any(t => t.hasUnfilledHoles())
     TypeKind.Tuple(types) => types.any(t => t.hasUnfilledHoles())
     TypeKind.Func(paramTypes, returnType) => paramTypes.any(t => t[0].hasUnfilledHoles()) || returnType.hasUnfilledHoles()
-    TypeKind.Struct => false
+    TypeKind.Type => false
     TypeKind.Hole => true
   }
 
@@ -238,6 +275,11 @@ export type Type {
   }
 }
 
+export enum StructOrEnum {
+  Struct(struct: Struct)
+  Enum(enum_: Enum)
+}
+
 export enum TypeKind {
   PrimitiveUnit
   PrimitiveInt
@@ -247,8 +289,9 @@ export enum TypeKind {
   Never
   Generic(name: String)
   Instance(struct: Struct, generics: Type[])
+  EnumInstance(enum_: Enum, generics: Type[])
   Func(paramTypes: (Type, Bool)[], returnType: Type)
-  Struct(struct: Struct)
+  Type(type_: StructOrEnum)
   Tuple(types: Type[])
   Hole
 }
@@ -384,6 +427,7 @@ export enum TypedAstNodeKind {
   BindingDeclaration(node: TypedBindingDeclarationNode)
   FunctionDeclaration(fn: Function)
   TypeDeclaration(struct: Struct)
+  EnumDeclaration(enum_: Enum)
   Break
   Continue
   Return(expr: TypedAstNode?)
@@ -840,7 +884,7 @@ export type Typechecker {
   project: Project
   currentModuleId: Int = -1
   currentScope: Scope = Scope(name: "\$root")
-  currentTypeDecl: Struct? = None
+  currentTypeDecl: StructOrEnum? = None
   currentFunction: Function? = None
   paramDefaultValueContext: ParamDefaultValueContext? = None
 
@@ -906,13 +950,25 @@ export type Typechecker {
   }
 
   func _addStructToScope(self, struct: Struct, scope = self.currentScope): Result<Int, TypeError> {
-    val structTy = Type(kind: TypeKind.Struct(struct))
+    val structTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Struct(struct)))
     match self._addTypeToScope(structTy) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
 
     val variable = Variable(label: struct.label, mutable: false, ty: structTy, alias: VariableAlias.Struct(struct))
     match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
 
     scope.structs.push(struct)
+
+    Result.Ok(0) // <- unnecessary 0
+  }
+
+  func _addEnumToScope(self, enum_: Enum, scope = self.currentScope): Result<Int, TypeError> {
+    val enumTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Enum(enum_)))
+    match self._addTypeToScope(enumTy) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+    val variable = Variable(label: enum_.label, mutable: false, ty: enumTy, alias: VariableAlias.Enum(enum_))
+    match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+    scope.enums.push(enum_)
 
     Result.Ok(0) // <- unnecessary 0
   }
@@ -977,10 +1033,20 @@ export type Typechecker {
             for ty in sc.types {
               match ty.kind {
                 TypeKind.Generic(name) => { if label.name == name return Result.Ok(ty) }
-                TypeKind.Struct(struct) => {
-                  if label.name == struct.label.name {
-                    val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-                    return Result.Ok(Type(kind: TypeKind.Instance(struct, instanceTypeArgs)))
+                TypeKind.Type(structOrEnum) => {
+                  match structOrEnum {
+                    StructOrEnum.Struct(struct) => {
+                      if label.name == struct.label.name {
+                        val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+                        return Result.Ok(Type(kind: TypeKind.Instance(struct, instanceTypeArgs)))
+                      }
+                    }
+                    StructOrEnum.Enum(enum_) => {
+                      if label.name == enum_.label.name {
+                        val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+                        return Result.Ok(Type(kind: TypeKind.EnumInstance(enum_, instanceTypeArgs)))
+                      }
+                    }
                   }
                 }
                 _ => continue
@@ -1253,20 +1319,28 @@ export type Typechecker {
 
   func _typecheckFunctionParam(self, param: FunctionParam, isRevisit = false): Result<(TypedFunctionParam, Bool), TypeError> {
     if param.label.name == "self" {
-      val ty = if self.currentTypeDecl |struct| {
-        val typeArgs = struct.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
+      if self.currentTypeDecl |structOrEnum| {
+        val ty = match structOrEnum {
+          StructOrEnum.Struct(struct) => {
+            val typeArgs = struct.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
 
-        Type(kind: TypeKind.Instance(struct, typeArgs))
-      } else {
-        // Should be unreachable since _typecheckFunctionPass2 already emits this error, but better safe than sorry
-        return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
+            Type(kind: TypeKind.Instance(struct, typeArgs))
+          }
+          StructOrEnum.Enum(enum_) => {
+            val typeArgs = enum_.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
+
+            Type(kind: TypeKind.EnumInstance(enum_, typeArgs))
+          }
+        }
+
+        val variable = Variable(label: param.label, mutable: false, ty: ty)
+        match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+        val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: None, isVariadic: false)
+        return Result.Ok((typedParam, false))
       }
 
-      val variable = Variable(label: param.label, mutable: false, ty: ty)
-      match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-
-      val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: None, isVariadic: false)
-      return Result.Ok((typedParam, false))
+      return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
     }
 
     val paramType = if param.typeAnnotation |typeAnn| {
@@ -1474,7 +1548,7 @@ export type Typechecker {
     val prevScope = self.currentScope
     self.currentScope = struct.scope
     val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = struct
+    self.currentTypeDecl = StructOrEnum.Struct(struct)
 
     val seenFields: Map<String, Label> = {}
     for field in node.fields {
@@ -1502,20 +1576,29 @@ export type Typechecker {
     Result.Ok(0)
   }
 
-  func _typecheckStructPass2_2(self, struct: Struct, node: TypeDeclarationNode): Result<Map<String, Int[]>, TypeError> {
-    val prevScope = self.currentScope
-    self.currentScope = struct.scope
-    val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = struct
+  func _typecheckMethodsPass2(self, structOrEnum: StructOrEnum, funcDeclNodes: FunctionDeclarationNode[]): Result<Map<Label, Int[]>, TypeError> {
+    val allParamsNeedingRevisit: Map<Label, Int[]> = {}
 
-    val allParamsNeedingRevisit: Map<String, Int[]> = {}
+    val _p = match structOrEnum {
+      StructOrEnum.Struct(struct) => (struct.scope, struct.instanceMethods, struct.staticMethods)
+      StructOrEnum.Enum(enum_) => (enum_.scope, enum_.instanceMethods, enum_.staticMethods)
+    }
+    // TODO: destructuring
+    val scope = _p[0]
+    val instanceMethods = _p[1]
+    val staticMethods = _p[2]
 
-    val instanceMethodsByName = struct.instanceMethods.keyBy(f => f.label)
-    val staticMethodsByName = struct.staticMethods.keyBy(f => f.label)
+    val selfInstanceType = match structOrEnum {
+      StructOrEnum.Struct(struct) => Type(kind: TypeKind.Instance(struct, []))
+      StructOrEnum.Enum(enum_) => Type(kind: TypeKind.EnumInstance(enum_, []))
+    }
+
+    val instanceMethodsByName = instanceMethods.keyBy(f => f.label)
+    val staticMethodsByName = staticMethods.keyBy(f => f.label)
     var toStringFn: Function? = None
     var hashFn: Function? = None
     var eqFn: Function? = None
-    for funcDeclNode in node.methods {
+    for funcDeclNode in funcDeclNodes {
       var isToString = false
       var isHash = false
       var isEq = false
@@ -1530,7 +1613,7 @@ export type Typechecker {
         return unreachable(funcDeclNode.name.position, "could not find function among instance/static methods")
       }
       val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn, funcDeclNode) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-      allParamsNeedingRevisit[fn.label.name] = paramsNeedingRevisit
+      allParamsNeedingRevisit[fn.label] = paramsNeedingRevisit
 
       if isToString {
         val required = Type(kind: TypeKind.Func([], Type(kind: TypeKind.PrimitiveString)))
@@ -1547,7 +1630,7 @@ export type Typechecker {
         hashFn = fn
       }
       if isEq {
-        val required = Type(kind: TypeKind.Func([(Type(kind: TypeKind.Instance(struct, [])), true)], Type(kind: TypeKind.PrimitiveBool)))
+        val required = Type(kind: TypeKind.Func([(selfInstanceType, true)], Type(kind: TypeKind.PrimitiveBool)))
         if !self._typeSatisfiesRequired(ty: fn.getType(), required: required) {
           return Result.Err(TypeError(position: fn.label.position, kind: TypeErrorKind.InvalidTraitMethodSignature(fn)))
         }
@@ -1556,16 +1639,31 @@ export type Typechecker {
     }
 
     // Ensure toString/hash/eq methods exist (include generated stubs if not), and sure the proper order
-    val instanceMethods = struct.instanceMethods
-    struct.instanceMethods = [
-      toStringFn ?: Function.generated(struct.scope, "toString", [], Type(kind: TypeKind.PrimitiveString)),
-      hashFn ?: Function.generated(struct.scope, "hash", [], Type(kind: TypeKind.PrimitiveInt)),
-      eqFn ?: Function.generated(struct.scope, "eq", [("other", Type(kind: TypeKind.Instance(struct, [])))], Type(kind: TypeKind.PrimitiveBool)),
+    val reorderedInstanceMethods = [
+      toStringFn ?: Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString)),
+      hashFn ?: Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt)),
+      eqFn ?: Function.generated(scope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool)),
     ]
     for m in instanceMethods {
       if m.label.name == "toString" || m.label.name == "hash" || m.label.name == "eq" continue
-      struct.instanceMethods.push(m)
+      reorderedInstanceMethods.push(m)
     }
+
+    match structOrEnum {
+      StructOrEnum.Struct(struct) => struct.instanceMethods = reorderedInstanceMethods
+      StructOrEnum.Enum(enum_) => enum_.instanceMethods = reorderedInstanceMethods
+    }
+
+    Result.Ok(allParamsNeedingRevisit)
+  }
+
+  func _typecheckStructPass2_2(self, struct: Struct, node: TypeDeclarationNode): Result<Map<Label, Int[]>, TypeError> {
+    val prevScope = self.currentScope
+    self.currentScope = struct.scope
+    val prevTypeDecl = self.currentTypeDecl
+    self.currentTypeDecl = StructOrEnum.Struct(struct)
+
+    val allParamsNeedingRevisit = match self._typecheckMethodsPass2(StructOrEnum.Struct(struct), node.methods) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
@@ -1573,11 +1671,11 @@ export type Typechecker {
     Result.Ok(allParamsNeedingRevisit)
   }
 
-  func _typecheckStructPass3(self, struct: Struct, node: TypeDeclarationNode, paramsNeedingRevisit: Map<String, Int[]>): Result<Int, TypeError> {
+  func _typecheckStructPass3(self, struct: Struct, node: TypeDeclarationNode, paramsNeedingRevisit: Map<Label, Int[]>): Result<Int, TypeError> {
     val prevScope = self.currentScope
     self.currentScope = struct.scope
     val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = struct
+    self.currentTypeDecl = StructOrEnum.Struct(struct)
 
     for field, idx in node.fields {
       val initializer = if field.initializer |v| v else continue
@@ -1602,10 +1700,156 @@ export type Typechecker {
         return unreachable(funcDeclNode.name.position, "method not visited in prior pass")
       }
 
-      // TODO: index paramsneedingrevisit by label rather than by string to prevent against name collisions between static/instance methods
-      val toRevisit = if paramsNeedingRevisit[fnLabel.name] |paramIds| paramIds else {
-        return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
+      val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
+      match self._typecheckFunctionPass3(fn, funcDeclNode, toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    }
+
+    self.currentTypeDecl = prevTypeDecl
+    self.currentScope = prevScope
+
+    Result.Ok(0)
+  }
+
+  func _typecheckEnumPass1(self, node: EnumDeclarationNode): Result<Enum, TypeError> {
+    val typeScope = self.currentScope.makeChild(node.name.name, ScopeKind.Type)
+    val prevScope = self.currentScope
+    self.currentScope = typeScope
+
+    val typeParams: String[] = []
+    val seenTypeParams: Map<String, Label> = {}
+    for label in node.typeParams {
+      if seenTypeParams[label.name] |original| {
+        return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.DuplicateName(original)))
       }
+      seenTypeParams[label.name] = label
+
+      val generic = Type(kind: TypeKind.Generic(label.name))
+      match self._addTypeToScope(generic) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      typeParams.push(label.name)
+    }
+
+    self.currentScope = prevScope
+
+    val enum_ = Enum(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams)
+    match self._addEnumToScope(enum_) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+    Result.Ok(enum_)
+  }
+
+  func _typecheckEnumPass2_1(self, enum_: Enum, node: EnumDeclarationNode): Result<Int, TypeError> {
+    val prevScope = self.currentScope
+    self.currentScope = enum_.scope
+    val prevTypeDecl = self.currentTypeDecl
+    self.currentTypeDecl = StructOrEnum.Enum(enum_)
+
+    var allVariantsConstant = true
+    val seenVariants: Map<String, Label> = {}
+    for variant, idx in node.variants {
+      val variantLabel = match variant { EnumVariant.Constant(label) => label, EnumVariant.Container(label) => label }
+      if seenVariants[variantLabel.name] |original| {
+        return Result.Err(TypeError(position: variantLabel.position, kind: TypeErrorKind.DuplicateName(original)))
+      }
+      seenVariants[variantLabel.name] = variantLabel
+
+      match variant {
+        EnumVariant.Constant(label) => {
+          enum_.variants.push(TypedEnumVariant(label: label, kind: EnumVariantKind.Constant))
+        }
+        EnumVariant.Container(label, fields) => {
+          allVariantsConstant = false
+
+          val typedFields: Field[] = []
+          val seenFields: Map<String, Label> = {}
+          for field in fields {
+            if seenFields[field.name.name] |original| {
+              return Result.Err(TypeError(position: field.name.position, kind: TypeErrorKind.DuplicateName(original)))
+            }
+            seenFields[field.name.name] = field.name
+
+            val ty = match self._resolveTypeIdentifier(field.typeAnnotation) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            // The initializer (if present) will be filled in during the next pass
+            typedFields.push(Field(name: field.name, ty: ty, initializer: None))
+          }
+
+          enum_.variants.push(TypedEnumVariant(label: label, kind: EnumVariantKind.Container(typedFields)))
+        }
+      }
+    }
+
+    for funcDeclNode in node.methods {
+      val fn = match self._typecheckFunctionPass1(funcDeclNode) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match fn.kind {
+        FunctionKind.InstanceMethod => enum_.instanceMethods.push(fn)
+        FunctionKind.StaticMethod => enum_.staticMethods.push(fn)
+        FunctionKind.Standalone => return unreachable(fn.label.position, "method has invalid function kind at this point")
+      }
+    }
+
+    self.currentTypeDecl = prevTypeDecl
+    self.currentScope = prevScope
+
+    Result.Ok(0)
+  }
+
+  func _typecheckEnumPass2_2(self, enum_: Enum, node: EnumDeclarationNode): Result<Map<Label, Int[]>, TypeError> {
+    val prevScope = self.currentScope
+    self.currentScope = enum_.scope
+    val prevTypeDecl = self.currentTypeDecl
+    self.currentTypeDecl = StructOrEnum.Enum(enum_)
+
+    for typedVariant, idx in enum_.variants {
+      match typedVariant.kind {
+        EnumVariantKind.Constant => continue
+        EnumVariantKind.Container(typedFields) => {
+          val fields = match node.variants[idx] {
+            EnumVariant.Container(_, fields) => fields
+            _ => return unreachable(typedVariant.label.position, "the untyped enum variant must exist at index, and must also be a Container")
+          }
+
+          for typedField, idx in typedFields {
+            val field = if fields[idx] |f| f else return unreachable(typedField.name.position, "the untyped field must exist at index")
+            if field.initializer |initializer| {
+              val typedInitializer = match self._typecheckExpression(initializer, typedField.ty) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              if !self._typeSatisfiesRequired(ty: typedInitializer.ty, required: typedField.ty) {
+                return Result.Err(TypeError(position: typedInitializer.token.position, kind: TypeErrorKind.TypeMismatch([typedField.ty], typedInitializer.ty)))
+              }
+
+              typedField.initializer = typedInitializer
+            } else {
+              continue
+            }
+          }
+        }
+      }
+    }
+
+    val allParamsNeedingRevisit = match self._typecheckMethodsPass2(StructOrEnum.Enum(enum_), node.methods) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+    self.currentTypeDecl = prevTypeDecl
+    self.currentScope = prevScope
+
+    Result.Ok(allParamsNeedingRevisit)
+  }
+
+  func _typecheckEnumPass3(self, enum_: Enum, node: EnumDeclarationNode, paramsNeedingRevisit: Map<Label, Int[]>): Result<Int, TypeError> {
+    val prevScope = self.currentScope
+    self.currentScope = enum_.scope
+    val prevTypeDecl = self.currentTypeDecl
+    self.currentTypeDecl = StructOrEnum.Enum(enum_)
+
+    val instanceMethods = enum_.instanceMethods.keyBy(f => f.label)
+    val staticMethods = enum_.staticMethods.keyBy(f => f.label)
+    for funcDeclNode in node.methods {
+      val fnLabel = funcDeclNode.name
+      val fn = if instanceMethods[fnLabel] |f| {
+        f
+      } else if staticMethods[fnLabel] |f| {
+        f
+      } else {
+        return unreachable(funcDeclNode.name.position, "method not visited in prior pass")
+      }
+
+      val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
       match self._typecheckFunctionPass3(fn, funcDeclNode, toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
     }
 
@@ -1618,20 +1862,28 @@ export type Typechecker {
   func _typecheckBlock(self, nodes: AstNode[]): Result<TypedAstNode[], TypeError> {
     val funcDecls: FunctionDeclarationNode[] = []
     val typeDecls: TypeDeclarationNode[] = []
+    val enumDecls: EnumDeclarationNode[] = []
     for node in nodes {
       match node.kind {
         AstNodeKind.FunctionDeclaration(node) => funcDecls.push(node)
         AstNodeKind.TypeDeclaration(node) => typeDecls.push(node)
+        AstNodeKind.EnumDeclaration(node) => enumDecls.push(node)
         _ => {}
       }
     }
 
-    // --- Pass 1 for types, (todo: enums), and functions
+    // --- Pass 1 for types, enums, and functions
 
     val structsPass1: (Struct, TypeDeclarationNode)[] = []
     for node in typeDecls {
       val struct = match self._typecheckStructPass1(node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
       structsPass1.push((struct, node))
+    }
+
+    val enumsPass1: (Enum, EnumDeclarationNode)[] = []
+    for node in enumDecls {
+      val enum_ = match self._typecheckEnumPass1(node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      enumsPass1.push((enum_, node))
     }
 
     val functionsPass1: (Function, Variable, FunctionDeclarationNode)[] = []
@@ -1642,7 +1894,7 @@ export type Typechecker {
       functionsPass1.push((fn, aliasVar, node))
     }
 
-    // --- Pass 2 for types, (todo: enums), and functions
+    // --- Pass 2 for types, enums, and functions
 
     val structsPass2_1: (Struct, TypeDeclarationNode)[] = []
     for pair in structsPass1 {
@@ -1653,13 +1905,31 @@ export type Typechecker {
       structsPass2_1.push((struct, node))
     }
 
-    val structsPass2_2: (Struct, TypeDeclarationNode, Map<String, Int[]>)[] = []
+    val enumsPass2_1: (Enum, EnumDeclarationNode)[] = []
+    for pair in enumsPass1 {
+      val enum_ = pair[0]
+      val node = pair[1]
+      match self._typecheckEnumPass2_1(enum_, node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+      enumsPass2_1.push((enum_, node))
+    }
+
+    val structsPass2_2: (Struct, TypeDeclarationNode, Map<Label, Int[]>)[] = []
     for pair in structsPass1 {
       val struct = pair[0]
       val node = pair[1]
       val toRevisit = match self._typecheckStructPass2_2(struct, node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
 
       structsPass2_2.push((struct, node, toRevisit))
+    }
+
+    val enumsPass2_2: (Enum, EnumDeclarationNode, Map<Label, Int[]>)[] = []
+    for pair in enumsPass2_1 {
+      val enum_ = pair[0]
+      val node = pair[1]
+      val toRevisit = match self._typecheckEnumPass2_2(enum_, node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+
+      enumsPass2_2.push((enum_, node, toRevisit))
     }
 
     val functionsPass2: (Function, FunctionDeclarationNode, Int[])[] = []
@@ -1675,6 +1945,7 @@ export type Typechecker {
 
     val functionsIter = functionsPass2.iterator()
     val structsIter = structsPass2_2.iterator()
+    val enumsIter = enumsPass2_2.iterator()
 
     val typedNodes: TypedAstNode[] = []
     for node in nodes {
@@ -1708,7 +1979,21 @@ export type Typechecker {
           typedNodes.push(typedNode)
           continue
         }
-        AstNodeKind.EnumDeclaration => return todo(node.token.position)
+        AstNodeKind.EnumDeclaration => {
+          val typedNode = if enumsIter.next() |pair| {
+            val enum_ = pair[0]
+            val enumDeclNode = pair[1]
+            val toRevisit = pair[2]
+
+            match self._typecheckEnumPass3(enum_, enumDeclNode, toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.EnumDeclaration(enum_))
+          } else {
+            return unreachable(node.token.position, "there should be as many enums as there are enumdecl nodes")
+          }
+
+          typedNodes.push(typedNode)
+          continue
+        }
         _ => self._typecheckStatement(node: node, typeHint: None)
       }
 
@@ -2363,12 +2648,34 @@ export type Typechecker {
 
         None
       }
+      TypeKind.EnumInstance(enum_, generics) => {
+        for fn in enum_.instanceMethods {
+          if fn.label.name == label.name {
+            val resolvedGenerics: Map<String, Type> = {}
+            for name, idx in enum_.typeParams {
+              resolvedGenerics[name] = if generics[idx] |g| g else {
+                println("enum_.typeParams.length != generics.length") // Pseudo-assert
+                break
+              }
+            }
+            val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true)
+            return (AccessorPathSegment.Method(label, method), method.getType())
+          }
+        }
+
+        None
+      }
       TypeKind.Tuple => None
       TypeKind.Func => None
-      TypeKind.Struct(struct) => {
+      TypeKind.Type(structOrEnum) => {
         // TODO: static fields
 
-        for method in struct.staticMethods {
+        val staticMethods = match structOrEnum {
+          StructOrEnum.Struct(struct) => struct.staticMethods
+          StructOrEnum.Enum(enum_) => enum_.staticMethods
+        }
+
+        for method in staticMethods {
           if method.label.name == label.name return (AccessorPathSegment.Method(label, method), method.getType())
         }
 
@@ -2406,7 +2713,7 @@ export type Typechecker {
         nextTy
       } else {
         val isSpecialCase = match ty.kind {
-          TypeKind.Instance(struct, _) => !!self._resolveAccessorPathSegment(Type(kind: TypeKind.Struct(struct)), label)
+          TypeKind.Instance(struct, _) => !!self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Struct(struct))), label)
           _ => false
         }
 
@@ -2433,6 +2740,7 @@ export type Typechecker {
               val initializerFn = Function.initializer(self.currentScope, struct)
               self._typecheckInvocationOfFunction(token, invokee, initializerFn, node, typeHint, struct)
             }
+            VariableAlias.Enum(enum_) => return Result.Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))))))
             None => self._typecheckInvocationOfExpression(token, invokee, invokee.token.position, node)
           }
         }

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -164,24 +164,28 @@ export type Type {
       TypeKind.PrimitiveString => "String"
       TypeKind.Never => "Never"
       TypeKind.Generic(name) => name
-      TypeKind.Instance(struct, typeParams) => {
-        if struct.moduleId == 0 && struct.label.name == "Array" {
-          val innerRepr = typeParams[0]?.repr() ?: "<unknown>"
-          "$innerRepr[]"
-        } else {
-          val genericsRepr = if typeParams.isEmpty() "" else {
-            val reprs = typeParams.map(t => t.repr()).join(", ")
-            "<$reprs>"
+      TypeKind.Instance(structOrEnum, typeParams) => {
+        match structOrEnum {
+          StructOrEnum.Struct(struct) => {
+            if struct.moduleId == 0 && struct.label.name == "Array" {
+              val innerRepr = typeParams[0]?.repr() ?: "<unknown>"
+              "$innerRepr[]"
+            } else {
+              val genericsRepr = if typeParams.isEmpty() "" else {
+                val reprs = typeParams.map(t => t.repr()).join(", ")
+                "<$reprs>"
+              }
+              "${struct.label.name}$genericsRepr"
+            }
           }
-          "${struct.label.name}$genericsRepr"
+          StructOrEnum.Enum(enum_) => {
+            val genericsRepr = if typeParams.isEmpty() "" else {
+              val reprs = typeParams.map(t => t.repr()).join(", ")
+              "<$reprs>"
+            }
+            "${enum_.label.name}$genericsRepr"
+          }
         }
-      }
-      TypeKind.EnumInstance(enum_, typeParams) => {
-        val genericsRepr = if typeParams.isEmpty() "" else {
-          val reprs = typeParams.map(t => t.repr()).join(", ")
-          "<$reprs>"
-        }
-        "${enum_.label.name}$genericsRepr"
       }
       TypeKind.Tuple(types) => "(${types.map(t => t.repr()).join(", ")})"
       TypeKind.Func(paramTypes, returnType) => {
@@ -211,7 +215,6 @@ export type Type {
     TypeKind.Never => false
     TypeKind.Generic => false
     TypeKind.Instance(_, generics) => generics.any(t => t.hasUnfilledHoles())
-    TypeKind.EnumInstance(_, generics) => generics.any(t => t.hasUnfilledHoles())
     TypeKind.Tuple(types) => types.any(t => t.hasUnfilledHoles())
     TypeKind.Func(paramTypes, returnType) => paramTypes.any(t => t[0].hasUnfilledHoles()) || returnType.hasUnfilledHoles()
     TypeKind.Type => false
@@ -223,10 +226,10 @@ export type Type {
   func tryFillHoles(self, other: Type) {
     // TODO: this code is pretty ugly - I really need a way of destructuring multiple values simultaneously in `match`es
     match self.kind {
-      TypeKind.Instance(selfStruct, selfTypeArgs) => {
+      TypeKind.Instance(selfStructOrEnum, selfTypeArgs) => {
         match other.kind {
-          TypeKind.Instance(otherStruct, otherTypeArgs) => {
-            if selfStruct != otherStruct return
+          TypeKind.Instance(otherStructOrEnum, otherTypeArgs) => {
+            if selfStructOrEnum != otherStructOrEnum return
 
             for typeArg, idx in selfTypeArgs {
               typeArg.tryFillHoles(otherTypeArgs[idx] ?: Type(kind: TypeKind.Hole))
@@ -256,13 +259,9 @@ export type Type {
   func withSubstitutedGenerics(self, resolvedGenerics: Map<String, Type>, retainUnknown: Bool): Type {
     val resultType = match self.kind {
       TypeKind.Generic(name) => resolvedGenerics[name]?.clone() ?: (if retainUnknown self else Type(kind: TypeKind.Hole))
-      TypeKind.Instance(struct, typeArgs) => {
+      TypeKind.Instance(structOrEnum, typeArgs) => {
         val substTypeArgs = typeArgs.map(ty => ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown))
-        Type(kind: TypeKind.Instance(struct, substTypeArgs))
-      }
-      TypeKind.EnumInstance(enum_, typeArgs) => {
-        val substTypeArgs = typeArgs.map(ty => ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown))
-        Type(kind: TypeKind.EnumInstance(enum_, substTypeArgs))
+        Type(kind: TypeKind.Instance(structOrEnum, substTypeArgs))
       }
       TypeKind.Tuple(typeArgs) => {
         val substTypeArgs = typeArgs.map(ty => ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown))
@@ -297,8 +296,7 @@ export enum TypeKind {
   PrimitiveString
   Never
   Generic(name: String)
-  Instance(struct: Struct, generics: Type[])
-  EnumInstance(enum_: Enum, generics: Type[])
+  Instance(structOrEnum: StructOrEnum, generics: Type[])
   Func(paramTypes: (Type, Bool)[], returnType: Type)
   Type(type_: StructOrEnum)
   Tuple(types: Type[])
@@ -372,7 +370,7 @@ export type Function {
     val structTypeParams = struct.typeParams.map(t => (Type(kind: TypeKind.Generic(t)), Label(name: t, position: bogusPosition)))
     val params = struct.fields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer))
     val typeArgs = struct.typeParams.map(t => Type(kind: TypeKind.Generic(t)))
-    val returnType = Type(kind: TypeKind.Instance(struct, typeArgs))
+    val returnType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
 
     Function(label: struct.label, scope: fnScope, kind: FunctionKind.Standalone, typeParams: structTypeParams, params: params, returnType: returnType, body: [], isGenerated: true)
   }
@@ -389,7 +387,7 @@ export type Function {
     val typeParams = enum_.typeParams.map(t => (Type(kind: TypeKind.Generic(t)), Label(name: t, position: bogusPosition)))
     val params = variantFields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer))
     val typeArgs = enum_.typeParams.map(t => Type(kind: TypeKind.Generic(t)))
-    val returnType = Type(kind: TypeKind.EnumInstance(enum_, typeArgs))
+    val returnType = Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
 
     Function(label: variantLabel, scope: fnScope, kind: FunctionKind.Standalone, typeParams: typeParams, params: params, returnType: returnType, body: [], isGenerated: true)
   }
@@ -607,10 +605,20 @@ type TypeError {
             lines.push(self._getCursorLine(self.position, contents))
             lines.push("Expression has type ${ty.repr()}, which cannot be used as a value")
           }
-          TypeKind.EnumInstance => {
-            lines.push("Forbidden type for $purpose")
-            lines.push(self._getCursorLine(self.position, contents))
-            lines.push("This enum variant is non-constant and must be constructed")
+          TypeKind.Instance(structOrEnum, _) => {
+            match structOrEnum {
+              StructOrEnum.Enum => {
+                lines.push("Forbidden type for $purpose")
+                lines.push(self._getCursorLine(self.position, contents))
+                lines.push("This enum variant is non-constant and must be constructed")
+              }
+              // TODO: This is duplicated below, I should be able to match on `TypeKind.Instance(StructOrEnum.Enum, _)` to avoid this duplication
+              _ => {
+                lines.push("Could not determine type for $purpose")
+                lines.push(self._getCursorLine(self.position, contents))
+                lines.push("Type '${ty.repr()}' has unfilled holes. Please use an explicit type annotation to denote the type")
+              }
+            }
           }
           _ => {
             lines.push("Could not determine type for $purpose")
@@ -774,7 +782,15 @@ type TypeError {
         lines.push("Cannot invoke target as function")
         lines.push(self._getCursorLine(self.position, contents))
         match ty.kind {
-          TypeKind.EnumInstance => lines.push("This is a constant enum variant, and it accepts no arguments")
+          TypeKind.Instance(structOrEnum) => {
+            match structOrEnum {
+              StructOrEnum.Enum => lines.push("This is a constant enum variant, and it accepts no arguments")
+              _ => {
+                // pseudo-assert
+                println("This should be unreachable")
+              }
+            }
+          }
           _ => lines.push("Type '${ty.repr()}' is not callable")
         }
       }
@@ -1070,11 +1086,11 @@ export type Typechecker {
         }
         "Map" => {
           val typeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, 2) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-          Type(kind: TypeKind.Instance(self.project.preludeMapStruct, typeArgs))
+          Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeMapStruct), typeArgs))
         }
         "Set" => {
           val typeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, 1) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-          Type(kind: TypeKind.Instance(self.project.preludeSetStruct, typeArgs))
+          Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeSetStruct), typeArgs))
         }
         _ => {
           var scope: Scope? = self.currentScope
@@ -1087,13 +1103,13 @@ export type Typechecker {
                     StructOrEnum.Struct(struct) => {
                       if label.name == struct.label.name {
                         val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-                        return Result.Ok(Type(kind: TypeKind.Instance(struct, instanceTypeArgs)))
+                        return Result.Ok(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), instanceTypeArgs)))
                       }
                     }
                     StructOrEnum.Enum(enum_) => {
                       if label.name == enum_.label.name {
                         val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-                        return Result.Ok(Type(kind: TypeKind.EnumInstance(enum_, instanceTypeArgs)))
+                        return Result.Ok(Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), instanceTypeArgs)))
                       }
                     }
                   }
@@ -1108,7 +1124,7 @@ export type Typechecker {
       }
       TypeIdentifier.Array(inner) => {
         val innerTy = match self._resolveTypeIdentifier(inner) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-        Type(kind: TypeKind.Instance(self.project.preludeArrayStruct, [innerTy]))
+        Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [innerTy]))
       }
       TypeIdentifier.Option(inner) => {
         val innerTy = match self._resolveTypeIdentifier(inner) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
@@ -1177,23 +1193,9 @@ export type Typechecker {
         }
         _ => false
       }
-      TypeKind.Instance(reqStruct, reqTypeArgs) => match ty.kind {
-        TypeKind.Instance(struct, typeArgs) => {
-          if reqStruct.moduleId != struct.moduleId || reqStruct.label != struct.label return false
-
-          if reqTypeArgs.length != typeArgs.length return false
-          for reqTypeArg, i in reqTypeArgs {
-            val typeArg = if typeArgs[i] |t| t else { return true }
-            if !self._typeSatisfiesRequired(ty: typeArg, required: reqTypeArg) return false
-          }
-
-          true
-        }
-        _ => false
-      }
-      TypeKind.EnumInstance(reqEnum, reqTypeArgs) => match ty.kind {
-        TypeKind.EnumInstance(enum_, typeArgs) => {
-          if reqEnum.moduleId != enum_.moduleId || reqEnum.label != enum_.label return false
+      TypeKind.Instance(reqStructOrEnum, reqTypeArgs) => match ty.kind {
+        TypeKind.Instance(structOrEnum, typeArgs) => {
+          if reqStructOrEnum != structOrEnum return false
 
           if reqTypeArgs.length != typeArgs.length return false
           for reqTypeArg, i in reqTypeArgs {
@@ -1227,7 +1229,6 @@ export type Typechecker {
     match ty.kind {
       TypeKind.Generic(name) => true
       TypeKind.Instance(_, typeArgs) => typeArgs.any(t => self._containsGenerics(t))
-      TypeKind.EnumInstance(_, typeArgs) => typeArgs.any(t => self._containsGenerics(t))
       TypeKind.Tuple(typeArgs) => typeArgs.any(t => self._containsGenerics(t))
       TypeKind.Func(paramTypes, returnType) => {
         if self._containsGenerics(returnType) return true
@@ -1246,25 +1247,6 @@ export type Typechecker {
       TypeKind.Instance(_, templateTypeArgs) => {
         match source.kind {
           TypeKind.Instance(_, sourceTypeArgs) => {
-            if templateTypeArgs.length != sourceTypeArgs.length {
-              // There's currently no notion of asserts, but this will show up in output files and fail tests so it won't go unnoticed.
-              println("templateTypeArgs.length != sourceTypeArgs.length")
-              return
-            }
-            for tplTypeArg, idx in templateTypeArgs {
-              val srcTypeArg = if sourceTypeArgs[idx] |t| t else {
-                println("templateTypeArgs.length != sourceTypeArgs.length")
-                return
-              }
-              self.__extractGenerics(template: tplTypeArg, source: srcTypeArg, extracted: extracted)
-            }
-          }
-          _ => {}
-        }
-      }
-      TypeKind.EnumInstance(_, templateTypeArgs) => {
-        match source.kind {
-          TypeKind.EnumInstance(_, sourceTypeArgs) => {
             if templateTypeArgs.length != sourceTypeArgs.length {
               // There's currently no notion of asserts, but this will show up in output files and fail tests so it won't go unnoticed.
               println("templateTypeArgs.length != sourceTypeArgs.length")
@@ -1317,14 +1299,14 @@ export type Typechecker {
 
   func _typeAsInstance1(self, ty: Type, struct: Struct): Type? {
     match ty.kind {
-      TypeKind.Instance(s, generics) => if s == struct { generics[0] } else None
+      TypeKind.Instance(s, generics) => if s == StructOrEnum.Struct(struct) { generics[0] } else None
       _ => None
     }
   }
 
   func _typeAsInstance2(self, ty: Type, struct: Struct): (Type, Type)? {
     match ty.kind {
-      TypeKind.Instance(s, generics) => if s == struct {
+      TypeKind.Instance(s, generics) => if s == StructOrEnum.Struct(struct) {
         if generics[0] |g1| (if generics[1] |g2| (g1, g2) else None) else None
       } else None
       _ => None
@@ -1406,13 +1388,11 @@ export type Typechecker {
         val ty = match structOrEnum {
           StructOrEnum.Struct(struct) => {
             val typeArgs = struct.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
-
-            Type(kind: TypeKind.Instance(struct, typeArgs))
+            Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
           }
           StructOrEnum.Enum(enum_) => {
             val typeArgs = enum_.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
-
-            Type(kind: TypeKind.EnumInstance(enum_, typeArgs))
+            Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
           }
         }
 
@@ -1672,8 +1652,8 @@ export type Typechecker {
     val staticMethods = _p[2]
 
     val selfInstanceType = match structOrEnum {
-      StructOrEnum.Struct(struct) => Type(kind: TypeKind.Instance(struct, []))
-      StructOrEnum.Enum(enum_) => Type(kind: TypeKind.EnumInstance(enum_, []))
+      StructOrEnum.Struct(struct) => Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), []))
+      StructOrEnum.Enum(enum_) => Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), []))
     }
 
     val instanceMethodsByName = instanceMethods.keyBy(f => f.label)
@@ -2712,40 +2692,33 @@ export type Typechecker {
       TypeKind.PrimitiveString => None // TODO
       TypeKind.Never => None
       TypeKind.Generic => None // TODO
-      TypeKind.Instance(struct, generics) => {
-        for field in struct.fields {
-          if field.name.name == label.name {
-            val resolvedGenerics: Map<String, Type> = {}
-            for name, idx in struct.typeParams {
-              resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "struct.typeParams.length != generics.length")
-            }
-            val ty = field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false)
-            return Result.Ok((AccessorPathSegment.Field(label, field), ty))
-          }
-        }
-
-        for fn in struct.instanceMethods {
-          if fn.label.name == label.name {
-            val resolvedGenerics: Map<String, Type> = {}
-            for name, idx in struct.typeParams {
-              resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "struct.typeParams.length != generics.length")
-            }
-            val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true)
-            return Result.Ok((AccessorPathSegment.Method(label, method), method.getType()))
-          }
-        }
-
-        None
-      }
-      TypeKind.EnumInstance(enum_, generics) => {
-        for fn in enum_.instanceMethods {
-          if fn.label.name == label.name {
-            val resolvedGenerics: Map<String, Type> = {}
-            for name, idx in enum_.typeParams {
-              resolvedGenerics[name] = if generics[idx] |g| g else {
-                println("enum_.typeParams.length != generics.length") // Pseudo-assert
-                break
+      TypeKind.Instance(structOrEnum, generics) => {
+        val _p = match structOrEnum {
+          StructOrEnum.Struct(struct) => {
+            for field in struct.fields {
+              if field.name.name == label.name {
+                val resolvedGenerics: Map<String, Type> = {}
+                for name, idx in struct.typeParams {
+                  resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
+                }
+                val ty = field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false)
+                return Result.Ok((AccessorPathSegment.Field(label, field), ty))
               }
+            }
+
+            (struct.instanceMethods, struct.typeParams)
+          }
+          StructOrEnum.Enum(enum_) => (enum_.instanceMethods, enum_.typeParams)
+        }
+        // TODO: destructuring
+        val instanceMethods = _p[0]
+        val typeParams = _p[1]
+
+        for fn in instanceMethods {
+          if fn.label.name == label.name {
+            val resolvedGenerics: Map<String, Type> = {}
+            for name, idx in typeParams {
+              resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
             }
             val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true)
             return Result.Ok((AccessorPathSegment.Method(label, method), method.getType()))
@@ -2765,7 +2738,7 @@ export type Typechecker {
             for variant in enum_.variants {
               if variant.label.name == label.name {
                 val typeArgs = enum_.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
-                val ty = Type(kind: TypeKind.EnumInstance(enum_, typeArgs))
+                val ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
 
                 match variant.kind {
                   EnumVariantKind.Container => {
@@ -2825,8 +2798,17 @@ export type Typechecker {
         nextTy
       } else {
         val isSpecialCase = match ty.kind {
-          TypeKind.Instance(struct, _) => {
-            val seg = match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Struct(struct))), label) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          TypeKind.Instance(structOrEnum, _) => {
+            val seg = match structOrEnum {
+              StructOrEnum.Struct(struct) => {
+                val seg = match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Struct(struct))), label) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+                seg
+              }
+              StructOrEnum.Enum(enum_) => {
+                val seg = match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))), label) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+                seg
+              }
+            }
             !!seg
           }
           _ => false
@@ -3124,7 +3106,7 @@ export type Typechecker {
     }
 
     val inner = innerType ?: Type(kind: TypeKind.Hole)
-    val ty = Type(kind: TypeKind.Instance(self.project.preludeArrayStruct, [inner]))
+    val ty = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [inner]))
     val innerHasUnfilledHoles = inner.hasUnfilledHoles()
 
     for item in typedItems {
@@ -3171,7 +3153,7 @@ export type Typechecker {
     }
 
     val inner = innerType ?: Type(kind: TypeKind.Hole)
-    val ty = Type(kind: TypeKind.Instance(self.project.preludeSetStruct, [inner]))
+    val ty = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeSetStruct), [inner]))
     val innerHasUnfilledHoles = inner.hasUnfilledHoles()
 
     for item in typedItems {
@@ -3267,7 +3249,7 @@ export type Typechecker {
 
     val kTy = keyTy ?: Type(kind: TypeKind.Hole)
     val vTy = valTy ?: Type(kind: TypeKind.Hole)
-    val ty = Type(kind: TypeKind.Instance(self.project.preludeMapStruct, [kTy, vTy]))
+    val ty = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeMapStruct), [kTy, vTy]))
     val keyTyHasUnfilledHoles = kTy.hasUnfilledHoles()
     val valTyHasUnfilledHoles = vTy.hasUnfilledHoles()
 

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -436,6 +436,7 @@ export enum TypedAstNodeKind {
 }
 
 export enum AccessorPathSegment {
+  EnumVariant(label: Label, enum_: Enum, variant: TypedEnumVariant)
   Method(label: Label, fn: Function)
   Field(label: Label, f: Field)
 }
@@ -563,18 +564,32 @@ type TypeError {
         lines.push("A 'var' must have either an initial value or a type annotation (or both)")
       }
       TypeErrorKind.IllegalValueType(ty, purpose) => {
-        if ty.kind == TypeKind.PrimitiveUnit {
-          lines.push("Forbidden type for $purpose")
-          lines.push(self._getCursorLine(self.position, contents))
-          lines.push("Instances of type ${ty.repr()} cannot be used as $purpose values")
-        } else if ty.kind == TypeKind.Never {
-          lines.push("Forbidden type for $purpose")
-          lines.push(self._getCursorLine(self.position, contents))
-          lines.push("Expression has type ${ty.repr()}, which can never be used for $purpose")
-        } else {
-          lines.push("Could not determine type for $purpose")
-          lines.push(self._getCursorLine(self.position, contents))
-          lines.push("Type '${ty.repr()}' has unfilled holes. Please use an explicit type annotation to denote the type")
+        match ty.kind {
+          TypeKind.PrimitiveUnit => {
+            lines.push("Forbidden type for $purpose")
+            lines.push(self._getCursorLine(self.position, contents))
+            lines.push("Instances of type ${ty.repr()} cannot be used as $purpose values")
+          }
+          TypeKind.Never => {
+            lines.push("Forbidden type for $purpose")
+            lines.push(self._getCursorLine(self.position, contents))
+            lines.push("Expression has type ${ty.repr()}, which can never be used for $purpose")
+          }
+          TypeKind.Type => {
+            lines.push("Forbidden type for $purpose")
+            lines.push(self._getCursorLine(self.position, contents))
+            lines.push("Expression has type ${ty.repr()}, which cannot be used as a value")
+          }
+          TypeKind.EnumInstance => {
+            lines.push("Forbidden type for $purpose")
+            lines.push(self._getCursorLine(self.position, contents))
+            lines.push("This enum variant is non-constant and must be constructed")
+          }
+          _ => {
+            lines.push("Could not determine type for $purpose")
+            lines.push(self._getCursorLine(self.position, contents))
+            lines.push("Type '${ty.repr()}' has unfilled holes. Please use an explicit type annotation to denote the type")
+          }
         }
       }
       TypeErrorKind.IllegalControlFlowType(ty, purpose) => {
@@ -794,6 +809,7 @@ type TypeError {
           IllegalAssignmentReason.ImmutableVariable => lines.push("'$name' is declared as immutable")
           IllegalAssignmentReason.TypeAlias => lines.push("'$name' is a type, which cannot be overwritten")
           IllegalAssignmentReason.FunctionAlias => lines.push("'$name' is a function, which cannot be overwritten")
+          IllegalAssignmentReason.EnumVariant => lines.push("'$name' is an enum variant, which cannot be overwritten")
           IllegalAssignmentReason.Method => lines.push("'$name' is a method, which cannot be overwritten")
           IllegalAssignmentReason.StaticMethod => lines.push("'$name' is a static method, which cannot be overwritten")
         }
@@ -834,6 +850,7 @@ enum IllegalAssignmentReason {
   ImmutableVariable
   TypeAlias
   FunctionAlias
+  EnumVariant
   Method
   StaticMethod
 }
@@ -887,6 +904,8 @@ export type Typechecker {
   currentTypeDecl: StructOrEnum? = None
   currentFunction: Function? = None
   paramDefaultValueContext: ParamDefaultValueContext? = None
+  isStructOrEnumValueAllowed: Bool = false
+  isEnumContainerValueAllowed: Bool = false
 
   func typecheckEntrypoint(self, modulePathAbs: String): Result<Int, TypecheckerError> {
     val mod = TypedModule(id: 0, name: "prelude", code: [], rootScope: self.currentScope.makeChild("module_0", ScopeKind.Module))
@@ -2129,6 +2148,9 @@ export type Typechecker {
         val _p = match typedLhs.kind {
           TypedAstNodeKind.Accessor(head, mid, tail) => {
             val t = match tail {
+              AccessorPathSegment.EnumVariant(label, _, variant) => {
+                return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAssignment("enum variant", variant.label.name, IllegalAssignmentReason.EnumVariant)))
+              }
               AccessorPathSegment.Method(label, fn) => {
                 val _p = if fn.kind == FunctionKind.StaticMethod {
                   ("static method", IllegalAssignmentReason.StaticMethod)
@@ -2438,6 +2460,15 @@ export type Typechecker {
       }
     }
 
+    match typedExpr.ty.kind {
+      TypeKind.Type => {
+        if !self.isStructOrEnumValueAllowed {
+          return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalValueType(typedExpr.ty, "value")))
+        }
+      }
+      _ => {}
+    }
+
     Result.Ok(typedExpr)
   }
 
@@ -2608,8 +2639,8 @@ export type Typechecker {
     Result.Ok(TypedAstNode(token: token, ty: _p[0], kind: TypedAstNodeKind.Identifier(_p[1])))
   }
 
-  func _resolveAccessorPathSegment(self, ty: Type, label: Label): (AccessorPathSegment, Type)? {
-    match ty.kind {
+  func _resolveAccessorPathSegment(self, ty: Type, label: Label): Result<(AccessorPathSegment, Type)?, TypeError> {
+    val foundSegment: (AccessorPathSegment, Type)? = match ty.kind {
       TypeKind.PrimitiveUnit => None
       TypeKind.PrimitiveInt => None // TODO
       TypeKind.PrimitiveFloat => None // TODO
@@ -2622,13 +2653,10 @@ export type Typechecker {
           if field.name.name == label.name {
             val resolvedGenerics: Map<String, Type> = {}
             for name, idx in struct.typeParams {
-              resolvedGenerics[name] = if generics[idx] |g| g else {
-                println("struct.typeParams.length != generics.length") // Pseudo-assert
-                break
-              }
+              resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "struct.typeParams.length != generics.length")
             }
             val ty = field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false)
-            return (AccessorPathSegment.Field(label, field), ty)
+            return Result.Ok((AccessorPathSegment.Field(label, field), ty))
           }
         }
 
@@ -2636,13 +2664,10 @@ export type Typechecker {
           if fn.label.name == label.name {
             val resolvedGenerics: Map<String, Type> = {}
             for name, idx in struct.typeParams {
-              resolvedGenerics[name] = if generics[idx] |g| g else {
-                println("struct.typeParams.length != generics.length") // Pseudo-assert
-                break
-              }
+              resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "struct.typeParams.length != generics.length")
             }
             val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true)
-            return (AccessorPathSegment.Method(label, method), method.getType())
+            return Result.Ok((AccessorPathSegment.Method(label, method), method.getType()))
           }
         }
 
@@ -2659,7 +2684,7 @@ export type Typechecker {
               }
             }
             val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true)
-            return (AccessorPathSegment.Method(label, method), method.getType())
+            return Result.Ok((AccessorPathSegment.Method(label, method), method.getType()))
           }
         }
 
@@ -2672,21 +2697,43 @@ export type Typechecker {
 
         val staticMethods = match structOrEnum {
           StructOrEnum.Struct(struct) => struct.staticMethods
-          StructOrEnum.Enum(enum_) => enum_.staticMethods
+          StructOrEnum.Enum(enum_) => {
+            for variant in enum_.variants {
+              if variant.label.name == label.name {
+                val typeArgs = enum_.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
+                val ty = Type(kind: TypeKind.EnumInstance(enum_, typeArgs))
+
+                match variant.kind {
+                  EnumVariantKind.Container => {
+                    if !self.isEnumContainerValueAllowed return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalValueType(ty, "value")))
+                  }
+                  _ => {}
+                }
+
+                return Result.Ok((AccessorPathSegment.EnumVariant(label, enum_, variant), ty))
+              }
+            }
+
+            enum_.staticMethods
+          }
         }
 
         for method in staticMethods {
-          if method.label.name == label.name return (AccessorPathSegment.Method(label, method), method.getType())
+          if method.label.name == label.name return Result.Ok((AccessorPathSegment.Method(label, method), method.getType()))
         }
 
         None
       }
       TypeKind.Hole => None
     }
+
+    Result.Ok(foundSegment)
   }
 
   func _typecheckAccessor(self, token: Token, node: AccessorAstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
+    self.isStructOrEnumValueAllowed = true
     val typedRoot = match self._typecheckExpression(node.root, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    self.isStructOrEnumValueAllowed = false
 
     val path: AccessorPathSegment[] = []
     var ty = typedRoot.ty
@@ -2700,7 +2747,8 @@ export type Typechecker {
         return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.UnnecessaryOptSafety))
       }
 
-      ty = if self._resolveAccessorPathSegment(ty, label) |_s| {
+      val seg = match self._resolveAccessorPathSegment(ty, label) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      ty = if seg |_s| {
         // TODO: destructuring
         val seg = _s[0]
         val nextTy = _s[1]
@@ -2713,7 +2761,10 @@ export type Typechecker {
         nextTy
       } else {
         val isSpecialCase = match ty.kind {
-          TypeKind.Instance(struct, _) => !!self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Struct(struct))), label)
+          TypeKind.Instance(struct, _) => {
+            val seg = match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Struct(struct))), label) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            !!seg
+          }
           _ => false
         }
 
@@ -2729,7 +2780,11 @@ export type Typechecker {
   }
 
   func _typecheckInvocation(self, token: Token, node: InvocationAstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
+    self.isStructOrEnumValueAllowed = true
+    self.isEnumContainerValueAllowed = true
     val invokee = match self._typecheckExpression(node.invokee, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    self.isEnumContainerValueAllowed = false
+    self.isStructOrEnumValueAllowed = false
 
     match invokee.kind {
       TypedAstNodeKind.Identifier(identKind) => match identKind {
@@ -2747,8 +2802,9 @@ export type Typechecker {
         TypedIdentifierKind.None_ => return Result.Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Hole, nullable: true))))
         TypedIdentifierKind.Discard => return unreachable(invokee.token.position, "resolving '_' should fail before reaching here")
       }
-      TypedAstNodeKind.Accessor(_, _, finalField) => {
-        match finalField {
+      TypedAstNodeKind.Accessor(_, _, tail) => {
+        match tail {
+          AccessorPathSegment.EnumVariant(_, enum_, variant) => return todo(token.position, "invocation of enum variants")
           AccessorPathSegment.Method(_, fn) => self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint)
           AccessorPathSegment.Field(label) => self._typecheckInvocationOfExpression(token, invokee, label.position, node)
         }

--- a/selfhost/src/typechecker_test_utils.abra
+++ b/selfhost/src/typechecker_test_utils.abra
@@ -75,7 +75,7 @@ export type Jsonifier {
         println()
       }
       TypeKind.EnumInstance(enum_, generics) => {
-        self.println("\"kind\": \"instance\",")
+        self.println("\"kind\": \"enumInstance\",")
         self.println("\"enum\": { \"moduleId\": ${enum_.moduleId}, \"name\": \"${enum_.label.name}\" },")
         self.print("\"typeParams\": ")
         self.array(generics, t => self.printType(t))
@@ -297,6 +297,10 @@ export type Jsonifier {
           self.indentInc()
 
           match seg {
+            AccessorPathSegment.EnumVariant(_, enum_, variant) => {
+              self.println("\"kind\": \"enumVariant\",")
+              self.println("\"name\": \"${enum_.label.name}.${variant.label.name}\"")
+            }
             AccessorPathSegment.Method(_, f) => {
               self.println("\"kind\": \"method\",")
               self.println("\"name\": \"${f.label.name}\"")
@@ -315,6 +319,10 @@ export type Jsonifier {
         self.println("\"tail\": {")
         self.indentInc()
         match tail {
+          AccessorPathSegment.EnumVariant(_, enum_, variant) => {
+            self.println("\"kind\": \"enumVariant\",")
+            self.println("\"name\": \"${enum_.label.name}.${variant.label.name}\"")
+          }
           AccessorPathSegment.Method(_, f) => {
             self.println("\"kind\": \"method\",")
             self.println("\"name\": \"${f.label.name}\"")

--- a/selfhost/src/typechecker_test_utils.abra
+++ b/selfhost/src/typechecker_test_utils.abra
@@ -1,6 +1,6 @@
 import printTokenAsJson, printLabelAsJson, printBindingPatternAsJson from "./test_utils"
 import LiteralAstNode, IndexingMode from "./parser"
-import Type, TypeKind, TypedModule, TypedAstNode, TypedAstNodeKind, Variable, Function, Scope, Struct, Enum, StructOrEnum, AccessorPathSegment, TypedIdentifierKind, TypedInvokee, TypedIndexingNode, TypedAssignmentMode from "./typechecker"
+import Type, TypeKind, TypedModule, TypedAstNode, TypedAstNodeKind, Variable, Function, Scope, Struct, Enum, StructOrEnum, AccessorPathSegment, TypedIdentifierKind, TypedInvokee, TypedIndexingNode, TypedAssignmentMode, Field, EnumVariantKind from "./typechecker"
 
 export type Jsonifier {
   indentLevel: Int = 0
@@ -150,25 +150,7 @@ export type Jsonifier {
     println(",")
 
     self.print("\"fields\": ")
-    self.array(struct.fields, f => {
-      println("{")
-      self.indentInc()
-
-      self.print("\"name\": ")
-      printLabelAsJson(f.name)
-      println(",")
-
-      self.print("\"type\": ")
-      self.printType(f.ty)
-      println(",")
-
-      self.print("\"initializer\": ")
-      self.opt(f.initializer, n => self.printNode(n))
-      println()
-
-      self.indentDec()
-      self.print("}")
-    })
+    self.array(struct.fields, f => self.printField(f))
     println(",")
 
     self.print("\"instanceMethods\": ")
@@ -177,6 +159,26 @@ export type Jsonifier {
 
     self.print("\"staticMethods\": ")
     self.array(struct.staticMethods, m => self.printFunc(m))
+    println()
+
+    self.indentDec()
+    self.print("}")
+  }
+
+  func printField(self, field: Field) {
+    println("{")
+    self.indentInc()
+
+    self.print("\"name\": ")
+    printLabelAsJson(field.name)
+    println(",")
+
+    self.print("\"type\": ")
+    self.printType(field.ty)
+    println(",")
+
+    self.print("\"initializer\": ")
+    self.opt(field.initializer, n => self.printNode(n))
     println()
 
     self.indentDec()
@@ -202,7 +204,31 @@ export type Jsonifier {
     self.array(enum_.typeParams, p => print("\"$p\""))
     println(",")
 
-    self.println("\"variants\": [],")
+    self.print("\"variants\": ")
+    self.array(enum_.variants, v => {
+      println("{")
+      self.indentInc()
+
+      self.print("\"label\": ")
+      printLabelAsJson(v.label)
+      println(",")
+
+      match v.kind {
+        EnumVariantKind.Constant => {
+          self.println("\"kind\": \"constant\"")
+        }
+        EnumVariantKind.Container(fields) => {
+          self.println("\"kind\": \"container\",")
+          self.print("\"fields\": ")
+          self.array(fields, f => self.printField(f))
+          println()
+        }
+      }
+
+      self.indentDec()
+      self.print("}")
+    })
+    println(",")
 
     self.print("\"instanceMethods\": ")
     self.array(enum_.instanceMethods, m => self.printFunc(m))
@@ -342,6 +368,7 @@ export type Jsonifier {
         match invokee {
           TypedInvokee.Struct(struct) => self.printStruct(struct: struct, abridged: true)
           TypedInvokee.Expr(expr) => self.printNode(expr)
+          TypedInvokee.EnumVariant(enum_, variant) => print("\"${enum_.label.name}.${variant.label.name}\"")
         }
         println(",")
 

--- a/selfhost/src/typechecker_test_utils.abra
+++ b/selfhost/src/typechecker_test_utils.abra
@@ -67,20 +67,28 @@ export type Jsonifier {
         self.println("\"kind\": \"generic\",")
         self.println("\"name\": \"$name\"")
       }
-      TypeKind.Instance(struct, generics) => {
-        self.println("\"kind\": \"instance\",")
-        self.println("\"struct\": { \"moduleId\": ${struct.moduleId}, \"name\": \"${struct.label.name}\" },")
+      TypeKind.Instance(structOrEnum, generics) => {
+        match structOrEnum {
+          StructOrEnum.Struct(struct) => {
+            self.println("\"kind\": \"instance\",")
+            self.println("\"struct\": { \"moduleId\": ${struct.moduleId}, \"name\": \"${struct.label.name}\" },")
+          }
+          StructOrEnum.Enum(enum_) => {
+            self.println("\"kind\": \"enumInstance\",")
+            self.println("\"enum\": { \"moduleId\": ${enum_.moduleId}, \"name\": \"${enum_.label.name}\" },")
+          }
+        }
         self.print("\"typeParams\": ")
         self.array(generics, t => self.printType(t))
         println()
       }
-      TypeKind.EnumInstance(enum_, generics) => {
-        self.println("\"kind\": \"enumInstance\",")
-        self.println("\"enum\": { \"moduleId\": ${enum_.moduleId}, \"name\": \"${enum_.label.name}\" },")
-        self.print("\"typeParams\": ")
-        self.array(generics, t => self.printType(t))
-        println()
-      }
+      // TypeKind.EnumInstance(enum_, generics) => {
+      //   self.println("\"kind\": \"enumInstance\",")
+      //   self.println("\"enum\": { \"moduleId\": ${enum_.moduleId}, \"name\": \"${enum_.label.name}\" },")
+      //   self.print("\"typeParams\": ")
+      //   self.array(generics, t => self.printType(t))
+      //   println()
+      // }
       TypeKind.Tuple(types) => {
         self.println("\"kind\": \"tuple\",")
         self.print("\"types\": ")

--- a/selfhost/src/typechecker_test_utils.abra
+++ b/selfhost/src/typechecker_test_utils.abra
@@ -1,6 +1,6 @@
 import printTokenAsJson, printLabelAsJson, printBindingPatternAsJson from "./test_utils"
 import LiteralAstNode, IndexingMode from "./parser"
-import Type, TypeKind, TypedModule, TypedAstNode, TypedAstNodeKind, Variable, Function, Scope, Struct, AccessorPathSegment, TypedIdentifierKind, TypedInvokee, TypedIndexingNode, TypedAssignmentMode from "./typechecker"
+import Type, TypeKind, TypedModule, TypedAstNode, TypedAstNodeKind, Variable, Function, Scope, Struct, Enum, StructOrEnum, AccessorPathSegment, TypedIdentifierKind, TypedInvokee, TypedIndexingNode, TypedAssignmentMode from "./typechecker"
 
 export type Jsonifier {
   indentLevel: Int = 0
@@ -74,6 +74,13 @@ export type Jsonifier {
         self.array(generics, t => self.printType(t))
         println()
       }
+      TypeKind.EnumInstance(enum_, generics) => {
+        self.println("\"kind\": \"instance\",")
+        self.println("\"enum\": { \"moduleId\": ${enum_.moduleId}, \"name\": \"${enum_.label.name}\" },")
+        self.print("\"typeParams\": ")
+        self.array(generics, t => self.printType(t))
+        println()
+      }
       TypeKind.Tuple(types) => {
         self.println("\"kind\": \"tuple\",")
         self.print("\"types\": ")
@@ -101,10 +108,19 @@ export type Jsonifier {
         self.printType(ret)
         println()
       }
-      TypeKind.Struct(struct) => {
-        self.println("\"kind\": \"struct\",")
-        self.print("\"struct\": ")
-        self.printStruct(struct: struct, abridged: true)
+      TypeKind.Type(structOrEnum) => {
+        match structOrEnum {
+          StructOrEnum.Struct(struct) => {
+            self.println("\"kind\": \"struct\",")
+            self.print("\"struct\": ")
+            self.printStruct(struct: struct, abridged: true)
+          }
+          StructOrEnum.Enum(enum_) => {
+            self.println("\"kind\": \"enum\",")
+            self.print("\"enum\": ")
+            self.printEnum(enum_: enum_, abridged: true)
+          }
+        }
         println()
       }
       TypeKind.Hole => self.println("\"kind\": \"hole\"")
@@ -161,6 +177,39 @@ export type Jsonifier {
 
     self.print("\"staticMethods\": ")
     self.array(struct.staticMethods, m => self.printFunc(m))
+    println()
+
+    self.indentDec()
+    self.print("}")
+  }
+
+  func printEnum(self, enum_: Enum, abridged: Bool) {
+    if abridged {
+      print("{ \"moduleId\": ${enum_.moduleId}, \"name\": \"${enum_.label.name}\" }")
+      return
+    }
+
+    println("{")
+    self.indentInc()
+
+    self.println("\"moduleId\": ${enum_.moduleId},")
+
+    self.print("\"name\": ")
+    printLabelAsJson(enum_.label)
+    println(",")
+
+    self.print("\"typeParams\": ")
+    self.array(enum_.typeParams, p => print("\"$p\""))
+    println(",")
+
+    self.println("\"variants\": [],")
+
+    self.print("\"instanceMethods\": ")
+    self.array(enum_.instanceMethods, m => self.printFunc(m))
+    println(",")
+
+    self.print("\"staticMethods\": ")
+    self.array(enum_.staticMethods, m => self.printFunc(m))
     println()
 
     self.indentDec()
@@ -490,6 +539,12 @@ export type Jsonifier {
         self.println("\"kind\": \"typeDeclaration\",")
         self.print("\"struct\": ")
         self.printStruct(struct: struct, abridged: false)
+        println()
+      }
+      TypedAstNodeKind.EnumDeclaration(enum_) => {
+        self.println("\"kind\": \"enumDeclaration\",")
+        self.print("\"enum\": ")
+        self.printEnum(enum_: enum_, abridged: false)
         println()
       }
       TypedAstNodeKind.Break => {

--- a/selfhost/test/typechecker/accessor/accessor.4.abra
+++ b/selfhost/test/typechecker/accessor/accessor.4.abra
@@ -1,0 +1,3 @@
+enum Foo { Bar }
+
+val f = Foo.Bar

--- a/selfhost/test/typechecker/accessor/accessor.4.out.json
+++ b/selfhost/test/typechecker/accessor/accessor.4.out.json
@@ -90,103 +90,17 @@
                 "primitive": "Bool"
               },
               "body": []
-            },
-            {
-              "label": { "name": "foo", "position": [6, 8] },
-              "scope": {
-                "name": "$root::module_1::Foo::foo",
-                "variables": [
-                  {
-                    "label": { "name": "self", "position": [6, 12] },
-                    "mutable": false,
-                    "type": {
-                      "nullable": false,
-                      "kind": "enumInstance",
-                      "enum": { "moduleId": 1, "name": "Foo" },
-                      "typeParams": []
-                    }
-                  }
-                ],
-                "functions": [],
-                "types": []
-              },
-              "kind": "FunctionKind.InstanceMethod",
-              "typeParameters": [],
-              "parameters": [],
-              "returnType": {
-                "nullable": false,
-                "kind": "primitive",
-                "primitive": "Int"
-              },
-              "body": [
-                {
-                  "token": {
-                    "position": [6, 25],
-                    "kind": {
-                      "name": "Int",
-                      "value": 123
-                    }
-                  },
-                  "type": {
-                    "nullable": false,
-                    "kind": "primitive",
-                    "primitive": "Int"
-                  },
-                  "node": {
-                    "kind": "literal",
-                    "value": 123
-                  }
-                }
-              ]
             }
           ],
-          "staticMethods": [
-            {
-              "label": { "name": "fooStatic", "position": [7, 8] },
-              "scope": {
-                "name": "$root::module_1::Foo::fooStatic",
-                "variables": [],
-                "functions": [],
-                "types": []
-              },
-              "kind": "FunctionKind.StaticMethod",
-              "typeParameters": [],
-              "parameters": [],
-              "returnType": {
-                "nullable": false,
-                "kind": "primitive",
-                "primitive": "Int"
-              },
-              "body": [
-                {
-                  "token": {
-                    "position": [7, 27],
-                    "kind": {
-                      "name": "Int",
-                      "value": 123
-                    }
-                  },
-                  "type": {
-                    "nullable": false,
-                    "kind": "primitive",
-                    "primitive": "Int"
-                  },
-                  "node": {
-                    "kind": "literal",
-                    "value": 123
-                  }
-                }
-              ]
-            }
-          ]
+          "staticMethods": []
         }
       }
     },
     {
       "token": {
-        "position": [10, 1],
+        "position": [3, 1],
         "kind": {
-          "name": "Var"
+          "name": "Val"
         }
       },
       "type": {
@@ -198,12 +112,12 @@
         "kind": "bindingDeclaration",
         "pattern": {
           "kind": "variable",
-          "label": { "name": "f", "position": [10, 5] }
+          "label": { "name": "f", "position": [3, 5] }
         },
         "variables": [
           {
-            "label": { "name": "f", "position": [10, 5] },
-            "mutable": true,
+            "label": { "name": "f", "position": [3, 5] },
+            "mutable": false,
             "type": {
               "nullable": false,
               "kind": "enumInstance",
@@ -212,7 +126,46 @@
             }
           }
         ],
-        "expr": null
+        "expr": {
+          "token": {
+            "position": [3, 12],
+            "kind": {
+              "name": "Dot"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "enumInstance",
+            "enum": { "moduleId": 1, "name": "Foo" },
+            "typeParams": []
+          },
+          "node": {
+            "kind": "accessor",
+            "head": {
+              "token": {
+                "position": [3, 9],
+                "kind": {
+                  "name": "Ident",
+                  "value": "Foo"
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "enum",
+                "enum": { "moduleId": 1, "name": "Foo" }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "Foo"
+              }
+            },
+            "middle": [],
+            "tail": {
+              "kind": "enumVariant",
+              "name": "Foo.Bar"
+            }
+          }
+        }
       }
     }
   ]

--- a/selfhost/test/typechecker/accessor/error_unknown_enum_variant.1.abra
+++ b/selfhost/test/typechecker/accessor/error_unknown_enum_variant.1.abra
@@ -1,0 +1,3 @@
+enum Foo { Bar }
+
+val f = Foo.Baz

--- a/selfhost/test/typechecker/accessor/error_unknown_enum_variant.1.out
+++ b/selfhost/test/typechecker/accessor/error_unknown_enum_variant.1.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:3:13
+Unknown field 'Baz'
+  |  val f = Foo.Baz
+                 ^
+No field 'Baz' found on type <#enum Foo>

--- a/selfhost/test/typechecker/assignment/accessor_error_enum_variant.abra
+++ b/selfhost/test/typechecker/assignment/accessor_error_enum_variant.abra
@@ -1,0 +1,5 @@
+enum Foo {
+  Bar
+}
+
+Foo.Bar = "abcd"

--- a/selfhost/test/typechecker/assignment/accessor_error_enum_variant.out
+++ b/selfhost/test/typechecker/assignment/accessor_error_enum_variant.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:5:5
+Cannot assign to enum variant 'Bar'
+  |  Foo.Bar = "abcd"
+         ^
+'Bar' is an enum variant, which cannot be overwritten

--- a/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_enum.abra
+++ b/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_enum.abra
@@ -1,0 +1,3 @@
+enum Foo {}
+
+val f = Foo

--- a/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_enum.out
+++ b/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_enum.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:3:9
+Forbidden type for value
+  |  val f = Foo
+             ^
+Expression has type <#enum Foo>, which cannot be used as a value

--- a/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_enum_container_variant.abra
+++ b/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_enum_container_variant.abra
@@ -1,0 +1,5 @@
+enum Foo {
+  Bar(a: Int)
+}
+
+val f = Foo.Bar

--- a/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_enum_container_variant.out
+++ b/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_enum_container_variant.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:5:13
+Forbidden type for value
+  |  val f = Foo.Bar
+                 ^
+This enum variant is non-constant and must be constructed

--- a/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_type.abra
+++ b/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_type.abra
@@ -1,0 +1,3 @@
+type Foo {}
+
+val f = Foo

--- a/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_type.out
+++ b/selfhost/test/typechecker/bindingdecl/error_illegal_value_type_type.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:3:9
+Forbidden type for value
+  |  val f = Foo
+             ^
+Expression has type <#type Foo>, which cannot be used as a value

--- a/selfhost/test/typechecker/enumdecl/enumdecl.1.abra
+++ b/selfhost/test/typechecker/enumdecl/enumdecl.1.abra
@@ -1,0 +1,10 @@
+enum Foo {
+  Bar
+  Baz(a: Int)
+  Qux(a: Int, b: String = "abcd")
+
+  func foo(self): Int = 123
+  func fooStatic(): Int = 123
+}
+
+var f: Foo

--- a/selfhost/test/typechecker/enumdecl/enumdecl.1.out.json
+++ b/selfhost/test/typechecker/enumdecl/enumdecl.1.out.json
@@ -20,7 +20,68 @@
           "moduleId": 1,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
-          "variants": [],
+          "variants": [
+            {
+              "label": { "name": "Bar", "position": [2, 3] },
+              "kind": "constant"
+            },
+            {
+              "label": { "name": "Baz", "position": [3, 3] },
+              "kind": "container",
+              "fields": [
+                {
+                  "name": { "name": "a", "position": [3, 7] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "initializer": null
+                }
+              ]
+            },
+            {
+              "label": { "name": "Qux", "position": [4, 3] },
+              "kind": "container",
+              "fields": [
+                {
+                  "name": { "name": "a", "position": [4, 7] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "initializer": null
+                },
+                {
+                  "name": { "name": "b", "position": [4, 15] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "String"
+                  },
+                  "initializer": {
+                    "token": {
+                      "position": [4, 27],
+                      "kind": {
+                        "name": "String",
+                        "value": "abcd"
+                      }
+                    },
+                    "type": {
+                      "nullable": false,
+                      "kind": "primitive",
+                      "primitive": "String"
+                    },
+                    "node": {
+                      "kind": "literal",
+                      "value": "abcd"
+                    }
+                  }
+                }
+              ]
+            }
+          ],
           "instanceMethods": [
             {
               "label": { "name": "toString", "position": [0, 0] },

--- a/selfhost/test/typechecker/enumdecl/enumdecl.1.out.json
+++ b/selfhost/test/typechecker/enumdecl/enumdecl.1.out.json
@@ -1,0 +1,219 @@
+{
+  "id": 1,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "Enum"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "enumDeclaration",
+        "enum": {
+          "moduleId": 1,
+          "name": { "name": "Foo", "position": [1, 6] },
+          "typeParams": [],
+          "variants": [],
+          "instanceMethods": [
+            {
+              "label": { "name": "toString", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo::toString",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "String"
+              },
+              "body": []
+            },
+            {
+              "label": { "name": "hash", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo::hash",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "body": []
+            },
+            {
+              "label": { "name": "eq", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo::eq",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [
+                {
+                  "label": { "name": "other", "position": [0, 0] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "instance",
+                    "enum": { "moduleId": 1, "name": "Foo" },
+                    "typeParams": []
+                  },
+                  "defaultValue": null,
+                  "isVariadic": false
+                }
+              ],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "body": []
+            },
+            {
+              "label": { "name": "foo", "position": [6, 8] },
+              "scope": {
+                "name": "$root::module_1::Foo::foo",
+                "variables": [
+                  {
+                    "label": { "name": "self", "position": [6, 12] },
+                    "mutable": false,
+                    "type": {
+                      "nullable": false,
+                      "kind": "instance",
+                      "enum": { "moduleId": 1, "name": "Foo" },
+                      "typeParams": []
+                    }
+                  }
+                ],
+                "functions": [],
+                "types": []
+              },
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "body": [
+                {
+                  "token": {
+                    "position": [6, 25],
+                    "kind": {
+                      "name": "Int",
+                      "value": 123
+                    }
+                  },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": 123
+                  }
+                }
+              ]
+            }
+          ],
+          "staticMethods": [
+            {
+              "label": { "name": "fooStatic", "position": [7, 8] },
+              "scope": {
+                "name": "$root::module_1::Foo::fooStatic",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "kind": "FunctionKind.StaticMethod",
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "body": [
+                {
+                  "token": {
+                    "position": [7, 27],
+                    "kind": {
+                      "name": "Int",
+                      "value": 123
+                    }
+                  },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": 123
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [10, 1],
+        "kind": {
+          "name": "Var"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "f", "position": [10, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "f", "position": [10, 5] },
+            "mutable": true,
+            "type": {
+              "nullable": false,
+              "kind": "instance",
+              "enum": { "moduleId": 1, "name": "Foo" },
+              "typeParams": []
+            }
+          }
+        ],
+        "expr": null
+      }
+    }
+  ]
+}

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_enum_enum.abra
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_enum_enum.abra
@@ -1,0 +1,2 @@
+enum Foo { Bar }
+enum Foo { Baz }

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_enum_enum.out
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_enum_enum.out
@@ -1,0 +1,7 @@
+Error at %FILE_NAME%:2:6
+Duplicate name 'Foo'
+  |  enum Foo { Baz }
+          ^
+This name is also declared at (1:6)
+  |  enum Foo { Bar }
+          ^

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_enum_func.abra
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_enum_func.abra
@@ -1,0 +1,3 @@
+enum Foo { Bar }
+
+func Foo() {}

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_enum_func.out
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_enum_func.out
@@ -1,0 +1,7 @@
+Error at %FILE_NAME%:3:6
+Duplicate name 'Foo'
+  |  func Foo() {}
+          ^
+This name is also declared at (1:6)
+  |  enum Foo { Bar }
+          ^

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_enum_type.abra
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_enum_type.abra
@@ -1,0 +1,2 @@
+enum Foo { Bar }
+type Foo { b: String }

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_enum_type.out
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_enum_type.out
@@ -1,0 +1,7 @@
+Error at %FILE_NAME%:1:6
+Duplicate name 'Foo'
+  |  enum Foo { Bar }
+          ^
+This name is also declared at (2:6)
+  |  type Foo { b: String }
+          ^

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_variant.abra
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_variant.abra
@@ -1,0 +1,5 @@
+enum Foo {
+  Bar
+  Baz
+  Bar
+}

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_variant.out
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_variant.out
@@ -1,0 +1,7 @@
+Error at %FILE_NAME%:4:3
+Duplicate name 'Bar'
+  |    Bar
+       ^
+This name is also declared at (2:3)
+  |    Bar
+       ^

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_variant_field.abra
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_variant_field.abra
@@ -1,0 +1,3 @@
+enum Foo {
+  Bar(a: Int, b: String, b: Int)
+}

--- a/selfhost/test/typechecker/enumdecl/error_duplicate_variant_field.out
+++ b/selfhost/test/typechecker/enumdecl/error_duplicate_variant_field.out
@@ -1,0 +1,7 @@
+Error at %FILE_NAME%:2:26
+Duplicate name 'b'
+  |    Bar(a: Int, b: String, b: Int)
+                              ^
+This name is also declared at (2:15)
+  |    Bar(a: Int, b: String, b: Int)
+                   ^

--- a/selfhost/test/typechecker/enumdecl/error_invalid_eq_signature.1.abra
+++ b/selfhost/test/typechecker/enumdecl/error_invalid_eq_signature.1.abra
@@ -1,0 +1,3 @@
+enum Foo {
+  func eq(self, other: String): Bool {}
+}

--- a/selfhost/test/typechecker/enumdecl/error_invalid_eq_signature.1.out
+++ b/selfhost/test/typechecker/enumdecl/error_invalid_eq_signature.1.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:2:8
+Invalid signature for method 'eq'
+  |    func eq(self, other: String): Bool {}
+            ^

--- a/selfhost/test/typechecker/enumdecl/error_invalid_eq_signature.2.abra
+++ b/selfhost/test/typechecker/enumdecl/error_invalid_eq_signature.2.abra
@@ -1,0 +1,3 @@
+type Foo {
+  func eq(self, other: Foo): Int {}
+}

--- a/selfhost/test/typechecker/enumdecl/error_invalid_eq_signature.2.out
+++ b/selfhost/test/typechecker/enumdecl/error_invalid_eq_signature.2.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:2:8
+Invalid signature for method 'eq'
+  |    func eq(self, other: Foo): Int {}
+            ^

--- a/selfhost/test/typechecker/enumdecl/error_invalid_hash_signature.abra
+++ b/selfhost/test/typechecker/enumdecl/error_invalid_hash_signature.abra
@@ -1,0 +1,3 @@
+type Foo {
+  func hash(self): Bool {}
+}

--- a/selfhost/test/typechecker/enumdecl/error_invalid_hash_signature.out
+++ b/selfhost/test/typechecker/enumdecl/error_invalid_hash_signature.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:2:8
+Invalid signature for method 'hash'
+  |    func hash(self): Bool {}
+            ^

--- a/selfhost/test/typechecker/enumdecl/error_invalid_tostring_signature.abra
+++ b/selfhost/test/typechecker/enumdecl/error_invalid_tostring_signature.abra
@@ -1,0 +1,3 @@
+type Foo {
+  func toString(self) {}
+}

--- a/selfhost/test/typechecker/enumdecl/error_invalid_tostring_signature.out
+++ b/selfhost/test/typechecker/enumdecl/error_invalid_tostring_signature.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:2:8
+Invalid signature for method 'toString'
+  |    func toString(self) {}
+            ^

--- a/selfhost/test/typechecker/enumdecl/error_method_bad_self_position.abra
+++ b/selfhost/test/typechecker/enumdecl/error_method_bad_self_position.abra
@@ -1,0 +1,6 @@
+enum Foo {
+  Bar
+  Baz
+
+  func foo(a: Int, self, b: Int): Int = a + b
+}

--- a/selfhost/test/typechecker/enumdecl/error_method_bad_self_position.out
+++ b/selfhost/test/typechecker/enumdecl/error_method_bad_self_position.out
@@ -1,0 +1,4 @@
+Error at %FILE_NAME%:5:20
+Unexpected token 'self', expected 'identifier':
+  |    func foo(a: Int, self, b: Int): Int = a + b
+                        ^

--- a/selfhost/test/typechecker/enumdecl/error_variant_field_initializer_type_mismatch.abra
+++ b/selfhost/test/typechecker/enumdecl/error_variant_field_initializer_type_mismatch.abra
@@ -1,0 +1,3 @@
+enum Foo {
+  Bar(a: Int = "abc")
+}

--- a/selfhost/test/typechecker/enumdecl/error_variant_field_initializer_type_mismatch.out
+++ b/selfhost/test/typechecker/enumdecl/error_variant_field_initializer_type_mismatch.out
@@ -1,0 +1,6 @@
+Error at %FILE_NAME%:2:16
+Type mismatch
+  |    Bar(a: Int = "abc")
+                    ^
+Expected: Int
+but instead found: String

--- a/selfhost/test/typechecker/if/expr.abra
+++ b/selfhost/test/typechecker/if/expr.abra
@@ -52,3 +52,11 @@ val _: Int = i
 val j_: Int? = 123
 val j = if j_ |j| { j } else 0
 val _: Int = j
+
+type Foo1 { a: Int }
+val k = if true Foo1(a: 1) else Foo1(a: 2)
+val _: Foo1 = k
+
+enum Foo2 { Bar, Baz }
+val l = if true Foo2.Bar else Foo2.Baz
+val _: Foo2 = l

--- a/selfhost/test/typechecker/if/expr.out.json
+++ b/selfhost/test/typechecker/if/expr.out.json
@@ -2508,7 +2508,16 @@
           "moduleId": 1,
           "name": { "name": "Foo2", "position": [60, 6] },
           "typeParams": [],
-          "variants": [],
+          "variants": [
+            {
+              "label": { "name": "Bar", "position": [60, 13] },
+              "kind": "constant"
+            },
+            {
+              "label": { "name": "Baz", "position": [60, 18] },
+              "kind": "constant"
+            }
+          ],
           "instanceMethods": [
             {
               "label": { "name": "toString", "position": [0, 0] },

--- a/selfhost/test/typechecker/if/expr.out.json
+++ b/selfhost/test/typechecker/if/expr.out.json
@@ -2185,6 +2185,608 @@
           }
         }
       }
+    },
+    {
+      "token": {
+        "position": [56, 1],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "typeDeclaration",
+        "struct": {
+          "moduleId": 1,
+          "name": { "name": "Foo1", "position": [56, 6] },
+          "typeParams": [],
+          "fields": [
+            {
+              "name": { "name": "a", "position": [56, 13] },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "initializer": null
+            }
+          ],
+          "instanceMethods": [
+            {
+              "label": { "name": "toString", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo1::toString",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "String"
+              },
+              "body": []
+            },
+            {
+              "label": { "name": "hash", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo1::hash",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "body": []
+            },
+            {
+              "label": { "name": "eq", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo1::eq",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [
+                {
+                  "label": { "name": "other", "position": [0, 0] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "instance",
+                    "struct": { "moduleId": 1, "name": "Foo1" },
+                    "typeParams": []
+                  },
+                  "defaultValue": null,
+                  "isVariadic": false
+                }
+              ],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "body": []
+            }
+          ],
+          "staticMethods": []
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [57, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "k", "position": [57, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "k", "position": [57, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "instance",
+              "struct": { "moduleId": 1, "name": "Foo1" },
+              "typeParams": []
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [57, 9],
+            "kind": {
+              "name": "If"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "instance",
+            "struct": { "moduleId": 1, "name": "Foo1" },
+            "typeParams": []
+          },
+          "node": {
+            "kind": "if",
+            "isStatement": false,
+            "condition": {
+              "token": {
+                "position": [57, 12],
+                "kind": {
+                  "name": "Bool",
+                  "value": true
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "node": {
+                "kind": "literal",
+                "value": true
+              }
+            },
+            "conditionBindingPattern": null,
+            "ifBlock": [
+              {
+                "token": {
+                  "position": [57, 21],
+                  "kind": {
+                    "name": "LParen"
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "instance",
+                  "struct": { "moduleId": 1, "name": "Foo1" },
+                  "typeParams": []
+                },
+                "node": {
+                  "kind": "invocation",
+                  "invokee": { "moduleId": 1, "name": "Foo1" },
+                  "arguments": [
+                    {
+                      "token": {
+                        "position": [57, 25],
+                        "kind": {
+                          "name": "Int",
+                          "value": 1
+                        }
+                      },
+                      "type": {
+                        "nullable": false,
+                        "kind": "primitive",
+                        "primitive": "Int"
+                      },
+                      "node": {
+                        "kind": "literal",
+                        "value": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "elseBlock": [
+              {
+                "token": {
+                  "position": [57, 37],
+                  "kind": {
+                    "name": "LParen"
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "instance",
+                  "struct": { "moduleId": 1, "name": "Foo1" },
+                  "typeParams": []
+                },
+                "node": {
+                  "kind": "invocation",
+                  "invokee": { "moduleId": 1, "name": "Foo1" },
+                  "arguments": [
+                    {
+                      "token": {
+                        "position": [57, 41],
+                        "kind": {
+                          "name": "Int",
+                          "value": 2
+                        }
+                      },
+                      "type": {
+                        "nullable": false,
+                        "kind": "primitive",
+                        "primitive": "Int"
+                      },
+                      "node": {
+                        "kind": "literal",
+                        "value": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [58, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [58, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [58, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "instance",
+              "struct": { "moduleId": 1, "name": "Foo1" },
+              "typeParams": []
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [58, 15],
+            "kind": {
+              "name": "Ident",
+              "value": "k"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "instance",
+            "struct": { "moduleId": 1, "name": "Foo1" },
+            "typeParams": []
+          },
+          "node": {
+            "kind": "identifier",
+            "name": "k"
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [60, 1],
+        "kind": {
+          "name": "Enum"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "enumDeclaration",
+        "enum": {
+          "moduleId": 1,
+          "name": { "name": "Foo2", "position": [60, 6] },
+          "typeParams": [],
+          "variants": [],
+          "instanceMethods": [
+            {
+              "label": { "name": "toString", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo2::toString",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "String"
+              },
+              "body": []
+            },
+            {
+              "label": { "name": "hash", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo2::hash",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "body": []
+            },
+            {
+              "label": { "name": "eq", "position": [0, 0] },
+              "scope": {
+                "name": "$root::module_1::Foo2::eq",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "isGenerated": true,
+              "kind": "FunctionKind.InstanceMethod",
+              "typeParameters": [],
+              "parameters": [
+                {
+                  "label": { "name": "other", "position": [0, 0] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "enumInstance",
+                    "enum": { "moduleId": 1, "name": "Foo2" },
+                    "typeParams": []
+                  },
+                  "defaultValue": null,
+                  "isVariadic": false
+                }
+              ],
+              "returnType": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "body": []
+            }
+          ],
+          "staticMethods": []
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [61, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "l", "position": [61, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "l", "position": [61, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "enumInstance",
+              "enum": { "moduleId": 1, "name": "Foo2" },
+              "typeParams": []
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [61, 9],
+            "kind": {
+              "name": "If"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "enumInstance",
+            "enum": { "moduleId": 1, "name": "Foo2" },
+            "typeParams": []
+          },
+          "node": {
+            "kind": "if",
+            "isStatement": false,
+            "condition": {
+              "token": {
+                "position": [61, 12],
+                "kind": {
+                  "name": "Bool",
+                  "value": true
+                }
+              },
+              "type": {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "node": {
+                "kind": "literal",
+                "value": true
+              }
+            },
+            "conditionBindingPattern": null,
+            "ifBlock": [
+              {
+                "token": {
+                  "position": [61, 21],
+                  "kind": {
+                    "name": "Dot"
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "enumInstance",
+                  "enum": { "moduleId": 1, "name": "Foo2" },
+                  "typeParams": []
+                },
+                "node": {
+                  "kind": "accessor",
+                  "head": {
+                    "token": {
+                      "position": [61, 17],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "Foo2"
+                      }
+                    },
+                    "type": {
+                      "nullable": false,
+                      "kind": "enum",
+                      "enum": { "moduleId": 1, "name": "Foo2" }
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "Foo2"
+                    }
+                  },
+                  "middle": [],
+                  "tail": {
+                    "kind": "enumVariant",
+                    "name": "Foo2.Bar"
+                  }
+                }
+              }
+            ],
+            "elseBlock": [
+              {
+                "token": {
+                  "position": [61, 35],
+                  "kind": {
+                    "name": "Dot"
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "enumInstance",
+                  "enum": { "moduleId": 1, "name": "Foo2" },
+                  "typeParams": []
+                },
+                "node": {
+                  "kind": "accessor",
+                  "head": {
+                    "token": {
+                      "position": [61, 31],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "Foo2"
+                      }
+                    },
+                    "type": {
+                      "nullable": false,
+                      "kind": "enum",
+                      "enum": { "moduleId": 1, "name": "Foo2" }
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "Foo2"
+                    }
+                  },
+                  "middle": [],
+                  "tail": {
+                    "kind": "enumVariant",
+                    "name": "Foo2.Baz"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [62, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [62, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [62, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "enumInstance",
+              "enum": { "moduleId": 1, "name": "Foo2" },
+              "typeParams": []
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [62, 15],
+            "kind": {
+              "name": "Ident",
+              "value": "l"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "enumInstance",
+            "enum": { "moduleId": 1, "name": "Foo2" },
+            "typeParams": []
+          },
+          "node": {
+            "kind": "identifier",
+            "name": "l"
+          }
+        }
+      }
     }
   ]
 }

--- a/selfhost/test/typechecker/invocation/error_enum_variant_constant.abra
+++ b/selfhost/test/typechecker/invocation/error_enum_variant_constant.abra
@@ -1,0 +1,5 @@
+enum Foo {
+  Bar
+}
+
+val f = Foo.Bar()

--- a/selfhost/test/typechecker/invocation/error_enum_variant_constant.out
+++ b/selfhost/test/typechecker/invocation/error_enum_variant_constant.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:5:13
+Cannot invoke target as function
+  |  val f = Foo.Bar()
+                 ^
+This is a constant enum variant, and it accepts no arguments

--- a/selfhost/test/typechecker/invocation/invocation_enum_variant.1.abra
+++ b/selfhost/test/typechecker/invocation/invocation_enum_variant.1.abra
@@ -1,0 +1,6 @@
+enum Foo {
+  Bar
+  Baz(a: Int, b: String)
+}
+
+val f = Foo.Baz(a: 123, b: "abc")

--- a/selfhost/test/typechecker/invocation/invocation_enum_variant.1.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_enum_variant.1.out.json
@@ -22,8 +22,32 @@
           "typeParams": [],
           "variants": [
             {
-              "label": { "name": "Bar", "position": [1, 12] },
+              "label": { "name": "Bar", "position": [2, 3] },
               "kind": "constant"
+            },
+            {
+              "label": { "name": "Baz", "position": [3, 3] },
+              "kind": "container",
+              "fields": [
+                {
+                  "name": { "name": "a", "position": [3, 7] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "initializer": null
+                },
+                {
+                  "name": { "name": "b", "position": [3, 15] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "String"
+                  },
+                  "initializer": null
+                }
+              ]
             }
           ],
           "instanceMethods": [
@@ -103,7 +127,7 @@
     },
     {
       "token": {
-        "position": [3, 1],
+        "position": [6, 1],
         "kind": {
           "name": "Val"
         }
@@ -117,11 +141,11 @@
         "kind": "bindingDeclaration",
         "pattern": {
           "kind": "variable",
-          "label": { "name": "f", "position": [3, 5] }
+          "label": { "name": "f", "position": [6, 5] }
         },
         "variables": [
           {
-            "label": { "name": "f", "position": [3, 5] },
+            "label": { "name": "f", "position": [6, 5] },
             "mutable": false,
             "type": {
               "nullable": false,
@@ -133,9 +157,9 @@
         ],
         "expr": {
           "token": {
-            "position": [3, 12],
+            "position": [6, 16],
             "kind": {
-              "name": "Dot"
+              "name": "LParen"
             }
           },
           "type": {
@@ -145,30 +169,46 @@
             "typeParams": []
           },
           "node": {
-            "kind": "accessor",
-            "head": {
-              "token": {
-                "position": [3, 9],
-                "kind": {
-                  "name": "Ident",
-                  "value": "Foo"
+            "kind": "invocation",
+            "invokee": "Foo.Baz",
+            "arguments": [
+              {
+                "token": {
+                  "position": [6, 20],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
                 }
               },
-              "type": {
-                "nullable": false,
-                "kind": "enum",
-                "enum": { "moduleId": 1, "name": "Foo" }
-              },
-              "node": {
-                "kind": "identifier",
-                "name": "Foo"
+              {
+                "token": {
+                  "position": [6, 28],
+                  "kind": {
+                    "name": "String",
+                    "value": "abc"
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": "abc"
+                }
               }
-            },
-            "middle": [],
-            "tail": {
-              "kind": "enumVariant",
-              "name": "Foo.Bar"
-            }
+            ]
           }
         }
       }

--- a/selfhost/test/typechecker/invocation/invocation_enum_variant.2.abra
+++ b/selfhost/test/typechecker/invocation/invocation_enum_variant.2.abra
@@ -1,0 +1,5 @@
+enum Foo {
+  Bar(a: Int, b: String = "abc")
+}
+
+val f = Foo.Bar(a: 123)

--- a/selfhost/test/typechecker/invocation/invocation_enum_variant.2.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_enum_variant.2.out.json
@@ -22,8 +22,45 @@
           "typeParams": [],
           "variants": [
             {
-              "label": { "name": "Bar", "position": [1, 12] },
-              "kind": "constant"
+              "label": { "name": "Bar", "position": [2, 3] },
+              "kind": "container",
+              "fields": [
+                {
+                  "name": { "name": "a", "position": [2, 7] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "initializer": null
+                },
+                {
+                  "name": { "name": "b", "position": [2, 15] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "primitive",
+                    "primitive": "String"
+                  },
+                  "initializer": {
+                    "token": {
+                      "position": [2, 27],
+                      "kind": {
+                        "name": "String",
+                        "value": "abc"
+                      }
+                    },
+                    "type": {
+                      "nullable": false,
+                      "kind": "primitive",
+                      "primitive": "String"
+                    },
+                    "node": {
+                      "kind": "literal",
+                      "value": "abc"
+                    }
+                  }
+                }
+              ]
             }
           ],
           "instanceMethods": [
@@ -103,7 +140,7 @@
     },
     {
       "token": {
-        "position": [3, 1],
+        "position": [5, 1],
         "kind": {
           "name": "Val"
         }
@@ -117,11 +154,11 @@
         "kind": "bindingDeclaration",
         "pattern": {
           "kind": "variable",
-          "label": { "name": "f", "position": [3, 5] }
+          "label": { "name": "f", "position": [5, 5] }
         },
         "variables": [
           {
-            "label": { "name": "f", "position": [3, 5] },
+            "label": { "name": "f", "position": [5, 5] },
             "mutable": false,
             "type": {
               "nullable": false,
@@ -133,9 +170,9 @@
         ],
         "expr": {
           "token": {
-            "position": [3, 12],
+            "position": [5, 16],
             "kind": {
-              "name": "Dot"
+              "name": "LParen"
             }
           },
           "type": {
@@ -145,30 +182,29 @@
             "typeParams": []
           },
           "node": {
-            "kind": "accessor",
-            "head": {
-              "token": {
-                "position": [3, 9],
-                "kind": {
-                  "name": "Ident",
-                  "value": "Foo"
+            "kind": "invocation",
+            "invokee": "Foo.Bar",
+            "arguments": [
+              {
+                "token": {
+                  "position": [5, 20],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
                 }
               },
-              "type": {
-                "nullable": false,
-                "kind": "enum",
-                "enum": { "moduleId": 1, "name": "Foo" }
-              },
-              "node": {
-                "kind": "identifier",
-                "name": "Foo"
-              }
-            },
-            "middle": [],
-            "tail": {
-              "kind": "enumVariant",
-              "name": "Foo.Bar"
-            }
+              null
+            ]
           }
         }
       }

--- a/selfhost/test/typechecker/invocation/invocation_enum_variant.3.abra
+++ b/selfhost/test/typechecker/invocation/invocation_enum_variant.3.abra
@@ -1,0 +1,6 @@
+enum Foo<T> {
+  Bar(a: T)
+}
+
+val f = Foo.Bar(a: 123)
+val _: Foo<Int> = f

--- a/selfhost/test/typechecker/invocation/invocation_enum_variant.3.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_enum_variant.3.out.json
@@ -19,11 +19,24 @@
         "enum": {
           "moduleId": 1,
           "name": { "name": "Foo", "position": [1, 6] },
-          "typeParams": [],
+          "typeParams": [
+            "T"
+          ],
           "variants": [
             {
-              "label": { "name": "Bar", "position": [1, 12] },
-              "kind": "constant"
+              "label": { "name": "Bar", "position": [2, 3] },
+              "kind": "container",
+              "fields": [
+                {
+                  "name": { "name": "a", "position": [2, 7] },
+                  "type": {
+                    "nullable": false,
+                    "kind": "generic",
+                    "name": "T"
+                  },
+                  "initializer": null
+                }
+              ]
             }
           ],
           "instanceMethods": [
@@ -103,7 +116,7 @@
     },
     {
       "token": {
-        "position": [3, 1],
+        "position": [5, 1],
         "kind": {
           "name": "Val"
         }
@@ -117,58 +130,131 @@
         "kind": "bindingDeclaration",
         "pattern": {
           "kind": "variable",
-          "label": { "name": "f", "position": [3, 5] }
+          "label": { "name": "f", "position": [5, 5] }
         },
         "variables": [
           {
-            "label": { "name": "f", "position": [3, 5] },
+            "label": { "name": "f", "position": [5, 5] },
             "mutable": false,
             "type": {
               "nullable": false,
               "kind": "enumInstance",
               "enum": { "moduleId": 1, "name": "Foo" },
-              "typeParams": []
+              "typeParams": [
+                {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              ]
             }
           }
         ],
         "expr": {
           "token": {
-            "position": [3, 12],
+            "position": [5, 16],
             "kind": {
-              "name": "Dot"
+              "name": "LParen"
             }
           },
           "type": {
             "nullable": false,
             "kind": "enumInstance",
             "enum": { "moduleId": 1, "name": "Foo" },
-            "typeParams": []
+            "typeParams": [
+              {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              }
+            ]
           },
           "node": {
-            "kind": "accessor",
-            "head": {
-              "token": {
-                "position": [3, 9],
-                "kind": {
-                  "name": "Ident",
-                  "value": "Foo"
+            "kind": "invocation",
+            "invokee": "Foo.Bar",
+            "arguments": [
+              {
+                "token": {
+                  "position": [5, 20],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "type": {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 123
                 }
-              },
-              "type": {
-                "nullable": false,
-                "kind": "enum",
-                "enum": { "moduleId": 1, "name": "Foo" }
-              },
-              "node": {
-                "kind": "identifier",
-                "name": "Foo"
               }
-            },
-            "middle": [],
-            "tail": {
-              "kind": "enumVariant",
-              "name": "Foo.Bar"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [6, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "nullable": false,
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [6, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [6, 5] },
+            "mutable": false,
+            "type": {
+              "nullable": false,
+              "kind": "enumInstance",
+              "enum": { "moduleId": 1, "name": "Foo" },
+              "typeParams": [
+                {
+                  "nullable": false,
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              ]
             }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [6, 19],
+            "kind": {
+              "name": "Ident",
+              "value": "f"
+            }
+          },
+          "type": {
+            "nullable": false,
+            "kind": "enumInstance",
+            "enum": { "moduleId": 1, "name": "Foo" },
+            "typeParams": [
+              {
+                "nullable": false,
+                "kind": "primitive",
+                "primitive": "Int"
+              }
+            ]
+          },
+          "node": {
+            "kind": "identifier",
+            "name": "f"
           }
         }
       }

--- a/selfhost/test/typechecker/typedecl/error_duplicate_type_enum.abra
+++ b/selfhost/test/typechecker/typedecl/error_duplicate_type_enum.abra
@@ -1,0 +1,2 @@
+type Foo { a: Int }
+enum Foo { Bar }

--- a/selfhost/test/typechecker/typedecl/error_duplicate_type_enum.out
+++ b/selfhost/test/typechecker/typedecl/error_duplicate_type_enum.out
@@ -1,0 +1,7 @@
+Error at %FILE_NAME%:2:6
+Duplicate name 'Foo'
+  |  enum Foo { Bar }
+          ^
+This name is also declared at (1:6)
+  |  type Foo { a: Int }
+          ^

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -461,6 +461,9 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/accessor/error_unknown_field_chain_opt_known.abra", "typechecker/accessor/error_unknown_field_chain_opt_known.out")
         .add_test_vs_txt("typechecker/accessor/error_unknown_field_chain_opt_unknown.abra", "typechecker/accessor/error_unknown_field_chain_opt_unknown.out")
         .add_test_vs_txt("typechecker/accessor/error_static_member_referenced_by_instance.abra", "typechecker/accessor/error_static_member_referenced_by_instance.out")
+        .add_test_vs_txt("typechecker/accessor/accessor.4.abra", "typechecker/accessor/accessor.4.out.json")
+        .add_test_vs_txt("typechecker/accessor/error_unknown_enum_variant.1.abra", "typechecker/accessor/error_unknown_enum_variant.1.out")
+
 
         // Type identifiers
         .add_test_vs_txt("typechecker/typeidentifier/error_typearg_unknown.abra", "typechecker/typeidentifier/error_typearg_unknown.out")
@@ -476,6 +479,7 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/assignment/assignment_variable.abra", "typechecker/assignment/assignment_variable.out.json")
         .add_test_vs_txt("typechecker/assignment/accessor_error_method.1.abra", "typechecker/assignment/accessor_error_method.1.out")
         .add_test_vs_txt("typechecker/assignment/accessor_error_method.2.abra", "typechecker/assignment/accessor_error_method.2.out")
+        .add_test_vs_txt("typechecker/assignment/accessor_error_enum_variant.abra", "typechecker/assignment/accessor_error_enum_variant.out")
         .add_test_vs_txt("typechecker/assignment/accessor_error_type_mismatch.1.abra", "typechecker/assignment/accessor_error_type_mismatch.1.out")
         .add_test_vs_txt("typechecker/assignment/accessor_error_type_mismatch.2.abra", "typechecker/assignment/accessor_error_type_mismatch.2.out")
         .add_test_vs_txt("typechecker/assignment/variable_error_alias_fn.abra", "typechecker/assignment/variable_error_alias_fn.out")
@@ -522,6 +526,9 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/bindingdecl/error_type_mismatch_var.abra", "typechecker/bindingdecl/error_type_mismatch_var.out")
         .add_test_vs_txt("typechecker/bindingdecl/error_type_mismatch_option.abra", "typechecker/bindingdecl/error_type_mismatch_option.out")
         .add_test_vs_txt("typechecker/bindingdecl/error_unfilled_holes.abra", "typechecker/bindingdecl/error_unfilled_holes.out")
+        .add_test_vs_txt("typechecker/bindingdecl/error_illegal_value_type_enum.abra", "typechecker/bindingdecl/error_illegal_value_type_enum.out")
+        .add_test_vs_txt("typechecker/bindingdecl/error_illegal_value_type_enum_container_variant.abra", "typechecker/bindingdecl/error_illegal_value_type_enum_container_variant.out")
+        .add_test_vs_txt("typechecker/bindingdecl/error_illegal_value_type_type.abra", "typechecker/bindingdecl/error_illegal_value_type_type.out")
         // Function declaration
         .add_test_vs_txt("typechecker/funcdecl/funcdecl.1.abra", "typechecker/funcdecl/funcdecl.1.out.json")
         .add_test_vs_txt("typechecker/funcdecl/funcdecl.2.abra", "typechecker/funcdecl/funcdecl.2.out.json")

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -434,6 +434,7 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/invocation/error_instantiation_too_few_args.1.abra", "typechecker/invocation/error_instantiation_too_few_args.1.out")
         .add_test_vs_txt("typechecker/invocation/error_instantiation_too_few_args.2.abra", "typechecker/invocation/error_instantiation_too_few_args.2.out")
         .add_test_vs_txt("typechecker/invocation/error_invalid_ident_kind.abra", "typechecker/invocation/error_invalid_ident_kind.out")
+        .add_test_vs_txt("typechecker/invocation/error_enum_variant_constant.abra", "typechecker/invocation/error_enum_variant_constant.out")
         .add_test_vs_txt("typechecker/invocation/invocation_arbitrary_expr.1.abra", "typechecker/invocation/invocation_arbitrary_expr.1.out.json")
         .add_test_vs_txt("typechecker/invocation/invocation_arbitrary_expr.2.abra", "typechecker/invocation/invocation_arbitrary_expr.2.out.json")
         .add_test_vs_txt("typechecker/invocation/invocation_field.abra", "typechecker/invocation/invocation_field.out.json")
@@ -448,6 +449,10 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/invocation/generics_error_field.1.abra", "typechecker/invocation/generics_error_field.1.out")
         .add_test_vs_txt("typechecker/invocation/invocation_method_generics.1.abra", "typechecker/invocation/invocation_method_generics.1.out.json")
         .add_test_vs_txt("typechecker/invocation/invocation_method_generics.2.abra", "typechecker/invocation/invocation_method_generics.2.out.json")
+        .add_test_vs_txt("typechecker/invocation/invocation_enum_variant.1.abra", "typechecker/invocation/invocation_enum_variant.1.out.json")
+        .add_test_vs_txt("typechecker/invocation/invocation_enum_variant.2.abra", "typechecker/invocation/invocation_enum_variant.2.out.json")
+        .add_test_vs_txt("typechecker/invocation/invocation_enum_variant.3.abra", "typechecker/invocation/invocation_enum_variant.3.out.json")
+
         // Accessor
         .add_test_vs_txt("typechecker/accessor/accessor.1.abra", "typechecker/accessor/accessor.1.out.json")
         .add_test_vs_txt("typechecker/accessor/accessor.2.abra", "typechecker/accessor/accessor.2.out.json")

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -379,7 +379,6 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/indexing/tuple_error_range.abra", "typechecker/indexing/tuple_error_range.out")
         .add_test_vs_txt("typechecker/indexing/tuple_error_type_mismatch.abra", "typechecker/indexing/tuple_error_type_mismatch.out")
 
-
         // If expressions & statements
         .add_test_vs_txt("typechecker/if/error_bad_cond_type.abra", "typechecker/if/error_bad_cond_type.out")
         .add_test_vs_txt("typechecker/if/error_block_mismatch.1.abra", "typechecker/if/error_block_mismatch.1.out")
@@ -569,6 +568,7 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/typedecl/error_duplicate_field.abra", "typechecker/typedecl/error_duplicate_field.out")
         .add_test_vs_txt("typechecker/typedecl/error_method_bad_self_position.abra", "typechecker/typedecl/error_method_bad_self_position.out")
         .add_test_vs_txt("typechecker/typedecl/typedecl.1.abra", "typechecker/typedecl/typedecl.1.out.json")
+        .add_test_vs_txt("typechecker/typedecl/typedecl.2.abra", "typechecker/typedecl/typedecl.2.out.json")
         .add_test_vs_txt("typechecker/typedecl/error_field_initializer_type_mismatch.abra", "typechecker/typedecl/error_field_initializer_type_mismatch.out")
         .add_test_vs_txt("typechecker/typedecl/error_invalid_eq_signature.1.abra", "typechecker/typedecl/error_invalid_eq_signature.1.out")
         .add_test_vs_txt("typechecker/typedecl/error_invalid_eq_signature.2.abra", "typechecker/typedecl/error_invalid_eq_signature.2.out")
@@ -576,8 +576,20 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/typedecl/error_invalid_tostring_signature.abra", "typechecker/typedecl/error_invalid_tostring_signature.out")
         .add_test_vs_txt("typechecker/typedecl/error_duplicate_type_func.abra", "typechecker/typedecl/error_duplicate_type_func.out")
         .add_test_vs_txt("typechecker/typedecl/error_duplicate_type_type.abra", "typechecker/typedecl/error_duplicate_type_type.out")
-        .add_test_vs_txt("typechecker/typedecl/typedecl.2.abra", "typechecker/typedecl/typedecl.2.out.json")
-
+        .add_test_vs_txt("typechecker/typedecl/error_duplicate_type_enum.abra", "typechecker/typedecl/error_duplicate_type_enum.out")
+        // Enum declaration
+        .add_test_vs_txt("typechecker/enumdecl/enumdecl.1.abra", "typechecker/enumdecl/enumdecl.1.out.json")
+        .add_test_vs_txt("typechecker/enumdecl/error_duplicate_enum_enum.abra", "typechecker/enumdecl/error_duplicate_enum_enum.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_duplicate_enum_func.abra", "typechecker/enumdecl/error_duplicate_enum_func.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_duplicate_enum_type.abra", "typechecker/enumdecl/error_duplicate_enum_type.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_duplicate_variant.abra", "typechecker/enumdecl/error_duplicate_variant.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_duplicate_variant_field.abra", "typechecker/enumdecl/error_duplicate_variant_field.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_invalid_eq_signature.1.abra", "typechecker/enumdecl/error_invalid_eq_signature.1.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_invalid_eq_signature.2.abra", "typechecker/enumdecl/error_invalid_eq_signature.2.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_invalid_hash_signature.abra", "typechecker/enumdecl/error_invalid_hash_signature.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_invalid_tostring_signature.abra", "typechecker/enumdecl/error_invalid_tostring_signature.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_method_bad_self_position.abra", "typechecker/enumdecl/error_method_bad_self_position.out")
+        .add_test_vs_txt("typechecker/enumdecl/error_variant_field_initializer_type_mismatch.abra", "typechecker/enumdecl/error_variant_field_initializer_type_mismatch.out")
 
         // Returns
         .add_test_vs_txt("typechecker/return/return.1.abra", "typechecker/return/return.1.out.json")


### PR DESCRIPTION
Typechecking the declaration itself, including variants (constant and container, as well as containers that have fields with initializers), instance methods, and static methods.