### PR TITLE
Selfhost: match special cases

### DIFF
--- a/abra_core/std/fs.abra
+++ b/abra_core/std/fs.abra
@@ -1,4 +1,4 @@
-import Byte from "./_intrinsics"
+import Pointer, Byte from "./_intrinsics"
 import "libc" as libc
 
 export enum ReadFileError {

--- a/selfhost/src/parser.abra
+++ b/selfhost/src/parser.abra
@@ -1373,8 +1373,6 @@ export type Parser {
               last = label
             }
 
-            val typeIdent = TypeIdentifier.Normal(last, [], path)
-
             val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
             val args = match nextToken.kind {
               TokenKind.LParen => {
@@ -1395,7 +1393,11 @@ export type Parser {
               _ => []
             }
 
-            MatchCaseKind.Type(path, last, args)
+            if path.isEmpty() && (last.name == "Ok" || last.name == "Err") {
+              MatchCaseKind.Type([Label(position: last.position, name: "Result")], last, args)
+            } else {
+              MatchCaseKind.Type(path, last, args)
+            }
           }
         }
         TokenKind.Else => {

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -3384,7 +3384,14 @@ export type Typechecker {
 
               val subjectTy = if self._typeIsOption(subjectTy) |innerTy| innerTy else subjectTy
               // TODO: generics
-              val caseTy = Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), []))
+              val template = Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), enum_.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+              val extractedGenerics = self._extractGenerics(template: template, source: subjectTy)
+              val resolvedGenerics: Map<String, Type> = {}
+              for _p in extractedGenerics {
+                resolvedGenerics[_p[0]] = _p[1]
+              }
+
+              val caseTy = template.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
               if !self._typeSatisfiesRequired(ty: caseTy, required: subjectTy) {
                 return Err(TypeError(position: case.position, kind: TypeErrorKind.UnreachableMatchCase(UnreachableMatchCaseReason.NoOverlap(caseTy: Some(caseTy)), typedExpr.ty)))
               }
@@ -3406,7 +3413,12 @@ export type Typechecker {
                         val kind = TypeErrorKind.InvalidMatchCaseDestructuring(InvalidMatchCaseDestructuringReason.InvalidArity(expected: fields.length, given: args.length))
                         return Err(TypeError(position: case.position, kind: kind))
                       }
-                      val variable = Variable(label: arg, mutable: false, ty: field.ty)
+                      val variableTy = if self._containsGenerics(field.ty) {
+                        field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
+                      } else {
+                        field.ty
+                      }
+                      val variable = Variable(label: arg, mutable: false, ty: variableTy)
                       match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
                       variables.push(variable)
                     }
@@ -3777,7 +3789,7 @@ export type Typechecker {
       TypeKind.PrimitiveUnit => None
       TypeKind.PrimitiveInt => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeIntStruct), [])), label, None)
       TypeKind.PrimitiveFloat => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeFloatStruct), [])), label, None)
-      TypeKind.PrimitiveBool => None
+      TypeKind.PrimitiveBool => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeBoolStruct), [])), label, None)
       TypeKind.PrimitiveString => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeStringStruct), [])), label, None)
       TypeKind.Never => None
       TypeKind.Generic => self._resolveAccessorPathSegmentAny(label)

--- a/selfhost/test/parser/match.abra
+++ b/selfhost/test/parser/match.abra
@@ -21,3 +21,9 @@ val x = match foo() {
   _ => 0
   else f => f - 1
 }
+
+// special cases
+match foo() {
+  Ok(v) => v
+  Err(e) => e
+}

--- a/selfhost/test/parser/match.out.json
+++ b/selfhost/test/parser/match.out.json
@@ -625,6 +625,101 @@
           }
         }
       }
