### PR TITLE
Selfhost: compiling opt-safe field accessor

### DIFF
--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,9 +1,16 @@
-enum Color {
-  Red
-  Green
-  Blue
-}
+type Foo { name: String }
 
-val colors = [Color.Red, Color.Green, Color.Blue]
-println(colors[3]?.toString())
-println(colors[2]?.toString())
+val foo = Foo(name: "abc")
+val arr = [foo]
+
+println(arr[0]?.name?.length)
+// println(foo.name.length)
+
+// val arr = ["a", "b", "c", "d"]
+
+// val _ = arr[0]?.length?.abs()
+
+// /// Expect: Option.Some(value: 1)
+// println(arr[0]?.length)
+// /// Expect: Option.None
+// println(arr[6]?.length)

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -873,9 +873,9 @@ export type Compiler {
               val selfVal = match self._compileExpression(selfExpr) { Ok(v) => v, Err(e) => return Err(e) }
               val variantIsOptionSome = match self._emitOptValueIsSomeVariant(selfVal) { Ok(v) => v, Err(e) => return Err(e) }
 
-              val labelIsSome = self._currentFn.block.addLabel("optsafe_is_some")
-              val labelIsNone = self._currentFn.block.addLabel("optsafe_is_none")
-              val labelCont = self._currentFn.block.addLabel("optsafe_cont")
+              val labelIsSome = self._currentFn.block.addLabel("optsafe_call_is_some")
+              val labelIsNone = self._currentFn.block.addLabel("optsafe_call_is_none")
+              val labelCont = self._currentFn.block.addLabel("optsafe_call_cont")
 
               self._currentFn.block.addComment("begin opt-safe call...")
               self._currentFn.block.buildJnz(variantIsOptionSome, labelIsSome, labelIsNone)
@@ -1271,18 +1271,20 @@ export type Compiler {
         val _t = match self._getInstanceTypeForType(head.ty) { Ok(v) => v, Err(e) => return Err(e) }
         // TODO: destructuring
         val instTy = _t[0]
-        val _typeArgs = _t[1]
+        val typeArgs = _t[1]
+        val instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
 
         val curVal = match self._compileExpression(head) { Ok(v) => v, Err(e) => return Err(e) }
         self._currentFn.block.addCommentBefore("${curVal.repr()}: ${head.ty.repr()}")
 
-        (instTy, curVal)
+        (instTy, instType, curVal)
       }
-      _ => (StructOrEnum.Struct(self._project.preludeBoolStruct), Value.Ident("bogus", QbeType.F32))
+      _ => (StructOrEnum.Struct(self._project.preludeBoolStruct), Type(kind: TypeKind.Instance(StructOrEnum.Struct(self._project.preludeBoolStruct), [])), Value.Ident("bogus", QbeType.F32))
     }
     // TODO: destructuring
     var instTy = _p[0]
