### PR TITLE
Add shorthand for Result type

### DIFF
--- a/abra_core/std/fs.abra
+++ b/abra_core/std/fs.abra
@@ -12,30 +12,30 @@ export func readFile(path: String): Result<String, ReadFileError> {
   val fd = libc.open(path._buffer, libc.O_RDONLY)
   if fd == -1 {
     val errMsg = libc.strerror(libc.errno())
-    return Result.Err(error: ReadFileError.CouldNotOpen(message: errMsg))
+    return Err(error: ReadFileError.CouldNotOpen(message: errMsg))
   }
 
   val len = libc.lseek(fd, 0, libc.SEEK_END)
   if len == -1 {
     val errMsg = libc.strerror(libc.errno())
-    return Result.Err(error: ReadFileError.CouldNotSeek(message: errMsg))
+    return Err(error: ReadFileError.CouldNotSeek(message: errMsg))
   }
   if libc.lseek(fd, 0, libc.SEEK_SET) == -1 {
     val errMsg = libc.strerror(libc.errno())
-    return Result.Err(error: ReadFileError.CouldNotSeek(message: errMsg))
+    return Err(error: ReadFileError.CouldNotSeek(message: errMsg))
   }
 
   val str = String.withLength(len)
   if libc.read(fd, str._buffer, len) == -1 {
     val errMsg = libc.strerror(libc.errno())
-    return Result.Err(error: ReadFileError.CouldNotRead(message: errMsg))
+    return Err(error: ReadFileError.CouldNotRead(message: errMsg))
   }
   if libc.close(fd) == -1 {
     val errMsg = libc.strerror(libc.errno())
-    return Result.Err(error: ReadFileError.CouldNotClose(message: errMsg))
+    return Err(error: ReadFileError.CouldNotClose(message: errMsg))
   }
 
-  Result.Ok(value: str)
+  Ok(value: str)
 }
 
 export func getCurrentWorkingDirectory(): String {

--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -29,6 +29,14 @@ export enum Option<V> {
 
 func Some<T>(value: T): Option<T> = Option.Some(value)
 
+export enum Result<V, E> {
+  Ok(value: V)
+  Err(error: E)
+}
+
+func Ok<V, E>(value: V): Result<V, E> = Result.Ok(value)
+func Err<V, E>(error: E): Result<V, E> = Result.Err(error)
+
 type RangeIterator {
   start: Int
   end: Int
@@ -49,11 +57,6 @@ type RangeIterator {
 func range(start: Int, end: Int, stepBy = 1): RangeIterator = RangeIterator(start: start, end: end, stepBy: stepBy)
 
 func flattenOption<T>(value: T??): T? = if value |v| v else None
-
-enum Result<V, E> {
-  Ok(value: V)
-  Err(error: E)
-}
 
 type Int {
   func asFloat(self): Float = intrinsics.intAsFloat(self)

--- a/selfhost/src/lexer.abra
+++ b/selfhost/src/lexer.abra
@@ -224,24 +224,24 @@ export type Lexer {
     val lexer = Lexer(_input: contents)
     var nextToken = match lexer.nextToken() {
       Result.Ok(v) => v,
-      Result.Err(e) => return Result.Err(error: e)
+      Result.Err(e) => return Err(error: e)
     }
     while nextToken |tok| {
       tokens.push(tok)
 
       nextToken = match lexer.nextToken() {
         Result.Ok(v) => v,
-        Result.Err(e) => return Result.Err(error: e)
+        Result.Err(e) => return Err(error: e)
       }
     }
 
-    Result.Ok(tokens)
+    Ok(tokens)
   }
 
   func nextToken(self): Result<Token?, LexerError> {
     val sawNewline = self._skipWhitespace()
 
-    if self._cursor >= self._input.length return Result.Ok(None)
+    if self._cursor >= self._input.length return Ok(None)
     val ch = self._input[self._cursor]
     val peek = self._input[self._cursor + 1]
 
@@ -250,29 +250,29 @@ export type Lexer {
     val token = if ch.isDigit() {
       val tok = match self._tokenizeInteger(startPos: position) {
         Result.Ok(v) => v
-        Result.Err(e) => return Result.Err(error: e)
+        Result.Err(e) => return Err(error: e)
       }
       tok
     } else if ch == "\"" {
       val tok = match self._tokenizeString(startPos: position) {
         Result.Ok(v) => v
-        Result.Err(e) => return Result.Err(error: e)
+        Result.Err(e) => return Err(error: e)
       }
       tok
     } else if ch.isAlpha() || ch == "_" {
       self._tokenizeIdentifier(startPos: position)
     } else if ch == "/" && (peek == "/" || peek == "*") {
-      if self._skipComment() |error| return Result.Err(error)
+      if self._skipComment() |error| return Err(error)
       return self.nextToken()
     } else {
       val tok = match self._tokenizeSymbol(startPos: position, sawPreceedingNewline: sawNewline) {
         Result.Ok(v) => v
-        Result.Err(e) => return Result.Err(error: e)
+        Result.Err(e) => return Err(error: e)
       }
       tok
     }
 
-    Result.Ok(Some(token))
+    Ok(Some(token))
   }
 
   func _curPos(self): Position = Position(line: self._line, col: self._col)
@@ -370,10 +370,10 @@ export type Lexer {
             LexerErrorKind.UnexpectedEof
           }
 
-          return Result.Err(LexerError(position: self._curPos(), kind: kind))
+          return Err(LexerError(position: self._curPos(), kind: kind))
         }
 
-        return Result.Ok(Token(position: startPos, kind: TokenKind.Int(num)))
+        return Ok(Token(position: startPos, kind: TokenKind.Int(num)))
       } else if self._input[self._cursor + 1] == "b" {
         self._advance() // consume 'b'
         self._advance() // move to next
@@ -398,14 +398,14 @@ export type Lexer {
             LexerErrorKind.UnexpectedEof
           }
 
-          return Result.Err(LexerError(position: self._curPos(), kind: kind))
+          return Err(LexerError(position: self._curPos(), kind: kind))
         }
 
-        return Result.Ok(Token(position: startPos, kind: TokenKind.Int(num)))
+        return Ok(Token(position: startPos, kind: TokenKind.Int(num)))
       } else if self._input[self._cursor + 1].isDigit() {
         self._advance()
         val char = self._input[self._cursor]
-        return Result.Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedChar(char)))
+        return Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedChar(char)))
       }
     }
 
@@ -422,7 +422,7 @@ export type Lexer {
       return self._tokenizeFloat(startPos: startPos, wholeNumber: num)
     }
 
-    Result.Ok(Token(position: startPos, kind: TokenKind.Int(num)))
+    Ok(Token(position: startPos, kind: TokenKind.Int(num)))
   }
 
   func _tokenizeFloat(self, startPos: Position, wholeNumber: Int): Result<Token, LexerError> {
@@ -440,11 +440,11 @@ export type Lexer {
 
     if self._input[self._cursor] == "." && self._input[self._cursor + 1].isDigit() {
       val char = self._input[self._cursor]
-      return Result.Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedChar(char)))
+      return Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedChar(char)))
     }
 
     val float = wholeNumber + (num / 10 ** pow)
-    Result.Ok(Token(position: startPos, kind: TokenKind.Float(float)))
+    Ok(Token(position: startPos, kind: TokenKind.Float(float)))
   }
 
   func _tokenizeString(self, startPos: Position): Result<Token, LexerError> {
@@ -457,7 +457,7 @@ export type Lexer {
     while self._cursor < self._input.length {
       val ch = self._input[self._cursor]
       if ch == "\n" {
-        return Result.Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnterminatedString(startPos)))
+        return Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnterminatedString(startPos)))
       } else if ch == "\\" {
         val startCursor = self._cursor
         val pos = self._curPos()
@@ -474,9 +474,9 @@ export type Lexer {
           "$" => "$",
           "u" => match self._parseUnicodeEscape(pos) {
             Result.Ok(c) => c
-            Result.Err(e) => return Result.Err(e)
+            Result.Err(e) => return Err(e)
           }
-          _ => return Result.Err(LexerError(position: pos, kind: LexerErrorKind.UnsupportedEscapeSequence("\\$ch", false)))
+          _ => return Err(LexerError(position: pos, kind: LexerErrorKind.UnsupportedEscapeSequence("\\$ch", false)))
         }
 
         if !seenEscape {
@@ -500,14 +500,14 @@ export type Lexer {
     }
 
     if !closed {
-      return Result.Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnterminatedString(startPos)))
+      return Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnterminatedString(startPos)))
     }
 
     val str = if seenEscape chars.join() else self._input[start:self._cursor]
 
     self._advance() // consume closing '"'
 
-    Result.Ok(Token(position: startPos, kind: TokenKind.String(str)))
+    Ok(Token(position: startPos, kind: TokenKind.String(str)))
   }
 
   func _parseUnicodeEscape(self, startPos: Position): Result<String, LexerError> {
@@ -517,12 +517,12 @@ export type Lexer {
     for i in range(0, 4) {
       if self._cursor + i >= self._input.length {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
-        return Result.Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(escSeq, true)))
+        return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(escSeq, true)))
       }
       val ch = self._input._buffer.offset(self._cursor + i).load().asInt()
       val v = if valueIfValidHexDigit(ch) |v| v else {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
-        return Result.Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(escSeq, true)))
+        return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(escSeq, true)))
       }
       value = (value << 4) + v
     }
@@ -568,12 +568,12 @@ export type Lexer {
       "�"
     }
 
-    Result.Ok(str)
+    Ok(str)
   }
 
   func _tokenizeStringInterpolation(self, startPos: Position, firstChunk: String): Result<Token, LexerError> {
     // TODO
-    Result.Ok(Token(position: startPos, kind: TokenKind.StringInterpolation([Token(position: startPos, kind: TokenKind.String(firstChunk))])))
+    Ok(Token(position: startPos, kind: TokenKind.StringInterpolation([Token(position: startPos, kind: TokenKind.String(firstChunk))])))
   }
 
   func _tokenizeIdentifier(self, startPos: Position): Token {
@@ -643,10 +643,10 @@ export type Lexer {
       "&" => {
         self._advance() // consume '&'
         if self._cursor >= self._input.length {
-          return Result.Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedEof))
+          return Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedEof))
         } else if self._input[self._cursor] != "&" {
           val ch = self._input[self._cursor]
-          return Result.Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedChar(ch)))
+          return Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedChar(ch)))
         }
         self._advance() // consume second '&'
 
@@ -664,20 +664,20 @@ export type Lexer {
       "#" => {
         self._advance() // consume '#'
         if self._cursor >= self._input.length {
-          return Result.Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedEof))
+          return Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedEof))
         } else if self._input[self._cursor] != "{" {
           val ch = self._input[self._cursor]
-          return Result.Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedChar(ch)))
+          return Err(LexerError(position: self._curPos(), kind: LexerErrorKind.UnexpectedChar(ch)))
         }
 
         TokenKind.HashBrace
       }
       "@" => TokenKind.At
-      _ => return Result.Err(LexerError(position: startPos, kind: LexerErrorKind.UnexpectedChar(ch)))
+      _ => return Err(LexerError(position: startPos, kind: LexerErrorKind.UnexpectedChar(ch)))
     }
 
     self._advance()
 
-    Result.Ok(Token(position: startPos, kind: tokenKind))
+    Ok(Token(position: startPos, kind: tokenKind))
   }
 }

--- a/selfhost/src/parser.abra
+++ b/selfhost/src/parser.abra
@@ -355,10 +355,10 @@ export type Parser {
     while parser._peek() |token| {
       if token.kind == TokenKind.Import {
         if !importsAllowed {
-          return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+          return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
         }
 
-        val importNode = match parser._parseImport() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val importNode = match parser._parseImport() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         imports.push(importNode)
         continue
       }
@@ -366,18 +366,18 @@ export type Parser {
 
       match parser._parseStatement() {
         Result.Ok(node) => nodes.push(node)
-        Result.Err(e) => return Result.Err(e)
+        Result.Err(e) => return Err(e)
       }
     }
 
-    Result.Ok(ParsedModule(imports: imports, nodes: nodes))
+    Ok(ParsedModule(imports: imports, nodes: nodes))
   }
 
   func _peek(self, ahead = 0): Token? = self._tokens[self._cursor + ahead]
 
   func _expectPeek(self, ahead = 0): Result<Token, ParseError> {
     if self._peek(ahead) |token| {
-      Result.Ok(token)
+      Ok(token)
     } else {
       val position = if self._tokens[self._cursor - 1] |lastToken| {
         lastToken.position
@@ -387,7 +387,7 @@ export type Parser {
       // TODO: This isn't exactly correct (it should point just past the end of the token, and this would only work if
       // the token was of length 1), but it's close enough for now
       position.col += 1
-      Result.Err(ParseError(position: position, kind: ParseErrorKind.UnexpectedEof))
+      Err(ParseError(position: position, kind: ParseErrorKind.UnexpectedEof))
     }
   }
 
@@ -402,15 +402,15 @@ export type Parser {
   }
 
   func _expectNextLabel(self): Result<Label, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     match token.kind {
-      TokenKind.Ident(name) => Result.Ok(Label(name: name, position: token.position))
-      _ => Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
+      TokenKind.Ident(name) => Ok(Label(name: name, position: token.position))
+      _ => Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
     }
   }
 
   func _expectNextTokenKind(self, kind: TokenKind): Result<Token, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val nextTokenMatches = match kind {
       TokenKind.Int => match token.kind { TokenKind.Int => true, _ => false }
@@ -425,68 +425,68 @@ export type Parser {
     }
 
     if nextTokenMatches {
-      Result.Ok(token)
+      Ok(token)
     } else {
-      Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([kind], token.kind)))
+      Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([kind], token.kind)))
     }
   }
 
   func _parseImport(self): Result<ImportNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val importNode = match nextToken.kind {
       TokenKind.String(string) => {
         val moduleName = Label(name: string, position: nextToken.position)
         self._advance() // consume string token
 
-        val nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         if nextToken.kind != TokenKind.As {
-          return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.As], nextToken.kind)))
+          return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.As], nextToken.kind)))
         }
 
-        val aliasName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val aliasName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val kind = ImportKind.Alias(aliasName)
 
         ImportNode(token: token, kind: kind, moduleName: moduleName)
       }
       TokenKind.Ident => {
         val importsRes = self._commaSeparated(end: TokenKind.From, consumeFinal: true, fn: () => {
-          val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if label.name == "_" {
             val tok = Token(position: label.position, kind: TokenKind.Ident(label.name))
-            Result.Err(ParseError(position: label.position, kind: ParseErrorKind.UnexpectedToken(tok)))
+            Err(ParseError(position: label.position, kind: ParseErrorKind.UnexpectedToken(tok)))
           } else {
-            Result.Ok(label)
+            Ok(label)
           }
         })
-        val imports = match importsRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val imports = match importsRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val kind = ImportKind.List(imports)
 
-        val nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val moduleName = match nextToken.kind {
           TokenKind.String(name) => Label(name: name, position: nextToken.position)
-          _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String("")], nextToken.kind)))
+          _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String("")], nextToken.kind)))
         }
 
         ImportNode(token: token, kind: kind, moduleName: moduleName)
       }
-      _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String(""), TokenKind.Ident("")], nextToken.kind)))
+      _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String(""), TokenKind.Ident("")], nextToken.kind)))
     }
 
-    Result.Ok(importNode)
+    Ok(importNode)
   }
 
   func _parseStatement(self): Result<AstNode, ParseError> {
-    val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     match token.kind {
       TokenKind.At => {
-        match self._parseDecorator() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        match self._parseDecorator() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum, TokenKind.At, TokenKind.Export]
         if !expected.contains(nextToken.kind) {
-          return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
+          return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
         }
 
         self._parseStatement()
@@ -495,10 +495,10 @@ export type Parser {
         self._exportToken = Some(token)
         self._advance() // consume 'export' token
 
-        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum]
         if !expected.contains(nextToken.kind) {
-          return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
+          return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
         }
 
         self._parseStatement()
@@ -518,15 +518,15 @@ export type Parser {
   }
 
   func _parseDecorator(self): Result<Int, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val decoratorName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val decoratorName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val arguments = match nextToken.kind {
       TokenKind.LParen => {
         self._advance() // consume '(' token
-        val arguments = match self._parseInvocationArguments() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val arguments = match self._parseInvocationArguments() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         arguments
       }
       _ => []
@@ -537,7 +537,7 @@ export type Parser {
         AstNodeKind.Literal => {}
         _ => {
           val expected = [TokenKind.Int(0), TokenKind.Float(0.0), TokenKind.Bool(true), TokenKind.String("")]
-          return Result.Err(ParseError(position: arg.value.token.position, kind: ParseErrorKind.ExpectedToken(expected, arg.value.token.kind)))
+          return Err(ParseError(position: arg.value.token.position, kind: ParseErrorKind.ExpectedToken(expected, arg.value.token.kind)))
         }
       }
     }
@@ -545,20 +545,20 @@ export type Parser {
     val dec = DecoratorNode(name: decoratorName, arguments: arguments)
     self._seenDecorators.push(dec)
 
-    Result.Ok(0) // <- unneeded, but I can't construct a Unit type, so...
+    Ok(0) // <- unneeded, but I can't construct a Unit type, so...
   }
 
   func _parseBindingPattern(self): Result<BindingPattern, ParseError> {
-    val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val pat = match token.kind {
       TokenKind.Ident => {
-        val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         BindingPattern.Variable(label)
       }
-      _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
+      _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
     }
 
-    Result.Ok(pat)
+    Ok(pat)
   }
 
   func _parseBindingDeclaration(self, mutable: Bool): Result<AstNode, ParseError> {
@@ -568,8 +568,8 @@ export type Parser {
     val exportToken = self._exportToken
     self._exportToken = None
 
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     if self._cursor >= self._tokens.length {
       val node = BindingDeclarationNode(
@@ -579,13 +579,13 @@ export type Parser {
         typeAnnotation: None,
         expr: None,
       )
-      return Result.Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
+      return Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
     }
 
-    var colonToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    var colonToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val typeAnnotation = if colonToken.kind == TokenKind.Colon {
       self._advance() // consume ':' token
-      val a = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val a = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(a)
     } else {
       None
@@ -599,13 +599,13 @@ export type Parser {
         typeAnnotation: typeAnnotation,
         expr: None,
       )
-      return Result.Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
+      return Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
     }
 
-    val eqToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val eqToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val expr = if eqToken.kind == TokenKind.Eq {
       self._advance() // consume '=' token
-      val e = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val e = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(e)
     } else {
       None
@@ -618,7 +618,7 @@ export type Parser {
       typeAnnotation: typeAnnotation,
       expr: expr,
     )
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
+    Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
   }
 
   func _parseFunctionDeclaration(self): Result<AstNode, ParseError> {
@@ -628,29 +628,29 @@ export type Parser {
     val exportToken = self._exportToken
     self._exportToken = None
 
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val typeParams = match nextToken.kind {
       TokenKind.LT => {
         self._advance() // consume '<' token
-        val labels = match self._parseTypeParameters() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val labels = match self._parseTypeParameters() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         labels
       }
       TokenKind.LParen => []
-      _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
+      _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
     }
 
     // The `true` in LParen is disregarded within _expectNextTokenKind
-    match self._expectNextTokenKind(TokenKind.LParen(true)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._expectNextTokenKind(TokenKind.LParen(true)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val params = match self._parseFunctionParameters(allowSelf: true) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val params = match self._parseFunctionParameters(allowSelf: true) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val returnTypeAnnotation = if nextToken.kind == TokenKind.Colon {
       self._advance() // consume ':' token
 
-      val ann = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val ann = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(ann)
     } else {
       None
@@ -664,13 +664,13 @@ export type Parser {
     val body: AstNode[] = if isStub {
       []
     } else {
-      val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if nextToken.kind == TokenKind.Eq {
         self._advance() // consume '=' token
-        val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         [expr]
       } else {
-        match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       }
     }
 
@@ -683,7 +683,7 @@ export type Parser {
       returnTypeAnnotation: returnTypeAnnotation,
       body: body,
     )
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.FunctionDeclaration(node)))
+    Ok(AstNode(token: token, kind: AstNodeKind.FunctionDeclaration(node)))
   }
 
   func _parseTypeDeclaration(self): Result<AstNode, ParseError> {
@@ -693,29 +693,29 @@ export type Parser {
     val exportToken = self._exportToken
     self._exportToken = None
 
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val typeName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val typeName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val typeParams = match nextToken.kind {
       TokenKind.LT => {
         self._advance() // consume '<' token
-        val labels = match self._parseTypeParameters() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val labels = match self._parseTypeParameters() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         labels
       }
       TokenKind.LBrace => []
-      _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
+      _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
     }
 
-    match self._expectNextTokenKind(TokenKind.LBrace) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._expectNextTokenKind(TokenKind.LBrace) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val fields: TypeField[] = []
     while self._peek() |nextToken| {
       match nextToken.kind {
         TokenKind.Ident => {
-          val field = match self._parseField() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val field = match self._parseField() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-          val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if nextToken.kind == TokenKind.Comma {
             self._advance() // consume ',' token
           }
@@ -726,12 +726,12 @@ export type Parser {
       }
     }
 
-    val tuple = match self._parseBodyForTypeOrEnum() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val tuple = match self._parseBodyForTypeOrEnum() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val methods = tuple[0]
     val types = tuple[1]
     val enums = tuple[2]
 
-    match self._expectNextTokenKind(TokenKind.RBrace) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._expectNextTokenKind(TokenKind.RBrace) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val node = TypeDeclarationNode(
       decorators: decorators,
@@ -743,7 +743,7 @@ export type Parser {
       types: types,
       enums: enums,
     )
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.TypeDeclaration(node)))
+    Ok(AstNode(token: token, kind: AstNodeKind.TypeDeclaration(node)))
   }
 
   func _parseEnumDeclaration(self): Result<AstNode, ParseError> {
@@ -753,27 +753,27 @@ export type Parser {
     val exportToken = self._exportToken
     self._exportToken = None
 
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val enumName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val enumName = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val typeParams = match nextToken.kind {
       TokenKind.LT => {
         self._advance() // consume '<' token
-        val labels = match self._parseTypeParameters() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val labels = match self._parseTypeParameters() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         labels
       }
       TokenKind.LBrace => []
-      _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
+      _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
     }
 
-    match self._expectNextTokenKind(TokenKind.LBrace) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._expectNextTokenKind(TokenKind.LBrace) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val variants: EnumVariant[] = []
     while self._peek() |identTok| {
       val name = match identTok.kind {
         TokenKind.Ident => {
-          val name = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val name = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           name
         }
         TokenKind.None_ => {
@@ -783,35 +783,35 @@ export type Parser {
         _ => break
       }
 
-      var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       val variant = match nextToken.kind {
         TokenKind.LParen => {
           self._advance() // consume '(' token
 
           val paramsRes = self._commaSeparated(end: TokenKind.RParen, consumeFinal: false, fn: () => self._parseField())
-          val params = match paramsRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-          val rParen = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val params = match paramsRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+          val rParen = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if params.isEmpty() {
-            return Result.Err(ParseError(position: rParen.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], rParen.kind)))
+            return Err(ParseError(position: rParen.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], rParen.kind)))
           }
           EnumVariant.Container(name, params)
         }
         _ => EnumVariant.Constant(name)
       }
 
-      nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if nextToken.kind == TokenKind.Comma {
         self._advance() // consume ',' token
       }
       variants.push(variant)
     }
 
-    val tuple = match self._parseBodyForTypeOrEnum() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val tuple = match self._parseBodyForTypeOrEnum() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val methods = tuple[0]
     val types = tuple[1]
     val enums = tuple[2]
 
-    match self._expectNextTokenKind(TokenKind.RBrace) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._expectNextTokenKind(TokenKind.RBrace) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val node = EnumDeclarationNode(
       decorators: decorators,
@@ -823,24 +823,24 @@ export type Parser {
       types: types,
       enums: enums,
     )
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.EnumDeclaration(node)))
+    Ok(AstNode(token: token, kind: AstNodeKind.EnumDeclaration(node)))
   }
 
   func _parseField(self): Result<TypeField, ParseError> {
-    val name = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    match self._expectNextTokenKind(TokenKind.Colon) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val typeAnnotation = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val name = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    match self._expectNextTokenKind(TokenKind.Colon) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val typeAnnotation = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val initializer = if nextToken.kind == TokenKind.Eq {
       self._advance() // consume '=' token
-      val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(expr)
     } else {
       None
     }
 
-    Result.Ok(TypeField(name: name, typeAnnotation: typeAnnotation, initializer: initializer))
+    Ok(TypeField(name: name, typeAnnotation: typeAnnotation, initializer: initializer))
   }
 
   func _parseBodyForTypeOrEnum(self): Result<(FunctionDeclarationNode[], TypeDeclarationNode[], EnumDeclarationNode[]), ParseError> {
@@ -855,10 +855,10 @@ export type Parser {
         TokenKind.Func => self._parseStatement()
         TokenKind.Type => self._parseStatement()
         TokenKind.Enum => self._parseStatement()
-        _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.UnexpectedToken(nextToken)))
+        _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.UnexpectedToken(nextToken)))
       }
 
-      val node = match nodeRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val node = match nodeRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       match node.kind {
         AstNodeKind.FunctionDeclaration(node) => methods.push(node)
         AstNodeKind.TypeDeclaration(node) => types.push(node)
@@ -867,11 +867,11 @@ export type Parser {
       }
     }
 
-    Result.Ok((methods, types, enums))
+    Ok((methods, types, enums))
   }
 
   func _parseTypeIdentifier(self): Result<TypeIdentifier, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     var typeIdent =  match token.kind {
       TokenKind.Ident(name) => {
         var label = Label(name: name, position: token.position)
@@ -883,22 +883,22 @@ export type Parser {
             TokenKind.LT => {
               self._advance() // consume '<' token
 
-              val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               if nextToken.kind == TokenKind.GT {
-                return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], nextToken.kind)))
+                return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], nextToken.kind)))
               }