+    },
+    {
+      "token": {
+        "position": [26, 1],
+        "kind": {
+          "name": "Match"
+        }
+      },
+      "kind": {
+        "name": "match",
+        "expr": {
+          "token": {
+            "position": [26, 10],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "kind": {
+            "name": "invocation",
+            "invokee": {
+              "token": {
+                "position": [26, 7],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "kind": {
+                "name": "identifier",
+                "ident": "foo"
+              }
+            },
+            "typeArguments": [],
+            "arguments": []
+          }
+        },
+        "cases": [
+          {
+            "caseKind": {
+              "kind": "type",
+              "path": [
+                { "name": "Result", "position": [27, 3] },
+                { "name": "Ok", "position": [27, 3] }
+              ],
+              "arguments": [
+                { "name": "v", "position": [27, 6] }
+              ]
+            },
+            "caseBinding": null,
+            "body": [
+              {
+                "token": {
+                  "position": [27, 12],
+                  "kind": {
+                    "name": "Ident",
+                    "value": "v"
+                  }
+                },
+                "kind": {
+                  "name": "identifier",
+                  "ident": "v"
+                }
+              }
+            ]
+          },
+          {
+            "caseKind": {
+              "kind": "type",
+              "path": [
+                { "name": "Result", "position": [28, 3] },
+                { "name": "Err", "position": [28, 3] }
+              ],
+              "arguments": [
+                { "name": "e", "position": [28, 7] }
+              ]
+            },
+            "caseBinding": null,
+            "body": [
+              {
+                "token": {
+                  "position": [28, 13],
+                  "kind": {
+                    "name": "Ident",
+                    "value": "e"
+                  }
+                },
+                "kind": {
+                  "name": "identifier",
+                  "ident": "e"
+                }
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/selfhost/test/typechecker/match/match_Result.abra
+++ b/selfhost/test/typechecker/match/match_Result.abra
@@ -1,0 +1,4 @@
+func addOne(res: Result<Int, String>): Result<Int, String> {
+  val v = match res { Ok(v) => v Err(e) => return Err(e) }
+  Ok(v + 1)
+}

--- a/selfhost/test/typechecker/match/match_Result.out.json
+++ b/selfhost/test/typechecker/match/match_Result.out.json
@@ -1,0 +1,440 @@
+{
+  "id": 3,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "addOne", "position": [1, 6] },
+          "scope": {
+            "name": "$root::module_3::addOne",
+            "variables": [
+              {
+                "label": { "name": "res", "position": [1, 13] },
+                "mutable": false,
+                "type": {
+                  "kind": "enumInstance",
+                  "enum": { "moduleId": 0, "name": "Result" },
+                  "typeParams": [
+                    {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    {
+                      "kind": "primitive",
+                      "primitive": "String"
+                    }
+                  ]
+                }
+              },
+              {
+                "label": { "name": "v", "position": [2, 7] },
+                "mutable": false,
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              }
+            ],
+            "functions": [],
+            "types": []
+          },
+          "kind": "FunctionKind.Standalone",
+          "typeParameters": [],
+          "parameters": [
+            {
+              "label": { "name": "res", "position": [1, 13] },
+              "type": {
+                "kind": "enumInstance",
+                "enum": { "moduleId": 0, "name": "Result" },
+                "typeParams": [
+                  {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ]
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            }
+          ],
+          "returnType": {
+            "kind": "enumInstance",
+            "enum": { "moduleId": 0, "name": "Result" },
+            "typeParams": [
+              {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              {
+                "kind": "primitive",
+                "primitive": "String"
+              }
+            ]
+          },
+          "body": [
+            {
+              "token": {
+                "position": [2, 3],
+                "kind": {
+                  "name": "Val"
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Unit"
+              },
+              "node": {
+                "kind": "bindingDeclaration",
+                "pattern": {
+                  "kind": "variable",
+                  "label": { "name": "v", "position": [2, 7] }
+                },
+                "variables": [
+                  {
+                    "label": { "name": "v", "position": [2, 7] },
+                    "mutable": false,
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    }
+                  }
+                ],
+                "expr": {
+                  "token": {
+                    "position": [2, 11],
+                    "kind": {
+                      "name": "Match"
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "match",
+                    "isStatement": false,
+                    "subject": {
+                      "token": {
+                        "position": [2, 17],
+                        "kind": {
+                          "name": "Ident",
+                          "value": "res"
+                        }
+                      },
+                      "type": {
+                        "kind": "enumInstance",
+                        "enum": { "moduleId": 0, "name": "Result" },
+                        "typeParams": [
+                          {
+                            "kind": "primitive",
+                            "primitive": "Int"
+                          },
+                          {
+                            "kind": "primitive",
+                            "primitive": "String"
+                          }
+                        ]
+                      },
+                      "node": {
+                        "kind": "identifier",
+                        "name": "res"
+                      }
+                    },
+                    "cases": [
+                      {
+                        "kind": {
+                          "kind": "enumVariant",
+                          "variantIdx": 0,
+                          "enum": { "moduleId": 0, "name": "Result" },
+                          "destructuredVariables": [
+                            {
+                              "label": { "name": "v", "position": [2, 26] },
+                              "mutable": false,
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "Int"
+                              }
+                            }
+                          ]
+                        },
+                        "binding": null,
+                        "body": [
+                          {
+                            "token": {
+                              "position": [2, 32],
+                              "kind": {
+                                "name": "Ident",
+                                "value": "v"
+                              }
+                            },
+                            "type": {
+                              "kind": "primitive",
+                              "primitive": "Int"
+                            },
+                            "node": {
+                              "kind": "identifier",
+                              "name": "v"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "kind": {
+                          "kind": "enumVariant",
+                          "variantIdx": 1,
+                          "enum": { "moduleId": 0, "name": "Result" },
+                          "destructuredVariables": [
+                            {
+                              "label": { "name": "e", "position": [2, 38] },
+                              "mutable": false,
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "String"
+                              }
+                            }
+                          ]
+                        },
+                        "binding": null,
+                        "body": [
+                          {
+                            "token": {
+                              "position": [2, 44],
+                              "kind": {
+                                "name": "Return"
+                              }
+                            },
+                            "type": {
+                              "kind": "never"
+                            },
+                            "node": {
+                              "kind": "return",
+                              "expr": {
+                                "token": {
+                                  "position": [2, 54],
+                                  "kind": {
+                                    "name": "LParen"
+                                  }
+                                },
+                                "type": {
+                                  "kind": "enumInstance",
+                                  "enum": { "moduleId": 0, "name": "Result" },
+                                  "typeParams": [
+                                    {
+                                      "kind": "primitive",
+                                      "primitive": "Int"
+                                    },
+                                    {
+                                      "kind": "primitive",
+                                      "primitive": "String"
+                                    }
+                                  ]
+                                },
+                                "node": {
+                                  "kind": "invocation",
+                                  "invokee": {
+                                    "token": {
+                                      "position": [2, 51],
+                                      "kind": {
+                                        "name": "Ident",
+                                        "value": "Err"
+                                      }
+                                    },
+                                    "type": {
+                                      "kind": "function",
+                                      "parameters": [
+                                        {
+                                          "required": true,
+                                          "type": {
+                                            "kind": "generic",
+                                            "name": "E"
+                                          }
+                                        }
+                                      ],
+                                      "returnType": {
+                                        "kind": "enumInstance",
+                                        "enum": { "moduleId": 0, "name": "Result" },
+                                        "typeParams": [
+                                          {
+                                            "kind": "generic",
+                                            "name": "V"
+                                          },
+                                          {
+                                            "kind": "generic",
+                                            "name": "E"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "node": {
+                                      "kind": "identifier",
+                                      "name": "Err"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "token": {
+                                        "position": [2, 55],
+                                        "kind": {
+                                          "name": "Ident",
+                                          "value": "e"
+                                        }
+                                      },
+                                      "type": {
+                                        "kind": "primitive",
+                                        "primitive": "String"
+                                      },
+                                      "node": {
+                                        "kind": "identifier",
+                                        "name": "e"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "token": {
+                "position": [3, 5],
+                "kind": {
+                  "name": "LParen"
+                }
+              },
+              "type": {
+                "kind": "enumInstance",
+                "enum": { "moduleId": 0, "name": "Result" },
+                "typeParams": [
+                  {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  {
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ]
+              },
+              "node": {
+                "kind": "invocation",
+                "invokee": {
+                  "token": {
+                    "position": [3, 3],
+                    "kind": {
+                      "name": "Ident",
+                      "value": "Ok"
+                    }
+                  },
+                  "type": {
+                    "kind": "function",
+                    "parameters": [
+                      {
+                        "required": true,
+                        "type": {
+                          "kind": "generic",
+                          "name": "V"
+                        }
+                      }
+                    ],
+                    "returnType": {
+                      "kind": "enumInstance",
+                      "enum": { "moduleId": 0, "name": "Result" },
+                      "typeParams": [
+                        {
+                          "kind": "generic",
+                          "name": "V"
+                        },
+                        {
+                          "kind": "generic",
+                          "name": "E"
+                        }
+                      ]
+                    }
+                  },
+                  "node": {
+                    "kind": "identifier",
+                    "name": "Ok"
+                  }
+                },
+                "arguments": [
+                  {
+                    "token": {
+                      "position": [3, 8],
+                      "kind": {
+                        "name": "Plus"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.Add",
+                      "left": {
+                        "token": {
+                          "position": [3, 6],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "v"
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "v"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [3, 10],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -404,6 +404,7 @@ fn typechecker_tests() {
         // Match expressions & statements
         .add_test_vs_txt("typechecker/match/match_expr.abra", "typechecker/match/match_expr.out.json")
         .add_test_vs_txt("typechecker/match/match_stmt.abra", "typechecker/match/match_stmt.out.json")
+        .add_test_vs_txt("typechecker/match/match_Result.abra", "typechecker/match/match_Result.out.json")
         .add_test_vs_txt("typechecker/match/error_expr_empty_block.abra", "typechecker/match/error_expr_empty_block.out")
         .add_test_vs_txt("typechecker/match/error_unfilled_holes.1.abra", "typechecker/match/error_unfilled_holes.1.out")
         .add_test_vs_txt("typechecker/match/error_alreadycovered_None.abra", "typechecker/match/error_alreadycovered_None.out")


### PR DESCRIPTION
Add handling for special cases `Ok` and `Err`. Just like the reference implementation, this is a parser-level transformation which results in match cases `Ok` and `Err` getting replaced with `Result.Ok` and `Result.Err`, respectively. This also properly handles generics in match case types and destructured variables.

This is part of attempting to typecheck the selfhosted compiler, so there are a handful of other things in here as well.