### PR TITLE
Selfhost: update typechecker to handle `never`s

### DIFF
--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -3527,15 +3527,19 @@ export type Typechecker {
         }
         val bodyTy = lastBodyNode.ty
 
-        if resultTy |resultTy| {
-          if resultTy.hasUnfilledHoles() {
-            resultTy.tryFillHoles(bodyTy)
+        if resultTy |resTy| {
+          if resTy.hasUnfilledHoles() {
+            resTy.tryFillHoles(bodyTy)
           } else if bodyTy.hasUnfilledHoles() {
-            bodyTy.tryFillHoles(resultTy)
+            bodyTy.tryFillHoles(resTy)
           }
 
-          if !self._typeSatisfiesRequired(ty: bodyTy, required: resultTy) {
-            return Err(TypeError(position: lastBodyNode.token.position, kind: TypeErrorKind.TypeMismatch([resultTy], bodyTy)))
+          if !self._typeSatisfiesRequired(ty: bodyTy, required: resTy) {
+            return Err(TypeError(position: lastBodyNode.token.position, kind: TypeErrorKind.TypeMismatch([resTy], bodyTy)))
+          }
+
+          if resTy.kind == TypeKind.Never {
+            resultTy = Some(bodyTy)
           }
         } else {
           resultTy = typedBody[-1]?.ty

--- a/selfhost/test/typechecker/match/error_forbidden_type_all_branches_never.abra
+++ b/selfhost/test/typechecker/match/error_forbidden_type_all_branches_never.abra
@@ -1,0 +1,7 @@
+func foo(): Int {
+  val x = match 123 {
+    _ => return 0
+  }
+
+  0
+}

--- a/selfhost/test/typechecker/match/error_forbidden_type_all_branches_never.out
+++ b/selfhost/test/typechecker/match/error_forbidden_type_all_branches_never.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:2:11
+Forbidden type for assignment
+  |    val x = match 123 {
+               ^
+Expression has type Never, which can never be used for assignment

--- a/selfhost/test/typechecker/match/match_expr_terminators.abra
+++ b/selfhost/test/typechecker/match/match_expr_terminators.abra
@@ -1,0 +1,43 @@
+// return
+func foo(a: Int): Int {
+  val x = match a {
+    123 => return 0
+    Int a => a + 1
+  }
+  val _: Int = x
+
+  x * 7
+}
+
+// break
+while true {
+  val x = match 123 {
+    123 => break
+    Int a => a + 1
+  }
+  val _: Int = x
+}
+
+// continue
+while true {
+  val x = match 123 {
+    123 => continue
+    Int a => a + 1
+  }
+  val _: Int = x
+}
+
+// all three
+func bar(): Int {
+  while true {
+    val x = match 123 {
+        1 => return 0
+        2 => break
+        3 => continue
+        Int a => a + 1
+    }
+    val _: Int = x
+  }
+
+  0
+}

--- a/selfhost/test/typechecker/match/match_expr_terminators.out.json
+++ b/selfhost/test/typechecker/match/match_expr_terminators.out.json
@@ -1,0 +1,1159 @@
+{
+  "id": 3,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [2, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "foo", "position": [2, 6] },
+          "scope": {
+            "name": "$root::module_3::foo",
+            "variables": [
+              {
+                "label": { "name": "a", "position": [2, 10] },
+                "mutable": false,
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              },
+              {
+                "label": { "name": "x", "position": [3, 7] },
+                "mutable": false,
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                }
+              }
+            ],
+            "functions": [],
+            "types": []
+          },
+          "kind": "FunctionKind.Standalone",
+          "typeParameters": [],
+          "parameters": [
+            {
+              "label": { "name": "a", "position": [2, 10] },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "defaultValue": null,
+              "isVariadic": false
+            }
+          ],
+          "returnType": {
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "body": [
+            {
+              "token": {
+                "position": [3, 3],
+                "kind": {
+                  "name": "Val"
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Unit"
+              },
+              "node": {
+                "kind": "bindingDeclaration",
+                "pattern": {
+                  "kind": "variable",
+                  "label": { "name": "x", "position": [3, 7] }
+                },
+                "variables": [
+                  {
+                    "label": { "name": "x", "position": [3, 7] },
+                    "mutable": false,
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    }
+                  }
+                ],
+                "expr": {
+                  "token": {
+                    "position": [3, 11],
+                    "kind": {
+                      "name": "Match"
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "match",
+                    "isStatement": false,
+                    "subject": {
+                      "token": {
+                        "position": [3, 17],
+                        "kind": {
+                          "name": "Ident",
+                          "value": "a"
+                        }
+                      },
+                      "type": {
+                        "kind": "primitive",
+                        "primitive": "Int"
+                      },
+                      "node": {
+                        "kind": "identifier",
+                        "name": "a"
+                      }
+                    },
+                    "cases": [
+                      {
+                        "kind": {
+                          "kind": "literal",
+                          "value": 123
+                        },
+                        "binding": null,
+                        "body": [
+                          {
+                            "token": {
+                              "position": [4, 12],
+                              "kind": {
+                                "name": "Return"
+                              }
+                            },
+                            "type": {
+                              "kind": "never"
+                            },
+                            "node": {
+                              "kind": "return",
+                              "expr": {
+                                "token": {
+                                  "position": [4, 19],
+                                  "kind": {
+                                    "name": "Int",
+                                    "value": 0
+                                  }
+                                },
+                                "type": {
+                                  "kind": "primitive",
+                                  "primitive": "Int"
+                                },
+                                "node": {
+                                  "kind": "literal",
+                                  "value": 0
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "kind": {
+                          "kind": "type",
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "Int"
+                          }
+                        },
+                        "binding": {
+                          "label": { "name": "a", "position": [5, 9] },
+                          "mutable": false,
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "Int"
+                          }
+                        },
+                        "body": [
+                          {
+                            "token": {
+                              "position": [5, 16],
+                              "kind": {
+                                "name": "Plus"
+                              }
+                            },
+                            "type": {
+                              "kind": "primitive",
+                              "primitive": "Int"
+                            },
+                            "node": {
+                              "kind": "binary",
+                              "op": "BinaryOp.Add",
+                              "left": {
+                                "token": {
+                                  "position": [5, 14],
+                                  "kind": {
+                                    "name": "Ident",
+                                    "value": "a"
+                                  }
+                                },
+                                "type": {
+                                  "kind": "primitive",
+                                  "primitive": "Int"
+                                },
+                                "node": {
+                                  "kind": "identifier",
+                                  "name": "a"
+                                }
+                              },
+                              "right": {
+                                "token": {
+                                  "position": [5, 18],
+                                  "kind": {
+                                    "name": "Int",
+                                    "value": 1
+                                  }
+                                },
+                                "type": {
+                                  "kind": "primitive",
+                                  "primitive": "Int"
+                                },
+                                "node": {
+                                  "kind": "literal",
+                                  "value": 1
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "token": {
+                "position": [7, 3],
+                "kind": {
+                  "name": "Val"
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Unit"
+              },
+              "node": {
+                "kind": "bindingDeclaration",
+                "pattern": {
+                  "kind": "variable",
+                  "label": { "name": "_", "position": [7, 7] }
+                },
+                "variables": [
+                  {
+                    "label": { "name": "_", "position": [7, 7] },
+                    "mutable": false,
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    }
+                  }
+                ],
+                "expr": {
+                  "token": {
+                    "position": [7, 16],
+                    "kind": {
+                      "name": "Ident",
+                      "value": "x"
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "identifier",
+                    "name": "x"
+                  }
+                }
+              }
+            },
+            {
+              "token": {
+                "position": [9, 5],
+                "kind": {
+                  "name": "Star"
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "node": {
+                "kind": "binary",
+                "op": "BinaryOp.Mul",
+                "left": {
+                  "token": {
+                    "position": [9, 3],
+                    "kind": {
+                      "name": "Ident",
+                      "value": "x"
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "identifier",
+                    "name": "x"
+                  }
+                },
+                "right": {
+                  "token": {
+                    "position": [9, 7],
+                    "kind": {
+                      "name": "Int",
+                      "value": 7
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": 7
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [13, 1],
+        "kind": {
+          "name": "While"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "while",
+        "condition": {
+          "token": {
+            "position": [13, 7],
+            "kind": {
+              "name": "Bool",
+              "value": true
+            }
+          },
+          "type": {
+            "kind": "primitive",
+            "primitive": "Bool"
+          },
+          "node": {
+            "kind": "literal",
+            "value": true
+          }
+        },
+        "conditionBindingPattern": null,
+        "block": [
+          {
+            "token": {
+              "position": [14, 3],
+              "kind": {
+                "name": "Val"
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Unit"
+            },
+            "node": {
+              "kind": "bindingDeclaration",
+              "pattern": {
+                "kind": "variable",
+                "label": { "name": "x", "position": [14, 7] }
+              },
+              "variables": [
+                {
+                  "label": { "name": "x", "position": [14, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                }
+              ],
+              "expr": {
+                "token": {
+                  "position": [14, 11],
+                  "kind": {
+                    "name": "Match"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "match",
+                  "isStatement": false,
+                  "subject": {
+                    "token": {
+                      "position": [14, 17],
+                      "kind": {
+                        "name": "Int",
+                        "value": 123
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "literal",
+                      "value": 123
+                    }
+                  },
+                  "cases": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": 123
+                      },
+                      "binding": null,
+                      "body": [
+                        {
+                          "token": {
+                            "position": [15, 12],
+                            "kind": {
+                              "name": "Break"
+                            }
+                          },
+                          "type": {
+                            "kind": "never"
+                          },
+                          "node": {
+                            "kind": "break"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "kind": {
+                        "kind": "type",
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        }
+                      },
+                      "binding": {
+                        "label": { "name": "a", "position": [16, 9] },
+                        "mutable": false,
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        }
+                      },
+                      "body": [
+                        {
+                          "token": {
+                            "position": [16, 16],
+                            "kind": {
+                              "name": "Plus"
+                            }
+                          },
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "Int"
+                          },
+                          "node": {
+                            "kind": "binary",
+                            "op": "BinaryOp.Add",
+                            "left": {
+                              "token": {
+                                "position": [16, 14],
+                                "kind": {
+                                  "name": "Ident",
+                                  "value": "a"
+                                }
+                              },
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "Int"
+                              },
+                              "node": {
+                                "kind": "identifier",
+                                "name": "a"
+                              }
+                            },
+                            "right": {
+                              "token": {
+                                "position": [16, 18],
+                                "kind": {
+                                  "name": "Int",
+                                  "value": 1
+                                }
+                              },
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "Int"
+                              },
+                              "node": {
+                                "kind": "literal",
+                                "value": 1
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "token": {
+              "position": [18, 3],
+              "kind": {
+                "name": "Val"
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Unit"
+            },
+            "node": {
+              "kind": "bindingDeclaration",
+              "pattern": {
+                "kind": "variable",
+                "label": { "name": "_", "position": [18, 7] }
+              },
+              "variables": [
+                {
+                  "label": { "name": "_", "position": [18, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                }
+              ],
+              "expr": {
+                "token": {
+                  "position": [18, 16],
+                  "kind": {
+                    "name": "Ident",
+                    "value": "x"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "identifier",
+                  "name": "x"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "token": {
+        "position": [22, 1],
+        "kind": {
+          "name": "While"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "while",
+        "condition": {
+          "token": {
+            "position": [22, 7],
+            "kind": {
+              "name": "Bool",
+              "value": true
+            }
+          },
+          "type": {
+            "kind": "primitive",
+            "primitive": "Bool"
+          },
+          "node": {
+            "kind": "literal",
+            "value": true
+          }
+        },
+        "conditionBindingPattern": null,
+        "block": [
+          {
+            "token": {
+              "position": [23, 3],
+              "kind": {
+                "name": "Val"
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Unit"
+            },
+            "node": {
+              "kind": "bindingDeclaration",
+              "pattern": {
+                "kind": "variable",
+                "label": { "name": "x", "position": [23, 7] }
+              },
+              "variables": [
+                {
+                  "label": { "name": "x", "position": [23, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                }
+              ],
+              "expr": {
+                "token": {
+                  "position": [23, 11],
+                  "kind": {
+                    "name": "Match"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "match",
+                  "isStatement": false,
+                  "subject": {
+                    "token": {
+                      "position": [23, 17],
+                      "kind": {
+                        "name": "Int",
+                        "value": 123
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "literal",
+                      "value": 123
+                    }
+                  },
+                  "cases": [
+                    {
+                      "kind": {
+                        "kind": "literal",
+                        "value": 123
+                      },
+                      "binding": null,
+                      "body": [
+                        {
+                          "token": {
+                            "position": [24, 12],
+                            "kind": {
+                              "name": "Continue"
+                            }
+                          },
+                          "type": {
+                            "kind": "never"
+                          },
+                          "node": {
+                            "kind": "continue"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "kind": {
+                        "kind": "type",
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        }
+                      },
+                      "binding": {
+                        "label": { "name": "a", "position": [25, 9] },
+                        "mutable": false,
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        }
+                      },
+                      "body": [
+                        {
+                          "token": {
+                            "position": [25, 16],
+                            "kind": {
+                              "name": "Plus"
+                            }
+                          },
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "Int"
+                          },
+                          "node": {
+                            "kind": "binary",
+                            "op": "BinaryOp.Add",
+                            "left": {
+                              "token": {
+                                "position": [25, 14],
+                                "kind": {
+                                  "name": "Ident",
+                                  "value": "a"
+                                }
+                              },
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "Int"
+                              },
+                              "node": {
+                                "kind": "identifier",
+                                "name": "a"
+                              }
+                            },
+                            "right": {
+                              "token": {
+                                "position": [25, 18],
+                                "kind": {
+                                  "name": "Int",
+                                  "value": 1
+                                }
+                              },
+                              "type": {
+                                "kind": "primitive",
+                                "primitive": "Int"
+                              },
+                              "node": {
+                                "kind": "literal",
+                                "value": 1
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "token": {
+              "position": [27, 3],
+              "kind": {
+                "name": "Val"
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Unit"
+            },
+            "node": {
+              "kind": "bindingDeclaration",
+              "pattern": {
+                "kind": "variable",
+                "label": { "name": "_", "position": [27, 7] }
+              },
+              "variables": [
+                {
+                  "label": { "name": "_", "position": [27, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                }
+              ],
+              "expr": {
+                "token": {
+                  "position": [27, 16],
+                  "kind": {
+                    "name": "Ident",
+                    "value": "x"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "identifier",
+                  "name": "x"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "token": {
+        "position": [31, 1],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "functionDeclaration",
+        "function": {
+          "label": { "name": "bar", "position": [31, 6] },
+          "scope": {
+            "name": "$root::module_3::bar",
+            "variables": [],
+            "functions": [],
+            "types": []
+          },
+          "kind": "FunctionKind.Standalone",
+          "typeParameters": [],
+          "parameters": [],
+          "returnType": {
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "body": [
+            {
+              "token": {
+                "position": [32, 3],
+                "kind": {
+                  "name": "While"
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Unit"
+              },
+              "node": {
+                "kind": "while",
+                "condition": {
+                  "token": {
+                    "position": [32, 9],
+                    "kind": {
+                      "name": "Bool",
+                      "value": true
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Bool"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": true
+                  }
+                },
+                "conditionBindingPattern": null,
+                "block": [
+                  {
+                    "token": {
+                      "position": [33, 5],
+                      "kind": {
+                        "name": "Val"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Unit"
+                    },
+                    "node": {
+                      "kind": "bindingDeclaration",
+                      "pattern": {
+                        "kind": "variable",
+                        "label": { "name": "x", "position": [33, 9] }
+                      },
+                      "variables": [
+                        {
+                          "label": { "name": "x", "position": [33, 9] },
+                          "mutable": false,
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "Int"
+                          }
+                        }
+                      ],
+                      "expr": {
+                        "token": {
+                          "position": [33, 13],
+                          "kind": {
+                            "name": "Match"
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "match",
+                          "isStatement": false,
+                          "subject": {
+                            "token": {
+                              "position": [33, 19],
+                              "kind": {
+                                "name": "Int",
+                                "value": 123
+                              }
+                            },
+                            "type": {
+                              "kind": "primitive",
+                              "primitive": "Int"
+                            },
+                            "node": {
+                              "kind": "literal",
+                              "value": 123
+                            }
+                          },
+                          "cases": [
+                            {
+                              "kind": {
+                                "kind": "literal",
+                                "value": 1
+                              },
+                              "binding": null,
+                              "body": [
+                                {
+                                  "token": {
+                                    "position": [34, 14],
+                                    "kind": {
+                                      "name": "Return"
+                                    }
+                                  },
+                                  "type": {
+                                    "kind": "never"
+                                  },
+                                  "node": {
+                                    "kind": "return",
+                                    "expr": {
+                                      "token": {
+                                        "position": [34, 21],
+                                        "kind": {
+                                          "name": "Int",
+                                          "value": 0
+                                        }
+                                      },
+                                      "type": {
+                                        "kind": "primitive",
+                                        "primitive": "Int"
+                                      },
+                                      "node": {
+                                        "kind": "literal",
+                                        "value": 0
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "kind": {
+                                "kind": "literal",
+                                "value": 2
+                              },
+                              "binding": null,
+                              "body": [
+                                {
+                                  "token": {
+                                    "position": [35, 14],
+                                    "kind": {
+                                      "name": "Break"
+                                    }
+                                  },
+                                  "type": {
+                                    "kind": "never"
+                                  },
+                                  "node": {
+                                    "kind": "break"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "kind": {
+                                "kind": "literal",
+                                "value": 3
+                              },
+                              "binding": null,
+                              "body": [
+                                {
+                                  "token": {
+                                    "position": [36, 14],
+                                    "kind": {
+                                      "name": "Continue"
+                                    }
+                                  },
+                                  "type": {
+                                    "kind": "never"
+                                  },
+                                  "node": {
+                                    "kind": "continue"
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "kind": {
+                                "kind": "type",
+                                "type": {
+                                  "kind": "primitive",
+                                  "primitive": "Int"
+                                }
+                              },
+                              "binding": {
+                                "label": { "name": "a", "position": [37, 13] },
+                                "mutable": false,
+                                "type": {
+                                  "kind": "primitive",
+                                  "primitive": "Int"
+                                }
+                              },
+                              "body": [
+                                {
+                                  "token": {
+                                    "position": [37, 20],
+                                    "kind": {
+                                      "name": "Plus"
+                                    }
+                                  },
+                                  "type": {
+                                    "kind": "primitive",
+                                    "primitive": "Int"
+                                  },
+                                  "node": {
+                                    "kind": "binary",
+                                    "op": "BinaryOp.Add",
+                                    "left": {
+                                      "token": {
+                                        "position": [37, 18],
+                                        "kind": {
+                                          "name": "Ident",
+                                          "value": "a"
+                                        }
+                                      },
+                                      "type": {
+                                        "kind": "primitive",
+                                        "primitive": "Int"
+                                      },
+                                      "node": {
+                                        "kind": "identifier",
+                                        "name": "a"
+                                      }
+                                    },
+                                    "right": {
+                                      "token": {
+                                        "position": [37, 22],
+                                        "kind": {
+                                          "name": "Int",
+                                          "value": 1
+                                        }
+                                      },
+                                      "type": {
+                                        "kind": "primitive",
+                                        "primitive": "Int"
+                                      },
+                                      "node": {
+                                        "kind": "literal",
+                                        "value": 1
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "token": {
+                      "position": [39, 5],
+                      "kind": {
+                        "name": "Val"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Unit"
+                    },
+                    "node": {
+                      "kind": "bindingDeclaration",
+                      "pattern": {
+                        "kind": "variable",
+                        "label": { "name": "_", "position": [39, 9] }
+                      },
+                      "variables": [
+                        {
+                          "label": { "name": "_", "position": [39, 9] },
+                          "mutable": false,
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "Int"
+                          }
+                        }
+                      ],
+                      "expr": {
+                        "token": {
+                          "position": [39, 18],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "x"
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "x"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "token": {
+                "position": [42, 3],
+                "kind": {
+                  "name": "Int",
+                  "value": 0
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "node": {
+                "kind": "literal",
+                "value": 0
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -405,6 +405,7 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/match/match_expr.abra", "typechecker/match/match_expr.out.json")
         .add_test_vs_txt("typechecker/match/match_stmt.abra", "typechecker/match/match_stmt.out.json")
         .add_test_vs_txt("typechecker/match/match_Result.abra", "typechecker/match/match_Result.out.json")
+        .add_test_vs_txt("typechecker/match/match_expr_terminators.abra", "typechecker/match/match_expr_terminators.out.json")
         .add_test_vs_txt("typechecker/match/error_expr_empty_block.abra", "typechecker/match/error_expr_empty_block.out")
         .add_test_vs_txt("typechecker/match/error_unfilled_holes.1.abra", "typechecker/match/error_unfilled_holes.1.out")
         .add_test_vs_txt("typechecker/match/error_alreadycovered_None.abra", "typechecker/match/error_alreadycovered_None.out")
@@ -432,6 +433,7 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/match/error_destructuring_variant_duplicate_variable.2.abra", "typechecker/match/error_destructuring_variant_duplicate_variable.2.out")
         .add_test_vs_txt("typechecker/match/error_destructuring_variant_too_few.abra", "typechecker/match/error_destructuring_variant_too_few.out")
         .add_test_vs_txt("typechecker/match/error_destructuring_variant_too_many.abra", "typechecker/match/error_destructuring_variant_too_many.out")
+        .add_test_vs_txt("typechecker/match/error_forbidden_type_all_branches_never.abra", "typechecker/match/error_forbidden_type_all_branches_never.out")
 
         // Invocation
         .add_test_vs_txt("typechecker/invocation/invocation.1.abra", "typechecker/invocation/invocation.1.out.json")


### PR DESCRIPTION
Match expressions should be able to have cases whose bodies result in Never types (eg. `return`, `break`, `continue`) as long as not _all_ of the cases result in a Never.