-    var curVal = _p[1]
+    var instType = _p[1]
+    var curVal = _p[2]
 
     for seg, idx in segs {
       match seg {
@@ -1294,8 +1296,45 @@ export type Compiler {
 
           instTy = StructOrEnum.Enum(enum_)
         }
-        AccessorPathSegment.Method(label, fn) => return todo("method accessor")
-        AccessorPathSegment.Field(label, ty, field) => {
+        AccessorPathSegment.Method(label, fn, _) => return todo("method accessor")
+        AccessorPathSegment.Field(label, ty, field, isOptSafe) => {
+          var optSafeCtx: (Label, Value, QbeFunction, Label)? = None
+
+          if isOptSafe {
+            val innerTy = if self._typeIsOption(instType) |innerTy| innerTy else return unreachable("an opt-safe field accessor needs to have an Option type as its lhs")
+            instType = innerTy
+            val _t = match self._getInstanceTypeForType(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
+            // TODO: destructuring
+            instTy = _t[0]
+
+            val variantIsOptionSome = match self._emitOptValueIsSomeVariant(curVal) { Ok(v) => v, Err(e) => return Err(e) }
+            val labelIsSome = self._currentFn.block.addLabel("optsafe_field_is_some")
+            val labelIsNone = self._currentFn.block.addLabel("optsafe_field_is_none")
+            val labelCont = self._currentFn.block.addLabel("optsafe_field_cont")
+
+            self._currentFn.block.addComment("begin opt-safe field accessor...")
+            self._currentFn.block.buildJnz(variantIsOptionSome, labelIsSome, labelIsNone)
+
+            self._currentFn.block.registerLabel(labelIsNone)
+            val optNoneVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "None") |v| v else return unreachable("Option.None must exist")
+            match self._resolvedGenerics.addLayer("Option.None", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: label.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.None", message: e))) }
+            val noneVariantFn = match self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant) { Ok(v) => v, Err(e) => return Err(e) }
+            self._resolvedGenerics.popLayer()
+            val noneRes = match self._currentFn.block.buildCall(noneVariantFn, []) { Ok(v) => v, Err(e) => return qbeError(e) }
+            self._currentFn.block.buildJmp(labelCont)
+
+            self._currentFn.block.registerLabel(labelIsSome)
+            val optSomeVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "Some") |v| v else return unreachable("Option.Some must exist")
+            match self._resolvedGenerics.addLayer("Option.Some", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: label.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.Some", message: e))) }
+            val someVariantFn = match self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optSomeVariant) { Ok(v) => v, Err(e) => return Err(e) }
+            self._resolvedGenerics.popLayer()
+
+            optSafeCtx = Some((labelIsNone, noneRes, someVariantFn, labelCont))
+
+            val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
+            curVal = match self._emitOptValueGetValue(innerQbeType, curVal) { Ok(v) => v, Err(e) => return Err(e) }
+          }
+
           match instTy {
             StructOrEnum.Struct(struct) => {
               var offset = 0
@@ -1323,6 +1362,29 @@ export type Compiler {
             }
             StructOrEnum.Enum(_enum) => return todo("enum field accessor")
           }
+
+          if optSafeCtx |_ctx| {
+            val labelIsNone = _ctx[0]
+            val noneRes = _ctx[1]
+            val someVariantFn = _ctx[2]
+            val labelCont = _ctx[3]
+
+            val labelIsSome = self._currentFn.block.currentLabel
+            val someRes = match self._currentFn.block.buildCall(someVariantFn, [curVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+            self._currentFn.block.buildJmp(labelCont)
+
+            self._currentFn.block.addComment("...opt-safe field accessor end")
+            self._currentFn.block.registerLabel(labelCont)
+
+            val phiCases = [(labelIsNone, noneRes), (labelIsSome, someRes)]
+            curVal = match self._currentFn.block.buildPhi(phiCases, localName) { Ok(v) => v, Err(e) => return qbeError(e) }
+          }
+
+          val _t = match self._getInstanceTypeForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+          // TODO: destructuring
+          instTy = _t[0]
+          val typeArgs = _t[1]
+          instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
         }
       }
     }

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -716,14 +716,14 @@ export enum TypedAstNodeKind {
 
 export enum AccessorPathSegment {
   EnumVariant(label: Label, ty: Type, enum_: Enum, variant: TypedEnumVariant)
-  Method(label: Label, fn: Function)
-  Field(label: Label, ty: Type, f: Field)
+  Method(label: Label, fn: Function, optSafe: Bool)
+  Field(label: Label, ty: Type, f: Field, optSafe: Bool)
 
   func getType(self): Type {
     match self {
       AccessorPathSegment.EnumVariant(_, ty, _, _) => ty
-      AccessorPathSegment.Method(_, fn) => fn.getType()
-      AccessorPathSegment.Field(_, ty, _) => ty
+      AccessorPathSegment.Method(_, fn, _) => fn.getType()
+      AccessorPathSegment.Field(_, ty, _, _) => ty
     }
   }
 }
@@ -2998,7 +2998,7 @@ export type Typechecker {
               AccessorPathSegment.EnumVariant(label, _, _, variant) => {
                 return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAssignment("enum variant", variant.label.name, IllegalAssignmentReason.EnumVariant)))
               }
-              AccessorPathSegment.Method(label, fn) => {
+              AccessorPathSegment.Method(label, fn, _) => {
                 val _p = match fn.kind {
                   FunctionKind.StaticMethod => ("static method", IllegalAssignmentReason.StaticMethod)
                   _ => ("method", IllegalAssignmentReason.Method)
@@ -3804,7 +3804,7 @@ export type Typechecker {
     Ok(TypedAstNode(token: token, ty: _p[0], kind: TypedAstNodeKind.Identifier(_p[1])))
   }
 
-  func _resolveAccessorPathSegmentAny(self, label: Label): AccessorPathSegment? {
+  func _resolveAccessorPathSegmentAny(self, label: Label, optSafe: Bool): AccessorPathSegment? {
     val scope = self.project.preludeScope.makeChild("Any", ScopeKind.Type)
     val method: Function? = if label.name == "toString" {
       Some(Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(None)))
@@ -3817,22 +3817,22 @@ export type Typechecker {
     }
 
     if method |method| {
-      Some(AccessorPathSegment.Method(label, method))
+      Some(AccessorPathSegment.Method(label, method, optSafe))
     } else {
       None
     }
   }
 
-  func _resolveAccessorPathSegment(self, ty: Type, label: Label, typeHint: Type?): Result<AccessorPathSegment?, TypeError> {
+  func _resolveAccessorPathSegment(self, ty: Type, label: Label, typeHint: Type?, optSafe = false): Result<AccessorPathSegment?, TypeError> {
     val foundSegment = match ty.kind {
-      TypeKind.Any => self._resolveAccessorPathSegmentAny(label)
+      TypeKind.Any => self._resolveAccessorPathSegmentAny(label, optSafe)
       TypeKind.PrimitiveUnit => None
-      TypeKind.PrimitiveInt => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeIntStruct), [])), label, None)
-      TypeKind.PrimitiveFloat => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeFloatStruct), [])), label, None)
-      TypeKind.PrimitiveBool => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeBoolStruct), [])), label, None)
-      TypeKind.PrimitiveString => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeStringStruct), [])), label, None)
+      TypeKind.PrimitiveInt => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeIntStruct), [])), label, None, optSafe)
+      TypeKind.PrimitiveFloat => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeFloatStruct), [])), label, None, optSafe)
+      TypeKind.PrimitiveBool => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeBoolStruct), [])), label, None, optSafe)
+      TypeKind.PrimitiveString => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeStringStruct), [])), label, None, optSafe)
       TypeKind.Never => None