-              typeArguments = match self._commaSeparated(end: TokenKind.GT, consumeFinal: true, fn: () => self._parseTypeIdentifier()) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              typeArguments = match self._commaSeparated(end: TokenKind.GT, consumeFinal: true, fn: () => self._parseTypeIdentifier()) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               break
             }
             TokenKind.Dot => {
               self._advance() // consume '.' token
-              val nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              val nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               match nextToken.kind {
                 TokenKind.Ident(name) => {
                   path.push(label)
                   label = Label(name: name, position: nextToken.position)
                 }
-                _ => return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], nextToken.kind)))
+                _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], nextToken.kind)))
               }
             }
             _ => break
@@ -909,12 +909,12 @@ export type Parser {
       }
       TokenKind.LParen => {
         val a = self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => self._parseTypeIdentifier())
-        val args = match a { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val args = match a { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
         val nextTokenIsArrow = if self._peek()?.kind |kind| kind == TokenKind.Arrow else false
         if nextTokenIsArrow {
           self._advance() // consume '=>' token
-          val retType = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val retType = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           TypeIdentifier.Function(args, retType)
         } else if args[0] |first| {
           // TODO: There should be a more ergonomic way of writing this... maybe like
@@ -925,11 +925,11 @@ export type Parser {
             TypeIdentifier.Tuple(args)
           }
         } else {
-          val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-          return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Arrow], nextToken.kind)))
+          val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+          return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Arrow], nextToken.kind)))
         }
       }
-      _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
+      _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
     }
 
     while self._peek() |nextToken| {
@@ -938,7 +938,7 @@ export type Parser {
           break
         } else {
           self._advance() // consume '[' token
-          match self._expectNextTokenKind(TokenKind.RBrack) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          match self._expectNextTokenKind(TokenKind.RBrack) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
           typeIdent = TypeIdentifier.Array(inner: typeIdent)
         }
@@ -950,16 +950,16 @@ export type Parser {
       }
     }
 
-    Result.Ok(typeIdent)
+    Ok(typeIdent)
   }
 
   func _parseFunctionParameters(self, allowSelf: Bool): Result<FunctionParam[], ParseError> {
     self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: paramIdx => {
-      var token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      var token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       var starToken: Token? = None
       val isVariadic = if token.kind == TokenKind.Star {
         starToken = Some(token)
-        token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         true
       } else {
         false
@@ -968,122 +968,122 @@ export type Parser {
       val label = match token.kind {
         TokenKind.Ident(name) => Label(name: name, position: token.position)
         TokenKind.Self => if allowSelf && paramIdx == 0 {
-          if starToken |token| return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+          if starToken |token| return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
 
           Label(name: "self", position: token.position)
         } else {
-          return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
+          return Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
         }
-        _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
+        _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
       }
 
       if label.name == "self" {
-        return Result.Ok(FunctionParam(label: label, isVariadic: false, typeAnnotation: None, defaultValue: None))
+        return Ok(FunctionParam(label: label, isVariadic: false, typeAnnotation: None, defaultValue: None))
       }
 
-      var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       val typeAnnotation = if nextToken.kind == TokenKind.Colon {
         self._advance() // consume ':' token
-        val ann = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val ann = match self._parseTypeIdentifier() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         Some(ann)
       } else {
         None
       }
 
-      nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       val defaultValue = if nextToken.kind == TokenKind.Eq {
         self._advance() // consume '=' token
-        val e = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val e = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         Some(e)
       } else {
         None
       }
 
       val param = FunctionParam(label: label, isVariadic: isVariadic, typeAnnotation: typeAnnotation, defaultValue: defaultValue)
-      Result.Ok(param)
+      Ok(param)
     })
   }
 
   func _parseTypeParameters(self): Result<Label[], ParseError> {
-    val labels = match self._commaSeparated(end: TokenKind.GT, consumeFinal: false, fn: () => self._expectNextLabel()) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val labels = match self._commaSeparated(end: TokenKind.GT, consumeFinal: false, fn: () => self._expectNextLabel()) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     if labels.isEmpty() {
-      val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-      Result.Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
+      val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+      Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
     } else {
       self._advance() // consume '>' token
-      Result.Ok(labels)
+      Ok(labels)
     }
   }
 
   func _parseBlockOrSingleExpression(self, allowTerminators = false): Result<AstNode[], ParseError> {
-    val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val nodes = match token.kind {
       TokenKind.LBrace => {
         self._advance() // consume '{' token
         val nodes: AstNode[] = []
         while true {
-          val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if nextToken.kind == TokenKind.RBrace {
             self._advance() // consume '}' token
             break
           }
 
-          val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           nodes.push(node)
         }
         nodes
       }
       TokenKind.Break => if allowTerminators {
-        val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         [node]
       } else {
-        return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+        return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
       TokenKind.Continue => if allowTerminators {
-        val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         [node]
       } else {
-        return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+        return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
       TokenKind.Return => if allowTerminators {
-        val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val node = match self._parseStatement() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         [node]
       } else {
-        return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+        return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
       _ => {
-        val node = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val node = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         [node]
       }
     }
 
-    Result.Ok(nodes)
+    Ok(nodes)
   }
 
   func _parseExpressionStatement(self): Result<AstNode, ParseError> = self._parsePrecedence(prec: 0)
 
   func _parseExpression(self): Result<AstNode, ParseError> {
-    val node = match self._parsePrecedence(prec: 0) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val node = match self._parsePrecedence(prec: 0) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     if node.kind.isAssignmentExpression() {
-      return Result.Err(ParseError(position: node.token.position, kind: ParseErrorKind.UnexpectedToken(node.token)))
+      return Err(ParseError(position: node.token.position, kind: ParseErrorKind.UnexpectedToken(node.token)))
     }
-    Result.Ok(node)
+    Ok(node)
   }
 
   func _parsePrecedence(self, prec: Int): Result<AstNode, ParseError> {
-    val prefixToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    var leftNode = match self._prefixRule(prefixToken) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val prefixToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    var leftNode = match self._prefixRule(prefixToken) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     while self._peek() |nextToken| {
       val nextPrec = Precedence.forToken(nextToken)
       if prec < nextPrec {
-        leftNode = match self._infixRule(leftNode) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        leftNode = match self._infixRule(leftNode) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       } else {
         break
       }
     }
 
-    Result.Ok(leftNode)
+    Ok(leftNode)
   }
 
   func _prefixRule(self, token: Token): Result<AstNode, ParseError> {
@@ -1103,12 +1103,12 @@ export type Parser {
       TokenKind.LBrace => self._parseMap()
       TokenKind.If => self._parseIf()
       TokenKind.Match => self._parseMatch()
-      _ => Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+      _ => Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
     }
   }
 
   func _infixRule(self, left: AstNode): Result<AstNode, ParseError> {
-    val infixToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val infixToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     match infixToken.kind {
       TokenKind.Dot => self._parseAccessor(infixToken, left)
       TokenKind.QuestionDot => self._parseAccessor(infixToken, left)
@@ -1121,43 +1121,43 @@ export type Parser {
   }
 
   func _parseLiteral(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val literal = match token.kind {
       TokenKind.Int(value) => LiteralAstNode.Int(value)
       TokenKind.Float(value) => LiteralAstNode.Float(value)
       TokenKind.Bool(value) => LiteralAstNode.Bool(value)
       TokenKind.String(value) => LiteralAstNode.String(value)
-      TokenKind.StringInterpolation => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.NotYetImplemented))
-      _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+      TokenKind.StringInterpolation => return Err(ParseError(position: token.position, kind: ParseErrorKind.NotYetImplemented))
+      _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
     }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Literal(literal)))
+    Ok(AstNode(token: token, kind: AstNodeKind.Literal(literal)))
   }
 
   func _parseUnary(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val op = match token.kind {
       TokenKind.Minus => UnaryOp.Minus
       TokenKind.Bang => UnaryOp.Negate
-      _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.NotYetImplemented))
+      _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.NotYetImplemented))
     }
 
-    val expr = match self._parsePrecedence(prec: Precedence.unary()) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Unary(UnaryAstNode(op: op, expr: expr))))
+    val expr = match self._parsePrecedence(prec: Precedence.unary()) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    Ok(AstNode(token: token, kind: AstNodeKind.Unary(UnaryAstNode(op: op, expr: expr))))
   }
 
   func _parseGroupedOrTupleOrLambda(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     // If the next token is ')' then we must be parsing a no-args lambda
     match nextToken.kind {
       TokenKind.RParen => {
         self._advance() // consume ')' token
-        val arrowToken = match self._expectNextTokenKind(TokenKind.Arrow) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-        val body = match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val arrowToken = match self._expectNextTokenKind(TokenKind.Arrow) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+        val body = match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-        return Result.Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: [], body: body))))
+        return Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: [], body: body))))
       }
       TokenKind.Ident => {
         // A lambda expression can be of the form `(a, b) => c`, but it can also look like `(a, b = 4) => a + b`. At this point, it's impossible
@@ -1171,9 +1171,9 @@ export type Parser {
           Result.Ok(params) => {
             match self._expectNextTokenKind(TokenKind.Arrow) {
               Result.Ok(arrowToken) => {
-                val body = match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+                val body = match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-                return Result.Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
+                return Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
               }
               Result.Err => { self._cursor = cursor }
             }
@@ -1182,16 +1182,16 @@ export type Parser {
         }
       }
       TokenKind.Star => { // a variadic parameter could be first
-        val params = match self._parseFunctionParameters(allowSelf: false) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-        val arrowToken = match self._expectNextTokenKind(TokenKind.Arrow) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-        val body = match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val params = match self._parseFunctionParameters(allowSelf: false) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+        val arrowToken = match self._expectNextTokenKind(TokenKind.Arrow) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+        val body = match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-        return Result.Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
+        return Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
       }
       _ => {}
     }
 
-    val exprs = match self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => self._parseExpression()) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val exprs = match self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => self._parseExpression()) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val nodeKind = if exprs.length == 1 {
       // TODO: Again, there needs to be a more ergonomic way of doing this. `if exprs.length == 1 && exprs[0] |inner| { ... }` maybe? or even just `exprs[0].!` to force-unwrap
       if exprs[0] |inner| {
@@ -1202,7 +1202,7 @@ export type Parser {
     } else {
       AstNodeKind.Tuple(items: exprs)
     }
-    Result.Ok(AstNode(token: token, kind: nodeKind))
+    Ok(AstNode(token: token, kind: nodeKind))
   }
 
   func _tryParseInvocationWithTypeArgs(self, invokee: AstNode): Result<AstNode?, ParseError> {
@@ -1216,14 +1216,14 @@ export type Parser {
             if typeArgs.isEmpty() {
               self._cursor = savedCursor
             } else {
-              val nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              val nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               if nextToken.kind != TokenKind.LParen(false) {
-                return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(false)], nextToken.kind)))
+                return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(false)], nextToken.kind)))
               }
 
-              val arguments = match self._parseInvocationArguments() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              val arguments = match self._parseInvocationArguments() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               val invocationNode = InvocationAstNode(invokee: invokee, typeArguments: typeArgs, arguments: arguments)
-              return Result.Ok(Some(AstNode(token: nextToken, kind: AstNodeKind.Invocation(invocationNode))))
+              return Ok(Some(AstNode(token: nextToken, kind: AstNodeKind.Invocation(invocationNode))))
             }
           }
           Result.Err => {
@@ -1236,84 +1236,84 @@ export type Parser {
       }
     }
 
-    Result.Ok(None)
+    Ok(None)
   }
 
   func _parseIdentifier(self, kind: IdentifierKind): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val identNode = AstNode(token: token, kind: AstNodeKind.Identifier(kind))
 
-    val res = match self._tryParseInvocationWithTypeArgs(invokee: identNode) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    if res |invocationNode| return Result.Ok(invocationNode)
+    val res = match self._tryParseInvocationWithTypeArgs(invokee: identNode) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    if res |invocationNode| return Ok(invocationNode)
 
-    Result.Ok(identNode)
+    Ok(identNode)
   }
 
   func _parseArray(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val itemsRes = self._commaSeparated(end: TokenKind.RBrack, consumeFinal: true, fn: () => self._parseExpression())
-    val items = match itemsRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val items = match itemsRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Array(items)))
+    Ok(AstNode(token: token, kind: AstNodeKind.Array(items)))
   }
 
   func _parseSet(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val itemsRes = self._commaSeparated(end: TokenKind.RBrace, consumeFinal: true, fn: () => self._parseExpression())
-    val items = match itemsRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val items = match itemsRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Set(items)))
+    Ok(AstNode(token: token, kind: AstNodeKind.Set(items)))
   }
 
   func _parseMap(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val itemsRes = self._commaSeparated(end: TokenKind.RBrace, consumeFinal: true, fn: () => {
-      val keyToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val keyToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       val keyRes = match keyToken.kind {
         TokenKind.String => self._parseExpression()
         TokenKind.Ident => self._parseExpression()
         TokenKind.LParen => {
           self._advance() // consume '(' token
           val key = self._parseExpression()
-          match self._expectNextTokenKind(TokenKind.RParen) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          match self._expectNextTokenKind(TokenKind.RParen) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           key
         }
         _ => {
-          return Result.Err(ParseError(position: keyToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String(""), TokenKind.Ident(""), TokenKind.LParen(false)], keyToken.kind)))
+          return Err(ParseError(position: keyToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String(""), TokenKind.Ident(""), TokenKind.LParen(false)], keyToken.kind)))
         }
       }
-      val key = match keyRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val key = match keyRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-      match self._expectNextTokenKind(TokenKind.Colon) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._expectNextTokenKind(TokenKind.Colon) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-      val value = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val value = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-      Result.Ok((key, value))
+      Ok((key, value))
     })
-    val items = match itemsRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val items = match itemsRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Map(items)))
+    Ok(AstNode(token: token, kind: AstNodeKind.Map(items)))
   }
 
   func _parseIf(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val condition = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val condition = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val conditionBinding = if nextToken.kind == TokenKind.Pipe {
       self._advance() // consume opening '|' token
-      val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-      match self._expectNextTokenKind(TokenKind.Pipe) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+      match self._expectNextTokenKind(TokenKind.Pipe) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(pat)
     } else {
       None
     }
 
-    val ifBlock = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val ifBlock = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val elseBlock = if self._peek() |nextToken| {
       if nextToken.kind == TokenKind.Else {
         self._advance() // consume 'else' token
-        val elseBlock = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val elseBlock = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         Some(elseBlock)
       } else {
         None
@@ -1322,14 +1322,14 @@ export type Parser {
       None
     }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.If(condition, conditionBinding, ifBlock, elseBlock)))
+    Ok(AstNode(token: token, kind: AstNodeKind.If(condition, conditionBinding, ifBlock, elseBlock)))
   }
 
   func _parseMatch(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    match self._expectNextTokenKind(TokenKind.LBrace) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._expectNextTokenKind(TokenKind.LBrace) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val cases: MatchCase[] = []
     while self._peek() |next| {
@@ -1360,17 +1360,17 @@ export type Parser {
             self._advance() // consume '_' token
             MatchCaseKind.Else
           } else {
-            val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             val path = [label]
             while self._peek() |nextToken| {
               if nextToken.kind != TokenKind.Dot break
               self._advance() // consume '.' token
-              val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               path.push(label)
             }
 
             // TODO: Destructuring types in match cases
-            val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             match nextToken.kind {
               TokenKind.LParen => return todo(nextToken.position)
               _ => {}
@@ -1385,27 +1385,27 @@ export type Parser {
         }
         _ => {
           val expected = [TokenKind.RBrace, TokenKind.Int(0), TokenKind.Float(0.0), TokenKind.Bool(true), TokenKind.String(""), TokenKind.Ident(""), TokenKind.Else]
-          return Result.Err(ParseError(position: next.position, kind: ParseErrorKind.ExpectedToken(expected, next.kind)))
+          return Err(ParseError(position: next.position, kind: ParseErrorKind.ExpectedToken(expected, next.kind)))
         }
       }
 
-      var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       val binding = match nextToken.kind {
         TokenKind.Ident => {
-          val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           Some(label)
         }
         _ => None
       }
 
-      nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      nextToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if nextToken.kind != TokenKind.Arrow {
         val expected = if binding { [TokenKind.Arrow] } else [TokenKind.Ident(""), TokenKind.Arrow]
-        return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
+        return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
       }
 
-      val body = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-      nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val body = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+      nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if nextToken.kind == TokenKind.Comma {
         self._advance() // consume ',' token
       }
@@ -1414,64 +1414,64 @@ export type Parser {
     }
     self._advance() // consume '}' token
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Match(expr, cases)))
+    Ok(AstNode(token: token, kind: AstNodeKind.Match(expr, cases)))
   }
 
   func _parseWhileLoop(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val condition = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val condition = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val conditionBinding = if nextToken.kind == TokenKind.Pipe {
       self._advance() // consume opening '|' token
-      val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-      match self._expectNextTokenKind(TokenKind.Pipe) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+      match self._expectNextTokenKind(TokenKind.Pipe) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(pat)
     } else {
       None
     }
 
-    val block = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val block = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.While(condition, conditionBinding, block)))
+    Ok(AstNode(token: token, kind: AstNodeKind.While(condition, conditionBinding, block)))
   }
 
   func _parseForLoop(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    val itemPattern = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    val itemPattern = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    var nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val indexPattern = if nextToken.kind == TokenKind.Comma {
       self._advance() // consume ',' token
-      val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val pat = match self._parseBindingPattern() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(pat)
     } else {
       None
     }
 
-    match self._expectNextTokenKind(TokenKind.In) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._expectNextTokenKind(TokenKind.In) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val iterator = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val iterator = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    val block = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val block = match self._parseBlockOrSingleExpression(allowTerminators: true) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.For(itemPattern, indexPattern, iterator, block)))
+    Ok(AstNode(token: token, kind: AstNodeKind.For(itemPattern, indexPattern, iterator, block)))
   }
 
   func _parseBreak(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Break))
