### PR TITLE
Continuing running the typechecker via itself

### DIFF
--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -59,6 +59,8 @@ func range(start: Int, end: Int, stepBy = 1): RangeIterator = RangeIterator(star
 func flattenOption<T>(value: T??): T? = if value |v| v else None
 
 type Int {
+  func asByte(self): Byte = Byte.fromInt(self)
+
   func asFloat(self): Float = intrinsics.intAsFloat(self)
 
   func abs(self): Int = if self < 0 { -self } else { self }

--- a/abra_llvm/tests/arrays.abra
+++ b/abra_llvm/tests/arrays.abra
@@ -207,6 +207,16 @@ for ch in ["a", "b", "c"] println(ch)
   println(arr)
 })()
 
+// Array#concat
+(() => {
+  val arr1 = [1, 2, 3, 4]
+  val arr2 = [5, 6, 7]
+  /// Expect: [1, 2, 3, 4, 5, 6, 7]
+  println(arr1.concat(arr2))
+  /// Expect: [1, 2, 3, 4] [5, 6, 7]
+  println(arr1, arr2) // verify originals unmodified
+})()
+
 // Array#map
 func addOne(i: Int): Int = i + 1
 func exclaim(i: Int, _: Int, x = "!"): String = "$i$x"
@@ -324,6 +334,25 @@ func printItem(item: Int) = println(item)
   println(strArr.find(s => s == "hello"))
   /// Expect: Option.None
   println(strArr.find(s => s == "HELLO"))
+})()
+
+// Array#findIndex
+(() => {
+  val intArr = [123, 456, 789]
+  /// Expect: Option.Some(value: (123, 0))
+  println(intArr.findIndex(i => i == 123))
+  /// Expect: Option.None
+  println(intArr.findIndex(i => i == 10))
+
+  val empty: Int[] = []
+  /// Expect: Option.None
+  println(empty.findIndex(i => i == 123))
+
+  val strArr = ["hello", "world"]
+  /// Expect: Option.Some(value: ("hello", 0))
+  println(strArr.findIndex(s => s == "hello"))
+  /// Expect: Option.None
+  println(strArr.findIndex(s => s == "HELLO"))
 })()
 
 // Array#any

--- a/selfhost/src/lexer.abra
+++ b/selfhost/src/lexer.abra
@@ -461,7 +461,7 @@ export type Lexer {
           "\"" => "\"",
           "$" => "$",
           "u" => match self._parseUnicodeEscape(pos) { Ok(v) => v, Err(e) => return Err(e) }
-          _ => return Err(LexerError(position: pos, kind: LexerErrorKind.UnsupportedEscapeSequence("\\$ch", false)))
+          _ => return Err(LexerError(position: pos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: "\\$ch", isUnicode: false)))
         }
 
         if !seenEscape {
@@ -502,12 +502,12 @@ export type Lexer {
     for i in range(0, 4) {
       if self._cursor + i >= self._input.length {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
-        return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(escSeq, true)))
+        return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: escSeq, isUnicode: true)))
       }
       val ch = self._input._buffer.offset(self._cursor + i).load().asInt()
       val v = if valueIfValidHexDigit(ch) |v| v else {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
-        return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(escSeq, true)))
+        return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: escSeq, isUnicode: true)))
       }
       value = (value << 4) + v
     }