-      TypeKind.Generic => self._resolveAccessorPathSegmentAny(label)
+      TypeKind.Generic => self._resolveAccessorPathSegmentAny(label, optSafe)
       TypeKind.Instance(structOrEnum, generics) => {
         val _p = match structOrEnum {
           StructOrEnum.Struct(struct) => {
@@ -3842,8 +3842,11 @@ export type Typechecker {
                 for name, idx in struct.typeParams {
                   resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
                 }
-                val ty = field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
-                return Ok(Some(AccessorPathSegment.Field(label, ty, field)))
+                var ty = field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
+                if optSafe {
+                  ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [ty]))
+                }
+                return Ok(Some(AccessorPathSegment.Field(label, ty, field, optSafe)))
               }
             }
 
@@ -3862,7 +3865,7 @@ export type Typechecker {
               resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
             }
             val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true, genericsInScope: #{})
-            return Ok(Some(AccessorPathSegment.Method(label, method)))
+            return Ok(Some(AccessorPathSegment.Method(label, method, optSafe)))
           }
         }
 
@@ -3916,7 +3919,7 @@ export type Typechecker {
         }
 
         for method in staticMethods {
-          if method.label.name == label.name return Ok(Some(AccessorPathSegment.Method(label, method)))
+          if method.label.name == label.name return Ok(Some(AccessorPathSegment.Method(label, method, optSafe)))
         }
 
         None
@@ -4007,15 +4010,16 @@ export type Typechecker {
         ty
       }
 