+    Ok(AstNode(token: token, kind: AstNodeKind.Break))
   }
 
   func _parseContinue(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Continue))
+    Ok(AstNode(token: token, kind: AstNodeKind.Continue))
   }
 
   func _parseReturn(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val token = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val hasNewline = match token.kind {
       TokenKind.Return(hasNewline) => hasNewline
       _ => false // unreachable
@@ -1480,10 +1480,10 @@ export type Parser {
     val expr = if hasNewline {
       None
     } else {
-      val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(expr)
     }
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Return(expr)))
+    Ok(AstNode(token: token, kind: AstNodeKind.Return(expr)))
   }
 
   func _parseBinary(self, token: Token, left: AstNode): Result<AstNode, ParseError> {
@@ -1510,7 +1510,7 @@ export type Parser {
       TokenKind.EqEq => BinaryOp.Eq
       TokenKind.Neq => BinaryOp.Neq
       TokenKind.LT => {
-        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         if nextToken.kind == TokenKind.LT {
           self._advance() // consume '<' token
           BinaryOp.Shl
@@ -1520,7 +1520,7 @@ export type Parser {
       }
       TokenKind.LTE => BinaryOp.LTE
       TokenKind.GT => {
-        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         if nextToken.kind == TokenKind.GT {
           self._advance() // consume '>' token
           BinaryOp.Shr
@@ -1529,15 +1529,15 @@ export type Parser {
         }
       }
       TokenKind.GTE => BinaryOp.GTE
-      _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+      _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
     }
 
-    val right = match self._parsePrecedence(prec: prec) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Binary(BinaryAstNode(left: left, op: op, right: right))))
+    val right = match self._parsePrecedence(prec: prec) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    Ok(AstNode(token: token, kind: AstNodeKind.Binary(BinaryAstNode(left: left, op: op, right: right))))
   }
 
   func _parseAccessor(self, token: Token, left: AstNode): Result<AstNode, ParseError> {
-    val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val label = match self._expectNextLabel() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val accessorNode = match left.kind {
       AstNodeKind.Accessor(accessorNode) => accessorNode
@@ -1547,10 +1547,10 @@ export type Parser {
 
     val node = AstNode(token: token, kind: AstNodeKind.Accessor(accessorNode))
 
-    val res = match self._tryParseInvocationWithTypeArgs(invokee: node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    if res |invocationNode| return Result.Ok(invocationNode)
+    val res = match self._tryParseInvocationWithTypeArgs(invokee: node) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    if res |invocationNode| return Ok(invocationNode)
 
-    Result.Ok(node)
+    Ok(node)
   }
 
   func _commaSeparated<T>(self, end: TokenKind, consumeFinal: Bool, fn: (Int) => Result<T, ParseError>): Result<T[], ParseError> {
@@ -1559,19 +1559,19 @@ export type Parser {
     var endExpected = false
     var idx = 0
     while true {
-      val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if nextToken.kind == end {
         if consumeFinal self._advance() // consume end token before exiting
         break
       } else if endExpected {
         val kind = ParseErrorKind.ExpectedToken(expected: [TokenKind.Comma, end], received: nextToken.kind)
-        return Result.Err(ParseError(position: nextToken.position, kind: kind))
+        return Err(ParseError(position: nextToken.position, kind: kind))
       }
 
-      val item = match fn(idx) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val item = match fn(idx) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       items.push(item)
 
-      val peekToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val peekToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if peekToken.kind == TokenKind.Comma {
         self._advance() // consume ',' token
       } else {
@@ -1581,15 +1581,15 @@ export type Parser {
       idx += 1
     }
 
-    Result.Ok(items)
+    Ok(items)
   }
 
   func _parseInvocationArguments(self): Result<InvocationArgument[], ParseError> {
     val argsRes = self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => {
-      val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       val arg = match expr.kind {
         AstNodeKind.Identifier(identifierKind) => {
-          val peekToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val peekToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           val arg = if peekToken.kind == TokenKind.Colon {
             self._advance() // consume ':' token
 
@@ -1597,10 +1597,10 @@ export type Parser {
               IdentifierKind.Named(name) => Label(name: name, position: expr.token.position)
               _ => {
                 val kind = ParseErrorKind.ExpectedToken(expected: [TokenKind.Ident("")], received: expr.token.kind)
-                return Result.Err(ParseError(position: expr.token.position, kind: kind))
+                return Err(ParseError(position: expr.token.position, kind: kind))
               }
             }
-            val value = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val value = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
             InvocationArgument(label: Some(label), value: value)
           } else {
@@ -1611,15 +1611,15 @@ export type Parser {
         _ => InvocationArgument(label: None, value: expr)
       }
 
-      Result.Ok(arg)
+      Ok(arg)
     })
-    val arguments = match argsRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val arguments = match argsRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(arguments)
+    Ok(arguments)
   }
 
   func _parseInvocation(self, token: Token, left: AstNode): Result<AstNode, ParseError> {
-    val arguments = match self._parseInvocationArguments() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val arguments = match self._parseInvocationArguments() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val isSome = match left.kind {
       AstNodeKind.Identifier(identKind) => match identKind {
@@ -1641,56 +1641,56 @@ export type Parser {
     }
 
     // TODO: Explicit type arguments
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Invocation(InvocationAstNode(invokee: invokee, typeArguments: [], arguments: arguments))))
+    Ok(AstNode(token: token, kind: AstNodeKind.Invocation(InvocationAstNode(invokee: invokee, typeArguments: [], arguments: arguments))))
   }
 
   func _parseIndexing(self, token: Token, left: AstNode): Result<AstNode, ParseError> {
-    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     // TODO: ensure this type annotation is unnecessary
     val index = if nextToken.kind == TokenKind.Colon {
       self._advance() // consume ':' token
-      val rangeEnd = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val rangeEnd = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       IndexingMode.Range(start: None, end: Some(rangeEnd))
     } else {
-      val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-      val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val expr = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+      val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if nextToken.kind == TokenKind.RBrack {
         IndexingMode.Single(expr)
       } else if nextToken.kind == TokenKind.Colon {
         self._advance() // consume ':' token
-        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val nextToken = match self._expectPeek() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         if nextToken.kind == TokenKind.RBrack {
           IndexingMode.Range(start: Some(expr), end: None)
         } else {
-          val rangeEnd = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val rangeEnd = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           IndexingMode.Range(start: Some(expr), end: Some(rangeEnd))
         }
       } else {
-        return Result.Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Colon, TokenKind.RBrack], nextToken.kind)))
+        return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Colon, TokenKind.RBrack], nextToken.kind)))
       }
     }
 
-    val lastToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val lastToken = match self._expectNext() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     if lastToken.kind != TokenKind.RBrack {
-      return Result.Err(ParseError(position: lastToken.position, kind: ParseErrorKind.UnexpectedToken(lastToken)))
+      return Err(ParseError(position: lastToken.position, kind: ParseErrorKind.UnexpectedToken(lastToken)))
     }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Indexing(expr: left, index: index)))
+    Ok(AstNode(token: token, kind: AstNodeKind.Indexing(expr: left, index: index)))
   }
 
   func _parseLambda(self, token: Token, left: AstNode): Result<AstNode, ParseError> {
     val params = match left.kind {
       AstNodeKind.Identifier(identifier) => match identifier {
         IdentifierKind.Named(name) => [FunctionParam(label: Label(name: name, position: left.token.position))]
-        _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+        _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
       AstNodeKind.Grouped(inner) => {
         match inner.kind {
           AstNodeKind.Identifier(identifier) => match identifier {
             IdentifierKind.Named(name) => [FunctionParam(label: Label(name: name, position: inner.token.position))]
-            _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+            _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
           }
-          _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+          _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
         }
       }
       AstNodeKind.Tuple(items) => {
@@ -1702,36 +1702,36 @@ export type Parser {
                 params.push(FunctionParam(label: Label(name: name, position: item.token.position)))
                 0 // <- awkward; this is needed because of an outstanding bug with Unit-returning `match`es (even though this is a statement so it shouldn't matter)
               }
-              _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+              _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
             }
-            _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+            _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
           }
         }
         params
       }
-      _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+      _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
     }
 
-    val body = match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val body = match self._parseBlockOrSingleExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    return Result.Ok(AstNode(token: token, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
+    Ok(AstNode(token: token, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
   }
 
   func _parseAssignment(self, token: Token, left: AstNode, assignOp: AssignOp = AssignOp.Assign): Result<AstNode, ParseError> {
     val mode = match left.kind {
       AstNodeKind.Identifier(identKind) => match identKind {
         IdentifierKind.Named(name) => AssignmentMode.Variable(name, left.token)
-        _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+        _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
       AstNodeKind.Accessor(node) => AssignmentMode.Accessor(node)
       AstNodeKind.Indexing(expr, indexMode) => match indexMode {
         IndexingMode.Single(indexExpr) => AssignmentMode.Indexing(expr, indexExpr)
-        _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+        _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
-      _ => return Result.Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
+      _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
     }
 
-    val rhs = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val rhs = match self._parseExpression() { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val expr = match assignOp {
       AssignOp.Assign => rhs
@@ -1745,16 +1745,16 @@ export type Parser {
       AssignOp.CoalesceEq => AstNode(token: token, kind: AstNodeKind.Binary(BinaryAstNode(left: left, op: BinaryOp.Coalesce, right: rhs)))
     }
 
-    Result.Ok(AstNode(token: token, kind: AstNodeKind.Assignment(mode: mode, op: assignOp, expr: expr)))
+    Ok(AstNode(token: token, kind: AstNodeKind.Assignment(mode: mode, op: assignOp, expr: expr)))
   }
 }
 
 func todo<V>(position: Position): Result<V, ParseError> {
-  Result.Err(ParseError(position: position, kind: ParseErrorKind.NotYetImplemented))
+  Err(ParseError(position: position, kind: ParseErrorKind.NotYetImplemented))
 }
 
 func unreachable<V>(): Result<V, ParseError> {
-  Result.Err(ParseError(position: Position(line: 0, col: 0), kind: ParseErrorKind.Unreachable))
+  Err(ParseError(position: Position(line: 0, col: 0), kind: ParseErrorKind.Unreachable))
 }
 
 type Precedence {

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -25,7 +25,7 @@ export type ModuleLoader {
   func hasSeenModule(self, modulePathAbs: String): Bool = self.parsedModules.containsKey(modulePathAbs)
 
   func tokenizeAndParse(self, modulePath: String): Result<ParsedModule, TokenizeAndParseError> {
-    if self.parsedModules[modulePath] |m| return Result.Ok(m)
+    if self.parsedModules[modulePath] |m| return Ok(m)
 
     val parsedModule = match fs.readFile(modulePath) {
       Result.Ok(contents) => {
@@ -33,19 +33,19 @@ export type ModuleLoader {
           Result.Ok(tokens) => {
             val m = match Parser.parse(tokens) {
               Result.Ok(parsedModule) => parsedModule
-              Result.Err(error) => return Result.Err(TokenizeAndParseError.ParseError(error))
+              Result.Err(error) => return Err(TokenizeAndParseError.ParseError(error))
             }
             m
           }
-          Result.Err(error) => return Result.Err(TokenizeAndParseError.LexerError(error))
+          Result.Err(error) => return Err(TokenizeAndParseError.LexerError(error))
         }
         m
       }
-      Result.Err(e) => return Result.Err(TokenizeAndParseError.ReadFileError(modulePath))
+      Result.Err(e) => return Err(TokenizeAndParseError.ReadFileError(modulePath))
     }
     self.parsedModules[modulePath] = parsedModule
 
-    Result.Ok(parsedModule)
+    Ok(parsedModule)
   }
 }
 
@@ -1080,7 +1080,7 @@ export type Typechecker {
   func typecheckEntrypoint(self, modulePathAbs: String): Result<Int, TypecheckerError> {
     val preludeModulePathSegs = getAbsolutePath(self.moduleLoader.stdRoot + "/prelude.abra")
     val preludeModulePathAbs = "/" + preludeModulePathSegs.join("/")
-    match self._typecheckModule(preludeModulePathAbs) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._typecheckModule(preludeModulePathAbs) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val preludeStructs = [
       self.project.preludeIntStruct,
@@ -1095,7 +1095,7 @@ export type Typechecker {
       if struct.label.position == Position(line: 0, col: 0) {
         val message = "Improperly initialized prelude struct ${struct.label.name}"
         val err = TypeError(position: struct.label.position, kind: TypeErrorKind.Unreachable(message))
-        return Result.Err(TypecheckerError(modulePath: preludeModulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
+        return Err(TypecheckerError(modulePath: preludeModulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
       }
     }
 
@@ -1106,18 +1106,18 @@ export type Typechecker {
       if enum_.label.position == Position(line: 0, col: 0) {
         val message = "Improperly initialized prelude enum ${enum_.label.name}"
         val err = TypeError(position: enum_.label.position, kind: TypeErrorKind.Unreachable(message))
-        return Result.Err(TypecheckerError(modulePath: preludeModulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
+        return Err(TypecheckerError(modulePath: preludeModulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
       }
     }
 
-    match self._typecheckModule(modulePathAbs) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._typecheckModule(modulePathAbs) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(0)
+    Ok(0)
   }
 
   func _tokenizeAndParse(self, modulePathAbs: String): Result<ParsedModule, TypecheckerError> {
     match self.moduleLoader.tokenizeAndParse(modulePathAbs) {
-      Result.Ok(mod) => Result.Ok(mod)
+      Result.Ok(mod) => Ok(mod)
       Result.Err(e) => {
         val kind = match e {
           TokenizeAndParseError.ReadFileError(path) => TypecheckerErrorKind.ReadFileError(path)
@@ -1125,7 +1125,7 @@ export type Typechecker {
           TokenizeAndParseError.ParseError(inner) => TypecheckerErrorKind.ParseError(inner)
         }
 
-        return Result.Err(TypecheckerError(modulePath: modulePathAbs, kind: kind))
+        return Err(TypecheckerError(modulePath: modulePathAbs, kind: kind))
       }
     }
   }
@@ -1169,27 +1169,27 @@ export type Typechecker {
   }
 
   func _addVariableToScope(self, variable: Variable, scope = self.currentScope): Result<Int, TypeError> {
-    if variable.label.name == "_" return Result.Ok(0) // <- unnecessary 0
+    if variable.label.name == "_" return Ok(0) // <- unnecessary 0
 
-    if self._verifyNameUniqueInScope(variable.label, scope) |e| return Result.Err(e)
+    if self._verifyNameUniqueInScope(variable.label, scope) |e| return Err(e)
     scope.variables.push(variable)
 
-    Result.Ok(0) // <- unnecessary 0
+    Ok(0) // <- unnecessary 0
   }
 
   func _addFunctionToScope(self, fn: Function, scope = self.currentScope): Result<Int, TypeError> {
-    if self._verifyNameUniqueInScope(fn.label, scope) |e| return Result.Err(e)
+    if self._verifyNameUniqueInScope(fn.label, scope) |e| return Err(e)
     scope.functions.push(fn)
 
-    Result.Ok(0) // <- unnecessary 0
+    Ok(0) // <- unnecessary 0
   }
 
   func _addStructToScope(self, struct: Struct, isExported: Bool, scope = self.currentScope): Result<Int, TypeError> {
     val structTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Struct(struct)))
-    match self._addTypeToScope(structTy) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._addTypeToScope(structTy) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val variable = Variable(label: struct.label, mutable: false, ty: structTy, alias: Some(VariableAlias.Struct(struct)))
-    match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     scope.structs.push(struct)
 
@@ -1198,15 +1198,15 @@ export type Typechecker {
       self.currentModuleExports[struct.label.name] = Export.Type(StructOrEnum.Struct(struct), variable)
     }
 
-    Result.Ok(0) // <- unnecessary 0
+    Ok(0) // <- unnecessary 0
   }
 
   func _addEnumToScope(self, enum_: Enum, isExported: Bool, scope = self.currentScope): Result<Int, TypeError> {
     val enumTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Enum(enum_)))
-    match self._addTypeToScope(enumTy) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._addTypeToScope(enumTy) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val variable = Variable(label: enum_.label, mutable: false, ty: enumTy, alias: Some(VariableAlias.Enum(enum_)))
-    match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     scope.enums.push(enum_)
 
@@ -1215,13 +1215,13 @@ export type Typechecker {
       self.currentModuleExports[enum_.label.name] = Export.Type(StructOrEnum.Enum(enum_), variable)
     }
 
-    Result.Ok(0) // <- unnecessary 0
+    Ok(0) // <- unnecessary 0
   }
 
   func _addTypeToScope(self, ty: Type, scope = self.currentScope): Result<Int, TypeError> {
     scope.types.push(ty)
 
-    Result.Ok(0) // <- unnecessary 0
+    Ok(0) // <- unnecessary 0
   }
 
   func _findModuleByAlias(self, name: String): Result<(TypedModule, Label)?, TypeError> {
@@ -1231,53 +1231,53 @@ export type Typechecker {
       val importedModule = _m[1]
       if importedModule.aliases.find(a => a.name == name) |alias| {
         val mod = if self.project.modules[importModulePath] |m| m else return unreachable(alias.position, "unknown module")
-        return Result.Ok(Some((mod, alias)))
+        return Ok(Some((mod, alias)))
       }
     }
 
-    Result.Ok(None)
+    Ok(None)
   }
 
   func _verifyNumTypeArgs(self, position: Position, typeArguments: TypeIdentifier[], num: Int): Result<Type[], TypeError> {
     if typeArguments.length != num {
-      return Result.Err(TypeError(position: position, kind: TypeErrorKind.WrongTypeArgumentArity(expected: num, given: typeArguments.length)))
+      return Err(TypeError(position: position, kind: TypeErrorKind.WrongTypeArgumentArity(expected: num, given: typeArguments.length)))
     }
 
     val types: Type[] = []
     for i in range(0, num) {
       val typeIdent = if typeArguments.get(i) |typeIdent| typeIdent else return unreachable(position, "verified above that typeArguments.length == num")
-      val ty = match self._resolveTypeIdentifier(typeIdent) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val ty = match self._resolveTypeIdentifier(typeIdent) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       types.push(ty)
     }
 
-    Result.Ok(types)
+    Ok(types)
   }
 
   func _resolveInstanceTypeIdentifier(self, structOrEnum: StructOrEnum, label: Label, typeArguments: TypeIdentifier[]): Result<Type?, TypeError> {
     match structOrEnum {
       StructOrEnum.Struct(struct) => {
         if label.name == struct.label.name {
-          val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-          return Result.Ok(Some(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), instanceTypeArgs))))
+          val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+          return Ok(Some(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), instanceTypeArgs))))
         }
       }
       StructOrEnum.Enum(enum_) => {
         if label.name == enum_.label.name {
-          val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-          return Result.Ok(Some(Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), instanceTypeArgs))))
+          val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+          return Ok(Some(Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), instanceTypeArgs))))
         }
       }
     }
 
-    Result.Ok(None)
+    Ok(None)
   }
 
   func _resolveTypeIdentifier(self, typeIdent: TypeIdentifier): Result<Type, TypeError> {
     val ty = match typeIdent {
       TypeIdentifier.Normal(label, typeArguments, path) => {
         if path[0] |firstSeg| {
-          val _mod = match self._findModuleByAlias(firstSeg.name) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-          val _m = if _mod |mod| mod else return Result.Err(TypeError(position: firstSeg.position, kind: TypeErrorKind.UnknownName(firstSeg.name, "module")))
+          val _mod = match self._findModuleByAlias(firstSeg.name) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+          val _m = if _mod |mod| mod else return Err(TypeError(position: firstSeg.position, kind: TypeErrorKind.UnknownName(firstSeg.name, "module")))
           // TODO: destructuring
           val mod = _m[0]
           val aliasLabel = _m[1]
@@ -1285,53 +1285,53 @@ export type Typechecker {
           if path[1] |seg| return todo(seg.position, "qualified type paths longer than 2")
 
           val foundTy = match mod.exports[label.name] {
-            None => return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownImportForAlias(label.name, aliasLabel)))
+            None => return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownImportForAlias(label.name, aliasLabel)))
             Export.Type(structOrEnum) => {
-              val t = match self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              val t = match self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               t
             }
             _ => None
           }
 
-          // TODO: clean this up, it's gross
+          // TODO: clean this up, it's not ideal
           val res: Result<Type, TypeError> = if foundTy |ty|
-            Result.Ok(ty)
+            Ok(ty)
           else
-            Result.Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownName(label.name, "type")))
+            Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownName(label.name, "type")))
           return res
         }
 
         val t = match label.name {
           "Any" => {
-            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             Type(kind: TypeKind.Any)
           }
           "Unit" => {
-            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             Type(kind: TypeKind.PrimitiveUnit)
           }
           "Int" => {
-            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             Type(kind: TypeKind.PrimitiveInt)
           }
           "Float" => {
-            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             Type(kind: TypeKind.PrimitiveFloat)
           }
           "Bool" => {
-            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             Type(kind: TypeKind.PrimitiveBool)
           }
           "String" => {
-            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             Type(kind: TypeKind.PrimitiveString)
           }
           "Map" => {
-            val typeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, 2) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val typeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, 2) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeMapStruct), typeArgs))
           }
           "Set" => {
-            val typeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, 1) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val typeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, 1) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeSetStruct), typeArgs))
           }
           _ => {
@@ -1339,15 +1339,26 @@ export type Typechecker {
             while scope |sc| {
               for ty in sc.types {
                 match ty.kind {
-                  TypeKind.Generic(name) => { if label.name == name return Result.Ok(ty) }
+                  TypeKind.Generic(name) => { if label.name == name return Ok(ty) }
                   TypeKind.Type(structOrEnum) => {
-                    val foundTy = match self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-                    if foundTy |ty| return Result.Ok(ty)
+                    val foundTy = match self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+                    if foundTy |ty| return Ok(ty)
                   }
                   _ => continue
                 }
               }
               scope = sc.parent
+            }
+
+            for ty in self.project.preludeScope.types {
+              match ty.kind {
+                TypeKind.Generic(name) => { if label.name == name return Ok(ty) }
+                TypeKind.Type(structOrEnum) => {
+                  val foundTy = match self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+                  if foundTy |ty| return Ok(ty)
+                }
+                _ => continue
+              }
             }
 
             for importedModule in self.currentModuleImports.values() {
@@ -1358,8 +1369,8 @@ export type Typechecker {
                 if name == label.name {
                   match imp.kind {
                     TypedImportKind.Type(structOrEnum) => {
-                      val foundTy = match self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-                      if foundTy |ty| return Result.Ok(ty)
+                      val foundTy = match self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+                      if foundTy |ty| return Ok(ty)
                     }
                     _ => continue
                   }
@@ -1367,23 +1378,23 @@ export type Typechecker {
               }
             }
 
-            return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownName(label.name, "type")))
+            return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownName(label.name, "type")))
           }
         }
         t
       }
       TypeIdentifier.Array(inner) => {
-        val innerTy = match self._resolveTypeIdentifier(inner) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val innerTy = match self._resolveTypeIdentifier(inner) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [innerTy]))
       }
       TypeIdentifier.Option(inner) => {
-        val innerTy = match self._resolveTypeIdentifier(inner) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val innerTy = match self._resolveTypeIdentifier(inner) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [innerTy]))
       }
       TypeIdentifier.Tuple(typeIdents) => {
         val types: Type[] = []
         for typeIdent in typeIdents {
-          val ty = match self._resolveTypeIdentifier(typeIdent) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val ty = match self._resolveTypeIdentifier(typeIdent) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           types.push(ty)
         }
 
@@ -1392,16 +1403,16 @@ export type Typechecker {
       TypeIdentifier.Function(params, ret) => {
         val paramTypes: (Type, Bool)[] = []
         for p in params {
-          val t = match self._resolveTypeIdentifier(p) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val t = match self._resolveTypeIdentifier(p) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           paramTypes.push((t, true))
         }
 
-        val returnType = match self._resolveTypeIdentifier(ret) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val returnType = match self._resolveTypeIdentifier(ret) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         Type(kind: TypeKind.Func(paramTypes, returnType))
       }
     }
 
-    Result.Ok(ty)
+    Ok(ty)
   }
 
   func _resolveIdentifier(self, ident: String): Variable? {
@@ -1714,9 +1725,9 @@ export type Typechecker {
 
   func _ensureValidExportScope(self, exportToken: Token): Result<Int, TypeError> {
     if self.currentScope.kind != ScopeKind.Module {
-      Result.Err(TypeError(position: exportToken.position, kind: TypeErrorKind.IllegalExportScope))
+      Err(TypeError(position: exportToken.position, kind: TypeErrorKind.IllegalExportScope))
     } else {
-      Result.Ok(0) // <-- unnecessary int
+      Ok(0) // <-- unnecessary int
     }
   }
 
@@ -1733,7 +1744,7 @@ export type Typechecker {
     val mod = TypedModule(id: moduleId, name: modulePathAbs, code: [], rootScope: moduleScope)
     self.project.modules[modulePathAbs] = mod
 
-    val parsedModule = match self._tokenizeAndParse(modulePathAbs) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val parsedModule = match self._tokenizeAndParse(modulePathAbs) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     for importNode in parsedModule.imports {
       var importNodePath = importNode.moduleName.name
       val isRelativeImport = importNodePath.startsWith(".")
@@ -1748,7 +1759,7 @@ export type Typechecker {
       val typedImportModule = if self.project.modules[importPathAbs] |m| {
         if !m.complete {
           val err = TypeError(position: importNode.moduleName.position, kind: TypeErrorKind.CircularDependency)
-          return Result.Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
+          return Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
         }
 
         m
@@ -1771,7 +1782,7 @@ export type Typechecker {
               _ => e
             }
 
-            return Result.Err(err)
+            return Err(err)
           }
         }
 
@@ -1780,13 +1791,13 @@ export type Typechecker {
 
       match self._typecheckImport(typedImportModule, importNode) {
         Result.Ok(v) => v
-        Result.Err(e) => return Result.Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(e)))
+        Result.Err(e) => return Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(e)))
       }
     }
 
     mod.code = match self._typecheckBlock(parsedModule.nodes) {
       Result.Ok(v) => v
-      Result.Err(e) => return Result.Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(e)))
+      Result.Err(e) => return Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(e)))
     }
 
     mod.imports = self.currentModuleImports