@@ -520,23 +520,23 @@ export type Lexer {
       "�"
     } else if value.isBetween(0, 0x007F, true) {
       val s = String.withLength(1)
-      s._buffer.offset(0).store(Byte.fromInt(value))
+      s._buffer.offset(0).store(value.asByte())
       s
     } else if value.isBetween(0x0080, 0x07FF, true) {
       val s = String.withLength(2)
       val b1 = 0b11000000 || (value && 0b11111000000)
       val b2 = 0b10000000 || (value && 0b00000111111)
-      s._buffer.offset(0).store(Byte.fromInt(b1))
-      s._buffer.offset(1).store(Byte.fromInt(b2))
+      s._buffer.offset(0).store(b1.asByte())
+      s._buffer.offset(1).store(b2.asByte())
       s
     } else if value.isBetween(0x0800, 0xFFFF, true) {
       val s = String.withLength(3)
       val b1 = 0b11100000 || ((value && 0b1111000000000000) >> 12)
       val b2 = 0b10000000 || ((value && 0b0000111111000000) >> 6)
       val b3 = 0b10000000 || (value && 0b0000000000111111)
-      s._buffer.offset(0).store(Byte.fromInt(b1))
-      s._buffer.offset(1).store(Byte.fromInt(b2))
-      s._buffer.offset(2).store(Byte.fromInt(b3))
+      s._buffer.offset(0).store(b1.asByte())
+      s._buffer.offset(1).store(b2.asByte())
+      s._buffer.offset(2).store(b3.asByte())
       s
     } else if value.isBetween(0x10000, 0x10FFFF, true) {
       val s = String.withLength(4)
@@ -544,10 +544,10 @@ export type Lexer {
       val b2 = 0b10000000 || (value && 0b000111111000000000000)
       val b3 = 0b10000000 || (value && 0b000000000111111000000)
       val b4 = 0b10000000 || (value && 0b000000000000000111111)
-      s._buffer.offset(0).store(Byte.fromInt(b1))
-      s._buffer.offset(1).store(Byte.fromInt(b2))
-      s._buffer.offset(2).store(Byte.fromInt(b3))
-      s._buffer.offset(3).store(Byte.fromInt(b4))
+      s._buffer.offset(0).store(b1.asByte())
+      s._buffer.offset(1).store(b2.asByte())
+      s._buffer.offset(2).store(b3.asByte())
+      s._buffer.offset(3).store(b4.asByte())
       s
     } else {
       "�"

--- a/selfhost/src/parser.abra
+++ b/selfhost/src/parser.abra
@@ -779,7 +779,7 @@ export type Parser {
         }
         TokenKind.None_ => {
           self._advance() // consume 'None' token
-          Label(position: identTok.position, name: "None")
+          Label(name: "None", position: identTok.position)
         }
         _ => break
       }

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -2190,7 +2190,7 @@ export type Typechecker {
     Ok(paramsNeedingRevisit)
   }
 
-  func _typecheckFunctionPass3(self, fn: Function, allowSelf: Bool, params: FunctionParam[], body: AstNode[], paramsNeedingRevisit: Int[], paramHints: Type[] = []): Result<Int, TypeError> {
+  func _typecheckFunctionPass3(self, fn: Function, allowSelf: Bool, params: FunctionParam[], body: AstNode[], paramsNeedingRevisit: Int[], paramHints: Type[] = []): Result<Type, TypeError> {
     val prevScope = self.currentScope
     self.currentScope = fn.scope
     val prevFn = self.currentFunction
@@ -2219,6 +2219,17 @@ export type Typechecker {
       fn.params[idx] = typedParam
     }
 
+    // Capture the return type of the function and return it. This will be used during typechecking of lambdas to aid in generic resolution.
+    // For example, consider this case:
+    //   func foo<T>(fn: () => T[]): T[] {
+    //     val r = fn()
+    //     return r
+    //   }
+    //   func bar(): Int[] = [123]
+    //   val v = foo(() => bar())
+    // When typechecking the lambda, we lose track of the fact that T in this case is meant to be determined by the return type of the lambda. This
+    // is one way of bubbling that information up.
+    var returnType = fn.returnType
     for node, idx in body {
       if self.currentScope.terminator return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
@@ -2248,6 +2259,8 @@ export type Typechecker {
           expr
         }
 
+        returnType = expr.ty
+
         expr
       } else {
         val stmt = match self._typecheckStatement(node, None) { Ok(v) => v, Err(e) => return Err(e) }
@@ -2259,7 +2272,7 @@ export type Typechecker {
     self.currentFunction = prevFn
     self.currentScope = prevScope
 
-    Ok(0)
+    Ok(returnType)
   }
 
   func _typecheckStructPass1(self, node: TypeDeclarationNode): Result<Struct, TypeError> {
@@ -3270,7 +3283,8 @@ export type Typechecker {
 
           if ifType.hasUnfilledHoles() {
             ifType.tryFillHoles(elseType)
-          } else if elseType.hasUnfilledHoles() {
+          }
+          if elseType.hasUnfilledHoles() {
             elseType.tryFillHoles(ifType)
           }
 
@@ -4055,7 +4069,15 @@ export type Typechecker {
 
             self._typecheckInvocationOfFunction(token, invokee, enumVariantAsFn, node, typeHint, Some(Instantiatable.EnumContainerVariant(enum_, variant, fields)))
           }
-          AccessorPathSegment.Method(_, fn) => self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint)
+          AccessorPathSegment.Method(_, fn) => {
+            if self._typeIsOption(invokee.ty) {
+              val typedNode = match self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
+              typedNode.ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [typedNode.ty]))
+              Ok(typedNode)
+            } else {
+              self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint)
+            }
+          }
           AccessorPathSegment.Field(label) => self._typecheckInvocationOfExpression(token, invokee, label.position, node)
         }
       }
