### PR TITLE
Selfhost: compiling range indexing

### DIFF
--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,12 +1,1 @@
-func foo(a: Int = if true 123 else if false 456 else 789): Int {
-  a + 1
-}
-// val a = if true {
-//   123
-// } else if false {
-//   456
-// } else {
-//   789
-// }
-// println(a)
-println(foo())
+println("-hElLo!".toLower())

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -682,7 +682,7 @@ export type Compiler {
               Ok(Value.Ident(name, varTy))
             } else {
               val slot = Value.Ident("$name.slot", QbeType.Pointer)
-              val res = self._currentFn.block.buildLoad(varTy, slot, Some(name))
+              val res = self._currentFn.block.buildLoad(varTy, slot)
               Ok(res)
             }
           }
@@ -844,14 +844,44 @@ export type Compiler {
                 // TODO: destructuring
                 val getFn = match _t[0] {
                   StructOrEnum.Struct(struct) => if struct.instanceMethods.find(m => m.label.name == "get") |fn| fn else return unreachable("#get must exist for array-like indexing")
-                  StructOrEnum.Enum => return todo("enum methods")
+                  StructOrEnum.Enum => return unreachable("array-like indexing never applies to enum instances")
                 }
                 val getFnVal = match self._getOrCompileMethod(instType, getFn) { Ok(v) => v, Err(e) => return Err(e) }
 
                 val res = match self._currentFn.block.buildCall(getFnVal, [exprVal, idxExprVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
                 Ok(res)
               }
-              IndexingMode.Range(start, end) => return todo("compiling range-indexing expression", node.token.position)
+              IndexingMode.Range(startExpr, endExpr) => {
+                var maskParam = 0
+                val startExprVal = if startExpr |startExpr| {
+                  val res = match self._compileExpression(startExpr) { Ok(v) => v, Err(e) => return Err(e) }
+                  res
+                } else {
+                  maskParam ||= 1
+                  Value.Int(0)
+                }
+                val endExprVal = if endExpr |endExpr| {
+                  val res = match self._compileExpression(endExpr) { Ok(v) => v, Err(e) => return Err(e) }
+                  res
+                } else {
+                  maskParam ||= (1 << 1)
+                  Value.Int(0)
+                }
+
+                val instType = match self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "getRange", expr.token.position) { Ok(v) => v, Err(e) => return Err(e) }
+                val _t = match self._getInstanceTypeForType(expr.ty) { Ok(v) => v, Err(e) => return Err(e) }
+                // TODO: destructuring
+                val getRangeFn = match _t[0] {
+                  StructOrEnum.Struct(struct) => if struct.instanceMethods.find(m => m.label.name == "getRange") |fn| fn else return unreachable("#getRange must exist for array-like indexing")
+                  StructOrEnum.Enum => return unreachable("array-like indexing never applies to enum instances")
+                }
+                val getRangeFnVal = match self._getOrCompileMethod(instType, getRangeFn) { Ok(v) => v, Err(e) => return Err(e) }
+
+                val res = match self._currentFn.block.buildCall(getRangeFnVal, [exprVal, startExprVal, endExprVal, Value.Int32(maskParam)]) { Ok(v) => v, Err(e) => return qbeError(e) }
+                Ok(res)
+
+                // return todo("compiling range-indexing expression", node.token.position)
+              }
             }
           }
           TypedIndexingNode.Map(expr, idx) => todo("compiling map-indexing expression", node.token.position)
@@ -1433,7 +1463,21 @@ export type Compiler {
         val ptrVal = match self._compileExpression(ptr) { Ok(v) => v, Err(e) => return Err(e) }
 
         val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_load) could not resolve T for Pointer<T>")
-        val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
+
+        val isByte = match innerTy.kind {
+          TypeKind.Instance(structOrEnum, _) => {
+            val r = match structOrEnum {
+              StructOrEnum.Struct(struct) => struct.moduleId == 1 && struct.label.name == "Byte"
+              _ => false
+            }
+            r
+          }
+          _ => false
+        }
+        val innerQbeType = if isByte QbeType.U8 else {
+          val res = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
+          res
+        }
 
         val v = self._currentFn.block.buildLoad(innerQbeType, ptrVal)
 