@@ -1798,26 +1809,26 @@ export type Typechecker {
     self.currentScope = prevScope
 
     mod.complete = true
-    Result.Ok(mod)
+    Ok(mod)
   }
 
   func _typecheckDecoratorNode(self, dec: DecoratorNode): Result<Decorator, TypeError> {
     val args: LiteralAstNode[] = []
     for arg in dec.arguments {
-      val typedArg = match self._typecheckExpression(arg.value, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedArg = match self._typecheckExpression(arg.value, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       match typedArg.kind {
         TypedAstNodeKind.Literal(litNode) => args.push(litNode)
         _ => return unreachable(typedArg.token.position, "should have been caught during parsing")
       }
     }
 
-    Result.Ok(Decorator(label: dec.name, arguments: args))
+    Ok(Decorator(label: dec.name, arguments: args))
   }
 
   func _typecheckFunctionPass1(self, node: FunctionDeclarationNode): Result<Function, TypeError> {
     val decorators: Decorator[] = []
     for d in node.decorators {
-      val dec = match self._typecheckDecoratorNode(d) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val dec = match self._typecheckDecoratorNode(d) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       decorators.push(dec)
     }
 
@@ -1829,17 +1840,17 @@ export type Typechecker {
     val seenTypeParams: Map<String, Label> = {}
     for label in node.typeParams {
       if seenTypeParams[label.name] |original| {
-        return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.DuplicateName(original)))
+        return Err(TypeError(position: label.position, kind: TypeErrorKind.DuplicateName(original)))
       }
       seenTypeParams[label.name] = label
 
       val generic = Type(kind: TypeKind.Generic(label.name))
-      match self._addTypeToScope(generic) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._addTypeToScope(generic) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       typeParams.push((generic, label))
     }
 
     val returnType = if node.returnTypeAnnotation |typeAnn| {
-      val ty = match self._resolveTypeIdentifier(typeAnn) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val ty = match self._resolveTypeIdentifier(typeAnn) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       ty
     } else {
       Type(kind: TypeKind.PrimitiveUnit)
@@ -1851,7 +1862,7 @@ export type Typechecker {
     val fnKind = if hasSelf {
       if !self.currentTypeDecl {
         val param = if node.params[0] |p| p else return unreachable(node.name.position, "expected a first parameter to be present")
-        return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
+        return Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
       }
 
       FunctionKind.InstanceMethod
@@ -1862,14 +1873,14 @@ export type Typechecker {
     }
 
     val fn = Function(label: node.name, scope: fnScope, kind: fnKind, typeParams: typeParams, params: [], returnType: returnType, body: [], decorators: decorators)
-    match self._addFunctionToScope(fn) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._addFunctionToScope(fn) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(fn)
+    Ok(fn)
   }
 
   func _typecheckFunctionParam(self, param: FunctionParam, typeHint: Type?, allowSelf: Bool, isRevisit = false): Result<(TypedFunctionParam, Bool), TypeError> {
     if param.label.name == "self" {
-      if !allowSelf return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
+      if !allowSelf return Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
 
       if self.currentTypeDecl |structOrEnum| {
         val ty = match structOrEnum {
@@ -1884,20 +1895,20 @@ export type Typechecker {
         }
 
         val variable = Variable(label: param.label, mutable: false, ty: ty)
-        match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
         val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: None, isVariadic: false)
-        return Result.Ok((typedParam, false))
+        return Ok((typedParam, false))
       }
 
-      return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
+      return Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
     }
 
     val paramType = if param.typeAnnotation |typeAnn| {
-      val ty = match self._resolveTypeIdentifier(typeAnn) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val ty = match self._resolveTypeIdentifier(typeAnn) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if typeHint |hintTy| {
         if !self._typeSatisfiesRequired(ty: ty, required: hintTy) {
-          return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.TypeMismatch([hintTy], ty)))
+          return Err(TypeError(position: param.label.position, kind: TypeErrorKind.TypeMismatch([hintTy], ty)))
         }
       }
       Some(ty)
@@ -1910,7 +1921,7 @@ export type Typechecker {
     var defaultValue: TypedAstNode? = None
     if param.defaultValue |node| {
       if isRevisit {
-        val expr = match self._typecheckExpression(node, paramType) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val expr = match self._typecheckExpression(node, paramType) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         defaultValue = Some(expr)
       } else {
         // TODO: There has to be a cleaner way of representing this
@@ -1923,15 +1934,15 @@ export type Typechecker {
             if ctx.exprContainsFunctionCall || ctx.exprContainsVariableRef {
               val placeholder = Some(TypedAstNode(token: node.token, ty: Type(kind: TypeKind.Hole), kind: TypedAstNodeKind.Placeholder))
               val typedParam = TypedFunctionParam(label: param.label, ty: Type(kind: TypeKind.Hole), defaultValue: placeholder, isVariadic: param.isVariadic)
-              return Result.Ok((typedParam, true))
+              return Ok((typedParam, true))
             }
-            return Result.Err(e)
+            return Err(e)
           }
         }
         self.paramDefaultValueContext = None
         if ctx.exprContainsFunctionCall || ctx.exprContainsVariableRef {
           val typedParam = TypedFunctionParam(label: param.label, ty: paramType ?: expr.ty, defaultValue: Some(expr), isVariadic: param.isVariadic)
-          return Result.Ok((typedParam, true))
+          return Ok((typedParam, true))
         }
         defaultValue = Some(expr)
       }
@@ -1940,7 +1951,7 @@ export type Typechecker {
     var ty = if paramType |paramType| {
       if defaultValue |defaultValue| {
         if !self._typeSatisfiesRequired(ty: defaultValue.ty, required: paramType) {
-          return Result.Err(TypeError(position: defaultValue.token.position, kind: TypeErrorKind.TypeMismatch([paramType], defaultValue.ty)))
+          return Err(TypeError(position: defaultValue.token.position, kind: TypeErrorKind.TypeMismatch([paramType], defaultValue.ty)))
         }
       }
 
@@ -1949,27 +1960,27 @@ export type Typechecker {
       if defaultValue |defaultValue| {
         defaultValue.ty
       } else {
-        return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.UnknownParameterType(param.label.name)))
+        return Err(TypeError(position: param.label.position, kind: TypeErrorKind.UnknownParameterType(param.label.name)))
       }
     }
 
     val variable = Variable(label: param.label, mutable: false, ty: ty)
-    match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     if param.isVariadic {
       if self._typeAsInstance1(ty, self.project.preludeArrayStruct) |innerType| {
         ty = innerType
       } else {
-        return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidVarargType(ty)))
+        return Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidVarargType(ty)))
       }
     }
 
     if ty.hasUnfilledHoles() {
-      return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.IllegalValueType(ty: ty, purpose: "parameter")))
+      return Err(TypeError(position: param.label.position, kind: TypeErrorKind.IllegalValueType(ty: ty, purpose: "parameter")))
     }
 
     val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: defaultValue, isVariadic: param.isVariadic)
-    Result.Ok((typedParam, false))
+    Ok((typedParam, false))
   }
 
   func _typecheckFunctionPass2(self, fn: Function, allowSelf: Bool, params: FunctionParam[], paramHints: Type[] = []): Result<Int[], TypeError> {
@@ -1981,22 +1992,22 @@ export type Typechecker {
     var startedOptionalParams = false
     for param, idx in params {
       if param.isVariadic && idx != params.length - 1 {
-        return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "vararg")))
+        return Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "vararg")))
       }
 
       if seenParamNames.contains(param.label.name) {
-        return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.DuplicateParameter(param.label.name)))
+        return Err(TypeError(position: param.label.position, kind: TypeErrorKind.DuplicateParameter(param.label.name)))
       }
       seenParamNames.insert(param.label.name)
 
       if param.defaultValue {
         startedOptionalParams = true
       } else if startedOptionalParams {
-        return Result.Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "required")))
+        return Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "required")))
       }
 
       val hint = paramHints[idx]
-      val _p = match self._typecheckFunctionParam(param, hint, allowSelf) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val _p = match self._typecheckFunctionParam(param, hint, allowSelf) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       // TODO: destructuring
       val typedParam = _p[0]
       val needsRevisit = _p[1]