@@ -4188,11 +4210,7 @@ export type Typechecker {
         }
       } else if instantiationOf |instantiatable| {
         match instantiatable {
-          Instantiatable.EnumContainerVariant(_, _, fields) => {
-            if fields.length != 1 {
-              return Err(TypeError(position: arg.position(), kind: TypeErrorKind.MissingRequiredArgumentLabel))
-            }
-          }
+          Instantiatable.EnumContainerVariant(_, _, _) => {}
           _ => return Err(TypeError(position: arg.position(), kind: TypeErrorKind.MissingRequiredArgumentLabel))
         }
       } else if mostRecentLabeledOptionalParam |label| {
@@ -4634,7 +4652,10 @@ export type Typechecker {
     )
 
     val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params, paramHints: paramHints) { Ok(v) => v, Err(e) => return Err(e) }
-    match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: node.params, body: node.body, paramsNeedingRevisit: paramsNeedingRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+    val seenReturnType = match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: node.params, body: node.body, paramsNeedingRevisit: paramsNeedingRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+    if fn.returnType.hasUnfilledHoles() {
+      fn.returnType.tryFillHoles(seenReturnType)
+    }
 
     val lambdaTy = fn.getType()
 

--- a/selfhost/test/typechecker/if/error_unfilled_holes_bindingdecl.4.out
+++ b/selfhost/test/typechecker/if/error_unfilled_holes_bindingdecl.4.out
@@ -1,6 +1,5 @@
-Error at %FILE_NAME%:1:35
-Type mismatch
+Error at %FILE_NAME%:1:9
+Could not determine type for assignment
   |  val a = if true { Some([]) } else None
-                                       ^
-Expected: <unknown>[]?
-but instead found: <unknown>?
+             ^
+Type '<unknown>[]?' has unfilled holes. Please use an explicit type annotation to denote the type

--- a/selfhost/test/typechecker/lambda/lambda_generic_inference.1.abra
+++ b/selfhost/test/typechecker/lambda/lambda_generic_inference.1.abra
@@ -1,0 +1,9 @@
+func foo<T>(fn: () => T[]): T[] {
+  val r = fn()
+  return r
+}
+
+func bar(): Int[] = [123]
+
+val v = foo(() => bar())
+val _: Int[] = v