--- a/selfhost/src/qbe.abra
+++ b/selfhost/src/qbe.abra
@@ -437,10 +437,10 @@ export type Block {
 
   func buildLoadB(self, mem: Value, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
-    val local = Value.Ident(dest, QbeType.U8)
+    val local = Value.Ident(dest, QbeType.U64)
 
     // TODO: condense these methods into one which automatically switches on the type of `value`
-    self.append(Instruction.LoadB(dst: Dest(name: local.repr(), ty: QbeType.U8), mem: mem))
+    self.append(Instruction.LoadB(dst: Dest(name: local.repr(), ty: QbeType.U64), mem: mem))
 
     local
   }
@@ -1027,7 +1027,7 @@ enum Instruction {
       }
       Instruction.LoadB(dst, m) => {
         dst.encode(file)
-        file.write(" loadb ")
+        file.write(" loadub ")
         m.encode(file)
         file.writeln()
       }

--- a/selfhost/test/compiler/arrays.abra
+++ b/selfhost/test/compiler/arrays.abra
@@ -9,8 +9,9 @@
 /// Expect: 1 2
 println([1].length, [[1, 2], [3, 4]].length)
 
-// // Test array literal construction
+// Test array literal construction
 // (() => {
+func test_arrayLiteralConstruction() {
   val emptyArr: Int[] = []
   /// Expect: []
   println(emptyArr)
@@ -31,9 +32,12 @@ println([1].length, [[1, 2], [3, 4]].length)
   /// Expect: [[1, 2], [3, 4], [5, 6]]
   println(nestedArr)
 // })()
+}
+test_arrayLiteralConstruction()
 
 // == operator (also Array#eq)
 // (() => {
+func test_arrayEq() {
   val arr = [1, 2]
 
   /// Expect: true
@@ -60,36 +64,44 @@ println([1].length, [[1, 2], [3, 4]].length)
 //   /// Expect: false
 //   println(arr == { (1): "a", (2): "b" })
 // })()
+}
+test_arrayEq()
 
 // Indexing (also Array#get(index: Int))
 // (() => {
-  val arr2 = [1, 2, 3]
+func test_arrayIndexing() {
+  val arr = [1, 2, 3]
   /// Expect: Option.None Option.Some(value: 1) Option.Some(value: 2) Option.Some(value: 3) Option.Some(value: 1) Option.Some(value: 2) Option.Some(value: 3) Option.None
-  println(arr2[-4], arr2[-3], arr2[-2], arr2[-1], arr2[0], arr2[1], arr2[2], arr2[3])
+  println(arr[-4], arr[-3], arr[-2], arr[-1], arr[0], arr[1], arr[2], arr[3])
 // })()
+}
+test_arrayIndexing()
 
-// // Range indexing (also Array#getRange(startIndex: Int, endIndex: Int))
+// Range indexing (also Array#getRange(startIndex: Int, endIndex: Int))
 // (() => {
-//   val arr = [1, 2, 3, 4, 5]
+func test_arrayRangeIndexing() {
+  val arr = [1, 2, 3, 4, 5]
 
-//   /// Expect: [2, 3, 4] [2, 3, 4] [2, 3, 4]
-//   println(arr[1:4], arr[-4:4], arr[1:-1])
+  /// Expect: [2, 3, 4] [2, 3, 4] [2, 3, 4]
+  println(arr[1:4], arr[-4:4], arr[1:-1])
 
-//   /// Expect: []
-//   println(arr[1:1])
+  /// Expect: []
+  println(arr[1:1])
 
-//   val x = 1
-//   val y = 4
+  val x = 1
+  val y = 4
 
-//   /// Expect: [2, 3, 4] [2, 3, 4]
-//   println(arr[x:y], arr[-y:y])
+  /// Expect: [2, 3, 4] [2, 3, 4]
+  println(arr[x:y], arr[-y:y])
 
-//   /// Expect: [2, 3, 4, 5] [1]
-//   println(arr[1:], arr[:1])
+  /// Expect: [2, 3, 4, 5] [1]
+  println(arr[1:], arr[:1])
 
-//   /// Expect: [2, 3, 4, 5] [1]
-//   println(arr[x:], arr[:x])
+  /// Expect: [2, 3, 4, 5] [1]
+  println(arr[x:], arr[:x])
 // })()
+}
+test_arrayRangeIndexing()
 
 // // Array.fill
 // (() => {
@@ -135,13 +147,16 @@ println([1].length, [[1, 2], [3, 4]].length)
 
 // Array#hash
 // (() => {
-  val arr3 = [1, 2, 3]
+func test_arrayHash() {
+  val arr = [1, 2, 3]
   /// Expect: true
-  println(arr3.hash() == [1, 2, 3].hash())
+  println(arr.hash() == [1, 2, 3].hash())
 
   /// Expect: false
-  println(arr3.hash() == [1, 2].hash())
+  println(arr.hash() == [1, 2].hash())
 // })()
+}
+test_arrayHash()
 
 // // Array#iterator
 // (() => {

--- a/selfhost/test/compiler/optionals.abra
+++ b/selfhost/test/compiler/optionals.abra
@@ -25,6 +25,7 @@ println(arr3)
 func hash<T>(t: T): Int = t.hash()
 // Hashes
 // (() => {
+func test_hashes() {
   val i: Int? = None
   /// Expect: 1
   println(hash(i))
@@ -33,9 +34,12 @@ func hash<T>(t: T): Int = t.hash()
   /// Expect: false
   println(hash(x) == (17).hash())
 // })()
+}
+test_hashes()
 
 // == operator
 // (() => {
+func test_eqOp() {
   // Test with primitive
   val i1: Int? = None
   val i2 = Some(17)
@@ -62,6 +66,8 @@ func hash<T>(t: T): Int = t.hash()
   /// Expect: true
   println(s2 == s3)
 // })()
+}
+test_eqOp()
 
 // // Coalescing (?:)
 // (() => {

--- a/selfhost/test/compiler/strings.abra
+++ b/selfhost/test/compiler/strings.abra
@@ -16,6 +16,7 @@ println("hello")
 
 // + operator
 // (() => {
+func test_plusOp() {
   /// Expect: helloworld
   println("hello" + "world")
   /// Expect: hello12 12hello
@@ -27,9 +28,12 @@ println("hello")
   /// Expect: hello[1, 2, 3] [1, 2, 3]hello
   println("hello" + [1, 2, 3], [1, 2, 3] + "hello")
 // })()
+}
+test_plusOp()
 
 // == operator (also String#eq)
 // (() => {
+func test_stringEq() {
   val s1 = "string"
   /// Expect: true
   println(s1 == s1)
@@ -52,6 +56,8 @@ println("hello")
 //   /// Expect: false
 //   println(s1 == { (1): "a", (2): "b" })
 // })()
+}
+test_stringEq()
 
 // // Interpolation (also String#concat<T>(other: T, *others: Any[]))
 // (() => {
@@ -60,47 +66,57 @@ println("hello")
 //   println("length of $array is ${array.length}")
 // })()
 
-// // Indexing (also String#get(index: Int))
+// Indexing (also String#get(index: Int))
 // (() => {
-//   val s = "abc"
-//   /// Expect: |  a b c a b c  |
-//   println("|", s[-4], s[-3], s[-2], s[-1], s[0], s[1], s[2], s[3], "|")
-// })()
+func test_stringIndexing() {
+  val s1 = "abc"
 
-// // Range indexing (also String#getRange(startIndex: Int, endIndex: Int))
+  /// Expect: |  a b c a b c  |
+  println("|", s1[-4], s1[-3], s1[-2], s1[-1], s1[0], s1[1], s1[2], s1[3], "|")
+
+  val s2 = "hello"
+
+  /// Expect: h e l l o
+  println(s2[0], s2[1], s2[2], s2[3], s2[4])
+
+  /// Expect: o l l e h
+  println(s2[-1], s2[-2], s2[-3], s2[-4], s2[-5])
+
+  /// Expect:   end
+  println(s2[5], s2[-6], "end")
+// })()
+}
+test_stringIndexing()
+
+// Range indexing (also String#getRange(startIndex: Int, endIndex: Int))
 // (() => {
-//   val s = "hello"
+func test_stringRangeIndexing() {
+  val s = "hello"
 
-//   /// Expect: h e l l o
-//   println(s[0], s[1], s[2], s[3], s[4])
+  /// Expect: ell ell
+  println(s[1:4], s[-4:4])
 
-//   /// Expect: o l l e h
-//   println(s[-1], s[-2], s[-3], s[-4], s[-5])
+  /// Expect:  end
+  println(s[1:1], "end")
 
-//   /// Expect:   end
-//   println(s[5], s[-6], "end")
+  val a = 1
+  val b = 4
 
-//   /// Expect: ell ell
-//   println(s[1:4], s[-4:4])
+  /// Expect: ell ell
+  println(s[a:b], s[-b:b])
 
-//   /// Expect:  end
-//   println(s[1:1], "end")
+  /// Expect: ello h
+  println(s[1:], s[:1])
 
-//   val a = 1
-//   val b = 4
-
-//   /// Expect: ell ell
-//   println(s[a:b], s[-b:b])
-
-//   /// Expect: ello h
-//   println(s[1:], s[:1])
-
-//   /// Expect: ello h
-//   println(s[a:], s[:a])
+  /// Expect: ello h
+  println(s[a:], s[:a])
 // })()
+}
+test_stringRangeIndexing()
 
 // String#hash
 // (() => {
+func test_stringHash() {
   val empty = ""
   /// Expect: true
   println(empty.hash() == "".hash())
@@ -109,38 +125,49 @@ println("hello")
   /// Expect: true
   println(nonEmpty.hash() == "hello".hash())
 // })()
+}
+test_stringHash()
 
-// // String#isEmpty
+// String#isEmpty
 // (() => {
-//   val empty = ""
-//   /// Expect: true
-//   println(empty.isEmpty())
+func test_stringIsEmpty() {
+  val empty = ""
+  /// Expect: true
+  println(empty.isEmpty())
 
-//   val nonEmpty = "hello"
-//   /// Expect: false
-//   println(nonEmpty.isEmpty())
+  val nonEmpty = "hello"
+  /// Expect: false
+  println(nonEmpty.isEmpty())
 // })()
+}
+test_stringIsEmpty()
 
-// // String#toLower
+// String#toLower
 // (() => {
-//   /// Expect:  |
-//   println("".toLower(), "|")
-//   /// Expect: -hello!
-//   println("-hElLo!".toLower())
+func test_stringToLower() {
+  /// Expect:  |
+  println("".toLower(), "|")
+  /// Expect: -hello!
+  println("-hElLo!".toLower())
 // })()
+}
+test_stringToLower()
 
-// // String#toUpper
+// String#toUpper
 // (() => {
-//   /// Expect:  |
-//   println("".toUpper(), "|")
-//   /// Expect: -HELLO!
-//   println("-hElLo!".toUpper())
+func test_stringToUpper() {
+  /// Expect:  |
+  println("".toUpper(), "|")
+  /// Expect: -HELLO!
+  println("-hElLo!".toUpper())
 // })()
+}
+test_stringToUpper()
 
 // // String#split
 // (() => {
-//   /// Expect: [a, s, d, f]
-//   println("a s d f".split(by: " "))
+  // /// Expect: [a, s, d, f]
+  // println("a s d f".split(by: " "))
 
 //   /// Expect: [, a, b, c d]
 //   println("  a  b  c d".split("  "))


### PR DESCRIPTION
This adds range indexing (using the appropriate `#getRange` method) for arraylike indexing (arrays and strings). Also, I uncommented some more String methods in the string test file, which required me to make a minor modification to the pointer_load intrinsic to account for loading Byte instances.