@@ -2012,7 +2023,7 @@ export type Typechecker {
 
     self.currentScope = prevScope
 
-    Result.Ok(paramsNeedingRevisit)
+    Ok(paramsNeedingRevisit)
   }
 
   func _typecheckFunctionPass3(self, fn: Function, allowSelf: Bool, params: FunctionParam[], body: AstNode[], paramsNeedingRevisit: Int[], paramHints: Type[] = []): Result<Int, TypeError> {
@@ -2024,7 +2035,7 @@ export type Typechecker {
     val hasReturnValue = fn.returnType.kind != TypeKind.PrimitiveUnit
     if hasReturnValue && body.isEmpty() {
       if !fn.decorators.find(dec => dec.label.name == "Stub" || dec.label.name == "Intrinsic" || dec.label.name == "CBinding")
-        return Result.Err(TypeError(position: fn.label.position, kind: TypeErrorKind.ReturnTypeMismatch(Some(fn.label.name), fn.returnType, None)))
+        return Err(TypeError(position: fn.label.position, kind: TypeErrorKind.ReturnTypeMismatch(Some(fn.label.name), fn.returnType, None)))
     }
 
     for param, idx in fn.params {
@@ -2036,7 +2047,7 @@ export type Typechecker {
       val defaultValueNode = if paramNode.defaultValue |n| n else return unreachable(param.label.position, "the only way a parameter needs revisiting is if it has a default value")
 
       val hint = paramHints[idx]
-      val _p = match self._typecheckFunctionParam(param: paramNode, typeHint: hint, allowSelf: allowSelf, isRevisit: true) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val _p = match self._typecheckFunctionParam(param: paramNode, typeHint: hint, allowSelf: allowSelf, isRevisit: true) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       // TODO: destructuring
       val typedParam = _p[0]
       val needsRevisit = _p[1]
@@ -2045,37 +2056,37 @@ export type Typechecker {
     }
 
     for node, idx in body {
-      if self.currentScope.terminator return Result.Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
+      if self.currentScope.terminator return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
       val typedNode = if idx == body.length - 1 && hasReturnValue {
         val fnName = if fn.isLambda None else Some(fn.label.name)
         val err = TypeError(position: node.token.position, kind: TypeErrorKind.ReturnTypeMismatch(fnName, fn.returnType, Some(Type(kind: TypeKind.PrimitiveUnit))))
         match node.kind {
-          AstNodeKind.While => return Result.Err(err)
-          AstNodeKind.For => return Result.Err(err)
-          AstNodeKind.BindingDeclaration => return Result.Err(err)
-          AstNodeKind.FunctionDeclaration => return Result.Err(err)
-          AstNodeKind.TypeDeclaration => return Result.Err(err)
-          AstNodeKind.EnumDeclaration => return Result.Err(err)
+          AstNodeKind.While => return Err(err)
+          AstNodeKind.For => return Err(err)
+          AstNodeKind.BindingDeclaration => return Err(err)
+          AstNodeKind.FunctionDeclaration => return Err(err)
+          AstNodeKind.TypeDeclaration => return Err(err)
+          AstNodeKind.EnumDeclaration => return Err(err)
           _ => {}
         }
 
         val expr = if fn.returnType.kind == TypeKind.Hole {
-          val expr = match self._typecheckExpressionOrTerminator(node, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val expr = match self._typecheckExpressionOrTerminator(node, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           fn.returnType = expr.ty
           expr
         } else {
-          val expr = match self._typecheckExpressionOrTerminator(node, Some(fn.returnType)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val expr = match self._typecheckExpressionOrTerminator(node, Some(fn.returnType)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if !self._typeSatisfiesRequired(ty: expr.ty, required: fn.returnType) {
             val fnName = if fn.isLambda None else Some(fn.label.name)
-            return Result.Err(TypeError(position: expr.token.position, kind: TypeErrorKind.ReturnTypeMismatch(fnName, fn.returnType, Some(expr.ty))))
+            return Err(TypeError(position: expr.token.position, kind: TypeErrorKind.ReturnTypeMismatch(fnName, fn.returnType, Some(expr.ty))))
           }
           expr
         }
 
         expr
       } else {
-        val stmt = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val stmt = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         stmt
       }
       fn.body.push(typedNode)
@@ -2084,12 +2095,12 @@ export type Typechecker {
     self.currentFunction = prevFn
     self.currentScope = prevScope
 
-    Result.Ok(0)
+    Ok(0)
   }
 
   func _typecheckStructPass1(self, node: TypeDeclarationNode): Result<Struct, TypeError> {
     val isExported = if node.exportToken |exportToken| {
-      match self._ensureValidExportScope(exportToken) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._ensureValidExportScope(exportToken) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       true
     } else {
       false
@@ -2103,21 +2114,21 @@ export type Typechecker {
     val seenTypeParams: Map<String, Label> = {}
     for label in node.typeParams {
       if seenTypeParams[label.name] |original| {
-        return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.DuplicateName(original)))
+        return Err(TypeError(position: label.position, kind: TypeErrorKind.DuplicateName(original)))
       }
       seenTypeParams[label.name] = label
 
       val generic = Type(kind: TypeKind.Generic(label.name))
-      match self._addTypeToScope(generic) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._addTypeToScope(generic) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       typeParams.push(label.name)
     }
 
     self.currentScope = prevScope
 
     val struct = Struct(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams)
-    match self._addStructToScope(struct, isExported) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._addStructToScope(struct, isExported) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(struct)
+    Ok(struct)
   }
 
   func _typecheckStructPass2_1(self, struct: Struct, node: TypeDeclarationNode): Result<Int, TypeError> {
@@ -2129,16 +2140,16 @@ export type Typechecker {
     val seenFields: Map<String, Label> = {}
     for field in node.fields {
       if seenFields[field.name.name] |original| {
-        return Result.Err(TypeError(position: field.name.position, kind: TypeErrorKind.DuplicateName(original)))
+        return Err(TypeError(position: field.name.position, kind: TypeErrorKind.DuplicateName(original)))
       }
       seenFields[field.name.name] = field.name
 
-      val ty = match self._resolveTypeIdentifier(field.typeAnnotation) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val ty = match self._resolveTypeIdentifier(field.typeAnnotation) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       struct.fields.push(Field(name: field.name, ty: ty, initializer: None))
     }
 
     for funcDeclNode in node.methods {
-      val fn = match self._typecheckFunctionPass1(funcDeclNode) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val fn = match self._typecheckFunctionPass1(funcDeclNode) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       match fn.kind {
         FunctionKind.InstanceMethod => struct.instanceMethods.push(fn)
         FunctionKind.StaticMethod => struct.staticMethods.push(fn)
@@ -2149,7 +2160,7 @@ export type Typechecker {
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
 
-    Result.Ok(0)
+    Ok(0)
   }
 
   func _typecheckMethodsPass2(self, structOrEnum: StructOrEnum, funcDeclNodes: FunctionDeclarationNode[]): Result<Map<Label, Int[]>, TypeError> {
@@ -2191,27 +2202,27 @@ export type Typechecker {
       } else {
         return unreachable(funcDeclNode.name.position, "could not find function among instance/static methods")
       }
-      val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: true, params: funcDeclNode.params) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: true, params: funcDeclNode.params) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       allParamsNeedingRevisit[fn.label] = paramsNeedingRevisit
 
       if isToString {
         val required = Type(kind: TypeKind.Func([], Type(kind: TypeKind.PrimitiveString)))
         if !self._typeSatisfiesRequired(ty: fn.getType(), required: required) {
-          return Result.Err(TypeError(position: fn.label.position, kind: TypeErrorKind.InvalidTraitMethodSignature(fn)))
+          return Err(TypeError(position: fn.label.position, kind: TypeErrorKind.InvalidTraitMethodSignature(fn)))
         }
         toStringFn = Some(fn)
       }
       if isHash {
         val required = Type(kind: TypeKind.Func([], Type(kind: TypeKind.PrimitiveInt)))
         if !self._typeSatisfiesRequired(ty: fn.getType(), required: required) {
-          return Result.Err(TypeError(position: fn.label.position, kind: TypeErrorKind.InvalidTraitMethodSignature(fn)))
+          return Err(TypeError(position: fn.label.position, kind: TypeErrorKind.InvalidTraitMethodSignature(fn)))
         }
         hashFn = Some(fn)
       }
       if isEq {
         val required = Type(kind: TypeKind.Func([(selfInstanceType, true)], Type(kind: TypeKind.PrimitiveBool)))
         if !self._typeSatisfiesRequired(ty: fn.getType(), required: required) {
-          return Result.Err(TypeError(position: fn.label.position, kind: TypeErrorKind.InvalidTraitMethodSignature(fn)))
+          return Err(TypeError(position: fn.label.position, kind: TypeErrorKind.InvalidTraitMethodSignature(fn)))
         }
         eqFn = Some(fn)
       }
@@ -2233,7 +2244,7 @@ export type Typechecker {
       StructOrEnum.Enum(enum_) => enum_.instanceMethods = reorderedInstanceMethods
     }
 
-    Result.Ok(allParamsNeedingRevisit)
+    Ok(allParamsNeedingRevisit)
   }
 
   func _typecheckStructPass2_2(self, struct: Struct, node: TypeDeclarationNode): Result<Map<Label, Int[]>, TypeError> {
@@ -2242,12 +2253,12 @@ export type Typechecker {
     val prevTypeDecl = self.currentTypeDecl
     self.currentTypeDecl = Some(StructOrEnum.Struct(struct))
 
-    val allParamsNeedingRevisit = match self._typecheckMethodsPass2(StructOrEnum.Struct(struct), node.methods) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val allParamsNeedingRevisit = match self._typecheckMethodsPass2(StructOrEnum.Struct(struct), node.methods) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
 
-    Result.Ok(allParamsNeedingRevisit)
+    Ok(allParamsNeedingRevisit)
   }
 
   func _typecheckStructPass3(self, struct: Struct, node: TypeDeclarationNode, paramsNeedingRevisit: Map<Label, Int[]>): Result<Int, TypeError> {
@@ -2260,9 +2271,9 @@ export type Typechecker {
       val initializer = if field.initializer |v| v else continue
       val structField = if struct.fields[idx] |f| f else return unreachable(struct.label.position, "")
 
-      val typedInitializer = match self._typecheckExpression(initializer, Some(structField.ty)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedInitializer = match self._typecheckExpression(initializer, Some(structField.ty)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if !self._typeSatisfiesRequired(ty: typedInitializer.ty, required: structField.ty) {
-        return Result.Err(TypeError(position: initializer.token.position, kind: TypeErrorKind.TypeMismatch([structField.ty], typedInitializer.ty)))
+        return Err(TypeError(position: initializer.token.position, kind: TypeErrorKind.TypeMismatch([structField.ty], typedInitializer.ty)))
       }
       structField.initializer = Some(typedInitializer)
     }
@@ -2280,18 +2291,18 @@ export type Typechecker {
       }
 
       val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
-      match self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     }
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
 
-    Result.Ok(0)
+    Ok(0)
   }
 
   func _typecheckEnumPass1(self, node: EnumDeclarationNode): Result<Enum, TypeError> {
     val isExported = if node.exportToken |exportToken| {
-      match self._ensureValidExportScope(exportToken) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._ensureValidExportScope(exportToken) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       true
     } else {
       false
@@ -2305,21 +2316,21 @@ export type Typechecker {
     val seenTypeParams: Map<String, Label> = {}
     for label in node.typeParams {
       if seenTypeParams[label.name] |original| {
-        return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.DuplicateName(original)))
+        return Err(TypeError(position: label.position, kind: TypeErrorKind.DuplicateName(original)))
       }
       seenTypeParams[label.name] = label
 
       val generic = Type(kind: TypeKind.Generic(label.name))
-      match self._addTypeToScope(generic) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._addTypeToScope(generic) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       typeParams.push(label.name)
     }
 
     self.currentScope = prevScope
 
     val enum_ = Enum(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams)
-    match self._addEnumToScope(enum_, isExported) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    match self._addEnumToScope(enum_, isExported) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-    Result.Ok(enum_)
+    Ok(enum_)
   }
 
   func _typecheckEnumPass2_1(self, enum_: Enum, node: EnumDeclarationNode): Result<Int, TypeError> {
@@ -2333,7 +2344,7 @@ export type Typechecker {
     for variant, idx in node.variants {
       val variantLabel = match variant { EnumVariant.Constant(label) => label, EnumVariant.Container(label) => label }
       if seenVariants[variantLabel.name] |original| {
-        return Result.Err(TypeError(position: variantLabel.position, kind: TypeErrorKind.DuplicateName(original)))
+        return Err(TypeError(position: variantLabel.position, kind: TypeErrorKind.DuplicateName(original)))
       }
       seenVariants[variantLabel.name] = variantLabel
 
@@ -2348,11 +2359,11 @@ export type Typechecker {
           val seenFields: Map<String, Label> = {}
           for field in fields {
             if seenFields[field.name.name] |original| {
-              return Result.Err(TypeError(position: field.name.position, kind: TypeErrorKind.DuplicateName(original)))
+              return Err(TypeError(position: field.name.position, kind: TypeErrorKind.DuplicateName(original)))
             }
             seenFields[field.name.name] = field.name
 
-            val ty = match self._resolveTypeIdentifier(field.typeAnnotation) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val ty = match self._resolveTypeIdentifier(field.typeAnnotation) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             // The initializer (if present) will be filled in during the next pass
             typedFields.push(Field(name: field.name, ty: ty, initializer: None))
           }
@@ -2363,7 +2374,7 @@ export type Typechecker {
     }
 
     for funcDeclNode in node.methods {
-      val fn = match self._typecheckFunctionPass1(funcDeclNode) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val fn = match self._typecheckFunctionPass1(funcDeclNode) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       match fn.kind {
         FunctionKind.InstanceMethod => enum_.instanceMethods.push(fn)
         FunctionKind.StaticMethod => enum_.staticMethods.push(fn)
@@ -2374,7 +2385,7 @@ export type Typechecker {
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
 
-    Result.Ok(0)
+    Ok(0)
   }
 
   func _typecheckEnumPass2_2(self, enum_: Enum, node: EnumDeclarationNode): Result<Map<Label, Int[]>, TypeError> {
@@ -2395,9 +2406,9 @@ export type Typechecker {
           for typedField, idx in typedFields {
             val field = if fields[idx] |f| f else return unreachable(typedField.name.position, "the untyped field must exist at index")
             if field.initializer |initializer| {
-              val typedInitializer = match self._typecheckExpression(initializer, Some(typedField.ty)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              val typedInitializer = match self._typecheckExpression(initializer, Some(typedField.ty)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               if !self._typeSatisfiesRequired(ty: typedInitializer.ty, required: typedField.ty) {
-                return Result.Err(TypeError(position: typedInitializer.token.position, kind: TypeErrorKind.TypeMismatch([typedField.ty], typedInitializer.ty)))
+                return Err(TypeError(position: typedInitializer.token.position, kind: TypeErrorKind.TypeMismatch([typedField.ty], typedInitializer.ty)))
               }
 
               typedField.initializer = Some(typedInitializer)
@@ -2409,12 +2420,12 @@ export type Typechecker {
       }
     }
 
-    val allParamsNeedingRevisit = match self._typecheckMethodsPass2(StructOrEnum.Enum(enum_), node.methods) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val allParamsNeedingRevisit = match self._typecheckMethodsPass2(StructOrEnum.Enum(enum_), node.methods) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
 
-    Result.Ok(allParamsNeedingRevisit)
+    Ok(allParamsNeedingRevisit)
   }
 
   func _typecheckEnumPass3(self, enum_: Enum, node: EnumDeclarationNode, paramsNeedingRevisit: Map<Label, Int[]>): Result<Int, TypeError> {
@@ -2436,13 +2447,13 @@ export type Typechecker {
       }
 
       val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
-      match self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     }
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
 
-    Result.Ok(0)
+    Ok(0)
   }
 
   func _typecheckImport(self, mod: TypedModule, node: ImportNode): Result<Int, TypeError> {
@@ -2462,7 +2473,7 @@ export type Typechecker {
               val importedName = _p[0]
               val importedValue = _p[1]
               if importedName == imp.name {
-                return Result.Err(TypeError(position: imp.position, kind: TypeErrorKind.DuplicateName(original: importedValue.label)))
+                return Err(TypeError(position: imp.position, kind: TypeErrorKind.DuplicateName(original: importedValue.label)))
               }
             }
           }
@@ -2471,20 +2482,20 @@ export type Typechecker {
             Export.Variable(v) => TypedImportKind.Variable(v)
             Export.Function(v) => TypedImportKind.Function(v)
             Export.Type(structOrEnum, v) => TypedImportKind.Type(structOrEnum, v)
-            None => return Result.Err(TypeError(position: imp.position, kind: TypeErrorKind.UnknownImport(moduleName: node.moduleName.name, importName: imp.name)))
+            None => return Err(TypeError(position: imp.position, kind: TypeErrorKind.UnknownImport(moduleName: node.moduleName.name, importName: imp.name)))
           }
 
           importedModule.imports[imp.name] = Import(label: imp, kind: typedImportKind)
         }
       }
       ImportKind.Alias(alias) => {
-        if self._verifyNameUniqueInScope(alias, self.currentScope) |e| return Result.Err(e)
+        if self._verifyNameUniqueInScope(alias, self.currentScope) |e| return Err(e)
 
         importedModule.aliases.push(alias)
       }
     }
 
-    Result.Ok(0)
+    Ok(0)
   }
 
   func _typecheckBlock(self, nodes: AstNode[]): Result<TypedAstNode[], TypeError> {
@@ -2504,7 +2515,7 @@ export type Typechecker {
 
     val structsPass1: (Struct, TypeDeclarationNode)[] = []
     for node in typeDecls {
-      val struct = match self._typecheckStructPass1(node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val struct = match self._typecheckStructPass1(node) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if self.currentModuleId == 0 {
         match struct.label.name {
           "Int" => self.project.preludeIntStruct = struct
@@ -2522,7 +2533,7 @@ export type Typechecker {
 
     val enumsPass1: (Enum, EnumDeclarationNode)[] = []
     for node in enumDecls {
-      val enum_ = match self._typecheckEnumPass1(node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val enum_ = match self._typecheckEnumPass1(node) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if self.currentModuleId == 0 {
         match enum_.label.name {
           "Option" => self.project.preludeOptionEnum = enum_
@@ -2535,13 +2546,13 @@ export type Typechecker {
     val functionsPass1: (Function, Variable, FunctionDeclarationNode)[] = []
     for node in funcDecls {
       val isExported = if node.exportToken |exportToken| {
-        match self._ensureValidExportScope(exportToken) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        match self._ensureValidExportScope(exportToken) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         true
       } else {
         false
       }
 
-      val fn = match self._typecheckFunctionPass1(node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val fn = match self._typecheckFunctionPass1(node) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       val aliasVar = Variable(label: fn.label, mutable: false, ty: fn.getType(), alias: Some(VariableAlias.Function(fn)))
       self.currentScope.variables.push(aliasVar)
       functionsPass1.push((fn, aliasVar, node))
@@ -2557,7 +2568,7 @@ export type Typechecker {
     for pair in structsPass1 {
       val struct = pair[0]
       val node = pair[1]
-      match self._typecheckStructPass2_1(struct, node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._typecheckStructPass2_1(struct, node) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
       structsPass2_1.push((struct, node))
     }
@@ -2566,7 +2577,7 @@ export type Typechecker {
     for pair in enumsPass1 {
       val enum_ = pair[0]
       val node = pair[1]
-      match self._typecheckEnumPass2_1(enum_, node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._typecheckEnumPass2_1(enum_, node) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
       enumsPass2_1.push((enum_, node))
     }
@@ -2575,7 +2586,7 @@ export type Typechecker {
     for pair in structsPass1 {
       val struct = pair[0]
       val node = pair[1]
-      val toRevisit = match self._typecheckStructPass2_2(struct, node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val toRevisit = match self._typecheckStructPass2_2(struct, node) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
       structsPass2_2.push((struct, node, toRevisit))
     }
@@ -2584,7 +2595,7 @@ export type Typechecker {
     for pair in enumsPass2_1 {
       val enum_ = pair[0]
       val node = pair[1]
-      val toRevisit = match self._typecheckEnumPass2_2(enum_, node) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val toRevisit = match self._typecheckEnumPass2_2(enum_, node) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
       enumsPass2_2.push((enum_, node, toRevisit))
     }
@@ -2594,7 +2605,7 @@ export type Typechecker {
       val fn = fnPair[0]
       val aliasVar = fnPair[1]
       val node = fnPair[2]
-      val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
       aliasVar.ty = fn.getType()
       functionsPass2.push((fn, node, paramsNeedingRevisit))
@@ -2612,7 +2623,7 @@ export type Typechecker {
             val fn = pair[0]
             val fnDeclNode = pair[1]
             val paramsNeedingRevisit = pair[2]
-            match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: fnDeclNode.params, body: fnDeclNode.body, paramsNeedingRevisit: paramsNeedingRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: fnDeclNode.params, body: fnDeclNode.body, paramsNeedingRevisit: paramsNeedingRevisit) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.FunctionDeclaration(fn))
           } else {
             return unreachable(node.token.position, "there should be as many functions as there are functiondecl nodes")
@@ -2627,7 +2638,7 @@ export type Typechecker {
             val typeDeclNode = pair[1]
             val toRevisit = pair[2]
 
-            match self._typecheckStructPass3(struct, typeDeclNode, toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._typecheckStructPass3(struct, typeDeclNode, toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.TypeDeclaration(struct))
           } else {
             return unreachable(node.token.position, "there should be as many types as there are typedecl nodes")
@@ -2642,7 +2653,7 @@ export type Typechecker {
             val enumDeclNode = pair[1]
             val toRevisit = pair[2]
 
-            match self._typecheckEnumPass3(enum_, enumDeclNode, toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            match self._typecheckEnumPass3(enum_, enumDeclNode, toRevisit) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.EnumDeclaration(enum_))
           } else {
             return unreachable(node.token.position, "there should be as many enums as there are enumdecl nodes")
@@ -2654,11 +2665,11 @@ export type Typechecker {
         _ => self._typecheckStatement(node: node, typeHint: None)
       }
 
-      val typedNode = match res { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedNode = match res { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       typedNodes.push(typedNode)
     }
 
-    return Result.Ok(typedNodes)
+    return Ok(typedNodes)
   }
 
   func _typecheckStatement(self, node: AstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
@@ -2680,9 +2691,9 @@ export type Typechecker {
     match pattern {
       BindingPattern.Variable(label) => {
         val variable = Variable(label: label, mutable: mutable, ty: ty)
-        match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        match self._addVariableToScope(variable) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
-        Result.Ok([variable])
+        Ok([variable])
       }
     }
   }
@@ -2690,24 +2701,24 @@ export type Typechecker {
   func _typecheckBindingDeclaration(self, token: Token, node: BindingDeclarationNode): Result<TypedAstNode, TypeError> {
     val isMutable = token.kind == TokenKind.Var
     val isExported = if node.exportToken |exportToken| {
-      match self._ensureValidExportScope(exportToken) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      match self._ensureValidExportScope(exportToken) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       true
     } else {
       false
     }
 
     val annType = if node.typeAnnotation |typeAnn| {
-      val ty = match self._resolveTypeIdentifier(typeAnn) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val ty = match self._resolveTypeIdentifier(typeAnn) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some(ty)
     } else {
       None
     }
 
     val _pair = if node.expr |expr| {
-      val typedExpr = match self._typecheckExpression(expr, annType) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedExpr = match self._typecheckExpression(expr, annType) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       val ty = if annType |annotatedType| {
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: annotatedType) {
-          return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([annotatedType], typedExpr.ty)))
+          return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([annotatedType], typedExpr.ty)))
         }
 
         annotatedType
@@ -2716,7 +2727,7 @@ export type Typechecker {
       }
 
       if ty.isInvalidValueType() {
-        return Result.Err(TypeError(position: expr.token.position, kind: TypeErrorKind.IllegalValueType(ty: ty, purpose: "assignment")))
+        return Err(TypeError(position: expr.token.position, kind: TypeErrorKind.IllegalValueType(ty: ty, purpose: "assignment")))
       }
 
       // TODO: type could not be auto-coerced to `TypedAstNode?` on its own
@@ -2725,23 +2736,23 @@ export type Typechecker {
     } else if !isMutable {
       val label = match node.bindingPattern {
         BindingPattern.Variable(label) => label
-        // _ => return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.MissingValExpr(None)))
+        // _ => return Err(TypeError(position: token.position, kind: TypeErrorKind.MissingValExpr(None)))
       }
-      return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.MissingValExpr(label.name)))
+      return Err(TypeError(position: label.position, kind: TypeErrorKind.MissingValExpr(label.name)))
     } else if annType |ty| {
       (None, ty)
     } else {
       val label = match node.bindingPattern {
         BindingPattern.Variable(label) => label
-        // _ => return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.MissingVarExprAndTypeAnn(None)))
+        // _ => return Err(TypeError(position: token.position, kind: TypeErrorKind.MissingVarExprAndTypeAnn(None)))
       }
-      return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.MissingVarExprAndTypeAnn(label.name)))
+      return Err(TypeError(position: label.position, kind: TypeErrorKind.MissingVarExprAndTypeAnn(label.name)))
     }
     // TODO: destructuring
     val expr = _pair[0]
     val ty = _pair[1]
 
-    val variables = match self._typecheckBindingPattern(isMutable, node.bindingPattern, ty) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val variables = match self._typecheckBindingPattern(isMutable, node.bindingPattern, ty) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     for v in variables {
       if isExported {
         v.isExported = true
@@ -2750,7 +2761,7 @@ export type Typechecker {
     }
 
     val typedNode = TypedBindingDeclarationNode(bindingPattern: node.bindingPattern, variables: variables, expr: expr)
-    Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.BindingDeclaration(typedNode)))
+    Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.BindingDeclaration(typedNode)))
   }
 
   func _typecheckAssignment(self, token: Token, expr: AstNode, op: AssignOp, mode: AssignmentMode): Result<TypedAstNode, TypeError> {
@@ -2759,47 +2770,47 @@ export type Typechecker {
         val pos = varToken.position
 
         val variable = if self._resolveIdentifier(name) |variable| variable else {
-          return Result.Err(TypeError(position: pos, kind: TypeErrorKind.UnknownName(name, "variable")))
+          return Err(TypeError(position: pos, kind: TypeErrorKind.UnknownName(name, "variable")))
         }
         match variable.alias {
-          VariableAlias.Function => return Result.Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "variable", name: name, reason: IllegalAssignmentReason.FunctionAlias)))
-          VariableAlias.Struct => return Result.Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "variable", name: name, reason: IllegalAssignmentReason.TypeAlias)))
+          VariableAlias.Function => return Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "variable", name: name, reason: IllegalAssignmentReason.FunctionAlias)))
+          VariableAlias.Struct => return Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "variable", name: name, reason: IllegalAssignmentReason.TypeAlias)))
           _ => {
-            if !variable.mutable return Result.Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "variable", name: name, reason: IllegalAssignmentReason.ImmutableVariable)))
+            if !variable.mutable return Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "variable", name: name, reason: IllegalAssignmentReason.ImmutableVariable)))
           }
         }
 
-        val typedExpr = match self._typecheckExpression(expr, Some(variable.ty)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedExpr = match self._typecheckExpression(expr, Some(variable.ty)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: variable.ty) {
-          return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([variable.ty], typedExpr.ty)))
+          return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([variable.ty], typedExpr.ty)))
         }
 
         val mode = TypedAssignmentMode.Variable(variable)
-        return Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
+        return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
       }
       AssignmentMode.Indexing(targetExpr, indexExpr) => {
-        val typedLhs = match self._typecheckIndexing(token, targetExpr, IndexingMode.Single(indexExpr), None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedLhs = match self._typecheckIndexing(token, targetExpr, IndexingMode.Single(indexExpr), None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val typedIndexingNode = match typedLhs.kind {
           TypedAstNodeKind.Indexing(node) => node
           _ => return unreachable(typedLhs.token.position, "_typecheckIndexing returned unexpected TypedAstNodeKind")
         }
         val assignmentTy = if self._typeIsOption(typedLhs.ty) |inner| inner else typedLhs.ty
 
-        val typedExpr = match self._typecheckExpression(expr, Some(assignmentTy)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedExpr = match self._typecheckExpression(expr, Some(assignmentTy)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: assignmentTy) {
-          return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([assignmentTy], typedExpr.ty)))
+          return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([assignmentTy], typedExpr.ty)))
         }
 
         val mode = TypedAssignmentMode.Indexing(typedIndexingNode)
-        return Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
+        return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
       }
       AssignmentMode.Accessor(accessorNode) => {
-        val typedLhs = match self._typecheckAccessor(token, accessorNode, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedLhs = match self._typecheckAccessor(token, accessorNode, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val _p = match typedLhs.kind {
           TypedAstNodeKind.Accessor(head, mid, tail) => {
             val t = match tail {
               AccessorPathSegment.EnumVariant(label, _, variant) => {
-                return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAssignment("enum variant", variant.label.name, IllegalAssignmentReason.EnumVariant)))
+                return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAssignment("enum variant", variant.label.name, IllegalAssignmentReason.EnumVariant)))
               }
               AccessorPathSegment.Method(label, fn) => {
                 val _p = if fn.kind == FunctionKind.StaticMethod {
@@ -2811,7 +2822,7 @@ export type Typechecker {
                 val kind = _p[0]
                 val reason = _p[1]
 
-                return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAssignment(kind, fn.label.name, reason)))
+                return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAssignment(kind, fn.label.name, reason)))
               }
               AccessorPathSegment.Field(label, field) => {
                 val mode = TypedAssignmentMode.Accessor(head, mid, tail)
@@ -2827,21 +2838,21 @@ export type Typechecker {
         val fieldLabel = _p[1]
         val field = _p[2]
 
-        val typedExpr = match self._typecheckExpression(expr, Some(field.ty)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedExpr = match self._typecheckExpression(expr, Some(field.ty)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: field.ty) {
-          return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([field.ty], typedExpr.ty)))
+          return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([field.ty], typedExpr.ty)))
         }
 
-        return Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
+        return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
       }
     }
   }
 
   func _typecheckWhile(self, token: Token, condition: AstNode, conditionBinding: BindingPattern?, block: AstNode[]): Result<TypedAstNode, TypeError> {
-    val typedCondition = match self._typecheckExpression(condition, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val typedCondition = match self._typecheckExpression(condition, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val condOptInnerTy = self._typeIsOption(typedCondition.ty)
     if !condOptInnerTy && !self._typeSatisfiesRequired(ty: typedCondition.ty, required: Type(kind: TypeKind.PrimitiveBool)) {
-      return Result.Err(TypeError(position: typedCondition.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedCondition.ty, purpose: "while")))
+      return Err(TypeError(position: typedCondition.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedCondition.ty, purpose: "while")))
     }
 
     val prevScope = self.currentScope
@@ -2850,7 +2861,7 @@ export type Typechecker {
     val conditionBindingPattern = if conditionBinding |pattern| {
       val ty = condOptInnerTy ?: typedCondition.ty
 
-      val vars = match self._typecheckBindingPattern(false, pattern, ty) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val vars = match self._typecheckBindingPattern(false, pattern, ty) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some((pattern, vars))
     } else {
       None
@@ -2858,9 +2869,9 @@ export type Typechecker {
 
     val typedNodes: TypedAstNode[] = []
     for node in block {
-      if self.currentScope.terminator return Result.Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
+      if self.currentScope.terminator return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
-      val typedNode = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedNode = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       typedNodes.push(typedNode)
     }
     val terminator = self.currentScope.terminator
@@ -2868,7 +2879,7 @@ export type Typechecker {
     self.currentScope = prevScope
     self.currentScope.terminator = terminator
 
-    Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.While(typedCondition, conditionBindingPattern, typedNodes)))
+    Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.While(typedCondition, conditionBindingPattern, typedNodes)))
   }
 
   func _typeIsOption(self, ty: Type): Type? {
@@ -2923,20 +2934,20 @@ export type Typechecker {
   }
 
   func _typecheckFor(self, token: Token, itemPattern: BindingPattern, indexPattern: BindingPattern?, iterator: AstNode, block: AstNode[]): Result<TypedAstNode, TypeError> {
-    val typedIterator = match self._typecheckExpression(iterator, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val typedIterator = match self._typecheckExpression(iterator, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val itemType = if self._typeIsIterable(typedIterator.ty) |innerTy| innerTy else {
-      return Result.Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
+      return Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
     }
     if itemType.kind == TypeKind.Hole {
-      return Result.Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
+      return Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
     }
 
     val prevScope = self.currentScope
     self.currentScope = self.currentScope.makeChild("for", ScopeKind.For)
 
-    val variables = match self._typecheckBindingPattern(false, itemPattern, itemType) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val variables = match self._typecheckBindingPattern(false, itemPattern, itemType) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val indexBinding = if indexPattern |pat| {
-      val variables = match self._typecheckBindingPattern(false, pat, Type(kind: TypeKind.PrimitiveInt)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val variables = match self._typecheckBindingPattern(false, pat, Type(kind: TypeKind.PrimitiveInt)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       variables[0]
     } else {
       None
@@ -2944,9 +2955,9 @@ export type Typechecker {
 
     val typedNodes: TypedAstNode[] = []
     for node in block {
-      if self.currentScope.terminator return Result.Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
+      if self.currentScope.terminator return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
-      val typedNode = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedNode = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       typedNodes.push(typedNode)
     }
     val terminator = self.currentScope.terminator
@@ -2955,7 +2966,7 @@ export type Typechecker {
     self.currentScope.terminator = terminator
 
     val kind = TypedAstNodeKind.For(typedIterator, (itemPattern, variables), indexBinding, typedNodes)
-    Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: kind))
+    Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: kind))
   }
 
   func _typecheckBreak(self, token: Token): Result<TypedAstNode, TypeError> = self._typecheckBreakContinue(token, "break", TypedAstNodeKind.Break)
@@ -2978,31 +2989,31 @@ export type Typechecker {
         ScopeKind.For => true
       }
 
-      if !isValid return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTerminatorPosition(terminator)))
+      if !isValid return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTerminatorPosition(terminator)))
       break
     }
     self.currentScope.terminator = Some(Terminator.NonReturning)
 
-    Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.Never), kind: kind))
+    Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.Never), kind: kind))
   }
 
   func _typecheckReturn(self, token: Token, expr: AstNode?): Result<TypedAstNode, TypeError> {
     val fn = if self.currentFunction |fn| fn else {
-      return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTerminatorPosition("return")))
+      return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTerminatorPosition("return")))
     }
 
     val typedExpr = if expr |expr| {
-      val typedExpr = match self._typecheckExpression(expr, Some(fn.returnType)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedExpr = match self._typecheckExpression(expr, Some(fn.returnType)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: fn.returnType) {
         val fnName = if fn.isLambda None else Some(fn.label.name)
-        return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.ReturnTypeMismatch(fnName, fn.returnType, Some(typedExpr.ty))))
+        return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.ReturnTypeMismatch(fnName, fn.returnType, Some(typedExpr.ty))))
       }
 
       Some(typedExpr)
     } else {
       if fn.returnType.kind != TypeKind.PrimitiveUnit {
         val fnName = if fn.isLambda None else Some(fn.label.name)
-        return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.ReturnTypeMismatch(fnName, fn.returnType, Some(Type(kind: TypeKind.PrimitiveUnit)))))
+        return Err(TypeError(position: token.position, kind: TypeErrorKind.ReturnTypeMismatch(fnName, fn.returnType, Some(Type(kind: TypeKind.PrimitiveUnit)))))
       }
 
       None