-      val seg = match self._resolveAccessorPathSegment(subjTy, label, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
+      val seg = match self._resolveAccessorPathSegment(subjTy, label, typeHint, isOptSafe) { Ok(v) => v, Err(e) => return Err(e) }
       if seg |seg| {
-        // TODO: destructuring
-        // val seg = _s[0]
         val nextTy = seg.getType()
 
         path.push(seg)
         ty = if isOptSafe {
-          Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [nextTy]))
+          match seg {
+            AccessorPathSegment.Field => nextTy // type is already wrapped in Option in _resolveAccessorPathSegment for fields if opt-safe
+            _ => Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [nextTy]))
+          }
         } else {
           nextTy
         }
@@ -4095,7 +4099,7 @@ export type Typechecker {
 
             self._typecheckInvocationOfFunction(token, invokee, enumVariantAsFn, node, typeHint, None, Some(Instantiatable.EnumContainerVariant(enum_, variant, fields)))
           }
-          AccessorPathSegment.Method(l, fn) => {
+          AccessorPathSegment.Method(l, fn, optSafe) => {
             match fn.kind {
               FunctionKind.InstanceMethod => {
                 val selfVal = if mid[-1] |newTail| {
@@ -4104,7 +4108,7 @@ export type Typechecker {
                   head
                 }
 
-                if self._typeIsOption(invokee.ty) {
+                if optSafe {
                   val typedNode = match self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint, Some((selfVal, true))) { Ok(v) => v, Err(e) => return Err(e) }
                   typedNode.ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [typedNode.ty]))
                   Ok(typedNode)

--- a/selfhost/test/compiler/optionals.abra
+++ b/selfhost/test/compiler/optionals.abra
@@ -17,9 +17,9 @@ val arr3: Int[]? = None
 /// Expect: Option.None
 println(arr3)
 
-// type Foo {
-//   f: Int
-// }
+type Foo {
+  f: String
+}
 
 // Workaround because optionals technically don't have _any_ directly-callable methods
 func hash<T>(t: T): Int = t.hash()
@@ -98,17 +98,26 @@ func test_optSafe() {
 //   /// Expect: [a, b, c, d]
 //   println(arr?.toString())
 
-//   // Getting field of Option value
-//   /// Expect: Option.Some(value: 1)
-//   println(arr[0]?.length)
-//   /// Expect: Option.None
-//   println(arr[6]?.length)
+  // Getting field of Option value
+  /// Expect: Option.Some(value: 1)
+  println(arr[0]?.length)
+  /// Expect: Option.None
+  println(arr[6]?.length)
 
   // Calling method of Option value
   /// Expect: Option.Some(value: false)
   println(arr[0]?.isEmpty())
   /// Expect: Option.None
   println(arr[6]?.isEmpty())
+
+  // nested opt-safe accessors
+  val foo = Foo(f: "abc")
+  val fooArr = [foo]
+
+  /// Expect: Option.Some(value: 3)
+  println(fooArr[0]?.f?.length)
+  /// Expect: Option.Some(value: 3)
+  println(fooArr[0]?.f?.length?.abs())
 
   // Calling unit method of Option value
   val t1: TestOptChainingMethodInvocation? = None

--- a/selfhost/test/typechecker/accessor/accessor.2.out.json
+++ b/selfhost/test/typechecker/accessor/accessor.2.out.json
@@ -317,9 +317,15 @@
                 "kind": "field",
                 "name": "bar",
                 "type": {
-                  "kind": "instance",
-                  "struct": { "moduleId": 3, "name": "Bar" },
-                  "typeParams": []
+                  "kind": "enumInstance",
+                  "enum": { "moduleId": 0, "name": "Option" },
+                  "typeParams": [
+                    {
+                      "kind": "instance",
+                      "struct": { "moduleId": 3, "name": "Bar" },
+                      "typeParams": []
+                    }
+                  ]
                 }
               }
             ],
@@ -327,8 +333,14 @@
               "kind": "field",
               "name": "str",
               "type": {
-                "kind": "primitive",
-                "primitive": "String"
+                "kind": "enumInstance",
+                "enum": { "moduleId": 0, "name": "Option" },
+                "typeParams": [
+                  {
+                    "kind": "primitive",
+                    "primitive": "String"
+                  }
+                ]
               }
             }
           }


### PR DESCRIPTION
This also fixes a bug in the selfhosted typechecker which would fail to properly chain along the current type of a nested field-accessor expression.