--- a/selfhost/test/typechecker/lambda/lambda_generic_inference.1.out.json
+++ b/selfhost/test/typechecker/lambda/lambda_generic_inference.1.out.json
@@ -1,0 +1,570 @@
+{
+  "id": 3,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "foo", "position": [1, 6] },
+          "scope": {
+            "name": "$root::module_3::foo",
+            "variables": [
+              {
+                "label": { "name": "fn", "position": [1, 13] },
+                "mutable": false,
+                "type": {
+                  "kind": "function",
+                  "parameters": [],
+                  "returnType": {
+                    "kind": "instance",
+                    "struct": { "moduleId": 0, "name": "Array" },
+                    "typeParams": [
+                      {
+                        "kind": "generic",
+                        "name": "T"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "label": { "name": "r", "position": [2, 7] },
+                "mutable": false,
+                "type": {
+                  "kind": "instance",
+                  "struct": { "moduleId": 0, "name": "Array" },
+                  "typeParams": [
+                    {
+                      "kind": "generic",
+                      "name": "T"
+                    }
+                  ]
+                }
+              }
+            ],
+            "functions": [],
+            "types": [
+              {
+                "kind": "generic",
+                "name": "T"
+              }
+            ]
+          },
+          "kind": "FunctionKind.Standalone",
+          "typeParameters": [
+            {
+              "label": { "name": "T", "position": [1, 10] },
+              "type": {
+                "kind": "generic",
+                "name": "T"
+              }
+            }
+          ],
+          "parameters": [
+            {
+              "label": { "name": "fn", "position": [1, 13] },
+              "type": {
+                "kind": "function",
+                "parameters": [],
+                "returnType": {
+                  "kind": "instance",
+                  "struct": { "moduleId": 0, "name": "Array" },
+                  "typeParams": [
+                    {
+                      "kind": "generic",
+                      "name": "T"
+                    }
+                  ]
+                }
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            }
+          ],
+          "returnType": {
+            "kind": "instance",
+            "struct": { "moduleId": 0, "name": "Array" },
+            "typeParams": [
+              {
+                "kind": "generic",
+                "name": "T"
+              }
+            ]
+          },
+          "body": [
+            {
+              "token": {
+                "position": [2, 3],
+                "kind": {
+                  "name": "Val"
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Unit"
+              },
+              "node": {
+                "kind": "bindingDeclaration",
+                "pattern": {
+                  "kind": "variable",
+                  "label": { "name": "r", "position": [2, 7] }
+                },
+                "variables": [
+                  {
+                    "label": { "name": "r", "position": [2, 7] },
+                    "mutable": false,
+                    "type": {
+                      "kind": "instance",
+                      "struct": { "moduleId": 0, "name": "Array" },
+                      "typeParams": [
+                        {
+                          "kind": "generic",
+                          "name": "T"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "expr": {
+                  "token": {
+                    "position": [2, 13],
+                    "kind": {
+                      "name": "LParen"
+                    }
+                  },
+                  "type": {
+                    "kind": "instance",
+                    "struct": { "moduleId": 0, "name": "Array" },
+                    "typeParams": [
+                      {
+                        "kind": "generic",
+                        "name": "T"
+                      }
+                    ]
+                  },
+                  "node": {
+                    "kind": "invocation",
+                    "invokee": {
+                      "token": {
+                        "position": [2, 11],
+                        "kind": {
+                          "name": "Ident",
+                          "value": "fn"
+                        }
+                      },
+                      "type": {
+                        "kind": "function",
+                        "parameters": [],
+                        "returnType": {
+                          "kind": "instance",
+                          "struct": { "moduleId": 0, "name": "Array" },
+                          "typeParams": [
+                            {
+                              "kind": "generic",
+                              "name": "T"
+                            }
+                          ]
+                        }
+                      },
+                      "node": {
+                        "kind": "identifier",
+                        "name": "fn"
+                      }
+                    },
+                    "arguments": []
+                  }
+                }
+              }
+            },
+            {
+              "token": {
+                "position": [3, 3],
+                "kind": {
+                  "name": "Return"
+                }
+              },
+              "type": {
+                "kind": "never"
+              },
+              "node": {
+                "kind": "return",
+                "expr": {
+                  "token": {
+                    "position": [3, 10],
+                    "kind": {
+                      "name": "Ident",
+                      "value": "r"
+                    }
+                  },
+                  "type": {
+                    "kind": "instance",
+                    "struct": { "moduleId": 0, "name": "Array" },
+                    "typeParams": [
+                      {
+                        "kind": "generic",
+                        "name": "T"
+                      }
+                    ]
+                  },
+                  "node": {
+                    "kind": "identifier",
+                    "name": "r"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [6, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "bar", "position": [6, 6] },
+          "scope": {
+            "name": "$root::module_3::bar",
+            "variables": [],
+            "functions": [],
+            "types": []
+          },
+          "kind": "FunctionKind.Standalone",
+          "typeParameters": [],
+          "parameters": [],
+          "returnType": {
+            "kind": "instance",
+            "struct": { "moduleId": 0, "name": "Array" },
+            "typeParams": [
+              {
+                "kind": "primitive",
+                "primitive": "Int"
+              }
+            ]
+          },
+          "body": [
+            {
+              "token": {
+                "position": [6, 21],
+                "kind": {
+                  "name": "LBrack"
+                }
+              },
+              "type": {
+                "kind": "instance",
+                "struct": { "moduleId": 0, "name": "Array" },
+                "typeParams": [
+                  {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                ]
+              },
+              "node": {
+                "kind": "array",
+                "items": [
+                  {
+                    "token": {
+                      "position": [6, 22],
+                      "kind": {
+                        "name": "Int",
+                        "value": 123
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "literal",
+                      "value": 123
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [8, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "v", "position": [8, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "v", "position": [8, 5] },
+            "mutable": false,
+            "type": {
+              "kind": "instance",
+              "struct": { "moduleId": 0, "name": "Array" },
+              "typeParams": [
+                {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              ]
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [8, 12],
+            "kind": {
+              "name": "LParen"
+            }
+          },
+          "type": {
+            "kind": "instance",
+            "struct": { "moduleId": 0, "name": "Array" },
+            "typeParams": [
+              {
+                "kind": "primitive",
+                "primitive": "Int"
+              }
+            ]
+          },
+          "node": {
+            "kind": "invocation",
+            "invokee": {
+              "token": {
+                "position": [8, 9],
+                "kind": {
+                  "name": "Ident",
+                  "value": "foo"
+                }
+              },
+              "type": {
+                "kind": "function",
+                "parameters": [
+                  {
+                    "required": true,
+                    "type": {
+                      "kind": "function",
+                      "parameters": [],
+                      "returnType": {
+                        "kind": "instance",
+                        "struct": { "moduleId": 0, "name": "Array" },
+                        "typeParams": [
+                          {
+                            "kind": "generic",
+                            "name": "T"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "returnType": {
+                  "kind": "instance",
+                  "struct": { "moduleId": 0, "name": "Array" },
+                  "typeParams": [
+                    {
+                      "kind": "generic",
+                      "name": "T"
+                    }
+                  ]
+                }
+              },
+              "node": {
+                "kind": "identifier",
+                "name": "foo"
+              }
+            },
+            "arguments": [
+              {
+                "token": {
+                  "position": [8, 16],
+                  "kind": {
+                    "name": "Arrow"
+                  }
+                },
+                "type": {
+                  "kind": "function",
+                  "parameters": [],
+                  "returnType": {
+                    "kind": "instance",
+                    "struct": { "moduleId": 0, "name": "Array" },
+                    "typeParams": [
+                      {
+                        "kind": "primitive",
+                        "primitive": "Int"
+                      }
+                    ]
+                  }
+                },
+                "node": {
+                  "kind": "lambda",
+                  "function": {
+                    "label": { "name": "lambda_0", "position": [8, 16] },
+                    "scope": {
+                      "name": "$root::module_3::lambda_0",
+                      "variables": [],
+                      "functions": [],
+                      "types": []
+                    },
+                    "kind": "FunctionKind.Standalone",
+                    "typeParameters": [],
+                    "parameters": [],
+                    "returnType": {
+                      "kind": "instance",
+                      "struct": { "moduleId": 0, "name": "Array" },
+                      "typeParams": [
+                        {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        }
+                      ]
+                    },
+                    "body": [
+                      {
+                        "token": {
+                          "position": [8, 22],
+                          "kind": {
+                            "name": "LParen"
+                          }
+                        },
+                        "type": {
+                          "kind": "instance",
+                          "struct": { "moduleId": 0, "name": "Array" },
+                          "typeParams": [
+                            {
+                              "kind": "primitive",
+                              "primitive": "Int"
+                            }
+                          ]
+                        },
+                        "node": {
+                          "kind": "invocation",
+                          "invokee": {
+                            "token": {
+                              "position": [8, 19],
+                              "kind": {
+                                "name": "Ident",
+                                "value": "bar"
+                              }
+                            },
+                            "type": {
+                              "kind": "function",
+                              "parameters": [],
+                              "returnType": {
+                                "kind": "instance",
+                                "struct": { "moduleId": 0, "name": "Array" },
+                                "typeParams": [
+                                  {
+                                    "kind": "primitive",
+                                    "primitive": "Int"
+                                  }
+                                ]
+                              }
+                            },
+                            "node": {
+                              "kind": "identifier",
+                              "name": "bar"
+                            }
+                          },
+                          "arguments": []
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [9, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [9, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [9, 5] },
+            "mutable": false,
+            "type": {
+              "kind": "instance",
+              "struct": { "moduleId": 0, "name": "Array" },
+              "typeParams": [
+                {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              ]
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [9, 16],
+            "kind": {
+              "name": "Ident",
+              "value": "v"
+            }
+          },
+          "type": {
+            "kind": "instance",
+            "struct": { "moduleId": 0, "name": "Array" },
+            "typeParams": [
+              {
+                "kind": "primitive",
+                "primitive": "Int"
+              }
+            ]
+          },
+          "node": {
+            "kind": "identifier",
+            "name": "v"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
There were a few things I needed to update in the lexer and parser that were very minor (eg. argument labeling).
I then ran into an interesting issue attempting to typecheck a generic function whose generic was resolved via a lambda parameter's return type. This turned out to be pretty difficult to debug and I'm not 100% certain I love the solution I came up with. I may revisit it.