@@ -3010,7 +3021,7 @@ export type Typechecker {
 
     self.currentScope.terminator = Some(Terminator.Returning)
 
-    Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.Never), kind: TypedAstNodeKind.Return(typedExpr)))
+    Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.Never), kind: TypedAstNodeKind.Return(typedExpr)))
   }
 
   func _typecheckIf(
@@ -3024,10 +3035,10 @@ export type Typechecker {
   ): Result<TypedAstNode, TypeError> {
     val isStatement = if typeHint |hint| hint.kind == TypeKind.PrimitiveUnit else false
 
-    val typedCondition = match self._typecheckExpression(condition, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val typedCondition = match self._typecheckExpression(condition, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val condOptInnerTy = self._typeIsOption(typedCondition.ty)
     if !condOptInnerTy && !self._typeSatisfiesRequired(ty: typedCondition.ty, required: Type(kind: TypeKind.PrimitiveBool)) {
-      return Result.Err(TypeError(position: typedCondition.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedCondition.ty, purpose: "if")))
+      return Err(TypeError(position: typedCondition.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedCondition.ty, purpose: "if")))
     }
 
     val typedIfBlock: TypedAstNode[] = []
@@ -3037,20 +3048,20 @@ export type Typechecker {
     val conditionBindingPattern = if conditionBinding |pattern| {
       val ty = condOptInnerTy ?: typedCondition.ty
 
-      val vars = match self._typecheckBindingPattern(false, pattern, ty) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val vars = match self._typecheckBindingPattern(false, pattern, ty) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       Some((pattern, vars))
     } else {
       None
     }
 
     for node, idx in ifBlock {
-      if self.currentScope.terminator return Result.Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
+      if self.currentScope.terminator return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
       if idx == ifBlock.length - 1 && !isStatement {
-        val typedNode = match self._typecheckExpressionOrTerminator(node, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedNode = match self._typecheckExpressionOrTerminator(node, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         typedIfBlock.push(typedNode)
       } else {
-        val typedNode = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedNode = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         typedIfBlock.push(typedNode)
       }
     }
@@ -3066,15 +3077,15 @@ export type Typechecker {
       hasElseBlock = true
       for node, idx in elseBlock {
         if self.currentScope.terminator {
-          return Result.Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
+          return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
         }
 
         if idx == elseBlock.length - 1 && !isStatement {
           val hint = if ifType |t| (if t.hasUnfilledHoles() None else ifType) else None
-          val typedNode = match self._typecheckExpressionOrTerminator(node, hint) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val typedNode = match self._typecheckExpressionOrTerminator(node, hint) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           typedElseBlock.push(typedNode)
         } else {
-          val typedNode = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val typedNode = match self._typecheckStatement(node, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           typedElseBlock.push(typedNode)
         }
       }
@@ -3096,16 +3107,16 @@ export type Typechecker {
           }
 
           if !self._typeSatisfiesRequired(ty: elseType, required: ifType) {
-            return Result.Err(TypeError(position: lastElseNode.token.position, kind: TypeErrorKind.TypeMismatch([ifType], elseType)))
+            return Err(TypeError(position: lastElseNode.token.position, kind: TypeErrorKind.TypeMismatch([ifType], elseType)))
           }
 
           val t = if ifType.kind == TypeKind.Never { elseType } else { ifType }
           t
         } else {
-          return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.MissingRequiredIfExprBlock(clause: "else", missing: !hasElseBlock)))
+          return Err(TypeError(position: token.position, kind: TypeErrorKind.MissingRequiredIfExprBlock(clause: "else", missing: !hasElseBlock)))
         }
       } else {
-        return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.MissingRequiredIfExprBlock(clause: "if", missing: false)))
+        return Err(TypeError(position: token.position, kind: TypeErrorKind.MissingRequiredIfExprBlock(clause: "if", missing: false)))
       }
       t
     } else {
@@ -3113,7 +3124,7 @@ export type Typechecker {
     }
 
     val kind = TypedAstNodeKind.If(isStatement, typedCondition, conditionBindingPattern, typedIfBlock, typedElseBlock)
-    Result.Ok(TypedAstNode(token: token, ty: ty, kind: kind))
+    Ok(TypedAstNode(token: token, ty: ty, kind: kind))
   }
 
   func _typecheckExpression(self, node: AstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
@@ -3127,13 +3138,13 @@ export type Typechecker {
           LiteralAstNode.String => TypeKind.PrimitiveString
         }
 
-        Result.Ok(TypedAstNode(token: token, ty: Type(kind: kind), kind: TypedAstNodeKind.Literal(literal)))
+        Ok(TypedAstNode(token: token, ty: Type(kind: kind), kind: TypedAstNodeKind.Literal(literal)))
       }
       AstNodeKind.Unary(node) => self._typecheckUnary(token, node)
       AstNodeKind.Binary(node) => self._typecheckBinary(token, node)
       AstNodeKind.Grouped(inner) => {
-        val expr = match self._typecheckExpression(inner, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-        Result.Ok(TypedAstNode(token: token, ty: expr.ty, kind: TypedAstNodeKind.Grouped(expr)))
+        val expr = match self._typecheckExpression(inner, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+        Ok(TypedAstNode(token: token, ty: expr.ty, kind: TypedAstNodeKind.Grouped(expr)))
       }
       AstNodeKind.Identifier(kind) => self._typecheckIdentifier(token, kind, typeHint)
       AstNodeKind.Accessor(node) => self._typecheckAccessor(token, node, typeHint)
@@ -3149,18 +3160,18 @@ export type Typechecker {
       _ => unreachable(node.token.position, "all other node types should have already been handled")
     }
 
-    val typedExpr = match typedExprRes { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val typedExpr = match typedExprRes { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     match typedExpr.ty.kind {
       TypeKind.Type => {
         if !self.isStructOrEnumValueAllowed {
-          return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalValueType(typedExpr.ty, "value")))
+          return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalValueType(typedExpr.ty, "value")))
         }
       }
       _ => {}
     }
 
-    Result.Ok(typedExpr)
+    Ok(typedExpr)
   }
 
   func _typecheckExpressionOrTerminator(self, node: AstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
@@ -3173,29 +3184,29 @@ export type Typechecker {
   }
 
   func _typecheckUnary(self, token: Token, node: UnaryAstNode): Result<TypedAstNode, TypeError> {
-    val expr = match self._typecheckExpression(node: node.expr, typeHint: None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val expr = match self._typecheckExpression(node: node.expr, typeHint: None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     match node.op {
       UnaryOp.Minus => {
         if !self._typeSatisfiesRequired(ty: expr.ty, required: Type(kind: TypeKind.PrimitiveInt)) &&
           !self._typeSatisfiesRequired(ty: expr.ty, required: Type(kind: TypeKind.PrimitiveFloat)) {
           val expected = [Type(kind: TypeKind.PrimitiveInt), Type(kind: TypeKind.PrimitiveFloat)]
-          return Result.Err(TypeError(position: expr.token.position, kind: TypeErrorKind.TypeMismatch(expected, expr.ty)))
+          return Err(TypeError(position: expr.token.position, kind: TypeErrorKind.TypeMismatch(expected, expr.ty)))
         }
       }
       UnaryOp.Negate => {
         if !self._typeIsOption(expr.ty) && !self._typeSatisfiesRequired(ty: expr.ty, required: Type(kind: TypeKind.PrimitiveBool)) {
-          return Result.Err(TypeError(position: expr.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveBool)], expr.ty)))
+          return Err(TypeError(position: expr.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveBool)], expr.ty)))
         }
       }
     }
 
-    Result.Ok(TypedAstNode(token: token, ty: expr.ty, kind: TypedAstNodeKind.Unary(op: node.op, expr: expr)))
+    Ok(TypedAstNode(token: token, ty: expr.ty, kind: TypedAstNodeKind.Unary(op: node.op, expr: expr)))
   }
 
   func _typecheckBinary(self, token: Token, node: BinaryAstNode): Result<TypedAstNode, TypeError> {
     val handleCases: ((TypeKind, TypeKind, TypeKind)[]) => Result<TypedAstNode, TypeError> = (cases) => {
-      val left = match self._typecheckExpression(node.left, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-      val right = match self._typecheckExpression(node.right, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val left = match self._typecheckExpression(node.left, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+      val right = match self._typecheckExpression(node.right, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       for _case in cases {
         // TODO: destructuring
         val lTy = _case[0]
@@ -3204,22 +3215,22 @@ export type Typechecker {
 
         if (lTy == TypeKind.Hole || self._typeSatisfiesRequired(ty: left.ty, required: Type(kind: lTy))) &&
           ((rTy == TypeKind.Hole || self._typeSatisfiesRequired(ty: right.ty, required: Type(kind: rTy)))) {
-          return Result.Ok(TypedAstNode(token: token, ty: Type(kind: outTy), kind: TypedAstNodeKind.Binary(left, node.op, right)))
+          return Ok(TypedAstNode(token: token, ty: Type(kind: outTy), kind: TypedAstNodeKind.Binary(left, node.op, right)))
         }
       }
 
-      return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.NoSuchOperator(left.ty, node.op, right.ty)))
+      return Err(TypeError(position: token.position, kind: TypeErrorKind.NoSuchOperator(left.ty, node.op, right.ty)))
     }
 
     val handleEquality: () => Result<TypedAstNode, TypeError> = () => {
-      val left = match self._typecheckExpression(node.left, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-      val right = match self._typecheckExpression(node.right, Some(left.ty)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val left = match self._typecheckExpression(node.left, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+      val right = match self._typecheckExpression(node.right, Some(left.ty)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
       if !self._typeSatisfiesRequired(ty: right.ty, required: left.ty) {
-        return Result.Err(TypeError(position: right.token.position, kind: TypeErrorKind.TypeMismatch([left.ty], right.ty)))
+        return Err(TypeError(position: right.token.position, kind: TypeErrorKind.TypeMismatch([left.ty], right.ty)))
       }
 
-      Result.Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveBool), kind: TypedAstNodeKind.Binary(left, node.op, right)))
+      Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveBool), kind: TypedAstNodeKind.Binary(left, node.op, right)))
     }
 
     val standardArithmeticCases = [
@@ -3267,20 +3278,20 @@ export type Typechecker {
       BinaryOp.Xor => handleCases(boolOpCases)
       BinaryOp.Coalesce => {
         // If the lhs isn't a nullable type then we can short-circuit and don't even typecheck the rhs
-        val left = match self._typecheckExpression(node.left, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val left = match self._typecheckExpression(node.left, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val right = if self._typeIsOption(left.ty) |innerTy| {
-          val right = match self._typecheckExpression(node.right, Some(innerTy)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val right = match self._typecheckExpression(node.right, Some(innerTy)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if !self._typeSatisfiesRequired(ty: right.ty, required: innerTy) {
-            return Result.Err(TypeError(position: right.token.position, kind: TypeErrorKind.TypeMismatch([innerTy], right.ty)))
+            return Err(TypeError(position: right.token.position, kind: TypeErrorKind.TypeMismatch([innerTy], right.ty)))
           }
 
           right
         } else {
           // Pass Hole as rhs type because it doesn't matter - there's special logic within NoSuchOperator for `?:` used with non-Option types
-          return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.NoSuchOperator(left.ty, node.op, Type(kind: TypeKind.Hole))))
+          return Err(TypeError(position: token.position, kind: TypeErrorKind.NoSuchOperator(left.ty, node.op, Type(kind: TypeKind.Hole))))
         }
 
-        Result.Ok(TypedAstNode(token: token, ty: right.ty, kind: TypedAstNodeKind.Binary(left, node.op, right)))
+        Ok(TypedAstNode(token: token, ty: right.ty, kind: TypedAstNodeKind.Binary(left, node.op, right)))
       }
       BinaryOp.Eq => handleEquality()
       BinaryOp.Neq => handleEquality()
@@ -3300,11 +3311,11 @@ export type Typechecker {
           if self.paramDefaultValueContext |ctx| {
             ctx.exprContainsVariableRef = true
           }
-          return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName(name, "variable")))
+          return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName(name, "variable")))
         }
         (variable.ty, TypedIdentifierKind.Named(name, variable))
       }
-      IdentifierKind.Discard => return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName("_", "variable")))
+      IdentifierKind.Discard => return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName("_", "variable")))
       IdentifierKind.None_ => {
         val replacement = AstNode(
           token: token,
@@ -3321,14 +3332,14 @@ export type Typechecker {
           if self.paramDefaultValueContext |ctx| {
             ctx.exprContainsVariableRef = true
           }
-          return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName("self", "variable")))
+          return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName("self", "variable")))
         }
         (variable.ty, TypedIdentifierKind.Named("self", variable))
       }
     }
 
     // TODO: destructuring
-    Result.Ok(TypedAstNode(token: token, ty: _p[0], kind: TypedAstNodeKind.Identifier(_p[1])))
+    Ok(TypedAstNode(token: token, ty: _p[0], kind: TypedAstNodeKind.Identifier(_p[1])))
   }
 
   func _resolveAccessorPathSegmentAny(self, label: Label): (AccessorPathSegment, Type)? {
@@ -3370,7 +3381,7 @@ export type Typechecker {
                   resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
                 }
                 val ty = field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
-                return Result.Ok(Some((AccessorPathSegment.Field(label, field), ty)))
+                return Ok(Some((AccessorPathSegment.Field(label, field), ty)))
               }
             }
 
@@ -3389,7 +3400,7 @@ export type Typechecker {
               resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
             }
             val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true, genericsInScope: #{})
-            return Result.Ok(Some((AccessorPathSegment.Method(label, method), method.getType())))
+            return Ok(Some((AccessorPathSegment.Method(label, method), method.getType())))
           }
         }
 
@@ -3429,12 +3440,12 @@ export type Typechecker {
 
                 match variant.kind {
                   EnumVariantKind.Container => {
-                    if !self.isEnumContainerValueAllowed return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalNonConstantEnumVariant))
+                    if !self.isEnumContainerValueAllowed return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalNonConstantEnumVariant))
                   }
                   _ => {}
                 }
 
-                return Result.Ok(Some((AccessorPathSegment.EnumVariant(label, enum_, variant), ty)))
+                return Ok(Some((AccessorPathSegment.EnumVariant(label, enum_, variant), ty)))
               }
             }
 
@@ -3443,7 +3454,7 @@ export type Typechecker {
         }
 
         for method in staticMethods {
-          if method.label.name == label.name return Result.Ok(Some((AccessorPathSegment.Method(label, method), method.getType())))
+          if method.label.name == label.name return Ok(Some((AccessorPathSegment.Method(label, method), method.getType())))
         }
 
         None
@@ -3451,7 +3462,7 @@ export type Typechecker {
       TypeKind.Hole => None
     }
 
-    Result.Ok(foundSegment)
+    Ok(foundSegment)
   }
 
   func _resolveModuleAliasAccessor(self, root: AstNode, field: (Token, Label)): Result<TypedAstNode?, TypeError> {
@@ -3459,7 +3470,7 @@ export type Typechecker {
       AstNodeKind.Identifier(identKind) => {
         val m = match identKind {
           IdentifierKind.Named(name) => {
-            val m = match self._findModuleByAlias(name) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val m = match self._findModuleByAlias(name) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             m
           }
           _ => None
@@ -3477,10 +3488,10 @@ export type Typechecker {
       // TODO: destructuring
       val dotTok = field[0]
       val label = field[1]
-      if dotTok.kind == TokenKind.QuestionDot return Result.Err(TypeError(position: dotTok.position, kind: TypeErrorKind.UnnecessaryOptSafety))
+      if dotTok.kind == TokenKind.QuestionDot return Err(TypeError(position: dotTok.position, kind: TypeErrorKind.UnnecessaryOptSafety))
 
       val exportVar = match mod.exports[label.name] {
-        None => return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownImportForAlias(label.name, aliasLabel)))
+        None => return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownImportForAlias(label.name, aliasLabel)))
         Export.Variable(v) => v
         Export.Function(v) => v
         Export.Type(_, v) => v
@@ -3493,22 +3504,22 @@ export type Typechecker {
       None
     }
 
-    Result.Ok(identifierNode)
+    Ok(identifierNode)
   }
 
   func _typecheckAccessor(self, token: Token, node: AccessorAstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
     var accessorPath = node.path
 
     val _firstSeg = if accessorPath[0] |p| p else return unreachable(token.position, "path should have at least 1 segment")
-    val maybeModuleAccessor = match self._resolveModuleAliasAccessor(node.root, _firstSeg) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val maybeModuleAccessor = match self._resolveModuleAliasAccessor(node.root, _firstSeg) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     val typedRoot = if maybeModuleAccessor |n| {
-      if accessorPath.length == 1 return Result.Ok(n)
+      if accessorPath.length == 1 return Ok(n)
 
       accessorPath = accessorPath[1:]
       n
     } else {
       self.isStructOrEnumValueAllowed = true
-      val typedNode = match self._typecheckExpression(node.root, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedNode = match self._typecheckExpression(node.root, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       self.isStructOrEnumValueAllowed = false
       typedNode
     }
@@ -3528,13 +3539,13 @@ export type Typechecker {
         if optInnerTy |innerTy| {
           innerTy
         } else {
-          return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.UnnecessaryOptSafety))
+          return Err(TypeError(position: token.position, kind: TypeErrorKind.UnnecessaryOptSafety))
         }
       } else {
         ty
       }
 
-      val seg = match self._resolveAccessorPathSegment(subjTy, label, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val seg = match self._resolveAccessorPathSegment(subjTy, label, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if seg |_s| {
         // TODO: destructuring
         val seg = _s[0]
@@ -3548,7 +3559,7 @@ export type Typechecker {
         }
       } else {
         val specialCase = if optInnerTy |innerTy| {
-          val seg = match self._resolveAccessorPathSegment(innerTy, label, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val seg = match self._resolveAccessorPathSegment(innerTy, label, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if seg {
             Some(UnknownFieldSpecialCase.ExistsButTypeIsNullable(seenOptSafeDot))
           } else {
@@ -3559,11 +3570,11 @@ export type Typechecker {
             TypeKind.Instance(structOrEnum, _) => {
               val seg = match structOrEnum {
                 StructOrEnum.Struct(struct) => {
-                  val seg = match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Struct(struct))), label, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+                  val seg = match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Struct(struct))), label, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
                   seg
                 }
                 StructOrEnum.Enum(enum_) => {
-                  val seg = match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))), label, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+                  val seg = match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))), label, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
                   seg
                 }
               }
@@ -3578,19 +3589,19 @@ export type Typechecker {
           }
         }
 
-        return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownField(ty, label.name, specialCase)))
+        return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownField(ty, label.name, specialCase)))
       }
     }
 
     val finalField = if path.pop() |f| f else return unreachable(node.root.token.position, "the accessor path should not be empty")
 
-    Result.Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Accessor(typedRoot, path, finalField)))
+    Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Accessor(typedRoot, path, finalField)))
   }
 
   func _typecheckInvocation(self, token: Token, node: InvocationAstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
     self.isStructOrEnumValueAllowed = true
     self.isEnumContainerValueAllowed = true
-    val invokee = match self._typecheckExpression(node.invokee, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val invokee = match self._typecheckExpression(node.invokee, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     self.isEnumContainerValueAllowed = false
     self.isStructOrEnumValueAllowed = false
 
@@ -3603,18 +3614,18 @@ export type Typechecker {
               val initializerFn = Function.initializer(self.currentScope, struct)
               self._typecheckInvocationOfFunction(token, invokee, initializerFn, node, typeHint, Some(Instantiatable.Struct(struct)))
             }
-            VariableAlias.Enum(enum_) => return Result.Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))))))
+            VariableAlias.Enum(enum_) => return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))))))
             None => self._typecheckInvocationOfExpression(token, invokee, invokee.token.position, node)
           }
         }
-        TypedIdentifierKind.None_ => return Result.Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Hole, /*nullable: true*/))))
+        TypedIdentifierKind.None_ => return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Hole, /*nullable: true*/))))
         TypedIdentifierKind.Discard => return unreachable(invokee.token.position, "resolving '_' should fail before reaching here")
       }
       TypedAstNodeKind.Accessor(_, _, tail) => {
         match tail {
           AccessorPathSegment.EnumVariant(label, enum_, variant) => {
             val fields = match variant.kind {
-              EnumVariantKind.Constant => return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalCallableType(invokee.ty)))
+              EnumVariantKind.Constant => return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalCallableType(invokee.ty)))
               EnumVariantKind.Container(fields) => fields
             }
 
@@ -3633,7 +3644,7 @@ export type Typechecker {
   func _typecheckInvocationOfExpression(self, token: Token, invokeeExpr: TypedAstNode, exprPos: Position, invocationNode: InvocationAstNode): Result<TypedAstNode, TypeError> {
     val _pair = match invokeeExpr.ty.kind {
       TypeKind.Func(paramTypes, returnType) => (paramTypes.map(p => p[0]), returnType)
-      _ => return Result.Err(TypeError(position: exprPos, kind: TypeErrorKind.IllegalCallableType(invokeeExpr.ty)))
+      _ => return Err(TypeError(position: exprPos, kind: TypeErrorKind.IllegalCallableType(invokeeExpr.ty)))
     }
     // TODO: destructuring
     val paramTypes = _pair[0]
@@ -3641,32 +3652,32 @@ export type Typechecker {
 
     if self.paramDefaultValueContext |ctx| {
       ctx.exprContainsFunctionCall = true
-      return Result.Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Placeholder))
+      return Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Placeholder))
     }
 
     val typedArguments: TypedAstNode?[] = []
     for arg, idx in invocationNode.arguments {
       if arg.label |label| {
-        return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalParameterLabel))
+        return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalParameterLabel))
       }
 
       var paramType = if paramTypes[idx] |t| t else {
-        return Result.Err(TypeError(position: arg.position(), kind: TypeErrorKind.WrongInvocationArity(expected: paramTypes.length, given: invocationNode.arguments.length)))
+        return Err(TypeError(position: arg.position(), kind: TypeErrorKind.WrongInvocationArity(expected: paramTypes.length, given: invocationNode.arguments.length)))
       }
 
-      val typedArg = match self._typecheckExpression(arg.value, Some(paramType)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedArg = match self._typecheckExpression(arg.value, Some(paramType)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if !self._typeSatisfiesRequired(ty: typedArg.ty, required: paramType) {
-        return Result.Err(TypeError(position: typedArg.token.position, kind: TypeErrorKind.ParameterTypeMismatch(None, paramType, typedArg.ty)))
+        return Err(TypeError(position: typedArg.token.position, kind: TypeErrorKind.ParameterTypeMismatch(None, paramType, typedArg.ty)))
       }
       typedArguments.push(Some(typedArg))
     }
 
     if typedArguments.length < paramTypes.length {
-      return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.WrongInvocationArity(expected: paramTypes.length, given: typedArguments.length)))
+      return Err(TypeError(position: token.position, kind: TypeErrorKind.WrongInvocationArity(expected: paramTypes.length, given: typedArguments.length)))
     }
 
     val typedInvokee = TypedInvokee.Expr(invokeeExpr)
-    Result.Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Invocation(typedInvokee, typedArguments)))
+    Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Invocation(typedInvokee, typedArguments)))
   }
 
   func _typecheckInvocationOfFunction(self, token: Token, invokee: TypedAstNode, fn: Function, invocationNode: InvocationAstNode, typeHint: Type?, instantiationOf: Instantiatable? = None): Result<TypedAstNode, TypeError> {
@@ -3680,13 +3691,13 @@ export type Typechecker {
     if !invocationNode.typeArguments.isEmpty() {
       for generic, idx in fn.typeParams {
         val typeArg = if invocationNode.typeArguments[idx] |typeArg| typeArg else {
-          return Result.Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.WrongTypeArgumentArity(expected: fn.typeParams.length, given: invocationNode.typeArguments.length)))
+          return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.WrongTypeArgumentArity(expected: fn.typeParams.length, given: invocationNode.typeArguments.length)))
         }
-        val typeArgTy = match self._resolveTypeIdentifier(typeArg) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typeArgTy = match self._resolveTypeIdentifier(typeArg) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         resolvedGenerics[generic[1].name] = typeArgTy
       }
       if invocationNode.typeArguments.length > fn.typeParams.length {
-        return Result.Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.WrongTypeArgumentArity(expected: fn.typeParams.length, given: invocationNode.typeArguments.length)))
+        return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.WrongTypeArgumentArity(expected: fn.typeParams.length, given: invocationNode.typeArguments.length)))
       }
     }
 
@@ -3698,7 +3709,7 @@ export type Typechecker {
           if resolvedGenerics[_p[0]] |original| {
             if original != _p[1] {
               val returnType = fn.returnType.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
-              return Result.Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.TypeMismatch([hint], returnType)))
+              return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.TypeMismatch([hint], returnType)))
             }
             continue
           }
@@ -3715,7 +3726,7 @@ export type Typechecker {
       } else {
         fn.returnType
       }
-      return Result.Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Placeholder))
+      return Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Placeholder))
     }
 
     val genericsInScope = self._genericsInScope()
@@ -3731,7 +3742,7 @@ export type Typechecker {
       val numAttempts = _a[2]
 
       var param = if fn.params[idx] |param| param else {
-        return Result.Err(TypeError(position: arg.position(), kind: TypeErrorKind.WrongInvocationArity(expected: fn.params.length, given: invocationNode.arguments.length)))
+        return Err(TypeError(position: arg.position(), kind: TypeErrorKind.WrongInvocationArity(expected: fn.params.length, given: invocationNode.arguments.length)))
       }
       if (!!param.defaultValue) || param.isVariadic { hasBegunOptionalParams = true }
 
@@ -3739,11 +3750,11 @@ export type Typechecker {
       if arg.label |label| {
         if label.name != param.label.name {
           if !hasBegunOptionalParams {
-            return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.ParameterLabelMismatch(expected: param.label.name, given: label.name)))
+            return Err(TypeError(position: label.position, kind: TypeErrorKind.ParameterLabelMismatch(expected: param.label.name, given: label.name)))
           }
 
           param = if paramsByName[label.name] |p| p else {
-            return Result.Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownParameterName(label.name)))
+            return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownParameterName(label.name)))
           }
           paramTy = param.ty
         }
@@ -3757,13 +3768,13 @@ export type Typechecker {
         match instantiatable {
           Instantiatable.EnumContainerVariant(_, _, fields) => {
             if fields.length != 1 {
-              return Result.Err(TypeError(position: arg.position(), kind: TypeErrorKind.MissingRequiredArgumentLabel))
+              return Err(TypeError(position: arg.position(), kind: TypeErrorKind.MissingRequiredArgumentLabel))
             }
           }
-          _ => return Result.Err(TypeError(position: arg.position(), kind: TypeErrorKind.MissingRequiredArgumentLabel))
+          _ => return Err(TypeError(position: arg.position(), kind: TypeErrorKind.MissingRequiredArgumentLabel))
         }
       } else if mostRecentLabeledOptionalParam |label| {
-        return Result.Err(TypeError(position: arg.position(), kind: TypeErrorKind.MixedArgumentType(label)))
+        return Err(TypeError(position: arg.position(), kind: TypeErrorKind.MixedArgumentType(label)))
       } else {
         if param.isVariadic { variadicParam = Some((param, idx)) }
       }
@@ -3771,7 +3782,7 @@ export type Typechecker {
       val _p = if self._containsGenerics(param.ty) {
         var paramType = paramTy.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: genericsInScope)
 
-        val typedArg = match self._typecheckExpression(arg.value, Some(paramType)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedArg = match self._typecheckExpression(arg.value, Some(paramType)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         if numAttempts < 1 && typedArg.ty.hasUnfilledHoles() {
           argumentsQueue.push((_a[0], _a[1], numAttempts + 1))
           continue
@@ -3789,7 +3800,7 @@ export type Typechecker {
               _ => {}
             }
             if !self._typesAreEquivalent(ty: original, other: _p[1]) {
-              return Result.Err(TypeError(position: typedArg.token.position, kind: TypeErrorKind.ParameterTypeMismatch(Some(param.label.name), original, typedArg.ty)))
+              return Err(TypeError(position: typedArg.token.position, kind: TypeErrorKind.ParameterTypeMismatch(Some(param.label.name), original, typedArg.ty)))
             }
             continue
           }
@@ -3799,14 +3810,14 @@ export type Typechecker {
         paramType = paramTy.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: genericsInScope)
         (typedArg, paramType)
       } else {
-        val typedArg = match self._typecheckExpression(arg.value, Some(paramTy)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedArg = match self._typecheckExpression(arg.value, Some(paramTy)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         (typedArg, paramTy)
       }
       // TODO: destructuring
       val typedArg = _p[0]
       val paramType = _p[1]
       if !self._typeSatisfiesRequired(ty: typedArg.ty, required: paramType) {
-        return Result.Err(TypeError(position: typedArg.token.position, kind: TypeErrorKind.ParameterTypeMismatch(Some(param.label.name), paramType, typedArg.ty)))
+        return Err(TypeError(position: typedArg.token.position, kind: TypeErrorKind.ParameterTypeMismatch(Some(param.label.name), paramType, typedArg.ty)))
       }
 
       if variadicParam {
@@ -3853,7 +3864,7 @@ export type Typechecker {
           TypeErrorKind.WrongInvocationArity(expected: numRequired, given: invocationNode.arguments.length)
         }
 
-        return Result.Err(TypeError(position: token.position, kind: errorKind))
+        return Err(TypeError(position: token.position, kind: errorKind))
       }
     }
 
@@ -3873,7 +3884,7 @@ export type Typechecker {
       TypedInvokee.Expr(invokee)
     }
 
-    Result.Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Invocation(typedInvokee, typedArguments)))
+    Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Invocation(typedInvokee, typedArguments)))
   }
 
   func _typecheckArray(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
@@ -3889,10 +3900,10 @@ export type Typechecker {
     var makeItemsNullable = false
     val typedItems: TypedAstNode[] = []
     for node in items {
-      val typedItem = match self._typecheckExpression(node: node, typeHint: innerType) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedItem = match self._typecheckExpression(node: node, typeHint: innerType) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if innerType |ty| {
         if !self._typeSatisfiesRequired(ty: typedItem.ty, required: ty) {
-          return Result.Err(TypeError(position: typedItem.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedItem.ty)))
+          return Err(TypeError(position: typedItem.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedItem.ty)))
         }
       } else if !typedItem.ty.hasUnfilledHoles() {
         innerType = Some(typedItem.ty)
@@ -3908,12 +3919,12 @@ export type Typechecker {
       if !innerHasUnfilledHoles && item.ty.hasUnfilledHoles() {
         item.ty.tryFillHoles(inner)
         if !self._typeSatisfiesRequired(ty: item.ty, required: inner) {
-          return Result.Err(TypeError(position: item.token.position, kind: TypeErrorKind.TypeMismatch([inner], item.ty)))
+          return Err(TypeError(position: item.token.position, kind: TypeErrorKind.TypeMismatch([inner], item.ty)))
         }
       }
     }
 
-    Result.Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Array(typedItems)))
+    Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Array(typedItems)))
   }
 
   func _typecheckSet(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
@@ -3929,10 +3940,10 @@ export type Typechecker {
     var makeItemsNullable = false
     val typedItems: TypedAstNode[] = []
     for node in items {
-      val typedItem = match self._typecheckExpression(node: node, typeHint: innerType) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedItem = match self._typecheckExpression(node: node, typeHint: innerType) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if innerType |ty| {
         if !self._typeSatisfiesRequired(ty: typedItem.ty, required: ty) {
-          return Result.Err(TypeError(position: typedItem.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedItem.ty)))
+          return Err(TypeError(position: typedItem.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedItem.ty)))
         }
       } else if !typedItem.ty.hasUnfilledHoles() {
         innerType = Some(typedItem.ty)
@@ -3948,12 +3959,12 @@ export type Typechecker {
       if !innerHasUnfilledHoles && item.ty.hasUnfilledHoles() {
         item.ty.tryFillHoles(inner)
         if !self._typeSatisfiesRequired(ty: item.ty, required: inner) {
-          return Result.Err(TypeError(position: item.token.position, kind: TypeErrorKind.TypeMismatch([inner], item.ty)))
+          return Err(TypeError(position: item.token.position, kind: TypeErrorKind.TypeMismatch([inner], item.ty)))
         }
       }
     }
 
-    Result.Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Set(typedItems)))
+    Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Set(typedItems)))
   }
 
   func _typecheckMap(self, token: Token, items: (AstNode, AstNode)[], typeHint: Type?): Result<TypedAstNode, TypeError> {
@@ -3984,32 +3995,32 @@ export type Typechecker {
           IdentifierKind.Named(name) => TypedAstNode(token: keyNode.token, ty: Type(kind: TypeKind.PrimitiveString), kind: TypedAstNodeKind.Literal(LiteralAstNode.String(name)))
           IdentifierKind.Discard => TypedAstNode(token: keyNode.token, ty: Type(kind: TypeKind.PrimitiveString), kind: TypedAstNodeKind.Literal(LiteralAstNode.String("_")))
           IdentifierKind.Self => {
-            val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             e
           }
           IdentifierKind.None_ => {
-            val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+            val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
             e
           }
         }
         _ => {
-          val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           e
         }
       }
 
       if keyTy |ty| {
         if !self._typeSatisfiesRequired(ty: typedKey.ty, required: ty) {
-          return Result.Err(TypeError(position: typedKey.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedKey.ty)))
+          return Err(TypeError(position: typedKey.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedKey.ty)))
         }
       } else if !typedKey.ty.hasUnfilledHoles() {
         keyTy = Some(typedKey.ty)
       }
 
-      val typedVal = match self._typecheckExpression(node: valNode, typeHint: valTy) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedVal = match self._typecheckExpression(node: valNode, typeHint: valTy) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if valTy |ty| {
         if !self._typeSatisfiesRequired(ty: typedVal.ty, required: ty) {
-          return Result.Err(TypeError(position: typedVal.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedVal.ty)))
+          return Err(TypeError(position: typedVal.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedVal.ty)))
         }
       } else if !typedVal.ty.hasUnfilledHoles() {
         valTy = Some(typedVal.ty)
@@ -4033,7 +4044,7 @@ export type Typechecker {
       if !valTyHasUnfilledHoles && typedVal.ty.hasUnfilledHoles() { typedVal.ty.tryFillHoles(vTy) }
      }
 
-    Result.Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Map(typedItems)))
+    Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Map(typedItems)))
   }
 
   func _typecheckTuple(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
@@ -4048,10 +4059,10 @@ export type Typechecker {
     val typedItems: TypedAstNode[] = []
     for node, idx in items {
       val typeHint = if typeHints |typeHints| typeHints[idx] else None
-      val typedExpr = match self._typecheckExpression(node, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+      val typedExpr = match self._typecheckExpression(node, typeHint) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
       if typeHint |hint| {
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: hint) {
-          return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([hint], typedExpr.ty)))
+          return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([hint], typedExpr.ty)))
         }
       }
       typedItems.push(typedExpr)
@@ -4060,17 +4071,17 @@ export type Typechecker {
     if typeHints |typeHints| {
       val hintTy = Type(kind: TypeKind.Tuple(typeHints))
       if !self._typeSatisfiesRequired(ty: ty, required: hintTy) {
-        return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.TypeMismatch([hintTy], ty)))
+        return Err(TypeError(position: token.position, kind: TypeErrorKind.TypeMismatch([hintTy], ty)))
       }
     }
 
-    Result.Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Tuple(typedItems)))
+    Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Tuple(typedItems)))
   }
 
   func _typecheckIndexing(self, token: Token, expr: AstNode, indexMode: IndexingMode<AstNode>, typeHint: Type?): Result<TypedAstNode, TypeError> {
-    val typedExpr = match self._typecheckExpression(expr, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val typedExpr = match self._typecheckExpression(expr, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
     if self._typeIsOption(typedExpr.ty) {
-      return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
+      return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
     }
 
     val res = match typedExpr.ty.kind {
@@ -4090,21 +4101,21 @@ export type Typechecker {
 
           match indexMode {
             IndexingMode.Single(idxExpr) => {
-              val typedIdxExpr = match self._typecheckExpression(idxExpr, Some(keyTy)) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+              val typedIdxExpr = match self._typecheckExpression(idxExpr, Some(keyTy)) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
               if !self._typeSatisfiesRequired(ty: typedIdxExpr.ty, required: keyTy) {
-                return Result.Err(TypeError(position: typedIdxExpr.token.position, kind: TypeErrorKind.TypeMismatch([keyTy], typedIdxExpr.ty)))
+                return Err(TypeError(position: typedIdxExpr.token.position, kind: TypeErrorKind.TypeMismatch([keyTy], typedIdxExpr.ty)))
               }
 
               val ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [Type(kind: valTy.kind, )]))//nullable: true)
-              Result.Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.Map(typedExpr, typedIdxExpr))))
+              Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.Map(typedExpr, typedIdxExpr))))
             }
-            IndexingMode.Range => return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: true)))
+            IndexingMode.Range => return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: true)))
           }
         } else {
-          return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
+          return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
         }
       }
-      _ => return Result.Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
+      _ => return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
     }
 
     res
@@ -4113,32 +4124,32 @@ export type Typechecker {
   func _typecheckIndexingArraylike(self, token: Token, typedExpr: TypedAstNode, indexMode: IndexingMode<AstNode>, singleModeType: Type, rangeModeType: Type): Result<TypedAstNode, TypeError> {
     match indexMode {
       IndexingMode.Single(idxExpr) => {
-        val typedIdxExpr = match self._typecheckExpression(idxExpr, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+        val typedIdxExpr = match self._typecheckExpression(idxExpr, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
         val idxTy = typedIdxExpr.ty
         if idxTy.kind != TypeKind.PrimitiveInt || !!self._typeIsOption(idxTy) {
-          return Result.Err(TypeError(position: typedIdxExpr.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], idxTy)))
+          return Err(TypeError(position: typedIdxExpr.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], idxTy)))
         }
 
         val typedIndexMode = IndexingMode.Single(typedIdxExpr)
-        return Result.Ok(TypedAstNode(token: token, ty: singleModeType, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.ArrayLike(typedExpr, typedIndexMode))))
+        return Ok(TypedAstNode(token: token, ty: singleModeType, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.ArrayLike(typedExpr, typedIndexMode))))
       }
       IndexingMode.Range(startExpr, endExpr) => {
         val typedStartExpr = if startExpr |expr| {
-          val e = match self._typecheckExpression(expr, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val e = match self._typecheckExpression(expr, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if e.ty.kind != TypeKind.PrimitiveInt || !!self._typeIsOption(e.ty) {
-            return Result.Err(TypeError(position: e.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], e.ty)))
+            return Err(TypeError(position: e.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], e.ty)))
           }
           Some(e)
         } else None
         val typedEndExpr = if endExpr |expr| {
-          val e = match self._typecheckExpression(expr, None) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+          val e = match self._typecheckExpression(expr, None) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
           if e.ty.kind != TypeKind.PrimitiveInt || !!self._typeIsOption(e.ty) {
-            return Result.Err(TypeError(position: e.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], e.ty)))
+            return Err(TypeError(position: e.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], e.ty)))
           }
           Some(e)
         } else None
         val typedIndexMode = IndexingMode.Range(typedStartExpr, typedEndExpr)
-        return Result.Ok(TypedAstNode(token: token, ty: rangeModeType, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.ArrayLike(typedExpr, typedIndexMode))))
+        return Ok(TypedAstNode(token: token, ty: rangeModeType, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.ArrayLike(typedExpr, typedIndexMode))))
       }
     }
   }
@@ -4151,22 +4162,22 @@ export type Typechecker {
             match lit {
               LiteralAstNode.Int(i) => {
                 val itemTy = if i < 0
-                  return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalTupleIndexing(tupleExpr.ty, IllegalTupleIndexingReason.IndexNegative)))
+                  return Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalTupleIndexing(tupleExpr.ty, IllegalTupleIndexingReason.IndexNegative)))
                 else if tupleItemTypes[i] |ty|
                   ty
                 else
-                  return Result.Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalTupleIndexing(tupleExpr.ty, IllegalTupleIndexingReason.IndexOutOfBounds)))
+                  return Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalTupleIndexing(tupleExpr.ty, IllegalTupleIndexingReason.IndexOutOfBounds)))
 
-                Result.Ok(TypedAstNode(token: token, ty: itemTy, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.Tuple(tupleExpr, i))))
+                Ok(TypedAstNode(token: token, ty: itemTy, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.Tuple(tupleExpr, i))))
               }
-              _ => Result.Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalTupleIndexing(tupleExpr.ty, IllegalTupleIndexingReason.NotIntLiteral)))
+              _ => Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalTupleIndexing(tupleExpr.ty, IllegalTupleIndexingReason.NotIntLiteral)))
             }
           }
-          _ => Result.Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalTupleIndexing(tupleExpr.ty, IllegalTupleIndexingReason.NotLiteralNode)))
+          _ => Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalTupleIndexing(tupleExpr.ty, IllegalTupleIndexingReason.NotLiteralNode)))
         }
       }
       // TODO: should tuples be indexable as a range? it could just create a sub-tuple copy? is that useful at all? seems silly to forbid it
-      IndexingMode.Range => Result.Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalIndexableType(ty: tupleExpr.ty, isRange: true)))
+      IndexingMode.Range => Err(TypeError(position: token.position, kind: TypeErrorKind.IllegalIndexableType(ty: tupleExpr.ty, isRange: true)))
     }
   }
 
@@ -4200,21 +4211,21 @@ export type Typechecker {
       isLambda: true,
     )
 
-    val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params, paramHints: paramHints) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
-    match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: node.params, body: node.body, paramsNeedingRevisit: paramsNeedingRevisit) { Result.Ok(v) => v, Result.Err(e) => return Result.Err(e) }
+    val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params, paramHints: paramHints) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
+    match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: node.params, body: node.body, paramsNeedingRevisit: paramsNeedingRevisit) { Result.Ok(v) => v, Result.Err(e) => return Err(e) }
 
     val lambdaTy = fn.getType()
 
-    Result.Ok(TypedAstNode(token: token, ty: lambdaTy, kind: TypedAstNodeKind.Lambda(fn)))
+    Ok(TypedAstNode(token: token, ty: lambdaTy, kind: TypedAstNodeKind.Lambda(fn)))
   }
 }
 
 func todo<V>(position: Position, reason = ""): Result<V, TypeError> {
-  Result.Err(TypeError(position: position, kind: TypeErrorKind.NotYetImplemented(reason)))
+  Err(TypeError(position: position, kind: TypeErrorKind.NotYetImplemented(reason)))
 }
 
 func unreachable<V>(position: Position, message: String): Result<V, TypeError> {
-  Result.Err(TypeError(position: position, kind: TypeErrorKind.Unreachable(message)))
+  Err(TypeError(position: position, kind: TypeErrorKind.Unreachable(message)))
 }
 
 // There's currently no notion of asserts in the language but the message here will show up in output files

--- a/selfhost/test/typechecker/enumdecl/enumdecl_Result_shorthand.abra
+++ b/selfhost/test/typechecker/enumdecl/enumdecl_Result_shorthand.abra
@@ -1,0 +1,13 @@
+func implicitReturn(): Result<Int, String> {
+  if true Ok(123) else Err("hello")
+}
+
+func explicitReturn(): Result<Int, String> {
+  if false return Err("asdf")
+
+  if true {
+    return Ok(123)
+  } else {
+    return Err("hello")
+  }
+}

--- a/selfhost/test/typechecker/enumdecl/enumdecl_Result_shorthand.out.json
+++ b/selfhost/test/typechecker/enumdecl/enumdecl_Result_shorthand.out.json
@@ -1,0 +1,671 @@
+{
+  "id": 3,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "implicitReturn", "position": [1, 6] },
+          "scope": {
+            "name": "$root::module_3::implicitReturn",
+            "variables": [],
+            "functions": [],
+            "types": []
+          },
+          "kind": "FunctionKind.Standalone",
+          "typeParameters": [],
+          "parameters": [],
+          "returnType": {
+            "kind": "enumInstance",
+            "enum": { "moduleId": 0, "name": "Result" },
+            "typeParams": [
+              {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              {
+                "kind": "primitive",
+                "primitive": "String"
+              }
+            ]
+          },
+          "body": [
+            {
+              "token": {
+                "position": [2, 3],
+                "kind": {
+                  "name": "If"
+                }
+              },
+              "type": {
+                "kind": "enumInstance",
+                "enum": { "moduleId": 0, "name": "Result" },
+                "typeParams": [
+                  {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ]
+              },
+              "node": {
+                "kind": "if",
+                "isStatement": false,
+                "condition": {
+                  "token": {
+                    "position": [2, 6],
+                    "kind": {
+                      "name": "Bool",
+                      "value": true
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": true
+                  }
+                },
+                "conditionBindingPattern": null,
+                "ifBlock": [
+                  {
+                    "token": {
+                      "position": [2, 13],
+                      "kind": {
+                        "name": "LParen"
+                      }
+                    },
+                    "type": {
+                      "kind": "enumInstance",
+                      "enum": { "moduleId": 0, "name": "Result" },
+                      "typeParams": [
+                        {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        {
+                          "kind": "primitive",
+                          "primitive": "String"
+                        }
+                      ]
+                    },
+                    "node": {
+                      "kind": "invocation",
+                      "invokee": {
+                        "token": {
+                          "position": [2, 11],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "Ok"
+                          }
+                        },
+                        "type": {
+                          "kind": "function",
+                          "parameters": [
+                            {
+                              "required": true,
+                              "type": {
+                                "kind": "generic",
+                                "name": "V"
+                              }
+                            }
+                          ],
+                          "returnType": {
+                            "kind": "enumInstance",
+                            "enum": { "moduleId": 0, "name": "Result" },
+                            "typeParams": [
+                              {
+                                "kind": "generic",
+                                "name": "V"
+                              },
+                              {
+                                "kind": "generic",
+                                "name": "E"
+                              }
+                            ]
+                          }
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "Ok"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "token": {
+                            "position": [2, 14],
+                            "kind": {
+                              "name": "Int",
+                              "value": 123
+                            }
+                          },
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "Int"
+                          },
+                          "node": {
+                            "kind": "literal",
+                            "value": 123
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "elseBlock": [
+                  {
+                    "token": {
+                      "position": [2, 27],
+                      "kind": {
+                        "name": "LParen"
+                      }
+                    },
+                    "type": {
+                      "kind": "enumInstance",
+                      "enum": { "moduleId": 0, "name": "Result" },
+                      "typeParams": [
+                        {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        {
+                          "kind": "primitive",
+                          "primitive": "String"
+                        }
+                      ]
+                    },
+                    "node": {
+                      "kind": "invocation",
+                      "invokee": {
+                        "token": {
+                          "position": [2, 24],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "Err"
+                          }
+                        },
+                        "type": {
+                          "kind": "function",
+                          "parameters": [
+                            {
+                              "required": true,
+                              "type": {
+                                "kind": "generic",
+                                "name": "E"
+                              }
+                            }
+                          ],
+                          "returnType": {
+                            "kind": "enumInstance",
+                            "enum": { "moduleId": 0, "name": "Result" },
+                            "typeParams": [
+                              {
+                                "kind": "generic",
+                                "name": "V"
+                              },
+                              {
+                                "kind": "generic",
+                                "name": "E"
+                              }
+                            ]
+                          }
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "Err"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "token": {
+                            "position": [2, 28],
+                            "kind": {
+                              "name": "String",
+                              "value": "hello"
+                            }
+                          },
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "String"
+                          },
+                          "node": {
+                            "kind": "literal",
+                            "value": "hello"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [5, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "explicitReturn", "position": [5, 6] },
+          "scope": {
+            "name": "$root::module_3::explicitReturn",
+            "variables": [],
+            "functions": [],
+            "types": []
+          },
+          "kind": "FunctionKind.Standalone",
+          "typeParameters": [],
+          "parameters": [],
+          "returnType": {
+            "kind": "enumInstance",
+            "enum": { "moduleId": 0, "name": "Result" },
+            "typeParams": [
+              {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              {
+                "kind": "primitive",
+                "primitive": "String"
+              }
+            ]
+          },
+          "body": [
+            {
+              "token": {
+                "position": [6, 3],
+                "kind": {
+                  "name": "If"
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Unit"
+              },
+              "node": {
+                "kind": "if",
+                "isStatement": true,
+                "condition": {
+                  "token": {
+                    "position": [6, 6],
+                    "kind": {
+                      "name": "Bool",
+                      "value": false
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": false
+                  }
+                },
+                "conditionBindingPattern": null,
+                "ifBlock": [
+                  {
+                    "token": {
+                      "position": [6, 12],
+                      "kind": {
+                        "name": "Return"
+                      }
+                    },
+                    "type": {
+                      "kind": "never"
+                    },
+                    "node": {
+                      "kind": "return",
+                      "expr": {
+                        "token": {
+                          "position": [6, 22],
+                          "kind": {
+                            "name": "LParen"
+                          }
+                        },
+                        "type": {
+                          "kind": "enumInstance",
+                          "enum": { "moduleId": 0, "name": "Result" },
+                          "typeParams": [
+                            {
+                              "kind": "primitive",
+                              "primitive": "Int"
+                            },
+                            {
+                              "kind": "primitive",
+                              "primitive": "String"
+                            }
+                          ]
+                        },
+                        "node": {
+                          "kind": "invocation",
+                          "invokee": {
+                            "token": {
+                              "position": [6, 19],
+                              "kind": {
+                                "name": "Ident",
+                                "value": "Err"
+                              }
+                            },
+                            "type": {
+                              "kind": "function",
+                              "parameters": [
+                                {
+                                  "required": true,
+                                  "type": {
+                                    "kind": "generic",
+                                    "name": "E"
+                                  }
+                                }
+                              ],
+                              "returnType": {
+                                "kind": "enumInstance",
+                                "enum": { "moduleId": 0, "name": "Result" },
+                                "typeParams": [
+                                  {
+                                    "kind": "generic",
+                                    "name": "V"
+                                  },
+                                  {
+                                    "kind": "generic",
+                                    "name": "E"
+                                  }
+                                ]
+                              }
+                            },
+                            "node": {
+                              "kind": "identifier",
+                              "name": "Err"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "token": {
+                                "position": [6, 23],
+                                "kind": {
+                                  "name": "String",
+                                  "value": "asdf"
+                                }
+                              },
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "String"
+                              },
+                              "node": {
+                                "kind": "literal",
+                                "value": "asdf"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ],
+                "elseBlock": []
+              }
+            },
+            {
+              "token": {
+                "position": [8, 3],
+                "kind": {
+                  "name": "If"
+                }
+              },
+              "type": {
+                "kind": "never"
+              },
+              "node": {
+                "kind": "if",
+                "isStatement": false,
+                "condition": {
+                  "token": {
+                    "position": [8, 6],
+                    "kind": {
+                      "name": "Bool",
+                      "value": true
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": true
+                  }
+                },
+                "conditionBindingPattern": null,
+                "ifBlock": [
+                  {
+                    "token": {
+                      "position": [9, 5],
+                      "kind": {
+                        "name": "Return"
+                      }
+                    },
+                    "type": {
+                      "kind": "never"
+                    },
+                    "node": {
+                      "kind": "return",
+                      "expr": {
+                        "token": {
+                          "position": [9, 14],
+                          "kind": {
+                            "name": "LParen"
+                          }
+                        },
+                        "type": {
+                          "kind": "enumInstance",
+                          "enum": { "moduleId": 0, "name": "Result" },
+                          "typeParams": [
+                            {
+                              "kind": "primitive",
+                              "primitive": "Int"
+                            },
+                            {
+                              "kind": "primitive",
+                              "primitive": "String"
+                            }
+                          ]
+                        },
+                        "node": {
+                          "kind": "invocation",
+                          "invokee": {
+                            "token": {
+                              "position": [9, 12],
+                              "kind": {
+                                "name": "Ident",
+                                "value": "Ok"
+                              }
+                            },
+                            "type": {
+                              "kind": "function",
+                              "parameters": [
+                                {
+                                  "required": true,
+                                  "type": {
+                                    "kind": "generic",
+                                    "name": "V"
+                                  }
+                                }
+                              ],
+                              "returnType": {
+                                "kind": "enumInstance",
+                                "enum": { "moduleId": 0, "name": "Result" },
+                                "typeParams": [
+                                  {
+                                    "kind": "generic",
+                                    "name": "V"
+                                  },
+                                  {
+                                    "kind": "generic",
+                                    "name": "E"
+                                  }
+                                ]
+                              }
+                            },
+                            "node": {
+                              "kind": "identifier",
+                              "name": "Ok"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "token": {
+                                "position": [9, 15],
+                                "kind": {
+                                  "name": "Int",
+                                  "value": 123
+                                }
+                              },
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "Int"
+                              },
+                              "node": {
+                                "kind": "literal",
+                                "value": 123
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ],
+                "elseBlock": [
+                  {
+                    "token": {
+                      "position": [11, 5],
+                      "kind": {
+                        "name": "Return"
+                      }
+                    },
+                    "type": {
+                      "kind": "never"
+                    },
+                    "node": {
+                      "kind": "return",
+                      "expr": {
+                        "token": {
+                          "position": [11, 15],
+                          "kind": {
+                            "name": "LParen"
+                          }
+                        },
+                        "type": {
+                          "kind": "enumInstance",
+                          "enum": { "moduleId": 0, "name": "Result" },
+                          "typeParams": [
+                            {
+                              "kind": "primitive",
+                              "primitive": "Int"
+                            },
+                            {
+                              "kind": "primitive",
+                              "primitive": "String"
+                            }
+                          ]
+                        },
+                        "node": {
+                          "kind": "invocation",
+                          "invokee": {
+                            "token": {
+                              "position": [11, 12],
+                              "kind": {
+                                "name": "Ident",
+                                "value": "Err"
+                              }
+                            },
+                            "type": {
+                              "kind": "function",
+                              "parameters": [
+                                {
+                                  "required": true,
+                                  "type": {
+                                    "kind": "generic",
+                                    "name": "E"
+                                  }
+                                }
+                              ],
+                              "returnType": {
+                                "kind": "enumInstance",
+                                "enum": { "moduleId": 0, "name": "Result" },
+                                "typeParams": [
+                                  {
+                                    "kind": "generic",
+                                    "name": "V"
+                                  },
+                                  {
+                                    "kind": "generic",
+                                    "name": "E"
+                                  }
+                                ]
+                              }
+                            },
+                            "node": {
+                              "kind": "identifier",
+                              "name": "Err"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "token": {
+                                "position": [11, 16],
+                                "kind": {
+                                  "name": "String",
+                                  "value": "hello"
+                                }
+                              },
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "String"
+                              },
+                              "node": {
+                                "kind": "literal",
+                                "value": "hello"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -626,6 +626,7 @@ fn typechecker_tests() {
         // Enum declaration
         .add_test_vs_txt("typechecker/enumdecl/enumdecl_exported.abra", "typechecker/enumdecl/enumdecl_exported.out.json")
         .add_test_vs_txt("typechecker/enumdecl/enumdecl.1.abra", "typechecker/enumdecl/enumdecl.1.out.json")
+        .add_test_vs_txt("typechecker/enumdecl/enumdecl_Result_shorthand.abra", "typechecker/enumdecl/enumdecl_Result_shorthand.out.json")
         .add_test_vs_txt("typechecker/enumdecl/error_duplicate_enum_enum.abra", "typechecker/enumdecl/error_duplicate_enum_enum.out")
         .add_test_vs_txt("typechecker/enumdecl/error_duplicate_enum_func.abra", "typechecker/enumdecl/error_duplicate_enum_func.out")
         .add_test_vs_txt("typechecker/enumdecl/error_duplicate_enum_type.abra", "typechecker/enumdecl/error_duplicate_enum_type.out")


### PR DESCRIPTION
Typing `Result.Ok`/`Result.Err` can become quite repetitive and adds a lot of noise. Since this is such a fundamental feature of the language, it deserves a special shorthand - `Ok(...)`/`Err(...)`. Thankfully, not much is needed to implement this shorthand, since it can simply be implemented as two standalone functions in the `prelude` module:
```
func Ok<V, E>(value: V): Result<V, E> = Result.Ok(value)
func Err<V, E>(error: E): Result<V, E> = Result.Err(error)
```

No special transformations are necessary here, like what I had to do in order to implement the `Option.Some`/`Option.None` -> `Some`/`None` shorthand in the previous changeset!