### PR TITLE
Selfhost: compiling functions as values

### DIFF
--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -8,7 +8,20 @@
 // val res = callFn//(x => x + 1, 7)
 // println(res)
 
-func add_(a: Int, b: Int): Int = a + b
+// func add_(a: Int, b: Int): Int = a + b
 
-val add = add_
-println(add(1, 2))
+// val add = add_
+// println(add(1, 2))
+
+func callFn1(fn: (Int, String) => Int) {
+  println(fn(24, "abc"))
+}
+// func callFn2(fn: (String) => Int) {
+//   println(fn("abc"))
+// }
+// func foo(a: Int, b: Int): Int = a + b
+func foo(a: Int): Int = a + 1
+// func foo(): Int = 12
+callFn1(foo)
+// callFn2(foo)
+

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -23,12 +23,39 @@
 // val foo: (Int) => Int = b => b + 1
 // println(foo(23))
 
-func makeAdder(x: Int): (Int) => Int {
+// func makeAdder(x: Int): (Int) => Int {
+//   i => i + x
+// }
+// val addOne = makeAdder(1)
+// /// Expect: 12
+// println(addOne(11))
+
+// var capturedInt = 1
+// func closure5() { capturedInt += 2 }
+// func containsClosures1() { closure5() }
+// containsClosures1()
+
+// println(capturedInt)
+
+// val one = 1
+// func makeClosureCapturingOutside(): (Int) => Int {
+//   i => i + one
+// }
+// func getClosureCapturingOutside(): (Int) => Int {
+//   val f = () => makeClosureCapturingOutside()
+//   f()
+// }
+// val closureCapturingOutside = getClosureCapturingOutside()
+// /// Expect: 12
+// println(closureCapturingOutside(11))
+
+func makeClosure(): (Int) => Int {
+  val x = 123
   i => i + x
 }
-val addOne = makeAdder(1)
-/// Expect: 12
-println(addOne(11))
+val closure = makeClosure()
+/// Expect: 134
+println(closure(11))
 
 // arr.push(2)
 // println(arr)

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -16,12 +16,19 @@
 // val fn: (Int, Int) => Int = (x) => x + 10
 // println(fn(23, 24))
 
-val arr = [1]
-// println(arr)
+// val arr = [1]
+// // println(arr)
 
-// func foo(b: Int): Int = arr.length + b
-val foo: (Int) => Int = b => b + 1
-println(foo(23))
+// // func foo(b: Int): Int = arr.length + b
+// val foo: (Int) => Int = b => b + 1
+// println(foo(23))
+
+func makeAdder(x: Int): (Int) => Int {
+  i => i + x
+}
+val addOne = makeAdder(1)
+/// Expect: 12
+println(addOne(11))
 
 // arr.push(2)
 // println(arr)

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -17,14 +17,15 @@
 // println(fn(23, 24))
 
 val arr = [1]
-println(arr)
+// println(arr)
 
-func foo(b: Int): Int = arr.length + b
+// func foo(b: Int): Int = arr.length + b
+val foo: (Int) => Int = b => b + 1
 println(foo(23))
 
-arr.push(2)
-println(arr)
-println(foo(23))
+// arr.push(2)
+// println(arr)
+// println(foo(23))
 
 // func callFn1(fn: (Int, String) => Int) {
 //   println(fn(24, "abc"))

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -20,7 +20,7 @@ func callFn1(fn: (Int, String) => Int) {
 //   println(fn("abc"))
 // }
 // func foo(a: Int, b: Int): Int = a + b
-func foo(a: Int): Int = a + 1
+func foo(a: Int, s = "qwer", d = 1): Int = a + s.length + d
 // func foo(): Int = 12
 callFn1(foo)
 // callFn2(foo)

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -16,10 +16,15 @@
 // val fn: (Int, Int) => Int = (x) => x + 10
 // println(fn(23, 24))
 
-val x = (() => {
-  1 + 23
-})()
-println(x)
+val arr = [1]
+println(arr)
+
+func foo(b: Int): Int = arr.length + b
+println(foo(23))
+
+arr.push(2)
+println(arr)
+println(foo(23))
 
 // func callFn1(fn: (Int, String) => Int) {
 //   println(fn(24, "abc"))

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -13,8 +13,13 @@
 // val add = add_
 // println(add(1, 2))
 
-val fn: (Int, Int) => Int = (x) => x + 10
-println(fn(23, 24))
+// val fn: (Int, Int) => Int = (x) => x + 10
+// println(fn(23, 24))
+
+val x = (() => {
+  1 + 23
+})()
+println(x)
 
 // func callFn1(fn: (Int, String) => Int) {
 //   println(fn(24, "abc"))

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,2 +1,14 @@
-val set = #{17, 18, 19}
-println(set)
+// val set = #{17, 18, 19}
+// println(set)
+
+// func callFn(fn: (Int) => Int, a: Int): Int {
+//   fn(a)
+// }
+
+// val res = callFn//(x => x + 1, 7)
+// println(res)
+
+func add_(a: Int, b: Int): Int = a + b
+
+val add = add_
+println(add(1, 2))

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -13,15 +13,18 @@
 // val add = add_
 // println(add(1, 2))
 
-func callFn1(fn: (Int, String) => Int) {
-  println(fn(24, "abc"))
-}
-// func callFn2(fn: (String) => Int) {
-//   println(fn("abc"))
+val fn: (Int, Int) => Int = (x) => x + 10
+println(fn(23, 24))
+
+// func callFn1(fn: (Int, String) => Int) {
+//   println(fn(24, "abc"))
 // }
-// func foo(a: Int, b: Int): Int = a + b
-func foo(a: Int, s = "qwer", d = 1): Int = a + s.length + d
-// func foo(): Int = 12
-callFn1(foo)
-// callFn2(foo)
+// // func callFn2(fn: (String) => Int) {
+// //   println(fn("abc"))
+// // }
+// // func foo(a: Int, b: Int): Int = a + b
+// func foo(a: Int, s = "qwer", d = 1): Int = a + s.length + d
+// // func foo(): Int = 12
+// callFn1(foo)
+// // callFn2(foo)
 

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -937,7 +937,14 @@ export type Compiler {
         // TODO: handle captured variables in closures, global variables, etc).
         val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
         if variable.isParameter {
-          Ok(Value.Ident(name, varTy))
+          if variable.isCaptured {
+            val ptr = match self._getCapturedVarPtr(variable.label.name) { Ok(v) => v, Err(e) => return Err(e) }
+            self._currentFn.block.addComment("deref ptr to captured '${variable.label.name}'")
+            val res = self._currentFn.block.buildLoad(varTy, ptr)
+            Ok(res)
+          } else {
+            Ok(Value.Ident(name, varTy))
+          }
         } else {
           match variable.alias {
             VariableAlias.Function(fn) => {
@@ -1590,13 +1597,14 @@ export type Compiler {
 
   func _getCapturedVarPtr(self, name: String): Result<Value, CompileError> {
     if self._currentFunction |fn| {
-      val fnCaptures = if self._currentFn._env |env| env else return unreachable("cannot resolve captured `$name`, current function has no `env` param", fn.label.position)
-      for v, idx in fn.captures {
-        if v.label.name == name {
-          self._currentFn.block.addComment("get ptr to captured '$name'")
-          val captureSlot = match self._currentFn.block.buildAdd(Value.Int(idx * QbeType.Pointer.size()), fnCaptures) { Ok(v) => v, Err(e) => return qbeError(e) }
-          val ptr = self._currentFn.block.buildLoad(QbeType.Pointer, captureSlot)
-          return Ok(ptr)
+      if self._currentFn._env |env| {
+        for v, idx in fn.captures {
+          if v.label.name == name {
+            self._currentFn.block.addComment("get ptr to captured '$name'")
+            val captureSlot = match self._currentFn.block.buildAdd(Value.Int(idx * QbeType.Pointer.size()), env) { Ok(v) => v, Err(e) => return qbeError(e) }
+            val ptr = self._currentFn.block.buildLoad(QbeType.Pointer, captureSlot)
+            return Ok(ptr)
+          }
         }
       }
     }
@@ -2629,6 +2637,17 @@ export type Compiler {
         match self._currentFn.block.buildPhi(phiCases, Some(param.label.name)) { Ok(v) => v, Err(e) => return qbeError(e) }
       } else {
         fnVal.addParameter(param.label.name, paramTy)
+      }
+
+      if param.variable.isCaptured {
+        self._currentFn.block.addComment("move param '${param.label.name}' to heap")
+        val size = paramTy.size()
+        val heapMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+        self._currentFn.block.buildStore(paramTy, Value.Ident(param.label.name, paramTy), heapMem)
+
+        val slotName = "${param.label.name}.slot"
+        val slot = self._buildStackAllocForQbeType(QbeType.Pointer, Some(slotName))
+        self._currentFn.block.buildStore(QbeType.Pointer, heapMem, slot)
       }
     }
     if addMaskParam {

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1074,7 +1074,7 @@ export type Compiler {
             val fnObj = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
             val fnValPtr = self._currentFn.block.buildLoadL(fnObj)
 
-            val retTypeQbe = if node.ty == TypeKind.PrimitiveUnit {
+            val retTypeQbe = if node.ty.kind == TypeKind.PrimitiveUnit {
               None
             } else {
               val ty = match self._getQbeTypeForTypeExpect(node.ty, "unacceptable return type", None) { Ok(v) => v, Err(e) => return Err(e) }

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -532,7 +532,7 @@ export type Compiler {
         Ok(None)
       }
       TypedAstNodeKind.FunctionDeclaration(fn) => {
-        if !fn.captures.isEmpty() {
+        if fn.isClosure() {
           val capturesMem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
           val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some("${fn.label.name}.captures"))
           self._currentFn.block.buildStore(QbeType.Pointer, capturesMem, capturesSlot)
@@ -959,7 +959,7 @@ export type Compiler {
                 None
               }
 
-              val capturesMem = if fn.captures.isEmpty() None else {
+              val capturesMem = if !fn.isClosure() None else {
                 val mem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
                 Some(mem)
               }
@@ -1012,8 +1012,9 @@ export type Compiler {
               return res
             }
 
-            if !fn.captures.isEmpty() {
-              closureEnvCtx = Some((self._getCapturesForClosure(fn), false))
+            if fn.isClosure() {
+              val capturesArr = match self._getCapturesArrForClosure(fn) { Ok(v) => v, Err(e) => return Err(e) }
+              closureEnvCtx = Some((capturesArr, false))
             }
 
             fnHasOptionalParameters = fn.params.any(p => !!p.defaultValue)
@@ -1046,8 +1047,9 @@ export type Compiler {
               return res
             }
 
-            if !fn.captures.isEmpty() {
-              closureEnvCtx = Some((self._getCapturesForClosure(fn), false))
+            if fn.isClosure() {
+              val capturesArr = match self._getCapturesArrForClosure(fn) { Ok(v) => v, Err(e) => return Err(e) }
+              closureEnvCtx = Some((capturesArr, false))
             }
 
             fnHasOptionalParameters = fn.params.any(p => !!p.defaultValue)
@@ -1502,7 +1504,7 @@ export type Compiler {
           None
         }
 
-        val capturesMem = if fn.captures.isEmpty() None else {
+        val capturesMem = if !fn.isClosure() None else {
           val mem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
           Some(mem)
         }
@@ -1618,28 +1620,55 @@ export type Compiler {
   }
 
   func _createClosureCaptures(self, fn: Function): Result<Value, CompileError> {
-    var size = 0
-    for variable in fn.captures {
-      val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
-      size += varTy.size()
-    }
+    val size = QbeType.Pointer.size() * (fn.captures.length + fn.capturedClosures.length)
     val capturesMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
     var cursor = capturesMem
 
     for variable in fn.captures {
       val ptr = match self._getCapturedVarPtr(variable.label.name) { Ok(v) => v, Err(e) => return Err(e) }
       self._currentFn.block.buildStore(QbeType.Pointer, ptr, cursor)
-      cursor = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), cursor) { Ok(v) => v, Err(e) => return qbeError(e) }
+      if fn.captures.length > 1 || fn.capturedClosures.length > 0 {
+        cursor = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), cursor) { Ok(v) => v, Err(e) => return qbeError(e) }
+      }
+    }
+
+    for capturedFn in fn.capturedClosures {
+      val capturesArr = match self._getCapturesArrForClosure(capturedFn) { Ok(v) => v, Err(e) => return Err(e) }
+      self._currentFn.block.buildStore(QbeType.Pointer, capturesArr, cursor)
+      if fn.capturedClosures.length > 1 {
+        cursor = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), cursor) { Ok(v) => v, Err(e) => return qbeError(e) }
+      }
     }
 
     Ok(capturesMem)
   }
 
-  func _getCapturesForClosure(self, fn: Function): Value {
-    // TODO: this assumes that the closure is being called in the same scope in which it was declared (and thus the `*.captures`
-    // value is visible as a stack local). This does not hold true for nested scopes, and will need to be handled.
-    val capturesName = "${fn.label.name}.captures"
-    self._currentFn.block.buildLoadL(Value.Ident(capturesName, QbeType.Pointer))
+  func _getCapturesArrForClosure(self, fn: Function): Result<Value, CompileError> {
+    val fnInvocationIsAtDeclaredScope = if self._currentFunction |currentFunc| {
+      fn.scope.parent == Some(currentFunc.scope)
+    } else {
+      true
+    }
+
+    val res = if !fnInvocationIsAtDeclaredScope {
+      val currentFunc = if self._currentFunction |currentFn| currentFn else return unreachable("we must be within a function to enter this case", fn.label.position)
+
+      val _p = if currentFunc.capturedClosures.findIndex(f => f.label.name == fn.label.name) |_p| _p else return unreachable("closure '${fn.label.name}' called within function '${currentFunc.label.name}', but not tracked in its capturedClosures", fn.label.position)
+      // TODO: destructuring
+      val idx = _p[1]
+
+      val env = if self._currentFn._env |env| env else return unreachable("expected currentFn ('${self._currentFn.name}') to have an `_env`, but it didn't")
+      val offset = QbeType.Pointer.size() * (currentFunc.captures.length + idx)
+
+      val ptr = match self._currentFn.block.buildAdd(Value.Int(offset), env) { Ok(v) => v, Err(e) => return qbeError(e) }
+      self._currentFn.block.buildLoadL(ptr)
+    } else {
+      // If the closure is being called in the same scope in which it was declared, then the `*.captures` value is visible as a stack local.
+      val capturesName = "${fn.label.name}.captures"
+      self._currentFn.block.buildLoadL(Value.Ident(capturesName, QbeType.Pointer))
+    }
+
+    Ok(res)
   }
 
   func _compileBinaryOperands(self, left: TypedAstNode, right: TypedAstNode, op: String): Result<(Value, Value), CompileError> {
@@ -2557,7 +2586,7 @@ export type Compiler {
 
     val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
     val fnVal = self._builder.buildFunction(name: fnName, returnType: returnTypeQbe)
-    if !fn.captures.isEmpty() fnVal.addEnv()
+    if fn.isClosure() fnVal.addEnv()
 
     match self._compileFunc(fnVal, fn) { Ok(v) => v, Err(e) => return Err(e) }
     fnVal.addComment(match self._fnSignature(None, fn) { Ok(v) => v, Err(e) => return Err(e) })

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -533,23 +533,8 @@ export type Compiler {
       }
       TypedAstNodeKind.FunctionDeclaration(fn) => {
         if !fn.captures.isEmpty() {
-          val capturesName = "${fn.label.name}.captures"
-          val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some(capturesName))
-
-          var size = 0
-          for variable in fn.captures {
-            val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
-            size += varTy.size()
-          }
-          val capturesMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
-          var cursor = capturesMem
-
-          for variable in fn.captures {
-            val ptr = match self._getCapturedVarPtr(variable.label.name) { Ok(v) => v, Err(e) => return Err(e) }
-            self._currentFn.block.buildStore(QbeType.Pointer, ptr, cursor)
-            cursor = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), cursor) { Ok(v) => v, Err(e) => return qbeError(e) }
-          }
-
+          val capturesMem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+          val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some("${fn.label.name}.captures"))
           self._currentFn.block.buildStore(QbeType.Pointer, capturesMem, capturesSlot)
         }
 
@@ -967,7 +952,12 @@ export type Compiler {
                 None
               }
 
-              self._compileFunctionValue(node.token.position, fn, targetParamTypes)
+              val capturesMem = if fn.captures.isEmpty() None else {
+                val mem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+                Some(mem)
+              }
+
+              self._compileFunctionValue(node.token.position, fn, targetParamTypes, capturesMem)
             }
             _ => {
               if variable.isCaptured {
@@ -989,7 +979,7 @@ export type Compiler {
         val args: Value[] = []
         var fnHasOptionalParameters = false
         var optSafeCtx: (Label, Value?, QbeFunction, Label)? = None
-        var closureEnvPtr: Value? = None
+        var closureEnvCtx: (Value, Bool)? = None
 
         val _p = match invokee {
           TypedInvokee.Function(fn) => {
@@ -1016,7 +1006,7 @@ export type Compiler {
             }
 
             if !fn.captures.isEmpty() {
-              closureEnvPtr = Some(self._getCapturesForClosure(fn))
+              closureEnvCtx = Some((self._getCapturesForClosure(fn), false))
             }
 
             fnHasOptionalParameters = fn.params.any(p => !!p.defaultValue)
@@ -1050,7 +1040,7 @@ export type Compiler {
             }
 
             if !fn.captures.isEmpty() {
-              closureEnvPtr = Some(self._getCapturesForClosure(fn))
+              closureEnvCtx = Some((self._getCapturesForClosure(fn), false))
             }
 
             fnHasOptionalParameters = fn.params.any(p => !!p.defaultValue)
@@ -1128,7 +1118,11 @@ export type Compiler {
           }
           TypedInvokee.Expr(expr) => {
             val fnObj = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
-            val fnValPtr = self._currentFn.block.buildLoadL(fnObj)
+            val envPtr = self._currentFn.block.buildLoadL(fnObj)
+            closureEnvCtx = Some((envPtr, true))
+
+            val fnValPtrSlot = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), fnObj) { Ok(v) => v, Err(e) => return qbeError(e) }
+            val fnValPtr = self._currentFn.block.buildLoadL(fnValPtrSlot)
 
             val retTypeQbe = if node.ty.kind == TypeKind.PrimitiveUnit {
               None
@@ -1176,10 +1170,70 @@ export type Compiler {
         }
 
         var res = if fnVal.returnType() {
-          val res = match self._currentFn.block.buildCall(fnVal, args, resultLocalName, closureEnvPtr) { Ok(v) => v, Err(e) => return qbeError(e) }
-          res
+          if closureEnvCtx |_ctx| {
+            // TODO: destructuring
+            val closureEnvPtr = _ctx[0]
+            val needsNullCheck = _ctx[1]
+            val res = if needsNullCheck {
+              val labelCallWithEnv = self._currentFn.block.addLabel("call_fn_val_with_env")
+              val labelCallWithoutEnv = self._currentFn.block.addLabel("call_fn_val_without_env")
+              val labelCont = self._currentFn.block.addLabel("call_fn_val_cont")
+
+              self._currentFn.block.buildJnz(closureEnvPtr, labelCallWithEnv, labelCallWithoutEnv)
+
+              self._currentFn.block.registerLabel(labelCallWithEnv)
+              val resWithEnv = match self._currentFn.block.buildCall(fnVal, args, resultLocalName, Some(closureEnvPtr)) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val resWithEnvLabel = self._currentFn.block.currentLabel
+              self._currentFn.block.buildJmp(labelCont)
+
+              self._currentFn.block.registerLabel(labelCallWithoutEnv)
+              val resWithoutEnv = match self._currentFn.block.buildCall(fnVal, args, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val resWithoutEnvLabel = self._currentFn.block.currentLabel
+              self._currentFn.block.buildJmp(labelCont)
+
+              self._currentFn.block.registerLabel(labelCont)
+
+              val phiCases = [(resWithEnvLabel, resWithEnv), (resWithoutEnvLabel, resWithoutEnv)]
+
+              val res = match self._currentFn.block.buildPhi(phiCases) { Ok(v) => v, Err(e) => return qbeError(e) }
+              res
+            } else {
+              val res = match self._currentFn.block.buildCall(fnVal, args, resultLocalName, Some(closureEnvPtr)) { Ok(v) => v, Err(e) => return qbeError(e) }
+              res
+            }
+            res
+          } else {
+            val res = match self._currentFn.block.buildCall(fnVal, args, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+            res
+          }
         } else {
-          self._currentFn.block.buildVoidCall(fnVal, args, closureEnvPtr)
+          if closureEnvCtx |_ctx| {
+            // TODO: destructuring
+            val closureEnvPtr = _ctx[0]
+            val needsNullCheck = _ctx[1]
+            if needsNullCheck {
+              val labelCallWithEnv = self._currentFn.block.addLabel("call_fn_val_with_env")
+              val labelCallWithoutEnv = self._currentFn.block.addLabel("call_fn_val_without_env")
+              val labelCont = self._currentFn.block.addLabel("call_fn_val_cont")
+
+              self._currentFn.block.buildJnz(closureEnvPtr, labelCallWithEnv, labelCallWithoutEnv)
+
+              self._currentFn.block.registerLabel(labelCallWithEnv)
+              self._currentFn.block.buildVoidCall(fnVal, args, Some(closureEnvPtr))
+              self._currentFn.block.buildJmp(labelCont)
+
+              self._currentFn.block.registerLabel(labelCallWithoutEnv)
+              self._currentFn.block.buildVoidCall(fnVal, args)
+              self._currentFn.block.buildJmp(labelCont)
+
+              self._currentFn.block.registerLabel(labelCont)
+            } else {
+              self._currentFn.block.buildVoidCall(fnVal, args, Some(closureEnvPtr))
+            }
+          } else {
+            self._currentFn.block.buildVoidCall(fnVal, args)
+          }
+
           Value.Ident("bogus", QbeType.F32)
         }
 
@@ -1441,7 +1495,12 @@ export type Compiler {
           None
         }
 
-        self._compileFunctionValue(node.token.position, fn, targetParamTypes)
+        val capturesMem = if fn.captures.isEmpty() None else {
+          val mem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+          Some(mem)
+        }
+
+        self._compileFunctionValue(node.token.position, fn, targetParamTypes, capturesMem)
       }
       TypedAstNodeKind.If(isStatement, cond, conditionBinding, ifBlock, ifBlockTerminator, elseBlock, elseBlockTerminator) => {
         if isStatement return unreachable("if-statements are handled elsewhere", node.token.position)
@@ -1550,6 +1609,24 @@ export type Compiler {
     Ok(res)
   }
 
+  func _createClosureCaptures(self, fn: Function): Result<Value, CompileError> {
+    var size = 0
+    for variable in fn.captures {
+      val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+      size += varTy.size()
+    }
+    val capturesMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    var cursor = capturesMem
+
+    for variable in fn.captures {
+      val ptr = match self._getCapturedVarPtr(variable.label.name) { Ok(v) => v, Err(e) => return Err(e) }
+      self._currentFn.block.buildStore(QbeType.Pointer, ptr, cursor)
+      cursor = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), cursor) { Ok(v) => v, Err(e) => return qbeError(e) }
+    }
+
+    Ok(capturesMem)
+  }
+
   func _getCapturesForClosure(self, fn: Function): Value {
     // TODO: this assumes that the closure is being called in the same scope in which it was declared (and thus the `*.captures`
     // value is visible as a stack local). This does not hold true for nested scopes, and will need to be handled.
@@ -1611,8 +1688,8 @@ export type Compiler {
     }
   }
 
-  func _compileFunctionValue(self, position: Position, fn: Function, targetParamTypes: (Type, Bool)[]?): Result<Value, CompileError> {
-    if !fn.captures.isEmpty() return todo("closures as values", fn.label.position)
+  func _compileFunctionValue(self, position: Position, fn: Function, targetParamTypes: (Type, Bool)[]?, capturesPtr: Value?): Result<Value, CompileError> {
+    val closureEnvPtr = capturesPtr ?: Value.Int(0)
 
     val numParams = fn.params.length
     var fnNumReqParams = 0
@@ -1748,7 +1825,8 @@ export type Compiler {
 
     self._resolvedGenerics.popLayer()
 
-    val res = match self._currentFn.block.buildCall(Callable.Function(initFnVal), [Value.Global(fnVal.name, QbeType.Pointer)]) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val initArgs = [closureEnvPtr, Value.Global(fnVal.name, QbeType.Pointer)]
+    val res = match self._currentFn.block.buildCall(Callable.Function(initFnVal), initArgs) { Ok(v) => v, Err(e) => return qbeError(e) }
     Ok(res)
   }
 
@@ -3476,7 +3554,7 @@ export type Compiler {
       val dummyModuleId = 0
       val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       val typeParams = (if hasReturnType { ["_R"] } else []).concat(alphabet[:arity].split(""))
-      val fields = [("_ptr", Type(kind: TypeKind.PrimitiveInt))]
+      val fields = [("_env", Type(kind: TypeKind.PrimitiveInt)), ("_ptr", Type(kind: TypeKind.PrimitiveInt))]
       val struct = Struct.makeDummy(moduleId: dummyModuleId, name: name, typeParams: typeParams, fields: fields)
 
       self._functionStructs[name] = struct

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1551,103 +1551,43 @@ export type Compiler {
         // In this case, consider the following example:
         //   func foo(): Int = ...
         //   callFn(foo)
-        // Create a wrapper of higher arity which discards parameters.
-        val numDiscardedParams = targetArity - numParams
-        var wrapperSuffix = "..w"
-        val discardedParamTypeReprs: String[] = []
-        for d in range(0, numDiscardedParams) {
-          val paramTy = if fnValParamTypes[numParams + d] |p| p else return unreachable("expected param type to exist at idx ${targetArity + d}", position)
-          discardedParamTypeReprs.push(paramTy.repr())
-          val _t = match self._getInstanceTypeForType(paramTy) { Ok(v) => v, Err(e) => return Err(e) }
-          // TODO: destructuring
-          val instTy = _t[0]
-          val typeArgs = _t[1]
-          val instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
-
-          val resolvedGenerics: Map<String, Type> = {}
-          val typeParams = match instTy {
-            StructOrEnum.Struct(s) => s.typeParams
-            StructOrEnum.Enum(e) => e.typeParams
-          }
-          val template = Type(kind: TypeKind.Instance(instTy, typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
-          for _p in instType.extractGenerics(template) {
-            resolvedGenerics[_p[0]] = _p[1]
-          }
-          match self._resolvedGenerics.addLayer("discarded param $d", resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: "discarded param $d", message: e))) }
-
-          val _paramTypeName = match instTy {
-            StructOrEnum.Struct(s) => self._structTypeName(s)
-            StructOrEnum.Enum(e) => self._enumTypeName(e)
-          }
-          val paramTypeName = match _paramTypeName { Ok(v) => v, Err(e) => return Err(e) }
-          self._resolvedGenerics.popLayer()
-
-          wrapperSuffix += "D${d + 1}$paramTypeName"
-        }
-        val wrapperFnName = self._fnName(fn) + wrapperSuffix
-        if self._builder.getFunction(wrapperFnName) |wrapperFnVal| {
-          wrapperFnVal
-        } else {
-          val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
-          val wrapperFnVal = self._builder.buildFunction(name: wrapperFnName, returnType: returnTypeQbe)
-
-          val prevFn = self._currentFn
-          self._currentFn = wrapperFnVal
-
-          val args: Value[] = []
-          for paramType, idx in fnValParamTypes {
-            val paramTy = match self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
-            if fn.params[idx] |param| {
-              args.push(wrapperFnVal.addParameter(param.label.name, paramTy))
-            } else {
-              wrapperFnVal.addParameter("_$idx", paramTy)
-            }
-          }
-
-          if fn.returnType.kind != TypeKind.PrimitiveUnit {
-            val res = match self._currentFn.block.buildCall(Callable.Function(fnValBase), args) { Ok(v) => v, Err(e) => return qbeError(e) }
-            wrapperFnVal.block.buildReturn(Some(res))
-          } else {
-            wrapperFnVal.block.buildReturn(None)
-          }
-
-          self._currentFn = prevFn
-
-          wrapperFnVal.addComment("Parameter-discarding wrapper for ${self._fnName(fn)}, adding discarded params: ${discardedParamTypeReprs.join(", ")}")
-          wrapperFnVal
-        }
+        // Create a wrapper of higher arity which discards parameters (and which doesn't consider default-valued parameters, since we
+        // know the wrapped function does not have any).
+        val wrapper = match self._compileParamDiscardingFunctionWrapper(targetArity, numParams, fnValParamTypes, fn, fnValBase, position, false) { Ok(v) => v, Err(e) => return Err(e) }
+        wrapper
       }
-    // } else if targetArity < fnNumReqParams {
-    //   // In this case, consider the following example:
-    //   //   func foo(a: Int, b: Int, c = 12): Int = ...
-    //   //   callFn(foo)
-    //   // In this case, typechecking fails since `callFn` won't provide a value for the parameter `b`.
-    //   // This is similar to the case above, except here we have an optional parameter.
-    //   return unreachable("This should be caught during typechecking", position)
-    // } else if fnNumReqParams <= targetArity && targetArity <= numParams {
-    //   // In this case, we need to "artificially (monotonically) shrink" the arity of the underlying function.
-    //   // It's "monotonically" because the arity itself might not actually shrink; consider this example:
-    //   //   func foo(x = 12): Int = ...
-    //   //   callFn(foo)
-    //   // In this case, the optional parameter `x` must be treated as if it's a required parameter, and so the
-    //   // arity of the wrapper function becomes 1.
-    //   // Nominally though, the arity must be artificially shrunk in these cases:
-    //   //   func foo1(x: Int, y = 12): Int = ...
-    //   //   callFn(foo1)
-    //   //   func foo2(x = 12, y = 16): Int = ...
-    //   //   callFn(foo2)
-    //   // In the case of `foo1`, the wrapper function has arity 1 and the parameter `y` will receive its default
-    //   // value. In the case of `foo2`, the wrapper function still has arity 1 and the parameter `y` will still
-    //   // receive its default value, but `x` will _not_.
-    //   return todo("default-valued param wrapper", position)
-    // } else if targetArity > numParams {
-    //   // In this case, consider the following example:
-    //   //   func callFn2(fn: (Int, Int, Int) => Int) = ...
-    //   //   func foo(x: Int, y = 12): Int = ...
-    //   //   callFn2(foo)
-    //   // Create a wrapper function of higher arity which discards parameters and _also_ passes 0 to the optional params flag; we know we can do this
-    //   // because in order to reach this case, it must be the case that all of the optional parameters are passed a value.
-    //   return todo("param-discarding wrapper", position)
+    } else if targetArity < fnNumReqParams {
+      // In this case, consider the following example:
+      //   func foo(a: Int, b: Int, c = 12): Int = ...
+      //   callFn(foo)
+      // In this case, typechecking fails since `callFn` won't provide a value for the parameter `b`.
+      // This is similar to the case above, except here we have an optional parameter.
+      return unreachable("This should be caught during typechecking", position)
+    } else if fnNumReqParams <= targetArity && targetArity <= numParams {
+      // In this case, we need to "artificially (monotonically) shrink" the arity of the underlying function.
+      // It's "monotonically" because the arity itself might not actually shrink; consider this example:
+      //   func foo(x = 12): Int = ...
+      //   callFn(foo)
+      // In this case, the optional parameter `x` must be treated as if it's a required parameter, and so the
+      // arity of the wrapper function becomes 1.
+      // Nominally though, the arity must be artificially shrunk in these cases:
+      //   func foo1(x: Int, y = 12): Int = ...
+      //   callFn(foo1)
+      //   func foo2(x = 12, y = 16): Int = ...
+      //   callFn(foo2)
+      // In the case of `foo1`, the wrapper function has arity 1 and the parameter `y` will receive its default
+      // value. In the case of `foo2`, the wrapper function still has arity 1 and the parameter `y` will still
+      // receive its default value, but `x` will _not_.
+      return todo("default-valued param wrapper", position)
+    } else if targetArity > numParams {
+      // In this case, consider the following example:
+      //   func callFn2(fn: (Int, Int, Int) => Int) = ...
+      //   func foo(x: Int, y = 12): Int = ...
+      //   callFn2(foo)
+      // Create a wrapper function of higher arity which discards parameters and _also_ passes 0 to the optional params flag; we know we can do this
+      // because in order to reach this case, it must be the case that all of the optional parameters are passed a value.
+      val wrapper = match self._compileParamDiscardingFunctionWrapper(targetArity, numParams, fnValParamTypes, fn, fnValBase, position, true) { Ok(v) => v, Err(e) => return Err(e) }
+      wrapper
     } else {
       return todo("the rest of the cases", position)
     }
@@ -1669,6 +1609,87 @@ export type Compiler {
 
     val res = match self._currentFn.block.buildCall(Callable.Function(initFnVal), [Value.Global(fnVal.name, QbeType.Pointer)]) { Ok(v) => v, Err(e) => return qbeError(e) }
     Ok(res)
+  }
+
+  func _compileParamDiscardingFunctionWrapper(
+    self,
+    targetArity: Int,
+    numParams: Int,
+    fnValParamTypes: Type[],
+    fn: Function,
+    fnValBase: QbeFunction,
+    position: Position,
+    passDefaultParamMask: Bool,
+  ): Result<QbeFunction, CompileError> {
+    val numDiscardedParams = targetArity - numParams
+    var wrapperSuffix = "..w"
+    val discardedParamTypeReprs: String[] = []
+    for d in range(0, numDiscardedParams) {
+      val paramTy = if fnValParamTypes[numParams + d] |p| p else return unreachable("expected param type to exist at idx ${targetArity + d}", position)
+      discardedParamTypeReprs.push(paramTy.repr())
+      val _t = match self._getInstanceTypeForType(paramTy) { Ok(v) => v, Err(e) => return Err(e) }
+      // TODO: destructuring
+      val instTy = _t[0]
+      val typeArgs = _t[1]
+      val instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
+
+      val resolvedGenerics: Map<String, Type> = {}
+      val typeParams = match instTy {
+        StructOrEnum.Struct(s) => s.typeParams
+        StructOrEnum.Enum(e) => e.typeParams
+      }
+      val template = Type(kind: TypeKind.Instance(instTy, typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+      for _p in instType.extractGenerics(template) {
+        resolvedGenerics[_p[0]] = _p[1]
+      }
+      match self._resolvedGenerics.addLayer("discarded param $d", resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: "discarded param $d", message: e))) }
+
+      val _paramTypeName = match instTy {
+        StructOrEnum.Struct(s) => self._structTypeName(s)
+        StructOrEnum.Enum(e) => self._enumTypeName(e)
+      }
+      val paramTypeName = match _paramTypeName { Ok(v) => v, Err(e) => return Err(e) }
+      self._resolvedGenerics.popLayer()
+
+      wrapperSuffix += "D${d + 1}$paramTypeName"
+    }
+    val wrapperFnName = self._fnName(fn) + wrapperSuffix
+
+    if self._builder.getFunction(wrapperFnName) |wrapperFnVal| return Ok(wrapperFnVal)
+
+    val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+    val wrapperFnVal = self._builder.buildFunction(name: wrapperFnName, returnType: returnTypeQbe)
+
+    val prevFn = self._currentFn
+    self._currentFn = wrapperFnVal
+
+    val args: Value[] = []
+    for paramType, idx in fnValParamTypes {
+      val paramTy = match self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+      if fn.params[idx] |param| {
+        args.push(wrapperFnVal.addParameter(param.label.name, paramTy))
+      } else {
+        wrapperFnVal.addParameter("_$idx", paramTy)
+      }
+    }
+
+    if passDefaultParamMask {
+      args.push(Value.Int32(0))
+    }
+
+    val ret = if fn.returnType.kind != TypeKind.PrimitiveUnit {
+      val res = match self._currentFn.block.buildCall(Callable.Function(fnValBase), args) { Ok(v) => v, Err(e) => return qbeError(e) }
+      Some(res)
+    } else {
+      self._currentFn.block.buildVoidCall(Callable.Function(fnValBase), args)
+      None
+    }
+    wrapperFnVal.block.buildReturn(ret)
+
+    self._currentFn = prevFn
+
+    wrapperFnVal.addComment("Parameter-discarding wrapper for ${self._fnName(fn)}, adding discarded params: ${discardedParamTypeReprs.join(", ")}")
+    Ok(wrapperFnVal)
   }
 
   func _constructString(self, ptrVal: Value, lenVal: Value, localName: String? = None): Result<Value, CompileError> {

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1532,15 +1532,13 @@ export type Compiler {
     }
     val targetArity = fnValParamTypes.length
 
-    val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
-
     // For the cases below, consider the function
     //   func callFn(fn: (Int) => Int) = ...
-    val fnVal = if fnNumOptParams == 0 {
+    val fnValRes = if fnNumOptParams == 0 {
       if targetArity == numParams {
         // If the referenced function's arity matches the required arity, and it has no optional parameters,
         // then we don't need to create a wrapper for it.
-        fnValBase
+        self._getOrCompileFunction(fn)
       } else if targetArity < numParams {
         // In this case, consider the following example:
         //   func foo(a: Int, b: Int): Int = ...
@@ -1553,8 +1551,7 @@ export type Compiler {
         //   callFn(foo)
         // Create a wrapper of higher arity which discards parameters (and which doesn't consider default-valued parameters, since we
         // know the wrapped function does not have any).
-        val wrapper = match self._compileParamDiscardingFunctionWrapper(targetArity, numParams, fnValParamTypes, fn, fnValBase, position, false) { Ok(v) => v, Err(e) => return Err(e) }
-        wrapper
+        self._compileParamDiscardingFunctionWrapper(fnValParamTypes, fn, position, false)
       }
     } else if targetArity < fnNumReqParams {
       // In this case, consider the following example:
@@ -1578,7 +1575,52 @@ export type Compiler {
       // In the case of `foo1`, the wrapper function has arity 1 and the parameter `y` will receive its default
       // value. In the case of `foo2`, the wrapper function still has arity 1 and the parameter `y` will still
       // receive its default value, but `x` will _not_.
-      return todo("default-valued param wrapper", position)
+      val firstOptionalParamIdxBeingGivenDefaultValue = targetArity - fnNumReqParams
+      val numOptionalParamsBeingGivenDefaultValue = fn.params.length - fnNumReqParams - firstOptionalParamIdxBeingGivenDefaultValue
+      val wrapperFnName = self._fnName(fn) + "..wd$numOptionalParamsBeingGivenDefaultValue"
+
+      if self._builder.getFunction(wrapperFnName) |wrapperFnVal| {
+        Ok(wrapperFnVal)
+      } else {
+        val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+        val wrapperFnVal = self._builder.buildFunction(name: wrapperFnName, returnType: returnTypeQbe)
+
+        val prevFn = self._currentFn
+        self._currentFn = wrapperFnVal
+
+        val args: Value[] = []
+        for paramType, idx in fnValParamTypes {
+          val paramTy = match self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+          if fn.params[idx] |param| {
+            args.push(wrapperFnVal.addParameter(param.label.name, paramTy))
+          } else {
+            wrapperFnVal.addParameter("_$idx", paramTy)
+          }
+        }
+
+        var defaultMaskFlag = 0
+        for paramToDefault, idx in fn.params[targetArity:] {
+          val paramTy = match self._getQbeTypeForTypeExpect(paramToDefault.ty, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+          args.push(paramTy.zeroValue())
+          defaultMaskFlag ||= (1 << (firstOptionalParamIdxBeingGivenDefaultValue + idx))
+        }
+        args.push(Value.Int32(defaultMaskFlag))
+
+        val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
+        val ret = if fn.returnType.kind != TypeKind.PrimitiveUnit {
+          val res = match self._currentFn.block.buildCall(Callable.Function(fnValBase), args) { Ok(v) => v, Err(e) => return qbeError(e) }
+          Some(res)
+        } else {
+          self._currentFn.block.buildVoidCall(Callable.Function(fnValBase), args)
+          None
+        }
+        wrapperFnVal.block.buildReturn(ret)
+
+        self._currentFn = prevFn
+
+        wrapperFnVal.addComment("Wrapper for ${self._fnName(fn)} in which the last $numOptionalParamsBeingGivenDefaultValue default-valued parameters receive their default value")
+        Ok(wrapperFnVal)
+      }
     } else if targetArity > numParams {
       // In this case, consider the following example:
       //   func callFn2(fn: (Int, Int, Int) => Int) = ...
@@ -1586,11 +1628,11 @@ export type Compiler {
       //   callFn2(foo)
       // Create a wrapper function of higher arity which discards parameters and _also_ passes 0 to the optional params flag; we know we can do this
       // because in order to reach this case, it must be the case that all of the optional parameters are passed a value.
-      val wrapper = match self._compileParamDiscardingFunctionWrapper(targetArity, numParams, fnValParamTypes, fn, fnValBase, position, true) { Ok(v) => v, Err(e) => return Err(e) }
-      wrapper
+      self._compileParamDiscardingFunctionWrapper(fnValParamTypes, fn, position, true)
     } else {
-      return todo("the rest of the cases", position)
+      return unreachable("All valid cases exhausted above", position)
     }
+    val fnVal = match fnValRes { Ok(v) => v, Err(e) => return Err(e) }
 
     val hasReturn = fn.returnType.kind != TypeKind.PrimitiveUnit
     val struct = self._functionStruct(targetArity, hasReturn)
@@ -1611,21 +1653,11 @@ export type Compiler {
     Ok(res)
   }
 
-  func _compileParamDiscardingFunctionWrapper(
-    self,
-    targetArity: Int,
-    numParams: Int,
-    fnValParamTypes: Type[],
-    fn: Function,
-    fnValBase: QbeFunction,
-    position: Position,
-    passDefaultParamMask: Bool,
-  ): Result<QbeFunction, CompileError> {
-    val numDiscardedParams = targetArity - numParams
+  func _compileParamDiscardingFunctionWrapper(self, fnValParamTypes: Type[], fn: Function, position: Position, passDefaultParamMask: Bool): Result<QbeFunction, CompileError> {
     var wrapperSuffix = "..w"
+    val numParams = fn.params.length
     val discardedParamTypeReprs: String[] = []
-    for d in range(0, numDiscardedParams) {
-      val paramTy = if fnValParamTypes[numParams + d] |p| p else return unreachable("expected param type to exist at idx ${targetArity + d}", position)
+    for paramTy, idx in fnValParamTypes[numParams:] {
       discardedParamTypeReprs.push(paramTy.repr())
       val _t = match self._getInstanceTypeForType(paramTy) { Ok(v) => v, Err(e) => return Err(e) }
       // TODO: destructuring
@@ -1642,7 +1674,7 @@ export type Compiler {
       for _p in instType.extractGenerics(template) {
         resolvedGenerics[_p[0]] = _p[1]
       }
-      match self._resolvedGenerics.addLayer("discarded param $d", resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: "discarded param $d", message: e))) }
+      match self._resolvedGenerics.addLayer("discarded param $idx", resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: "discarded param $idx", message: e))) }
 
       val _paramTypeName = match instTy {
         StructOrEnum.Struct(s) => self._structTypeName(s)
@@ -1651,7 +1683,7 @@ export type Compiler {
       val paramTypeName = match _paramTypeName { Ok(v) => v, Err(e) => return Err(e) }
       self._resolvedGenerics.popLayer()
 
-      wrapperSuffix += "D${d + 1}$paramTypeName"
+      wrapperSuffix += "D${idx + 1}$paramTypeName"
     }
     val wrapperFnName = self._fnName(fn) + wrapperSuffix
 
@@ -1672,11 +1704,9 @@ export type Compiler {
         wrapperFnVal.addParameter("_$idx", paramTy)
       }
     }
+    if passDefaultParamMask args.push(Value.Int32(0))
 
-    if passDefaultParamMask {
-      args.push(Value.Int32(0))
-    }
-
+    val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
     val ret = if fn.returnType.kind != TypeKind.PrimitiveUnit {
       val res = match self._currentFn.block.buildCall(Callable.Function(fnValBase), args) { Ok(v) => v, Err(e) => return qbeError(e) }
       Some(res)

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1373,7 +1373,20 @@ export type Compiler {
           }
         }
       }
-      TypedAstNodeKind.Lambda => todo("compiling lambda expression", node.token.position)
+      TypedAstNodeKind.Lambda(fn, typeHint) => {
+        val targetParamTypes = if typeHint |hint| {
+          val paramTypes = match hint.kind {
+            TypeKind.Func(paramTypes, _) => Some(paramTypes)
+            TypeKind.Any => None // if the function value is being treated as an Any, then no param type info needs to be known later anyway
+            _ => return unreachable("typeKind must be TypeKind.Func", node.token.position)
+          }
+          paramTypes
+        } else {
+          None
+        }
+
+        self._compileFunctionValue(node.token.position, fn, targetParamTypes)
+      }
       TypedAstNodeKind.If(isStatement, cond, conditionBinding, ifBlock, ifBlockTerminator, elseBlock, elseBlockTerminator) => {
         if isStatement return unreachable("if-statements are handled elsewhere", node.token.position)
         if elseBlock.isEmpty() return unreachable("if-expressions must not have empty else-blocks", node.token.position)

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -906,7 +906,7 @@ export type Compiler {
         }
       }
       TypedAstNodeKind.Grouped(inner) => self._compileExpression(inner, resultLocalName)
-      TypedAstNodeKind.Identifier(name, variable) => {
+      TypedAstNodeKind.Identifier(name, variable, fnAliasTypeHint) => {
         // If a variable is function parameter, it can just be referenced by name as a temporary/local, otherwise it can be obtained by
         // loading the value pointed to by the temporary/local with that name.
         // TODO: handle captured variables in closures, global variables, etc).
@@ -916,25 +916,18 @@ export type Compiler {
         } else {
           match variable.alias {
             VariableAlias.Function(fn) => {
-              val fnVal = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
-
-              val hasReturn = fn.returnType.kind != TypeKind.PrimitiveUnit
-              val struct = self._functionStruct(fn.params.length, hasReturn)
-              val typeArgs = (if hasReturn { [fn.returnType] } else []).concat(fn.params.map(p => p.ty))
-              val selfType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
-
-              val resolvedGenerics: Map<String, Type> = {}
-              val template = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
-              for _p in selfType.extractGenerics(template) {
-                resolvedGenerics[_p[0]] = _p[1]
+              val targetParamTypes = if fnAliasTypeHint |hint| {
+                val paramTypes = match hint.kind {
+                  TypeKind.Func(paramTypes, _) => Some(paramTypes)
+                  TypeKind.Any => None // if the function value is being treated as an Any, then no param type info needs to be known later anyway
+                  _ => return unreachable("fnAliasTypeKind must be TypeKind.Func", node.token.position)
+                }
+                paramTypes
+              } else {
+                None
               }
-              match self._resolvedGenerics.addLayer(struct.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: struct.label.name, message: e))) }
-              val initFnVal = match self._getOrCompileStructInitializer(struct) { Ok(v) => v, Err(e) => return Err(e) }
 
-              self._resolvedGenerics.popLayer()
-
-              val res = match self._currentFn.block.buildCall(Callable.Function(initFnVal), [Value.Global(fnVal.name, QbeType.Pointer)]) { Ok(v) => v, Err(e) => return qbeError(e) }
-              Ok(res)
+              self._compileFunctionValue(node.token.position, fn, targetParamTypes)
             }
             _ => {
               val slot = Value.Ident("$name.slot", QbeType.Pointer)
@@ -1519,6 +1512,163 @@ export type Compiler {
     } else {
       Ok(res)
     }
+  }
+
+  func _compileFunctionValue(self, position: Position, fn: Function, targetParamTypes: (Type, Bool)[]?): Result<Value, CompileError> {
+    val numParams = fn.params.length
+    var fnNumReqParams = 0
+    var fnNumOptParams = 0
+    for param in fn.params {
+      if !!param.defaultValue {
+        fnNumOptParams += 1
+      } else {
+        fnNumReqParams += 1
+      }
+    }
+    val fnValParamTypes = if targetParamTypes |paramTypes| {
+      paramTypes.filter(_p => _p[1]).map(_p => _p[0])
+    } else {
+      fn.params.filter(p => !p.defaultValue).map(p => p.ty)
+    }
+    val targetArity = fnValParamTypes.length
+
+    val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
+
+    // For the cases below, consider the function
+    //   func callFn(fn: (Int) => Int) = ...
+    val fnVal = if fnNumOptParams == 0 {
+      if targetArity == numParams {
+        // If the referenced function's arity matches the required arity, and it has no optional parameters,
+        // then we don't need to create a wrapper for it.
+        fnValBase
+      } else if targetArity < numParams {
+        // In this case, consider the following example:
+        //   func foo(a: Int, b: Int): Int = ...
+        //   callFn(foo)
+        // In this case, typechecking fails since `callFn` won't provide a value for the parameter `b`.
+        return unreachable("This should have been caught during typechecking", position)
+      } else {
+        // In this case, consider the following example:
+        //   func foo(): Int = ...
+        //   callFn(foo)
+        // Create a wrapper of higher arity which discards parameters.
+        val numDiscardedParams = targetArity - numParams
+        var wrapperSuffix = "..w"
+        val discardedParamTypeReprs: String[] = []
+        for d in range(0, numDiscardedParams) {
+          val paramTy = if fnValParamTypes[numParams + d] |p| p else return unreachable("expected param type to exist at idx ${targetArity + d}", position)
+          discardedParamTypeReprs.push(paramTy.repr())
+          val _t = match self._getInstanceTypeForType(paramTy) { Ok(v) => v, Err(e) => return Err(e) }
+          // TODO: destructuring
+          val instTy = _t[0]
+          val typeArgs = _t[1]
+          val instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
+
+          val resolvedGenerics: Map<String, Type> = {}
+          val typeParams = match instTy {
+            StructOrEnum.Struct(s) => s.typeParams
+            StructOrEnum.Enum(e) => e.typeParams
+          }
+          val template = Type(kind: TypeKind.Instance(instTy, typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+          for _p in instType.extractGenerics(template) {
+            resolvedGenerics[_p[0]] = _p[1]
+          }
+          match self._resolvedGenerics.addLayer("discarded param $d", resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: "discarded param $d", message: e))) }
+
+          val _paramTypeName = match instTy {
+            StructOrEnum.Struct(s) => self._structTypeName(s)
+            StructOrEnum.Enum(e) => self._enumTypeName(e)
+          }
+          val paramTypeName = match _paramTypeName { Ok(v) => v, Err(e) => return Err(e) }
+          self._resolvedGenerics.popLayer()
+
+          wrapperSuffix += "D${d + 1}$paramTypeName"
+        }
+        val wrapperFnName = self._fnName(fn) + wrapperSuffix
+        if self._builder.getFunction(wrapperFnName) |wrapperFnVal| {
+          wrapperFnVal
+        } else {
+          val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+          val wrapperFnVal = self._builder.buildFunction(name: wrapperFnName, returnType: returnTypeQbe)
+
+          val prevFn = self._currentFn
+          self._currentFn = wrapperFnVal
+
+          val args: Value[] = []
+          for paramType, idx in fnValParamTypes {
+            val paramTy = match self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+            if fn.params[idx] |param| {
+              args.push(wrapperFnVal.addParameter(param.label.name, paramTy))
+            } else {
+              wrapperFnVal.addParameter("_$idx", paramTy)
+            }
+          }
+
+          if fn.returnType.kind != TypeKind.PrimitiveUnit {
+            val res = match self._currentFn.block.buildCall(Callable.Function(fnValBase), args) { Ok(v) => v, Err(e) => return qbeError(e) }
+            wrapperFnVal.block.buildReturn(Some(res))
+          } else {
+            wrapperFnVal.block.buildReturn(None)
+          }
+
+          self._currentFn = prevFn
+
+          wrapperFnVal.addComment("Parameter-discarding wrapper for ${self._fnName(fn)}, adding discarded params: ${discardedParamTypeReprs.join(", ")}")
+          wrapperFnVal
+        }
+      }
+    // } else if targetArity < fnNumReqParams {
+    //   // In this case, consider the following example:
+    //   //   func foo(a: Int, b: Int, c = 12): Int = ...
+    //   //   callFn(foo)
+    //   // In this case, typechecking fails since `callFn` won't provide a value for the parameter `b`.
+    //   // This is similar to the case above, except here we have an optional parameter.
+    //   return unreachable("This should be caught during typechecking", position)
+    // } else if fnNumReqParams <= targetArity && targetArity <= numParams {
+    //   // In this case, we need to "artificially (monotonically) shrink" the arity of the underlying function.
+    //   // It's "monotonically" because the arity itself might not actually shrink; consider this example:
+    //   //   func foo(x = 12): Int = ...
+    //   //   callFn(foo)
+    //   // In this case, the optional parameter `x` must be treated as if it's a required parameter, and so the
+    //   // arity of the wrapper function becomes 1.
+    //   // Nominally though, the arity must be artificially shrunk in these cases:
+    //   //   func foo1(x: Int, y = 12): Int = ...
+    //   //   callFn(foo1)
+    //   //   func foo2(x = 12, y = 16): Int = ...
+    //   //   callFn(foo2)
+    //   // In the case of `foo1`, the wrapper function has arity 1 and the parameter `y` will receive its default
+    //   // value. In the case of `foo2`, the wrapper function still has arity 1 and the parameter `y` will still
+    //   // receive its default value, but `x` will _not_.
+    //   return todo("default-valued param wrapper", position)
+    // } else if targetArity > numParams {
+    //   // In this case, consider the following example:
+    //   //   func callFn2(fn: (Int, Int, Int) => Int) = ...
+    //   //   func foo(x: Int, y = 12): Int = ...
+    //   //   callFn2(foo)
+    //   // Create a wrapper function of higher arity which discards parameters and _also_ passes 0 to the optional params flag; we know we can do this
+    //   // because in order to reach this case, it must be the case that all of the optional parameters are passed a value.
+    //   return todo("param-discarding wrapper", position)
+    } else {
+      return todo("the rest of the cases", position)
+    }
+
+    val hasReturn = fn.returnType.kind != TypeKind.PrimitiveUnit
+    val struct = self._functionStruct(targetArity, hasReturn)
+    val typeArgs = (if hasReturn { [fn.returnType] } else []).concat(fnValParamTypes)
+    val selfType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
+
+    val resolvedGenerics: Map<String, Type> = {}
+    val template = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+    for _p in selfType.extractGenerics(template) {
+      resolvedGenerics[_p[0]] = _p[1]
+    }
+    match self._resolvedGenerics.addLayer(struct.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: struct.label.name, message: e))) }
+    val initFnVal = match self._getOrCompileStructInitializer(struct) { Ok(v) => v, Err(e) => return Err(e) }
+
+    self._resolvedGenerics.popLayer()
+
+    val res = match self._currentFn.block.buildCall(Callable.Function(initFnVal), [Value.Global(fnVal.name, QbeType.Pointer)]) { Ok(v) => v, Err(e) => return qbeError(e) }
+    Ok(res)
   }
 
   func _constructString(self, ptrVal: Value, lenVal: Value, localName: String? = None): Result<Value, CompileError> {

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -166,6 +166,7 @@ export type Compiler {
   _builder: ModuleBuilder
   _currentModule: TypedModule
   _currentFn: QbeFunction
+  _currentFunction: Function?
   _currentNode: TypedAstNode?
   _resolvedGenerics: ResolvedGenerics = ResolvedGenerics()
   _loopStack: (/* loopStart: */ Label, /* loopEnd: */ Label)[] = []
@@ -185,7 +186,7 @@ export type Compiler {
     fn.addComment("main entrypoint function")
     val mainFnBlock = fn.block
 
-    val compiler = Compiler(_project: project, _builder: builder, _currentModule: entry, _currentNode: None, _currentFn: fn)
+    val compiler = Compiler(_project: project, _builder: builder, _currentModule: entry, _currentNode: None, _currentFn: fn, _currentFunction: None)
 
     val moduleFn = match compiler._compileModule(entry) { Ok(v) => v, Err(e) => {
       // println(compiler._currentNode?.token)
@@ -511,16 +512,49 @@ export type Compiler {
 
         val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
         val slotName = "${variable.label.name}.slot"
-        val slot = self._buildStackAllocForQbeType(varTy, Some(slotName))
 
         if bindingDeclNode.expr |expr| {
           val res = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
-          self._currentFn.block.buildStore(varTy, res, slot)
+          if variable.isCaptured {
+            self._currentFn.block.addComment("move captured '${variable.label.name}' to heap")
+            val size = varTy.size()
+            val heapMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+            self._currentFn.block.buildStore(varTy, res, heapMem)
+
+            val slot = self._buildStackAllocForQbeType(QbeType.Pointer, Some(slotName))
+            self._currentFn.block.buildStore(QbeType.Pointer, heapMem, slot)
+          } else {
+            val slot = self._buildStackAllocForQbeType(varTy, Some(slotName))
+            self._currentFn.block.buildStore(varTy, res, slot)
+          }
         }
 
         Ok(None)
       }
-      TypedAstNodeKind.FunctionDeclaration => Ok(None)
+      TypedAstNodeKind.FunctionDeclaration(fn) => {
+        if !fn.captures.isEmpty() {
+          val capturesName = "${fn.label.name}.captures"
+          val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some(capturesName))
+
+          var size = 0
+          for variable in fn.captures {
+            val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+            size += varTy.size()
+          }
+          val capturesMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+          var cursor = capturesMem
+
+          for variable in fn.captures {
+            val ptr = match self._getCapturedVarPtr(variable.label.name) { Ok(v) => v, Err(e) => return Err(e) }
+            self._currentFn.block.buildStore(QbeType.Pointer, ptr, cursor)
+            cursor = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), cursor) { Ok(v) => v, Err(e) => return qbeError(e) }
+          }
+
+          self._currentFn.block.buildStore(QbeType.Pointer, capturesMem, capturesSlot)
+        }
+
+        Ok(None)
+      }
       TypedAstNodeKind.TypeDeclaration => Ok(None)
       TypedAstNodeKind.EnumDeclaration => Ok(None)
       TypedAstNodeKind.Break => {
@@ -563,10 +597,16 @@ export type Compiler {
           TypedAssignmentMode.Variable(variable) => {
             if variable.isParameter return unreachable("parameters cannot be reassigned to", node.token.position)
 
-            val slotName = "${variable.label.name}.slot"
-            val slot = Value.Ident(slotName, QbeType.Pointer)
             val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
-            self._currentFn.block.buildStore(varTy, res, slot)
+            if variable.isCaptured {
+              val ptr = match self._getCapturedVarPtr(variable.label.name) { Ok(v) => v, Err(e) => return Err(e) }
+              self._currentFn.block.addComment("overwrite ptr to captured '${variable.label.name}'")
+              self._currentFn.block.buildStore(varTy, res, ptr)
+            } else {
+              val slotName = "${variable.label.name}.slot"
+              val slot = Value.Ident(slotName, QbeType.Pointer)
+              self._currentFn.block.buildStore(varTy, res, slot)
+            }
           }
           TypedAssignmentMode.Indexing(idxNode) => {
             match idxNode {
@@ -930,9 +970,16 @@ export type Compiler {
               self._compileFunctionValue(node.token.position, fn, targetParamTypes)
             }
             _ => {
-              val slot = Value.Ident("$name.slot", QbeType.Pointer)
-              val res = self._currentFn.block.buildLoad(varTy, slot)
-              Ok(res)
+              if variable.isCaptured {
+                val ptr = match self._getCapturedVarPtr(variable.label.name) { Ok(v) => v, Err(e) => return Err(e) }
+                self._currentFn.block.addComment("deref ptr to captured '${variable.label.name}'")
+                val res = self._currentFn.block.buildLoad(varTy, ptr)
+                Ok(res)
+              } else {
+                val slot = Value.Ident("$name.slot", QbeType.Pointer)
+                val res = self._currentFn.block.buildLoad(varTy, slot)
+                Ok(res)
+              }
             }
           }
         }
@@ -942,6 +989,7 @@ export type Compiler {
         val args: Value[] = []
         var fnHasOptionalParameters = false
         var optSafeCtx: (Label, Value?, QbeFunction, Label)? = None
+        var closureEnvPtr: Value? = None
 
         val _p = match invokee {
           TypedInvokee.Function(fn) => {
@@ -965,6 +1013,10 @@ export type Compiler {
               val res = self._invokeCBindingFn(dec, fn, arguments)
               self._resolvedGenerics.popLayer()
               return res
+            }
+
+            if !fn.captures.isEmpty() {
+              closureEnvPtr = Some(self._getCapturesForClosure(fn))
             }
 
             fnHasOptionalParameters = fn.params.any(p => !!p.defaultValue)
@@ -995,6 +1047,10 @@ export type Compiler {
               val res = self._invokeIntrinsicFn(dec, fn, [Some(selfExpr)].concat(arguments))
               self._resolvedGenerics.popLayer()
               return res
+            }
+
+            if !fn.captures.isEmpty() {
+              closureEnvPtr = Some(self._getCapturesForClosure(fn))
             }
 
             fnHasOptionalParameters = fn.params.any(p => !!p.defaultValue)
@@ -1120,10 +1176,10 @@ export type Compiler {
         }
 
         var res = if fnVal.returnType() {
-          val res = match self._currentFn.block.buildCall(fnVal, args, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+          val res = match self._currentFn.block.buildCall(fnVal, args, resultLocalName, closureEnvPtr) { Ok(v) => v, Err(e) => return qbeError(e) }
           res
         } else {
-          self._currentFn.block.buildVoidCall(fnVal, args)
+          self._currentFn.block.buildVoidCall(fnVal, args, closureEnvPtr)
           Value.Ident("bogus", QbeType.F32)
         }
 
@@ -1473,6 +1529,34 @@ export type Compiler {
     res
   }
 
+  func _getCapturedVarPtr(self, name: String): Result<Value, CompileError> {
+    if self._currentFunction |fn| {
+      val fnCaptures = if self._currentFn._env |env| env else return unreachable("cannot resolve captured `$name`, current function has no `env` param", fn.label.position)
+      for v, idx in fn.captures {
+        if v.label.name == name {
+          self._currentFn.block.addComment("get ptr to captured '$name'")
+          val captureSlot = match self._currentFn.block.buildAdd(Value.Int(idx * QbeType.Pointer.size()), fnCaptures) { Ok(v) => v, Err(e) => return qbeError(e) }
+          val ptr = self._currentFn.block.buildLoad(QbeType.Pointer, captureSlot)
+          return Ok(ptr)
+        }
+      }
+    }
+
+    // If we're not currently in a function body, or if the captured variable is not a capture of the current function, then
+    // we need to undo the extra layer of pointer indirection which comes as a result of being captured by some other function.
+    self._currentFn.block.addComment("get ptr to captured '$name'")
+    val slot = Value.Ident("$name.slot", QbeType.Pointer)
+    val res = self._currentFn.block.buildLoad(QbeType.Pointer, slot)
+    Ok(res)
+  }
+
+  func _getCapturesForClosure(self, fn: Function): Value {
+    // TODO: this assumes that the closure is being called in the same scope in which it was declared (and thus the `*.captures`
+    // value is visible as a stack local). This does not hold true for nested scopes, and will need to be handled.
+    val capturesName = "${fn.label.name}.captures"
+    self._currentFn.block.buildLoadL(Value.Ident(capturesName, QbeType.Pointer))
+  }
+
   func _compileBinaryOperands(self, left: TypedAstNode, right: TypedAstNode, op: String): Result<(Value, Value), CompileError> {
     var leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
     var rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
@@ -1528,6 +1612,8 @@ export type Compiler {
   }
 
   func _compileFunctionValue(self, position: Position, fn: Function, targetParamTypes: (Type, Bool)[]?): Result<Value, CompileError> {
+    if !fn.captures.isEmpty() return todo("closures as values", fn.label.position)
+
     val numParams = fn.params.length
     var fnNumReqParams = 0
     var fnNumOptParams = 0
@@ -2385,6 +2471,8 @@ export type Compiler {
 
     val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
     val fnVal = self._builder.buildFunction(name: fnName, returnType: returnTypeQbe)
+    if !fn.captures.isEmpty() fnVal.addEnv()
+
     match self._compileFunc(fnVal, fn) { Ok(v) => v, Err(e) => return Err(e) }
     fnVal.addComment(match self._fnSignature(None, fn) { Ok(v) => v, Err(e) => return Err(e) })
 
@@ -2424,6 +2512,8 @@ export type Compiler {
   func _compileFunc(self, fnVal: QbeFunction, fn: Function): Result<Int, CompileError> {
     val prevFn = self._currentFn
     self._currentFn = fnVal
+    val prevFunction = self._currentFunction
+    self._currentFunction = Some(fn)
 
     var defaultValueParamIdx = 0
     var defaultValuesMaskParam: Value? = None
@@ -2477,6 +2567,7 @@ export type Compiler {
     fnVal.block.buildReturn(retVal)
 
     self._currentFn = prevFn
+    self._currentFunction = prevFunction
 
     Ok(0)
   }
@@ -2533,6 +2624,8 @@ export type Compiler {
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(stringTypeQbe))
     val prevFn = self._currentFn
     self._currentFn = fnVal
+    val prevFunction = self._currentFunction
+    self._currentFunction = Some(fn)
 
     val selfTyQbe = match self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self") { Ok(v) => v, Err(e) => return Err(e) }
     val selfParamVal = fnVal.addParameter("self", selfTyQbe)
@@ -2609,6 +2702,7 @@ export type Compiler {
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
     self._currentFn = prevFn
+    self._currentFunction = prevFunction
 
     Ok(fnVal)
   }
@@ -2953,6 +3047,8 @@ export type Compiler {
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(boolTypeQbe))
     val prevFn = self._currentFn
     self._currentFn = fnVal
+    val prevFunction = self._currentFunction
+    self._currentFunction = Some(fn)
 
     val selfTyQbe = match self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self") { Ok(v) => v, Err(e) => return Err(e) }
     val selfParamVal = fnVal.addParameter("self", selfTyQbe)
@@ -3032,6 +3128,7 @@ export type Compiler {
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
     self._currentFn = prevFn
+    self._currentFunction = prevFunction
 
     Ok(fnVal)
   }
@@ -3183,6 +3280,8 @@ export type Compiler {
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(intTypeQbe))
     val prevFn = self._currentFn
     self._currentFn = fnVal
+    val prevFunction = self._currentFunction
+    self._currentFunction = Some(fn)
 
     val selfTyQbe = match self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self") { Ok(v) => v, Err(e) => return Err(e) }
     val selfParamVal = fnVal.addParameter("self", selfTyQbe)
@@ -3246,6 +3345,7 @@ export type Compiler {
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
     self._currentFn = prevFn
+    self._currentFunction = prevFunction
 
     Ok(fnVal)
   }

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1,8 +1,8 @@
 import "fs" as fs
 import Position from "./lexer"
 import LiteralAstNode, UnaryOp, BinaryOp, AssignOp, BindingPattern, IndexingMode from "./parser"
-import Project, TypedModule, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode from "./typechecker"
-import ModuleBuilder, QbeType, Dest, QbeFunction, Value, Label from "./qbe"
+import Project, TypedModule, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias from "./typechecker"
+import ModuleBuilder, QbeType, Dest, QbeFunction, Value, Label, Callable from "./qbe"
 
 type CompilationError {
   modulePath: String
@@ -126,6 +126,17 @@ type ResolvedGenerics {
         }
         Ok(Type(kind: TypeKind.Tuple(resolvedGenerics)))
       }
+      TypeKind.Func(paramTypes, returnType) => {
+        val resolvedParams: (Type, Bool)[] = []
+        for _p in paramTypes {
+          // TODO: destructuring
+          val ty = match self._resolveType(_p[0]) { Ok(v) => v, Err(e) => return Err(e) }
+          resolvedParams.push((ty, _p[1]))
+        }
+        val resolvedReturn = match self._resolveType(returnType) { Ok(v) => v, Err(e) => return Err(e) }
+
+        Ok(Type(kind: TypeKind.Func(resolvedParams, resolvedReturn)))
+      }
       _ => Ok(ty)
     }
   }
@@ -165,6 +176,7 @@ export type Compiler {
   _malloc: QbeFunction = QbeFunction.spec(name: "GC_malloc", returnType: Some(QbeType.Pointer))
   _realloc: QbeFunction = QbeFunction.spec(name: "GC_realloc", returnType: Some(QbeType.Pointer))
   _tupleStructs: Map<String, Struct> = {}
+  _functionStructs: Map<String, Struct> = {}
 
   func compile(project: Project, entry: TypedModule): Result<ModuleBuilder, CompilationError> {
     val builder = ModuleBuilder()
@@ -180,7 +192,7 @@ export type Compiler {
       return Err(CompilationError(modulePath: entry.name, error: e))
     }}
     mainFnBlock.buildVoidCallRaw("GC_init", [])
-    mainFnBlock.buildVoidCall(moduleFn, [])
+    mainFnBlock.buildVoidCall(Callable.Function(moduleFn), [])
     mainFnBlock.buildReturn(Some(Value.Int(0)))
 
     match mainFnBlock.verify() { Ok(v) => v, Err(e) => return Err(CompilationError(modulePath: entry.name, error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e)))) }
@@ -206,10 +218,10 @@ export type Compiler {
           val dataPtr = self._builder.buildGlobalString("%s\\n")
           val tostringMethod = match self._getOrCompileToStringMethod(node.ty) { Ok(v) => v, Err(e) => return Err(e) }
 
-          val tostringRepr = match self._currentFn.block.buildCall(tostringMethod, [v], Some("_to_string_repr")) { Ok(v) => v, Err(e) => return qbeError(e) }
+          val tostringRepr = match self._currentFn.block.buildCall(Callable.Function(tostringMethod), [v], Some("_to_string_repr")) { Ok(v) => v, Err(e) => return qbeError(e) }
           val reprCharsPtr = match self._currentFn.block.buildAdd(Value.Int(8), tostringRepr, Some("_repr_chars_ptr")) { Ok(v) => v, Err(e) => return qbeError(e) }
           val reprChars = self._currentFn.block.buildLoadL(reprCharsPtr, Some("_repr_chars"))
-          self._currentFn.block.buildVoidCall(self._printf, [dataPtr, reprChars])
+          self._currentFn.block.buildVoidCall(Callable.Function(self._printf), [dataPtr, reprChars])
         }
       }
     }
@@ -364,7 +376,7 @@ export type Compiler {
               val iteratorFnVal = match self._getOrCompileMethod(instType, iteratorFn) { Ok(v) => v, Err(e) => return Err(e) }
               self._resolvedGenerics.popLayer()
 
-              val iter = match self._currentFn.block.buildCall(iteratorFnVal, [arrayVal], Some("iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val iter = match self._currentFn.block.buildCall(Callable.Function(iteratorFnVal), [arrayVal], Some("iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
               val _t = match self._getInstanceTypeForType(iteratorFn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
               // TODO: destructuring
@@ -386,7 +398,7 @@ export type Compiler {
               val iteratorFnVal = match self._getOrCompileMethod(instType, iteratorFn) { Ok(v) => v, Err(e) => return Err(e) }
               self._resolvedGenerics.popLayer()
 
-              val iter = match self._currentFn.block.buildCall(iteratorFnVal, [mapVal], Some("iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val iter = match self._currentFn.block.buildCall(Callable.Function(iteratorFnVal), [mapVal], Some("iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
               val _t = match self._getInstanceTypeForType(iteratorFn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
               // TODO: destructuring
@@ -409,7 +421,7 @@ export type Compiler {
               val iteratorFnVal = match self._getOrCompileMethod(instType, iteratorFn) { Ok(v) => v, Err(e) => return Err(e) }
               self._resolvedGenerics.popLayer()
 
-              val iter = match self._currentFn.block.buildCall(iteratorFnVal, [mapVal], Some("iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val iter = match self._currentFn.block.buildCall(Callable.Function(iteratorFnVal), [mapVal], Some("iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
               val _t = match self._getInstanceTypeForType(iteratorFn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
               // TODO: destructuring
@@ -464,7 +476,7 @@ export type Compiler {
         val itemName = match itemBindingPattern[0] {
           BindingPattern.Variable(label) => label.name
         }
-        val nextRet = match self._currentFn.block.buildCall(nextFnVal, [iterVal], Some("next_ret")) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val nextRet = match self._currentFn.block.buildCall(Callable.Function(nextFnVal), [iterVal], Some("next_ret")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
         val variantIsOptionSome = match self._emitOptValueIsSomeVariant(nextRet) { Ok(v) => v, Err(e) => return Err(e) }
         self._currentFn.block.buildJnz(variantIsOptionSome, loopBodyLabel, loopEndLabel)
@@ -577,7 +589,7 @@ export type Compiler {
                     val setFnVal = match self._getOrCompileMethod(instType, setFn) { Ok(v) => v, Err(e) => return Err(e) }
                     self._resolvedGenerics.popLayer()
 
-                    match self._currentFn.block.buildCall(setFnVal, [exprVal, idxExprVal, res]) { Ok(v) => v, Err(e) => return qbeError(e) }
+                    match self._currentFn.block.buildCall(Callable.Function(setFnVal), [exprVal, idxExprVal, res]) { Ok(v) => v, Err(e) => return qbeError(e) }
                   }
                   _ => return unreachable("cannot use range index in index-assignment")
                 }
@@ -599,7 +611,7 @@ export type Compiler {
                 val insertFnVal = match self._getOrCompileMethod(instType, insertFn) { Ok(v) => v, Err(e) => return Err(e) }
                 self._resolvedGenerics.popLayer()
 
-                match self._currentFn.block.buildCall(insertFnVal, [exprVal, idxExprVal, res]) { Ok(v) => v, Err(e) => return qbeError(e) }
+                match self._currentFn.block.buildCall(Callable.Function(insertFnVal), [exprVal, idxExprVal, res]) { Ok(v) => v, Err(e) => return qbeError(e) }
               }
               TypedIndexingNode.Tuple(_, _) => return unreachable("tuples are not assignable via index-assignment")
             }
@@ -691,7 +703,7 @@ export type Compiler {
                 val leftToStringFnVal = match self._getOrCompileToStringMethod(leftInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
                 self._resolvedGenerics.popLayer()
 
-                leftVal = match self._currentFn.block.buildCall(leftToStringFnVal, [leftVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+                leftVal = match self._currentFn.block.buildCall(Callable.Function(leftToStringFnVal), [leftVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
               }
 
               var rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
@@ -700,7 +712,7 @@ export type Compiler {
                 val rightToStringFnVal = match self._getOrCompileToStringMethod(rightInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
                 self._resolvedGenerics.popLayer()
 
-                rightVal = match self._currentFn.block.buildCall(rightToStringFnVal, [rightVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+                rightVal = match self._currentFn.block.buildCall(Callable.Function(rightToStringFnVal), [rightVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
               }
 
               val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
@@ -708,16 +720,16 @@ export type Compiler {
               val leftLength = self._currentFn.block.buildLoadL(leftVal)
               val rightLength = self._currentFn.block.buildLoadL(rightVal)
               val totalLength = match self._currentFn.block.buildAdd(leftLength, rightLength) { Ok(v) => v, Err(e) => return qbeError(e) }
-              val newString = match self._currentFn.block.buildCall(stringWithLengthFnVal, [totalLength]) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val newString = match self._currentFn.block.buildCall(Callable.Function(stringWithLengthFnVal), [totalLength]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
               var newBuffer = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), newString) { Ok(v) => v, Err(e) => return qbeError(e) })
 
               val leftBuffer = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), leftVal) { Ok(v) => v, Err(e) => return qbeError(e) })
-              self._currentFn.block.buildVoidCall(self._memcpy, [newBuffer, leftBuffer, leftLength])
+              self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [newBuffer, leftBuffer, leftLength])
 
               val rightBuffer = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), rightVal) { Ok(v) => v, Err(e) => return qbeError(e) })
               newBuffer = match self._currentFn.block.buildAdd(newBuffer, leftLength) { Ok(v) => v, Err(e) => return qbeError(e) }
-              self._currentFn.block.buildVoidCall(self._memcpy, [newBuffer, rightBuffer, rightLength])
+              self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [newBuffer, rightBuffer, rightLength])
 
               self._currentFn.block.addComment("...string concatenation end")
 
@@ -902,9 +914,34 @@ export type Compiler {
         if variable.isParameter {
           Ok(Value.Ident(name, varTy))
         } else {
-          val slot = Value.Ident("$name.slot", QbeType.Pointer)
-          val res = self._currentFn.block.buildLoad(varTy, slot)
-          Ok(res)
+          match variable.alias {
+            VariableAlias.Function(fn) => {
+              val fnVal = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
+
+              val hasReturn = fn.returnType.kind != TypeKind.PrimitiveUnit
+              val struct = self._functionStruct(fn.params.length, hasReturn)
+              val typeArgs = (if hasReturn { [fn.returnType] } else []).concat(fn.params.map(p => p.ty))
+              val selfType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
+
+              val resolvedGenerics: Map<String, Type> = {}
+              val template = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+              for _p in selfType.extractGenerics(template) {
+                resolvedGenerics[_p[0]] = _p[1]
+              }
+              match self._resolvedGenerics.addLayer(struct.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: struct.label.name, message: e))) }
+              val initFnVal = match self._getOrCompileStructInitializer(struct) { Ok(v) => v, Err(e) => return Err(e) }
+
+              self._resolvedGenerics.popLayer()
+
+              val res = match self._currentFn.block.buildCall(Callable.Function(initFnVal), [Value.Global(fnVal.name, QbeType.Pointer)]) { Ok(v) => v, Err(e) => return qbeError(e) }
+              Ok(res)
+            }
+            _ => {
+              val slot = Value.Ident("$name.slot", QbeType.Pointer)
+              val res = self._currentFn.block.buildLoad(varTy, slot)
+              Ok(res)
+            }
+          }
         }
       }
       TypedAstNodeKind.Accessor(head, middle, tail) => self._followAccessorPath(head: head, middle: middle, tail: tail, loadFinal: true, localName: resultLocalName)
@@ -951,8 +988,10 @@ export type Compiler {
               FunctionKind.InstanceMethod => return unreachable("instance methods handled elsewhere", node.token.position)
             }
 
+            self._resolvedGenerics.popLayer()
+
             val argMetadata = fn.params.map(p => (!!p.defaultValue, p.ty))
-            (fnVal, argMetadata)
+            (Callable.Function(fnVal), argMetadata)
           }
           TypedInvokee.Method(fn, selfExpr, isOptSafe) => {
             var selfInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(selfExpr.ty, fn.label.name, node.token.position, resolvedGenerics) { Ok(v) => v, Err(e) => return Err(e) }
@@ -987,7 +1026,7 @@ export type Compiler {
                 match self._resolvedGenerics.addLayer("Option.None", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.None", message: e))) }
                 val noneVariantFn = match self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant) { Ok(v) => v, Err(e) => return Err(e) }
                 self._resolvedGenerics.popLayer()
-                val noneRes = match self._currentFn.block.buildCall(noneVariantFn, []) { Ok(v) => v, Err(e) => return qbeError(e) }
+                val noneRes = match self._currentFn.block.buildCall(Callable.Function(noneVariantFn), []) { Ok(v) => v, Err(e) => return qbeError(e) }
                 Some(noneRes)
               } else None
               self._currentFn.block.buildJmp(labelCont)
@@ -1011,30 +1050,46 @@ export type Compiler {
             val fnVal = match self._getOrCompileMethod(selfInstanceType, fn) { Ok(v) => v, Err(e) => return Err(e) }
             args.push(selfVal)
 
+            self._resolvedGenerics.popLayer()
+
             val argMetadata = fn.params.map(p => (!!p.defaultValue, p.ty))
-            (fnVal, argMetadata)
+            (Callable.Function(fnVal), argMetadata)
           }
           TypedInvokee.Struct(struct) => {
             match self._resolvedGenerics.addLayer(struct.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: struct.label.name, message: e))) }
             fnHasOptionalParameters = struct.fields.any(f => !!f.initializer)
             val fnVal = match self._getOrCompileStructInitializer(struct) { Ok(v) => v, Err(e) => return Err(e) }
+
+            self._resolvedGenerics.popLayer()
+
             val argMetadata = struct.fields.map(f => (!!f.initializer, f.ty))
-            (fnVal, argMetadata)
+            (Callable.Function(fnVal), argMetadata)
           }
           TypedInvokee.EnumVariant(enum_, variant) => {
             match self._resolvedGenerics.addLayer(variant.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: variant.label.name, message: e))) }
             val enumVariantFn = match self._getOrCompileEnumVariantFn(enum_, variant) { Ok(v) => v, Err(e) => return Err(e) }
 
+            self._resolvedGenerics.popLayer()
+
             val argMetadata = match variant.kind {
               EnumVariantKind.Container(fields) => fields.map(f => (!!f.initializer, f.ty))
               _ => []
             }
-            (enumVariantFn, argMetadata)
+            (Callable.Function(enumVariantFn), argMetadata)
           }
-          TypedInvokee.Expr => return todo("invocation of arbitrary function expression", node.token.position)
-        }
-        self._resolvedGenerics.popLayer()
+          TypedInvokee.Expr(expr) => {
+            val fnObj = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
+            val fnValPtr = self._currentFn.block.buildLoadL(fnObj)
 
+            val retTypeQbe = if node.ty == TypeKind.PrimitiveUnit {
+              None
+            } else {
+              val ty = match self._getQbeTypeForTypeExpect(node.ty, "unacceptable return type", None) { Ok(v) => v, Err(e) => return Err(e) }
+              Some(ty)
+            }
+            (Callable.Value(fnValPtr, retTypeQbe), [])
+          }
+        }
         // TODO: destructuring
         val fnVal = _p[0]
         val argMetadata = _p[1]
@@ -1042,10 +1097,13 @@ export type Compiler {
         var defaultValueParamIdx = -1
         var defaultValueFlags = 0
         for arg, idx in arguments {
-          val _m = if argMetadata[idx] |m| m else return unreachable("arguments.length != argMetadata.length")
-          // TODO: destructuring
-          val argHasDefaultValue = _m[0]
-          val argTy = _m[1]
+          var argHasDefaultValue = false
+          var argTy: Type? = None
+          if argMetadata[idx] |_m| {
+            // TODO: destructuring
+            argHasDefaultValue = _m[0]
+            argTy = Some(_m[1])
+          }
 
           if argHasDefaultValue {
             defaultValueParamIdx += 1
@@ -1054,11 +1112,13 @@ export type Compiler {
           if arg |node| {
             val arg = match self._compileExpression(node) { Ok(v) => v, Err(e) => return Err(e) }
             args.push(arg)
-          } else {
+          } else if argTy |argTy| {
             defaultValueFlags ||= (1 << defaultValueParamIdx)
 
-            val argQbeType = match self._getQbeTypeForTypeExpect(argTy, "unacceptable type", Some(node.token.position)) { Ok(v) => v, Err(e) => return Err(e) }
+            val argQbeType = match self._getQbeTypeForTypeExpect(argTy, "unacceptable type for argument", Some(node.token.position)) { Ok(v) => v, Err(e) => return Err(e) }
             args.push(argQbeType.zeroValue())
+          } else {
+            return unreachable("invocation target must be an arbitrary expression, which do not have default-valued arguments", node.token.position)
           }
         }
 
@@ -1066,7 +1126,7 @@ export type Compiler {
           args.push(Value.Int32(defaultValueFlags))
         }
 
-        var res = if fnVal.returnType {
+        var res = if fnVal.returnType() {
           val res = match self._currentFn.block.buildCall(fnVal, args, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
           res
         } else {
@@ -1082,7 +1142,7 @@ export type Compiler {
 
           val labelIsSome = if noneRes |noneRes| {
             val labelIsSome = self._currentFn.block.currentLabel
-            val someRes = match self._currentFn.block.buildCall(someVariantFn, [res]) { Ok(v) => v, Err(e) => return qbeError(e) }
+            val someRes = match self._currentFn.block.buildCall(Callable.Function(someVariantFn), [res]) { Ok(v) => v, Err(e) => return qbeError(e) }
             Some((labelIsSome, someRes, noneRes))
           } else None
           self._currentFn.block.buildJmp(labelCont)
@@ -1115,7 +1175,7 @@ export type Compiler {
         val arrayWithCapacityFnVal = match self._getOrCompileMethod(node.ty, arrayWithCapacityFn) { Ok(v) => v, Err(e) => return Err(e) }
 
         val sizeVal = Value.Int(items.length.nextPowerOf2())
-        val arrayInstance = match self._currentFn.block.buildCall(arrayWithCapacityFnVal, [sizeVal], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val arrayInstance = match self._currentFn.block.buildCall(Callable.Function(arrayWithCapacityFnVal), [sizeVal], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
         self._currentFn.block.addCommentBefore("${arrayInstance.repr()}: ${node.ty.repr()}")
 
         val arrayPushFn = if self._project.preludeArrayStruct.instanceMethods.find(m => m.label.name == "push") |fn| fn else return unreachable("Array#push must exist")
@@ -1123,7 +1183,7 @@ export type Compiler {
 
         for item in items {
           val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
-          self._currentFn.block.buildVoidCall(arrayPushFnVal, [arrayInstance, itemVal])
+          self._currentFn.block.buildVoidCall(Callable.Function(arrayPushFnVal), [arrayInstance, itemVal])
         }
 
         self._resolvedGenerics.popLayer()
@@ -1142,7 +1202,7 @@ export type Compiler {
         val setNewFn = if self._project.preludeSetStruct.staticMethods.find(m => m.label.name == "new") |fn| fn else return unreachable("Set.new must exist")
         val setNewFnVal = match self._getOrCompileMethod(node.ty, setNewFn) { Ok(v) => v, Err(e) => return Err(e) }
 
-        val setInstance = match self._currentFn.block.buildCall(setNewFnVal, [Value.Int(0), Value.Int32(1)], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val setInstance = match self._currentFn.block.buildCall(Callable.Function(setNewFnVal), [Value.Int(0), Value.Int32(1)], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
         self._currentFn.block.addCommentBefore("${setInstance.repr()}: ${node.ty.repr()}")
 
         val setInsertFn = if self._project.preludeSetStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else return unreachable("Set#insert must exist")
@@ -1150,7 +1210,7 @@ export type Compiler {
 
         for item in items {
           val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
-          self._currentFn.block.buildVoidCall(setInsertFnVal, [setInstance, itemVal])
+          self._currentFn.block.buildVoidCall(Callable.Function(setInsertFnVal), [setInstance, itemVal])
         }
 
         self._resolvedGenerics.popLayer()
@@ -1171,7 +1231,7 @@ export type Compiler {
         val mapNewFn = if self._project.preludeMapStruct.staticMethods.find(m => m.label.name == "new") |fn| fn else return unreachable("Map.new must exist")
         val mapNewFnVal = match self._getOrCompileMethod(node.ty, mapNewFn) { Ok(v) => v, Err(e) => return Err(e) }
 
-        val mapInstance = match self._currentFn.block.buildCall(mapNewFnVal, [Value.Int(0), Value.Int32(1)], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val mapInstance = match self._currentFn.block.buildCall(Callable.Function(mapNewFnVal), [Value.Int(0), Value.Int32(1)], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
         self._currentFn.block.addCommentBefore("${mapInstance.repr()}: ${node.ty.repr()}")
 
         val mapInsertFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else return unreachable("Map#insert must exist")
@@ -1180,7 +1240,7 @@ export type Compiler {
         for _item in items {
           val keyVal = match self._compileExpression(_item[0]) { Ok(v) => v, Err(e) => return Err(e) }
           val valueVal = match self._compileExpression(_item[1]) { Ok(v) => v, Err(e) => return Err(e) }
-          match self._currentFn.block.buildCall(mapInsertFnVal, [mapInstance, keyVal, valueVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+          match self._currentFn.block.buildCall(Callable.Function(mapInsertFnVal), [mapInstance, keyVal, valueVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
         }
 
         self._resolvedGenerics.popLayer()
@@ -1207,7 +1267,7 @@ export type Compiler {
           itemVals.push(itemVal)
         }
 
-        val tuple = match self._currentFn.block.buildCall(fnVal, itemVals) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val tuple = match self._currentFn.block.buildCall(Callable.Function(fnVal), itemVals) { Ok(v) => v, Err(e) => return qbeError(e) }
         Ok(tuple)
       }
       TypedAstNodeKind.Indexing(indexingNode) => {
@@ -1229,7 +1289,7 @@ export type Compiler {
                 val getFnVal = match self._getOrCompileMethod(instType, getFn) { Ok(v) => v, Err(e) => return Err(e) }
                 self._resolvedGenerics.popLayer()
 
-                val res = match self._currentFn.block.buildCall(getFnVal, [exprVal, idxExprVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+                val res = match self._currentFn.block.buildCall(Callable.Function(getFnVal), [exprVal, idxExprVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
                 Ok(res)
               }
               IndexingMode.Range(startExpr, endExpr) => {
@@ -1259,7 +1319,7 @@ export type Compiler {
                 val getRangeFnVal = match self._getOrCompileMethod(instType, getRangeFn) { Ok(v) => v, Err(e) => return Err(e) }
                 self._resolvedGenerics.popLayer()
 
-                val res = match self._currentFn.block.buildCall(getRangeFnVal, [exprVal, startExprVal, endExprVal, Value.Int32(maskParam)]) { Ok(v) => v, Err(e) => return qbeError(e) }
+                val res = match self._currentFn.block.buildCall(Callable.Function(getRangeFnVal), [exprVal, startExprVal, endExprVal, Value.Int32(maskParam)]) { Ok(v) => v, Err(e) => return qbeError(e) }
                 Ok(res)
               }
             }
@@ -1281,7 +1341,7 @@ export type Compiler {
             val getFnVal = match self._getOrCompileMethod(instType, getFn) { Ok(v) => v, Err(e) => return Err(e) }
             self._resolvedGenerics.popLayer()
 
-            val res = match self._currentFn.block.buildCall(getFnVal, [exprVal, idxExprVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+            val res = match self._currentFn.block.buildCall(Callable.Function(getFnVal), [exprVal, idxExprVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(res)
           }
           TypedIndexingNode.Tuple(tupleExpr, idx) => {
@@ -1451,7 +1511,7 @@ export type Compiler {
     val eqFnVal = match self._getOrCompileEqMethod(instType) { Ok(v) => v, Err(e) => return Err(e) }
     self._resolvedGenerics.popLayer()
 
-    val res = match self._currentFn.block.buildCall(eqFnVal, [leftVal, rightVal], localName) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val res = match self._currentFn.block.buildCall(Callable.Function(eqFnVal), [leftVal, rightVal], localName) { Ok(v) => v, Err(e) => return qbeError(e) }
     if negate {
       val plusOneVal = match self._currentFn.block.buildAdd(Value.Int32(1), res) { Ok(v) => v, Err(e) => return qbeError(e) }
       val res = match self._currentFn.block.buildRem(plusOneVal, Value.Int32(2)) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -1465,7 +1525,7 @@ export type Compiler {
     val fnVal = match self._getOrCompileStructInitializer(self._project.preludeStringStruct) { Ok(v) => v, Err(e) => return Err(e) }
     val structTy = if fnVal.returnType |ty| ty else return unreachable("initializer functions must have return types specified")
 
-    val res = match self._currentFn.block.buildCall(fnVal, [lenVal, ptrVal, Value.Int32(0)], localName) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val res = match self._currentFn.block.buildCall(Callable.Function(fnVal), [lenVal, ptrVal, Value.Int32(0)], localName) { Ok(v) => v, Err(e) => return qbeError(e) }
     self._currentFn.block.addCommentBefore("${res.repr()}: String")
     Ok(res)
   }
@@ -1499,7 +1559,7 @@ export type Compiler {
 
         Ok(Some(QbeType.Pointer))
       }
-      TypeKind.Func(paramTypes, returnType) => todo("TypeKind.Func")
+      TypeKind.Func(paramTypes, returnType) => Ok(Some(QbeType.Pointer))
       TypeKind.Type(type_) => todo("TypeKind.Type")
       TypeKind.Tuple(_) => Ok(Some(QbeType.Pointer))
       TypeKind.Hole => unreachable("unexpected hole in emitted typed ast")
@@ -1539,7 +1599,7 @@ export type Compiler {
         AccessorPathSegment.EnumVariant(label, ty, enum_, variant) => {
           match self._addResolvedGenericsLayerForEnumVariant(ty, variant.label.name, label.position) { Ok(v) => v, Err(e) => return Err(e) }
           val enumVariantFn = match self._getOrCompileEnumVariantFn(enum_, variant) { Ok(v) => v, Err(e) => return Err(e) }
-          curVal = match self._currentFn.block.buildCall(enumVariantFn, []) { Ok(v) => v, Err(e) => return qbeError(e) }
+          curVal = match self._currentFn.block.buildCall(Callable.Function(enumVariantFn), []) { Ok(v) => v, Err(e) => return qbeError(e) }
           self._resolvedGenerics.popLayer()
 
           instTy = StructOrEnum.Enum(enum_)
@@ -1568,7 +1628,7 @@ export type Compiler {
             match self._resolvedGenerics.addLayer("Option.None", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: label.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.None", message: e))) }
             val noneVariantFn = match self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant) { Ok(v) => v, Err(e) => return Err(e) }
             self._resolvedGenerics.popLayer()
-            val noneRes = match self._currentFn.block.buildCall(noneVariantFn, []) { Ok(v) => v, Err(e) => return qbeError(e) }
+            val noneRes = match self._currentFn.block.buildCall(Callable.Function(noneVariantFn), []) { Ok(v) => v, Err(e) => return qbeError(e) }
             self._currentFn.block.buildJmp(labelCont)
 
             self._currentFn.block.registerLabel(labelIsSome)
@@ -1623,7 +1683,7 @@ export type Compiler {
             val labelCont = _ctx[3]
 
             val labelIsSome = self._currentFn.block.currentLabel
-            val someRes = match self._currentFn.block.buildCall(someVariantFn, [curVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+            val someRes = match self._currentFn.block.buildCall(Callable.Function(someVariantFn), [curVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
             self._currentFn.block.buildJmp(labelCont)
 
             self._currentFn.block.addComment("...opt-safe field accessor end")
@@ -1698,7 +1758,7 @@ export type Compiler {
       fnVal.addParameter("__default_params_mask__", QbeType.U32)
     }
 
-    val memLocal = match fnVal.block.buildCall(self._malloc, [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val memLocal = match fnVal.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     var offset = 0
     for field in struct.fields {
@@ -1744,7 +1804,7 @@ export type Compiler {
       _ => {}
     }
 
-    val memLocal = match fn.block.buildCall(self._malloc, [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val memLocal = match fn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     val variantIdx = if enum_.variants.findIndex(v => v.label.name == variant.label.name) |_v| _v[1] else return unreachable("variant '${variant.label.name}' must exist")
     fn.block.buildStoreW(Value.Int32(variantIdx), memLocal) // Store variant idx at designated slot
@@ -1800,14 +1860,14 @@ export type Compiler {
       val itemToStringFnVal = match self._getOrCompileToStringMethod(itemInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
       self._resolvedGenerics.popLayer()
 
-      val toStringVal = match self._currentFn.block.buildCall(itemToStringFnVal, [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+      val toStringVal = match self._currentFn.block.buildCall(Callable.Function(itemToStringFnVal), [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-      self._currentFn.block.buildVoidCall(stdoutWriteFnVal, [toStringVal])
+      self._currentFn.block.buildVoidCall(Callable.Function(stdoutWriteFnVal), [toStringVal])
 
       if idx == varargItems.length - 1 {
-        self._currentFn.block.buildVoidCall(stdoutWriteFnVal, [newlineStr])
+        self._currentFn.block.buildVoidCall(Callable.Function(stdoutWriteFnVal), [newlineStr])
       } else {
-        self._currentFn.block.buildVoidCall(stdoutWriteFnVal, [spaceStr])
+        self._currentFn.block.buildVoidCall(Callable.Function(stdoutWriteFnVal), [spaceStr])
       }
     }
     self._currentFn.block.addComment("...println end")
@@ -1888,7 +1948,7 @@ export type Compiler {
         val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
         val sizeVal = match self._currentFn.block.buildMul(Value.Int(innerTySize), countVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-        val mem = match self._currentFn.block.buildCall(self._malloc, [sizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val mem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [sizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
         self._currentFn.block.addComment("...pointer_malloc end")
 
@@ -1909,7 +1969,7 @@ export type Compiler {
         val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
         val sizeVal = match self._currentFn.block.buildMul(Value.Int(innerTySize), countVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-        val mem = match self._currentFn.block.buildCall(self._realloc, [ptrVal, sizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val mem = match self._currentFn.block.buildCall(Callable.Function(self._realloc), [ptrVal, sizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
         self._currentFn.block.addComment("...pointer_realloc end")
 
@@ -2005,7 +2065,7 @@ export type Compiler {
         val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
         val sizeVal = match self._currentFn.block.buildMul(Value.Int(innerTySize), sizeArg) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-        self._currentFn.block.buildVoidCall(self._memcpy, [ptrVal, otherVal, sizeVal])
+        self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [ptrVal, otherVal, sizeVal])
 
         self._currentFn.block.addComment("...pointer_copy_from end")
 
@@ -2267,15 +2327,22 @@ export type Compiler {
       StructOrEnum.Struct(struct) => {
         val data: (String, Position, Type)[] = []
 
-        val isTuple = self._isTupleStruct(struct)
-        for field in struct.fields {
-          val fieldName = if isTuple "" else field.name.name
-          data.push((fieldName, field.name.position, field.ty))
-        }
+        if self._isFunctionStruct(struct) {
+          val str = self._builder.buildGlobalString("<#function>")
+          val res = match self._constructString(str, Value.Int(11)) { Ok(v) => v, Err(e) => return Err(e) }
 
-        val prefix = if isTuple "" else struct.label.name
-        val res = match self._emitToStringLogicForStructuredData(prefix, selfParamVal, data) { Ok(v) => v, Err(e) => return Err(e) }
-        self._currentFn.block.buildReturn(Some(res))
+          self._currentFn.block.buildReturn(Some(res))
+        } else {
+          val isTuple = self._isTupleStruct(struct)
+          for field in struct.fields {
+            val fieldName = if isTuple "" else field.name.name
+            data.push((fieldName, field.name.position, field.ty))
+          }
+
+          val prefix = if isTuple "" else struct.label.name
+          val res = match self._emitToStringLogicForStructuredData(prefix, selfParamVal, data) { Ok(v) => v, Err(e) => return Err(e) }
+          self._currentFn.block.buildReturn(Some(res))
+        }
       }
       StructOrEnum.Enum(enum_) => {
         val variantIdxVal = self._emitGetEnumVariantIdx(selfParamVal)
@@ -2361,7 +2428,7 @@ export type Compiler {
 
       offset += itemTy.size()
 
-      val itemToStringVal = match self._currentFn.block.buildCall(itemToStringFnVal, [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+      val itemToStringVal = match self._currentFn.block.buildCall(Callable.Function(itemToStringFnVal), [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
       val itemToStringLengthVal = self._currentFn.block.buildLoadL(itemToStringVal)
       lenVal = match self._currentFn.block.buildAdd(lenVal, itemToStringLengthVal, Some("length_total")) { Ok(v) => v, Err(e) => return qbeError(e) }
       if itemIsString {
@@ -2375,11 +2442,11 @@ export type Compiler {
     val totalLengthVal = match self._currentFn.block.buildAdd(Value.Int(len), lenVal) { Ok(v) => v, Err(e) => return qbeError(e) }
     val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
     val stringWithLengthFnVal = match self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn) { Ok(v) => v, Err(e) => return Err(e) }
-    val newStr = match self._currentFn.block.buildCall(stringWithLengthFnVal, [totalLengthVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val newStr = match self._currentFn.block.buildCall(Callable.Function(stringWithLengthFnVal), [totalLengthVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     var newStrBuf = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), newStr) { Ok(v) => v, Err(e) => return qbeError(e) })
     if !prefix.isEmpty() {
-      self._currentFn.block.buildVoidCall(self._memcpy, [newStrBuf, prefixStr, Value.Int(prefix.length)])
+      self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [newStrBuf, prefixStr, Value.Int(prefix.length)])
     }
     var cursor = match self._currentFn.block.buildAdd(newStrBuf, Value.Int(prefix.length), Some("str_cursor")) { Ok(v) => v, Err(e) => return qbeError(e) }
     self._currentFn.block.addComment("'('")
@@ -2394,7 +2461,7 @@ export type Compiler {
 
       if !fieldName.isEmpty() {
         val fieldNameStr = self._builder.buildGlobalString(fieldName)
-        self._currentFn.block.buildVoidCall(self._memcpy, [cursor, fieldNameStr, Value.Int(fieldName.length)])
+        self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [cursor, fieldNameStr, Value.Int(fieldName.length)])
         cursor = match self._currentFn.block.buildAdd(cursor, Value.Int(fieldName.length), Some("str_cursor")) { Ok(v) => v, Err(e) => return qbeError(e) }
         self._currentFn.block.addComment("\": \"")
         self._currentFn.block.buildStoreB(Value.Int(58), cursor)
@@ -2411,7 +2478,7 @@ export type Compiler {
 
       val strValLen = self._currentFn.block.buildLoadL(strVal)
       val strValChars = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), strVal) { Ok(v) => v, Err(e) => return qbeError(e) })
-      self._currentFn.block.buildVoidCall(self._memcpy, [cursor, strValChars, strValLen])
+      self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [cursor, strValChars, strValLen])
       cursor = match self._currentFn.block.buildAdd(cursor, strValLen, Some("str_cursor")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
       if isString {
@@ -2451,11 +2518,11 @@ export type Compiler {
     val selfParam = fnVal.addParameter("self", intTypeQbe)
 
     val intFmtPtr = self._builder.buildGlobalString("%d")
-    val sizeVal = match fnVal.block.buildCall(self._snprintf, [Value.Int(0), Value.Int(0), intFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val sizeVal = match fnVal.block.buildCall(Callable.Function(self._snprintf), [Value.Int(0), Value.Int(0), intFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
     val mallocSizeVal = match fnVal.block.buildAdd(Value.Int(1), sizeVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-    val mem = match fnVal.block.buildCall(self._malloc, [mallocSizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
-    match fnVal.block.buildCall(self._snprintf, [mem, mallocSizeVal, intFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val mem = match fnVal.block.buildCall(Callable.Function(self._malloc), [mallocSizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    match fnVal.block.buildCall(Callable.Function(self._snprintf), [mem, mallocSizeVal, intFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     val str = match self._constructString(mem, sizeVal) { Ok(v) => v, Err(e) => return Err(e) }
     fnVal.block.buildReturn(Some(str))
@@ -2483,11 +2550,11 @@ export type Compiler {
     val selfParam = fnVal.addParameter("self", floatTypeQbe)
 
     val floatFmtPtr = self._builder.buildGlobalString("%g")
-    val sizeVal = match fnVal.block.buildCall(self._snprintf, [Value.Int(0), Value.Int(0), floatFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val sizeVal = match fnVal.block.buildCall(Callable.Function(self._snprintf), [Value.Int(0), Value.Int(0), floatFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
     val mallocSizeVal = match fnVal.block.buildAdd(Value.Int(1), sizeVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-    val mem = match fnVal.block.buildCall(self._malloc, [mallocSizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
-    match fnVal.block.buildCall(self._snprintf, [mem, mallocSizeVal, floatFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val mem = match fnVal.block.buildCall(Callable.Function(self._malloc), [mallocSizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    match fnVal.block.buildCall(Callable.Function(self._snprintf), [mem, mallocSizeVal, floatFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     val str = match self._constructString(mem, sizeVal) { Ok(v) => v, Err(e) => return Err(e) }
     fnVal.block.buildReturn(Some(str))
@@ -2987,7 +3054,7 @@ export type Compiler {
       val itemHashFnVal = match self._getOrCompileHashMethod(itemType) { Ok(v) => v, Err(e) => return Err(e) }
       self._resolvedGenerics.popLayer()
 
-      val itemHashVal = match self._currentFn.block.buildCall(itemHashFnVal, [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+      val itemHashVal = match self._currentFn.block.buildCall(Callable.Function(itemHashFnVal), [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
       val newPart = match self._currentFn.block.buildMul(Value.Int(31), itemHashVal) { Ok(v) => v, Err(e) => return qbeError(e) }
       retVal = match self._currentFn.block.buildAdd(retVal, newPart) { Ok(v) => v, Err(e) => return qbeError(e) }
 
@@ -3088,6 +3155,24 @@ export type Compiler {
     }
   }
 
+  func _functionStruct(self, arity: Int, hasReturnType: Bool): Struct {
+    val name = if hasReturnType "Function$arity" else "UnitFunction$arity"
+
+    if self._functionStructs[name] |struct| struct else {
+      val dummyModuleId = 0
+      val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      val typeParams = (if hasReturnType { ["_R"] } else []).concat(alphabet[:arity].split(""))
+      val fields = [("_ptr", Type(kind: TypeKind.PrimitiveInt))]
+      val struct = Struct.makeDummy(moduleId: dummyModuleId, name: name, typeParams: typeParams, fields: fields)
+
+      self._functionStructs[name] = struct
+
+      struct
+    }
+  }
+
+  func _isFunctionStruct(self, struct: Struct): Bool = if self._functionStructs[struct.label.name] |s| s == struct else false
+
   func _tupleStruct(self, arity: Int): Struct {
     val name = "Tuple$arity"
 
@@ -3123,7 +3208,13 @@ export type Compiler {
         val struct = self._tupleStruct(types.length)
         Ok((StructOrEnum.Struct(struct), types))
       }
-      TypeKind.Func(_paramTypes, _returnType) => todo("getInstanceTypeForType: Func")
+      TypeKind.Func(paramTypes, returnType) => {
+        val hasReturn = returnType.kind != TypeKind.PrimitiveUnit
+        val struct = self._functionStruct(paramTypes.length, hasReturn)
+
+        val typeArgs = (if hasReturn { [returnType] } else []).concat(paramTypes.map(_p => _p[0]))
+        Ok((StructOrEnum.Struct(struct), typeArgs))
+      }
       TypeKind.Type(structOrEnum) => Ok((structOrEnum, []))
       TypeKind.Hole => unreachable("getInstanceTypeForType: Hole")
     }
@@ -3151,10 +3242,16 @@ export type Compiler {
         }
       }
       TypeKind.Tuple(types) => {
-        val tupleStruct = self._tupleStruct(types.length)
-        self._getReprForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(tupleStruct), types)))
+        val struct = self._tupleStruct(types.length)
+        self._getReprForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), types)))
       }
-      TypeKind.Func(_paramTypes, _returnType) => todo("_getReprForType: Func")
+      TypeKind.Func(paramTypes, returnType) => {
+        val hasReturn = returnType.kind != TypeKind.PrimitiveUnit
+        val struct = self._functionStruct(paramTypes.length, hasReturn)
+
+        val typeArgs = (if hasReturn { [returnType] } else []).concat(paramTypes.map(_p => _p[0]))
+        self._getReprForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs)))
+      }
       _ => Ok(ty.repr())
     }
   }
@@ -3181,10 +3278,16 @@ export type Compiler {
         }
       }
       TypeKind.Tuple(types) => {
-        val tupleStruct = self._tupleStruct(types.length)
-        self._getNameForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(tupleStruct), types)))
+        val struct = self._tupleStruct(types.length)
+        self._getNameForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), types)))
       }
-      TypeKind.Func(_paramTypes, _returnType) => todo("_getNameForType: Func")
+      TypeKind.Func(paramTypes, returnType) => {
+        val hasReturn = returnType.kind != TypeKind.PrimitiveUnit
+        val struct = self._functionStruct(paramTypes.length, hasReturn)
+
+        val typeArgs = (if hasReturn { [returnType] } else []).concat(paramTypes.map(_p => _p[0]))
+        self._getNameForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs)))
+      }
       _ => Ok(ty.repr())
     }
   }

--- a/selfhost/src/qbe.abra
+++ b/selfhost/src/qbe.abra
@@ -26,7 +26,7 @@ export type ModuleBuilder {
 
     val block = Block.new(name: name)
 
-    val fn = QbeFunction(exported: exported, name: name, returnType: returnType, _parameters: [], block: block, variadicIdx: None, _comments: [])
+    val fn = QbeFunction(exported: exported, name: name, returnType: returnType, _parameters: [], block: block, variadicIdx: None, _comments: [], _env: None)
     self._functions.push(fn)
     self._functionsByName[name] = fn
     fn
@@ -550,7 +550,7 @@ export type Block {
     local
   }
 
-  func buildCall(self, callable: Callable, arguments: Value[], dst: String? = None): Result<Value, String> {
+  func buildCall(self, callable: Callable, arguments: Value[], dst: String? = None, envPtr: Value? = None): Result<Value, String> {
     val dest = dst ?: self._nextLocal()
 
     val fnReturnType = if callable.returnType() |ty| ty else return Err("function value ($callable) has no return type; cannot store result into destination '%$dest'")
@@ -562,13 +562,13 @@ export type Block {
         val fnIdent = Value.Global(fn.name, QbeType.Pointer)
 
         if fn.variadicIdx |idx| {
-          self.append(Instruction.CallVarargs(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnIdent, varargsIdx: idx, args: arguments))
+          self.append(Instruction.CallVarargs(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnIdent, varargsIdx: idx, args: arguments, env: envPtr))
         } else {
-          self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnIdent, args: arguments))
+          self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnIdent, args: arguments, env: envPtr))
         }
       }
       Callable.Value(fnValue) => {
-        self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnValue, args: arguments))
+        self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnValue, args: arguments, env: envPtr))
       }
     }
 
@@ -579,29 +579,29 @@ export type Block {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, returnType)
 
-    self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: returnType)), fn: Value.Global(fnName, QbeType.Pointer), args: arguments))
+    self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: returnType)), fn: Value.Global(fnName, QbeType.Pointer), args: arguments, env: None))
 
     Ok(local)
   }
 
-  func buildVoidCall(self, callable: Callable, arguments: Value[]) {
+  func buildVoidCall(self, callable: Callable, arguments: Value[], envPtr: Value? = None) {
     match callable {
       Callable.Function(fn) => {
         val fnIdent = Value.Global(fn.name, QbeType.Pointer)
         if fn.variadicIdx |idx| {
-          self.append(Instruction.CallVarargs(dst: None, fn: fnIdent, varargsIdx: idx, args: arguments))
+          self.append(Instruction.CallVarargs(dst: None, fn: fnIdent, varargsIdx: idx, args: arguments, env: envPtr))
         } else {
-          self.append(Instruction.Call(dst: None, fn: fnIdent, args: arguments))
+          self.append(Instruction.Call(dst: None, fn: fnIdent, args: arguments, env: envPtr))
         }
       }
       Callable.Value(fnValue) => {
-        self.append(Instruction.Call(dst: None, fn: fnValue, args: arguments))
+        self.append(Instruction.Call(dst: None, fn: fnValue, args: arguments, env: envPtr))
       }
     }
   }
 
   func buildVoidCallRaw(self, fnName: String, arguments: Value[]) {
-    self.append(Instruction.Call(dst: None, fn: Value.Global(fnName, QbeType.Pointer), args: arguments))
+    self.append(Instruction.Call(dst: None, fn: Value.Global(fnName, QbeType.Pointer), args: arguments, env: None))
   }
 
   func buildPhi(self, cases: (Label, Value)[], dst: String? = None): Result<Value, String> {
@@ -708,9 +708,10 @@ export type QbeFunction {
   _parameters: (String, QbeType)[] = []
   variadicIdx: Int? = None
   _comments: String[] = []
+  _env: Value? = None
 
   func spec(name: String, returnType: QbeType? = None, parameters: (String, QbeType)[] = [], variadicIdx: Int? = None): QbeFunction {
-    QbeFunction(name: name, block: Block.new(name), returnType: returnType, _parameters: parameters, variadicIdx: variadicIdx)
+    QbeFunction(name: name, block: Block.new(name), returnType: returnType, _parameters: parameters, variadicIdx: variadicIdx, _env: None)
   }
 
   func encode(self, file: File) {
@@ -722,6 +723,11 @@ export type QbeFunction {
     self.returnType?.encode(file)
     file.write(" \$${self.name}")
     file.write("(")
+    if self._env |env| {
+      file.write("env ")
+      env.encode(file)
+      if !self._parameters.isEmpty() file.write(", ")
+    }
     for param, idx in self._parameters {
       param[1].encode(file)
       file.write(" %${param[0]}")
@@ -748,6 +754,12 @@ export type QbeFunction {
   func addParameter(self, name: String, ty: QbeType): Value {
     self._parameters.push((name, ty))
     Value.Ident(name, ty)
+  }
+
+  func addEnv(self): Value {
+    val env = Value.Ident("__env__", QbeType.Pointer)
+    self._env = Some(env)
+    env
   }
 }
 
@@ -840,8 +852,8 @@ enum Instruction {
 
   Cast(dst: Dest, value: Value)
 
-  Call(dst: Dest?, fn: Value, args: Value[])
-  CallVarargs(dst: Dest?, fn: Value, varargsIdx: Int, args: Value[])
+  Call(dst: Dest?, fn: Value, args: Value[], env: Value?)
+  CallVarargs(dst: Dest?, fn: Value, varargsIdx: Int, args: Value[], env: Value?)
 
   Phi(dst: Dest, cases: (Label, Value)[])
 
@@ -1139,7 +1151,7 @@ enum Instruction {
         v.encode(file)
         file.writeln()
       }
-      Instruction.Call(dst, fnVal, args) => {
+      Instruction.Call(dst, fnVal, args, env) => {
         if dst |dst| {
           dst.encode(file)
           file.write(" ")
@@ -1147,6 +1159,11 @@ enum Instruction {
         file.write("call ")
         fnVal.encode(file)
         file.write("(")
+        if env |env| {
+          file.write("env ")
+          env.encode(file)
+          if !args.isEmpty() file.write(", ")
+        }
         for arg, idx in args {
           arg.ty().encode(file)
           file.write(" ")
@@ -1155,7 +1172,7 @@ enum Instruction {
         }
         file.writeln(")")
       }
-      Instruction.CallVarargs(dst, fnVal, varargsIdx, args) => {
+      Instruction.CallVarargs(dst, fnVal, varargsIdx, args, env) => {
         if dst |dst| {
           dst.encode(file)
           file.write(" ")
@@ -1163,6 +1180,11 @@ enum Instruction {
         file.write("call ")
         fnVal.encode(file)
         file.write("(")
+        if env |env| {
+          file.write("env ")
+          env.encode(file)
+          if !args.isEmpty() file.write(", ")
+        }
         for arg, idx in args {
           if idx == varargsIdx {
             file.write("..., ")

--- a/selfhost/src/qbe.abra
+++ b/selfhost/src/qbe.abra
@@ -553,7 +553,7 @@ export type Block {
   func buildCall(self, callable: Callable, arguments: Value[], dst: String? = None): Result<Value, String> {
     val dest = dst ?: self._nextLocal()
 
-    val fnReturnType = if callable.returnType() |ty| ty else return Err("function value has no return type; cannot store result into destination '%$dest'")
+    val fnReturnType = if callable.returnType() |ty| ty else return Err("function value ($callable) has no return type; cannot store result into destination '%$dest'")
 
     val local = Value.Ident(dest, fnReturnType)
 

--- a/selfhost/src/qbe.abra
+++ b/selfhost/src/qbe.abra
@@ -550,19 +550,26 @@ export type Block {
     local
   }
 
-  func buildCall(self, fnValue: QbeFunction, arguments: Value[], dst: String? = None): Result<Value, String> {
+  func buildCall(self, callable: Callable, arguments: Value[], dst: String? = None): Result<Value, String> {
     val dest = dst ?: self._nextLocal()
-    val fnReturnType = if fnValue.returnType |ty| ty else {
-      return Err("function value '${fnValue.name}' has no return type; cannot store result into destination '%$dest'")
-    }
+
+    val fnReturnType = if callable.returnType() |ty| ty else return Err("function value has no return type; cannot store result into destination '%$dest'")
 
     val local = Value.Ident(dest, fnReturnType)
 
-    val fnName = "\$${fnValue.name}"
-    if fnValue.variadicIdx |idx| {
-      self.append(Instruction.CallVarargs(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnName, varargsIdx: idx, args: arguments))
-    } else {
-      self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnName, args: arguments))
+    match callable {
+      Callable.Function(fn) => {
+        val fnIdent = Value.Global(fn.name, QbeType.Pointer)
+
+        if fn.variadicIdx |idx| {
+          self.append(Instruction.CallVarargs(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnIdent, varargsIdx: idx, args: arguments))
+        } else {
+          self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnIdent, args: arguments))
+        }
+      }
+      Callable.Value(fnValue) => {
+        self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnValue, args: arguments))
+      }
     }
 
     Ok(local)
@@ -572,22 +579,29 @@ export type Block {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, returnType)
 
-    self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: returnType)), fn: "\$$fnName", args: arguments))
+    self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: returnType)), fn: Value.Global(fnName, QbeType.Pointer), args: arguments))
 
     Ok(local)
   }
 
-  func buildVoidCall(self, fnValue: QbeFunction, arguments: Value[]) {
-    val fnName = "\$${fnValue.name}"
-    if fnValue.variadicIdx |idx| {
-      self.append(Instruction.CallVarargs(dst: None, fn: fnName, varargsIdx: idx, args: arguments))
-    } else {
-      self.append(Instruction.Call(dst: None, fn: fnName, args: arguments))
+  func buildVoidCall(self, callable: Callable, arguments: Value[]) {
+    match callable {
+      Callable.Function(fn) => {
+        val fnIdent = Value.Global(fn.name, QbeType.Pointer)
+        if fn.variadicIdx |idx| {
+          self.append(Instruction.CallVarargs(dst: None, fn: fnIdent, varargsIdx: idx, args: arguments))
+        } else {
+          self.append(Instruction.Call(dst: None, fn: fnIdent, args: arguments))
+        }
+      }
+      Callable.Value(fnValue) => {
+        self.append(Instruction.Call(dst: None, fn: fnValue, args: arguments))
+      }
     }
   }
 
   func buildVoidCallRaw(self, fnName: String, arguments: Value[]) {
-    self.append(Instruction.Call(dst: None, fn: "\$$fnName", args: arguments))
+    self.append(Instruction.Call(dst: None, fn: Value.Global(fnName, QbeType.Pointer), args: arguments))
   }
 
   func buildPhi(self, cases: (Label, Value)[], dst: String? = None): Result<Value, String> {
@@ -623,6 +637,16 @@ export type Block {
 
   func buildHalt(self) {
     self.append(Instruction.Hlt)
+  }
+}
+
+export enum Callable {
+  Function(fn: QbeFunction)
+  Value(v: Value, returnType: QbeType?)
+
+  func returnType(self): QbeType? = match self {
+    Callable.Function(fn) => fn.returnType
+    Callable.Value(_, returnType) => returnType
   }
 }
 
@@ -816,8 +840,8 @@ enum Instruction {
 
   Cast(dst: Dest, value: Value)
 
-  Call(dst: Dest?, fn: String, args: Value[])
-  CallVarargs(dst: Dest?, fn: String, varargsIdx: Int, args: Value[])
+  Call(dst: Dest?, fn: Value, args: Value[])
+  CallVarargs(dst: Dest?, fn: Value, varargsIdx: Int, args: Value[])
 
   Phi(dst: Dest, cases: (Label, Value)[])
 
@@ -1115,13 +1139,13 @@ enum Instruction {
         v.encode(file)
         file.writeln()
       }
-      Instruction.Call(dst, fnName, args) => {
+      Instruction.Call(dst, fnVal, args) => {
         if dst |dst| {
           dst.encode(file)
           file.write(" ")
         }
         file.write("call ")
-        file.write(fnName)
+        fnVal.encode(file)
         file.write("(")
         for arg, idx in args {
           arg.ty().encode(file)
@@ -1131,13 +1155,13 @@ enum Instruction {
         }
         file.writeln(")")
       }
-      Instruction.CallVarargs(dst, fnName, varargsIdx, args) => {
+      Instruction.CallVarargs(dst, fnVal, varargsIdx, args) => {
         if dst |dst| {
           dst.encode(file)
           file.write(" ")
         }
         file.write("call ")
-        file.write(fnName)
+        fnVal.encode(file)
         file.write("(")
         for arg, idx in args {
           if idx == varargsIdx {

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -99,6 +99,7 @@ export type Variable {
   alias: VariableAlias? = None
   isExported: Bool = false
   isParameter: Bool = false
+  isCaptured: Bool = false
 }
 
 export enum Terminator {
@@ -141,6 +142,8 @@ export type Scope {
   parent: Scope? = None
   terminator: Terminator? = None
   numLambdas: Int = 0
+
+  func eq(self, other: Scope): Bool = self.name == other.name
 
   func makeChild(self, name: String, kind: ScopeKind): Scope = Scope(name: "${self.name}::$name", kind: kind, parent: Some(self))
 }
@@ -593,6 +596,7 @@ export type Function {
   isGenerated: Bool = false
   isLambda: Bool = false
   decorators: Decorator[] = []
+  captures: Variable[] = []
 
   func generated(
     scope: Scope,
@@ -1761,16 +1765,47 @@ export type Typechecker {
   }
 
   func _resolveIdentifier(self, ident: String): Variable? {
+    val currentFnScope = self.currentFunction?.scope
     var scope: Scope? = Some(self.currentScope)
+    var fnBarrierBreached = false
+
     while scope |s| {
       for v in s.variables {
-        if v.label.name == ident return Some(v)
+        if v.label.name == ident {
+          if !v.alias && fnBarrierBreached {
+            v.isCaptured = true
+            if self.currentFunction |fn| {
+              if !fn.captures.contains(v) {
+                fn.captures.push(v)
+              }
+            }
+          }
+
+          return Some(v)
+        }
       }
+
       scope = s.parent
+      if currentFnScope |currentFnScope| {
+        if scope == currentFnScope.parent {
+          fnBarrierBreached = true
+        }
+      }
     }
 
     for v in self.project.preludeScope.variables {
-      if v.label.name == ident return Some(v)
+      if v.label.name == ident {
+        if !v.alias && fnBarrierBreached {
+          v.isCaptured = true
+          if self.currentFunction |fn| {
+            if !fn.captures.contains(v) {
+              fn.captures.push(v)
+            }
+          }
+        }
+
+        return Some(v)
+      }
     }
 
     for importedModule in self.currentModuleImports.values() {
@@ -1780,7 +1815,18 @@ export type Typechecker {
         val importedValue = _p[1]
         if importedName == ident {
           val v = match importedValue.kind {
-            TypedImportKind.Variable(v) => v
+            TypedImportKind.Variable(v) => {
+              if !v.alias && fnBarrierBreached {
+                v.isCaptured = true
+                if self.currentFunction |fn| {
+                  if !fn.captures.contains(v) {
+                    fn.captures.push(v)
+                  }
+                }
+              }
+
+              v
+            }
             TypedImportKind.Function(aliasVar) => aliasVar
             TypedImportKind.Type(_, aliasVar) => aliasVar
           }

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -142,12 +142,6 @@ export type Scope {
   terminator: Terminator? = None
   numLambdas: Int = 0
 
-  func nextLambdaName(self): String {
-    val name = "lambda_${self.numLambdas}"
-    self.numLambdas += 1
-    name
-  }
-
   func makeChild(self, name: String, kind: ScopeKind): Scope = Scope(name: "${self.name}::$name", kind: kind, parent: Some(self))
 }
 
@@ -1360,6 +1354,7 @@ export type Typechecker {
   paramDefaultValueContext: ParamDefaultValueContext? = None
   isStructOrEnumValueAllowed: Bool = false
   isEnumContainerValueAllowed: Bool = false
+  numLambdas: Int = 0
 
   func typecheckEntrypoint(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
     val preludeModulePathSegs = getAbsolutePath(self.moduleLoader.stdRoot + "/prelude.abra")
@@ -1932,6 +1927,13 @@ export type Typechecker {
       Ok(0) // <-- unnecessary int
     }
   }
+
+  func _nextLambdaName(self): String {
+    val name = "lambda_${self.currentModuleId}_${self.numLambdas}"
+    self.numLambdas += 1
+    name
+  }
+
 
   func _typecheckModule(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
     val moduleId = self.project.modules.size
@@ -4721,7 +4723,7 @@ export type Typechecker {
       }
     }
 
-    val lambdaName = self.currentScope.nextLambdaName()
+    val lambdaName = self._nextLambdaName()
     val fnScope = self.currentScope.makeChild(lambdaName, ScopeKind.Func)
     var returnType = retHint ?: Type(kind: TypeKind.Hole)
     if returnType.containsGenerics() {

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -100,6 +100,11 @@ export type Variable {
   isExported: Bool = false
   isParameter: Bool = false
   isCaptured: Bool = false
+
+  func bogus(): Variable {
+    val label = Label(name: "_bogus", position: Position(line: 0, col: 0))
+    Variable(label: label, mutable: false, ty: Type(kind: TypeKind.Never))
+  }
 }
 
 export enum Terminator {
@@ -577,6 +582,7 @@ type TypedFunctionParam {
   ty: Type
   defaultValue: TypedAstNode? = None
   isVariadic: Bool = false
+  variable: Variable
 }
 
 export enum FunctionKind {
@@ -610,7 +616,7 @@ export type Function {
 
     val label = Label(name: name, position: bogusPosition)
     val fnScope = scope.makeChild(name, ScopeKind.Func)
-    val fnParams = params.map(p => TypedFunctionParam(label: Label(name: p[0], position: bogusPosition), ty: p[1]))
+    val fnParams = params.map(p => TypedFunctionParam(label: Label(name: p[0], position: bogusPosition), ty: p[1], variable: Variable.bogus()))
     Function(label: label, scope: fnScope, kind: kind, typeParams: typeParams, params: fnParams, returnType: returnType, body: [], isGenerated: true)
   }
 
@@ -622,7 +628,7 @@ export type Function {
 
     val fnScope = scope.makeChild(struct.label.name, ScopeKind.Func)
     val structTypeParams = struct.typeParams.map(t => (Type(kind: TypeKind.Generic(t)), Label(name: t, position: bogusPosition)))
-    val params = struct.fields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer))
+    val params = struct.fields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer, variable: Variable.bogus()))
     val typeArgs = struct.typeParams.map(t => Type(kind: TypeKind.Generic(t)))
     val returnType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
 
@@ -639,7 +645,7 @@ export type Function {
 
     val fnScope = scope.makeChild("${enum_.label.name}.${variantLabel.name}", ScopeKind.Func)
     val typeParams = enum_.typeParams.map(t => (Type(kind: TypeKind.Generic(t)), Label(name: t, position: bogusPosition)))
-    val params = variantFields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer))
+    val params = variantFields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer, variable: Variable.bogus()))
     val typeArgs = enum_.typeParams.map(t => Type(kind: TypeKind.Generic(t)))
     val returnType = Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
 
@@ -651,7 +657,7 @@ export type Function {
   func withSubstitutedGenerics(self, resolvedGenerics: Map<String, Type>, retainUnknown: Bool, genericsInScope: Set<String>): Function {
     val params = self.params.map(p => {
       val ty = p.ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown, genericsInScope)
-      TypedFunctionParam(label: p.label, ty: ty, defaultValue: p.defaultValue, isVariadic: p.isVariadic)
+      TypedFunctionParam(label: p.label, ty: ty, defaultValue: p.defaultValue, isVariadic: p.isVariadic, variable: p.variable)
     })
     val returnType = self.returnType.withSubstitutedGenerics(resolvedGenerics, retainUnknown, genericsInScope)
 
@@ -2147,7 +2153,7 @@ export type Typechecker {
         val variable = Variable(label: param.label, mutable: false, ty: ty, isParameter: true)
         match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
 
-        val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: None, isVariadic: false)
+        val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: None, isVariadic: false, variable: variable)
         return Ok((typedParam, false))
       }
 
@@ -2183,7 +2189,7 @@ export type Typechecker {
             self.paramDefaultValueContext = None
             if ctx.exprContainsFunctionCall || ctx.exprContainsVariableRef {
               val placeholder = Some(TypedAstNode(token: node.token, ty: Type(kind: TypeKind.Hole), kind: TypedAstNodeKind.Placeholder))
-              val typedParam = TypedFunctionParam(label: param.label, ty: Type(kind: TypeKind.Hole), defaultValue: placeholder, isVariadic: param.isVariadic)
+              val typedParam = TypedFunctionParam(label: param.label, ty: Type(kind: TypeKind.Hole), defaultValue: placeholder, isVariadic: param.isVariadic, variable: Variable.bogus())
               return Ok((typedParam, true))
             }
             return Err(e)
@@ -2191,7 +2197,7 @@ export type Typechecker {
         }
         self.paramDefaultValueContext = None
         if ctx.exprContainsFunctionCall || ctx.exprContainsVariableRef {
-          val typedParam = TypedFunctionParam(label: param.label, ty: paramType ?: expr.ty, defaultValue: Some(expr), isVariadic: param.isVariadic)
+          val typedParam = TypedFunctionParam(label: param.label, ty: paramType ?: expr.ty, defaultValue: Some(expr), isVariadic: param.isVariadic, variable: Variable.bogus())
           return Ok((typedParam, true))
         }
         defaultValue = Some(expr)
@@ -2229,7 +2235,7 @@ export type Typechecker {
       return Err(TypeError(position: param.label.position, kind: TypeErrorKind.IllegalValueType(ty: ty, purpose: "parameter")))
     }
 
-    val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: defaultValue, isVariadic: param.isVariadic)
+    val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: defaultValue, isVariadic: param.isVariadic, variable: variable)
     Ok((typedParam, false))
   }
 

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -719,7 +719,7 @@ export enum TypedAstNodeKind {
   Map(items: (TypedAstNode, TypedAstNode)[])
   Tuple(items: TypedAstNode[])
   Indexing(node: TypedIndexingNode)
-  Lambda(fn: Function)
+  Lambda(fn: Function, typeHint: Type?)
   Assignment(mode: TypedAssignmentMode, op: AssignOp, expr: TypedAstNode)
   If(isStatement: Bool, typedCondition: TypedAstNode, conditionBinding: (BindingPattern, Variable[])?, typedIfBlock: TypedAstNode[], ifBlockTerminator: Terminator?, typedElseBlock: TypedAstNode[], elseBlockTerminator: Terminator?)
   Match(isStatement: Bool, expr: TypedAstNode, cases: TypedMatchCase[])
@@ -4743,7 +4743,7 @@ export type Typechecker {
 
     val lambdaTy = fn.getType()
 
-    Ok(TypedAstNode(token: token, ty: lambdaTy, kind: TypedAstNodeKind.Lambda(fn)))
+    Ok(TypedAstNode(token: token, ty: lambdaTy, kind: TypedAstNodeKind.Lambda(fn, typeHint)))
   }
 }
 

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -711,7 +711,7 @@ export enum TypedAstNodeKind {
   Unary(op: UnaryOp, expr: TypedAstNode)
   Binary(left: TypedAstNode, op: BinaryOp, right: TypedAstNode)
   Grouped(inner: TypedAstNode)
-  Identifier(name: String, variable: Variable)
+  Identifier(name: String, variable: Variable, fnAliasTypeHint: Type?)
   Accessor(head: TypedAstNode, middle: AccessorPathSegment[], tail: AccessorPathSegment)
   Invocation(invokee: TypedInvokee, arguments: TypedAstNode?[], resolvedGenerics: Map<String, Type>)
   Array(items: TypedAstNode[])
@@ -3796,7 +3796,12 @@ export type Typechecker {
           }
           return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName(name, "variable")))
         }
-        (variable.ty, name, variable)
+        val fnTypeHint = match variable.alias {
+          VariableAlias.Function(fn) => typeHint
+          _ => None
+        }
+
+        (variable.ty, name, variable, fnTypeHint)
       }
       IdentifierKind.Discard => return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName("_", "variable")))
       IdentifierKind.None_ => {
@@ -3818,12 +3823,12 @@ export type Typechecker {
           }
           return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName("self", "variable")))
         }
-        (variable.ty, "self", variable)
+        (variable.ty, "self", variable, None)
       }
     }
 
     // TODO: destructuring
-    Ok(TypedAstNode(token: token, ty: _p[0], kind: TypedAstNodeKind.Identifier(_p[1], _p[2])))
+    Ok(TypedAstNode(token: token, ty: _p[0], kind: TypedAstNodeKind.Identifier(_p[1], _p[2], _p[3])))
   }
 
   func _resolveAccessorPathSegmentAny(self, label: Label, optSafe: Bool): AccessorPathSegment? {
@@ -3985,7 +3990,7 @@ export type Typechecker {
       }
 
       val token = Token(position: label.position, kind: TokenKind.Ident(label.name))
-      Some(TypedAstNode(token: token, ty: exportVar.ty, kind: TypedAstNodeKind.Identifier(label.name, exportVar)))
+      Some(TypedAstNode(token: token, ty: exportVar.ty, kind: TypedAstNodeKind.Identifier(label.name, exportVar, None)))
     } else {
       None
     }

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -94,6 +94,7 @@ export enum VariableAlias {
 
 export type Variable {
   label: Label
+  scope: Scope
   mutable: Bool
   ty: Type
   alias: VariableAlias? = None
@@ -103,7 +104,7 @@ export type Variable {
 
   func bogus(): Variable {
     val label = Label(name: "_bogus", position: Position(line: 0, col: 0))
-    Variable(label: label, mutable: false, ty: Type(kind: TypeKind.Never))
+    Variable(label: label, scope: Scope.bogus(), mutable: false, ty: Type(kind: TypeKind.Never))
   }
 }
 
@@ -148,9 +149,24 @@ export type Scope {
   terminator: Terminator? = None
   numLambdas: Int = 0
 
+  func bogus(name = ""): Scope {
+    val scopeName = if name == "" "bogus" else "bogus($name)"
+    Scope(name: scopeName)
+  }
+
   func eq(self, other: Scope): Bool = self.name == other.name
 
   func makeChild(self, name: String, kind: ScopeKind): Scope = Scope(name: "${self.name}::$name", kind: kind, parent: Some(self))
+
+  func contains(self, other: Scope): Bool {
+    var child = Some(other)
+    while child |ch| {
+      if self == ch return true
+      child = ch.parent
+    }
+
+    false
+  }
 }
 
 export type Field {
@@ -176,7 +192,7 @@ export type Struct {
 
   func makeDummy(moduleId: Int, name: String, typeParams: String[] = [], fields: (String, Type)[] = []): Struct {
     val bogusPosition = Position(line: 0, col: 0)
-    val bogusScope = Scope(name: "bogus($name)")
+    val bogusScope = Scope.bogus(name)
 
     val struct = Struct(
       moduleId: moduleId,
@@ -237,7 +253,7 @@ enum Instantiatable {
 
 export type Project {
   modules: Map<String, TypedModule> = {}
-  preludeScope: Scope = Scope(name: "bogus")
+  preludeScope: Scope = Scope.bogus()
   preludeIntStruct: Struct = Struct(moduleId: 0, label: Label(name: "Int", position: Position(line: 0, col: 0)), scope: Scope(name: "Int"))
   preludeFloatStruct: Struct = Struct(moduleId: 0, label: Label(name: "Float", position: Position(line: 0, col: 0)), scope: Scope(name: "Float"))
   preludeBoolStruct: Struct = Struct(moduleId: 0, label: Label(name: "Bool", position: Position(line: 0, col: 0)), scope: Scope(name: "Bool"))
@@ -603,6 +619,7 @@ export type Function {
   isLambda: Bool = false
   decorators: Decorator[] = []
   captures: Variable[] = []
+  capturedClosures: Function[] = []
 
   func generated(
     scope: Scope,
@@ -673,6 +690,8 @@ export type Function {
       decorators: self.decorators,
     )
   }
+
+  func isClosure(self): Bool = !self.captures.isEmpty() || !self.capturedClosures.isEmpty()
 }
 
 export enum TypedInvokee {
@@ -1477,7 +1496,7 @@ export type Typechecker {
     val structTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Struct(struct)))
     match self._addTypeToScope(structTy) { Ok(v) => v, Err(e) => return Err(e) }
 
-    val variable = Variable(label: struct.label, mutable: false, ty: structTy, alias: Some(VariableAlias.Struct(struct)))
+    val variable = Variable(label: struct.label, scope: scope, mutable: false, ty: structTy, alias: Some(VariableAlias.Struct(struct)))
     match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
 
     scope.structs.push(struct)
@@ -1494,7 +1513,7 @@ export type Typechecker {
     val enumTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Enum(enum_)))
     match self._addTypeToScope(enumTy) { Ok(v) => v, Err(e) => return Err(e) }
 
-    val variable = Variable(label: enum_.label, mutable: false, ty: enumTy, alias: Some(VariableAlias.Enum(enum_)))
+    val variable = Variable(label: enum_.label, scope: scope, mutable: false, ty: enumTy, alias: Some(VariableAlias.Enum(enum_)))
     match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
 
     scope.enums.push(enum_)
@@ -2150,7 +2169,7 @@ export type Typechecker {
           }
         }
 
-        val variable = Variable(label: param.label, mutable: false, ty: ty, isParameter: true)
+        val variable = Variable(label: param.label, scope: self.currentScope, mutable: false, ty: ty, isParameter: true)
         match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
 
         val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: None, isVariadic: false, variable: variable)
@@ -2220,7 +2239,7 @@ export type Typechecker {
       }
     }
 
-    val variable = Variable(label: param.label, mutable: false, ty: ty, isParameter: true)
+    val variable = Variable(label: param.label, scope: self.currentScope, mutable: false, ty: ty, isParameter: true)
     match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
 
     if param.isVariadic {
@@ -2817,7 +2836,7 @@ export type Typechecker {
       }
 
       val fn = match self._typecheckFunctionPass1(node) { Ok(v) => v, Err(e) => return Err(e) }
-      val aliasVar = Variable(label: fn.label, mutable: false, ty: fn.getType(), alias: Some(VariableAlias.Function(fn)))
+      val aliasVar = Variable(label: fn.label, scope: self.currentScope, mutable: false, ty: fn.getType(), alias: Some(VariableAlias.Function(fn)))
       self.currentScope.variables.push(aliasVar)
       functionsPass1.push((fn, aliasVar, node))
       if isExported {
@@ -2954,7 +2973,7 @@ export type Typechecker {
   func _typecheckBindingPattern(self, mutable: Bool, pattern: BindingPattern, ty: Type): Result<Variable[], TypeError> {
     match pattern {
       BindingPattern.Variable(label) => {
-        val variable = Variable(label: label, mutable: mutable, ty: ty)
+        val variable = Variable(label: label, scope: self.currentScope, mutable: mutable, ty: ty)
         match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
 
         Ok([variable])
@@ -3465,7 +3484,7 @@ export type Typechecker {
               self.currentScope = self.currentScope.makeChild("matchcase_${caseTy.repr()}", ScopeKind.MatchCase)
               if case.binding |binding| {
                 // TODO: generics in ty
-                caseVar = Some(Variable(label: binding, mutable: false, ty: caseTy))
+                caseVar = Some(Variable(label: binding, scope: self.currentScope, mutable: false, ty: caseTy))
               }
 
               TypedMatchCaseKind.Type(caseTy)
@@ -3517,7 +3536,7 @@ export type Typechecker {
                       } else {
                         field.ty
                       }
-                      val variable = Variable(label: arg, mutable: false, ty: variableTy)
+                      val variable = Variable(label: arg, scope: self.currentScope, mutable: false, ty: variableTy)
                       match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
                       variables.push(variable)
                     }
@@ -3526,7 +3545,7 @@ export type Typechecker {
               }
 
               if case.binding |binding| {
-                caseVar = Some(Variable(label: binding, mutable: false, ty: caseTy))
+                caseVar = Some(Variable(label: binding, scope: self.currentScope, mutable: false, ty: caseTy))
               }
 
               TypedMatchCaseKind.EnumVariant(enum_, variant, variantIdx, variables)
@@ -3548,7 +3567,7 @@ export type Typechecker {
 
           self.currentScope = self.currentScope.makeChild("matchcase_$value", ScopeKind.MatchCase)
           if case.binding |binding| {
-            caseVar = Some(Variable(label: binding, mutable: false, ty: literalTy))
+            caseVar = Some(Variable(label: binding, scope: self.currentScope, mutable: false, ty: literalTy))
           }
 
           val subjectTy = if self._typeIsOption(subjectTy) |innerTy| innerTy else subjectTy
@@ -3566,7 +3585,7 @@ export type Typechecker {
 
           self.currentScope = self.currentScope.makeChild("matchcase_None", ScopeKind.MatchCase)
           if case.binding |binding| {
-            caseVar = Some(Variable(label: binding, mutable: false, ty: subjectTy))
+            caseVar = Some(Variable(label: binding, scope: self.currentScope, mutable: false, ty: subjectTy))
           }
 
           if self._typeIsOption(subjectTy) |ty| {
@@ -3582,7 +3601,7 @@ export type Typechecker {
 
           self.currentScope = self.currentScope.makeChild("matchcase_else", ScopeKind.MatchCase)
           if case.binding |binding| {
-            caseVar = Some(Variable(label: binding, mutable: false, ty: subjectTy))
+            caseVar = Some(Variable(label: binding, scope: self.currentScope, mutable: false, ty: subjectTy))
           }
 
           TypedMatchCaseKind.Else
@@ -4459,6 +4478,14 @@ export type Typechecker {
       TypedInvokee.Function(fn)
     }
 
+    if fn.isClosure() {
+      if self.currentFunction |currentFn| {
+        if !currentFn.capturedClosures.find(f => f.label.name == fn.label.name) {
+          currentFn.capturedClosures.push(fn)
+        }
+      }
+    }
+
     Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Invocation(typedInvokee, typedArguments, resolvedGenerics)))
   }
 
@@ -4794,6 +4821,23 @@ export type Typechecker {
 
     val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params, paramHints: paramHints) { Ok(v) => v, Err(e) => return Err(e) }
     match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: node.params, body: node.body, paramsNeedingRevisit: paramsNeedingRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+
+    if fn.isClosure() {
+      if self.currentFunction |currentFn| {
+        for capturedVar in fn.captures {
+          if !currentFn.captures.find(v => v.label.name == capturedVar.label.name) {
+            if !currentFn.scope.contains(capturedVar.scope) {
+              currentFn.captures.push(capturedVar)
+            }
+          }
+        }
+        for capturedClosure in fn.capturedClosures {
+          if !currentFn.capturedClosures.find(fn => fn.label.name == capturedClosure.label.name) {
+            currentFn.capturedClosures.push(capturedClosure)
+          }
+        }
+      }
+    }
 
     val lambdaTy = fn.getType()
 

--- a/selfhost/src/typechecker_test_utils.abra
+++ b/selfhost/src/typechecker_test_utils.abra
@@ -888,6 +888,14 @@ export type Jsonifier {
       println(",")
     }
 
+    if !function.capturedClosures.isEmpty() {
+      self.print("\"capturedClosures\": ")
+      self.array(function.capturedClosures, fn => {
+        print("\"${fn.label.name}\"")
+      })
+      println(",")
+    }
+
     self.print("\"body\": ")
     self.array(function.body, n => self.printNode(n))
     println()

--- a/selfhost/src/typechecker_test_utils.abra
+++ b/selfhost/src/typechecker_test_utils.abra
@@ -798,6 +798,10 @@ export type Jsonifier {
 
     self.println("\"mutable\": ${variable.mutable},")
 
+    if variable.isCaptured {
+      self.println("\"isCaptured\": true,")
+    }
+
     self.print("\"type\": ")
     self.printType(variable.ty)
     println()
@@ -875,6 +879,14 @@ export type Jsonifier {
     self.print("\"returnType\": ")
     self.printType(function.returnType)
     println(",")
+
+    if !function.captures.isEmpty() {
+      self.print("\"captures\": ")
+      self.array(function.captures, v => {
+        self.printVariable(v)
+      })
+      println(",")
+    }
 
     self.print("\"body\": ")
     self.array(function.body, n => self.printNode(n))

--- a/selfhost/test/compiler/arrays.abra
+++ b/selfhost/test/compiler/arrays.abra
@@ -10,8 +10,7 @@
 println([1].length, [[1, 2], [3, 4]].length)
 
 // Test array literal construction
-// (() => {
-func test_arrayLiteralConstruction() {
+(() => {
   val emptyArr: Int[] = []
   /// Expect: []
   println(emptyArr)
@@ -31,13 +30,10 @@ func test_arrayLiteralConstruction() {
   val nestedArr = [[1, 2], [3, 4], [5, 6]]
   /// Expect: [[1, 2], [3, 4], [5, 6]]
   println(nestedArr)
-// })()
-}
-test_arrayLiteralConstruction()
+})()
 
 // Test array indexing assignment
-// (() => {
-func test_arrayIndexingAssignment() {
+(() => {
   val emptyArr: Int[] = []
   emptyArr[0] = 123
   /// Expect: []
@@ -82,13 +78,10 @@ func test_arrayIndexingAssignment() {
   nestedArr[-1] = [3, 2]
   /// Expect: [[0, 1], [3, 4], [3, 2]]
   println(nestedArr)
-// })()
-}
-test_arrayIndexingAssignment()
+})()
 
 // == operator (also Array#eq)
-// (() => {
-func test_arrayEq() {
+(() => {
   val arr = [1, 2]
 
   /// Expect: true
@@ -114,23 +107,17 @@ func test_arrayEq() {
 //   println(arr == #{1, 2, 3})
 //   /// Expect: false
 //   println(arr == { (1): "a", (2): "b" })
-// })()
-}
-test_arrayEq()
+})()
 
 // Indexing (also Array#get(index: Int))
-// (() => {
-func test_arrayIndexing() {
+(() => {
   val arr = [1, 2, 3]
   /// Expect: Option.None Option.Some(value: 1) Option.Some(value: 2) Option.Some(value: 3) Option.Some(value: 1) Option.Some(value: 2) Option.Some(value: 3) Option.None
   println(arr[-4], arr[-3], arr[-2], arr[-1], arr[0], arr[1], arr[2], arr[3])
-// })()
-}
-test_arrayIndexing()
+})()
 
 // Range indexing (also Array#getRange(startIndex: Int, endIndex: Int))
-// (() => {
-func test_arrayRangeIndexing() {
+(() => {
   val arr = [1, 2, 3, 4, 5]
 
   /// Expect: [2, 3, 4] [2, 3, 4] [2, 3, 4]
@@ -150,13 +137,10 @@ func test_arrayRangeIndexing() {
 
   /// Expect: [2, 3, 4, 5] [1]
   println(arr[x:], arr[:x])
-// })()
-}
-test_arrayRangeIndexing()
+})()
 
 // Array.fill
-// (() => {
-func test_arrayFill() {
+(() => {
   val zeroes = Array.fill(5, 0)
   /// Expect: [0, 0, 0, 0, 0]
   println(zeroes)
@@ -168,9 +152,7 @@ func test_arrayFill() {
   arr.push(3)
   /// Expect: [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
   println(refs)
-// })()
-}
-test_arrayFill()
+})()
 
 // // Array.fillBy
 // (() => {
@@ -200,21 +182,17 @@ test_arrayFill()
 // })()
 
 // Array#hash
-// (() => {
-func test_arrayHash() {
+(() => {
   val arr = [1, 2, 3]
   /// Expect: true
   println(arr.hash() == [1, 2, 3].hash())
 
   /// Expect: false
   println(arr.hash() == [1, 2].hash())
-// })()
-}
-test_arrayHash()
+})()
 
 // Array#iterator
-// (() => {
-func test_arrayIterator() {
+(() => {
   val a = [1.23, 4.56, 7.89]
   val iter = a.iterator()
   /// Expect: Option.Some(value: 1.23)
@@ -227,9 +205,7 @@ func test_arrayIterator() {
   println(iter.next())
   /// Expect: Option.None
   println(iter.next())
-// })()
-}
-test_arrayIterator()
+})()
 
 // For-loops
 /// Expect: a
@@ -238,8 +214,7 @@ test_arrayIterator()
 for ch in ["a", "b", "c"] println(ch)
 
 // Array#push
-// (() => {
-func test_arrayPush() {
+(() => {
   val intArr = [1, 2, 3]
   /// Expect: [1, 2, 3] 3 4
   println(intArr, intArr.length, intArr._capacity)
@@ -264,13 +239,10 @@ func test_arrayPush() {
   strArr.push("e")
   /// Expect: [[a, b, c, d, e], [a, b, c, d, e]] 5 8
   println(arrArr, strArr.length, strArr._capacity)
-// })()
-}
-test_arrayPush()
+})()
 
 // Array#pop
-// (() => {
-func test_arrayPop() {
+(() => {
   val arr = [1, 2, 3]
   /// Expect: Option.Some(value: 3)
   println(arr.pop())
@@ -291,43 +263,39 @@ func test_arrayPop() {
   println(arr.pop())
   /// Expect: []
   println(arr)
-// })()
-}
-test_arrayPop()
+})()
 
 // Array#concat
-// (() => {
-func test_arrayConcat() {
+(() => {
   val arr1 = [1, 2, 3, 4]
   val arr2 = [5, 6, 7]
   /// Expect: [1, 2, 3, 4, 5, 6, 7]
   println(arr1.concat(arr2))
   /// Expect: [1, 2, 3, 4] [5, 6, 7]
   println(arr1, arr2) // verify originals unmodified
-// })()
-}
-test_arrayConcat()
+})()
 
-// // Array#map
-// func addOne(i: Int): Int = i + 1
-// func exclaim(i: Int, _: Int, x = "!"): String = "$i$x"
+// Array#map
+func addOne(i: Int): Int = i + 1
+func exclaim(i: Int, _: Int, x = "!"): String = i + x //"$i$x"
 // val one = 1
-// (() => {
-//   val arr = [1, 2, 3, 4]
+(() => {
+  val arr = [1, 2, 3, 4]
 
-//   /// Expect: [2, 3, 4, 5]
-//   println(arr.map(addOne))
-//   /// Expect: [2, 3, 4, 5]
-//   println(arr.map(i => i + 1))
-//   /// Expect: [2, 3, 4, 5]
-//   println(arr.map(i => i + one))
+  /// Expect: [2, 3, 4, 5]
+  println(arr.map(addOne))
+  /// Expect: [2, 3, 4, 5]
+  println(arr.map(i => i + 1))
+  // /// Expect: [2, 3, 4, 5]
+  // println(arr.map(i => i + one))
 
-//   /// Expect: [1!, 2!, 3!, 4!]
-//   println(arr.map(exclaim))
-//   /// Expect: [1!, 2!, 3!, 4!]
-//   println(arr.map((i, _, x = "!") => "$i$x"))
-// })()
+  /// Expect: [1!, 2!, 3!, 4!]
+  println(arr.map(exclaim))
+  /// Expect: [1!, 2!, 3!, 4!]
+  println(arr.map((i, _, x = "!") => i + x))
+})()
 
+// TODO: there's something up with printing an array of this particular size
 // // Array#flatMap
 // (() => {
 //   val arr = [1, 2, 3, 4]
@@ -336,50 +304,58 @@ test_arrayConcat()
 //   println(arr.flatMap(i => Array.fill(i, i)))
 // })()
 
-// // Array#filter
-// func isEven(i: Int): Bool = i % 2 == 0
-// (() => {
-//   val arr = [1, 2, 3, 4]
+// Array#filter
+func isEven(i: Int): Bool = i % 2 == 0
+(() => {
+  val arr = [1, 2, 3, 4]
 
-//   /// Expect: [2, 4]
-//   println(arr.filter(isEven))
-//   /// Expect: [2, 4]
-//   println(arr.filter(x => x % 2 == 0))
-// })()
+  /// Expect: [2, 4]
+  println(arr.filter(isEven))
+  /// Expect: [2, 4]
+  println(arr.filter(x => x % 2 == 0))
+})()
 
-// // Array#reduce
-// func doSum(acc: Int, i: Int): Int = acc + i
-// (() => {
-//   val arr = [1, 2, 3, 4]
+// Array#reduce
+func doSum(acc: Int, i: Int): Int = acc + i
+(() => {
+  val arr = [1, 2, 3, 4]
 
-//   /// Expect: 10
-//   println(arr.reduce(0, doSum))
-//   /// Expect: 10
-//   println(arr.reduce(0, (acc, i) => acc + i))
-// })()
+  // TODO: I shouldn't need r1/r2 below, but otherwise I get a typechecker error:
+  //   Type mismatch for parameter 'initialValue'
+  //     |    println(arr.reduce(0, doSum))
+  //                             ^
+  //   Expected: Any
+  //   but instead found: Int
 
-// // Array#forEach
-// func printItem(item: Int) = println(item)
-// (() => {
-//   val arr = [1, 2, 3, 4]
+  /// Expect: 10
+  val r1 = arr.reduce(0, doSum)
+  println(r1)
+  /// Expect: 10
+  val r2 = arr.reduce(0, (acc, i) => acc + i)
+  println(r2)
+})()
 
-//   /// Expect: 1
-//   /// Expect: 2
-//   /// Expect: 3
-//   /// Expect: 4
-//   arr.forEach(printItem)
-//   /// Expect: 1
-//   /// Expect: 2
-//   /// Expect: 3
-//   /// Expect: 4
-//   arr.forEach(i => {
-//     println(i)
-//   })
-// })()
+// Array#forEach
+func printItem(item: Int) = println(item)
+(() => {
+  val arr = [1, 2, 3, 4]
+
+  /// Expect: 1
+  /// Expect: 2
+  /// Expect: 3
+  /// Expect: 4
+  arr.forEach(printItem)
+  /// Expect: 1
+  /// Expect: 2
+  /// Expect: 3
+  /// Expect: 4
+  arr.forEach(i => {
+    println(i)
+  })
+})()
 
 // Array#join
-// (() => {
-func test_arrayJoin() {
+(() => {
   val arr = [123, 456, 789]
   /// Expect: 123|456|789
   println(arr.join("|"))
@@ -388,13 +364,10 @@ func test_arrayJoin() {
 
   /// Expect: 1
   println([1].join(", "))
-// })()
-}
-test_arrayJoin()
+})()
 
 // Array#contains
-// (() => {
-func test_arrayContains() {
+(() => {
   val intArr = [123, 456, 789]
   /// Expect: true
   println(intArr.contains(123))
@@ -410,133 +383,131 @@ func test_arrayContains() {
   println(strArr.contains("hello"))
   /// Expect: false
   println(strArr.contains("HELLO"))
-// })()
-}
-test_arrayContains()
+})()
 
-// // Array#find
-// (() => {
-//   val intArr = [123, 456, 789]
-//   /// Expect: Option.Some(value: 123)
-//   println(intArr.find(i => i == 123))
-//   /// Expect: Option.None
-//   println(intArr.find(i => i == 10))
+// Array#find
+(() => {
+  val intArr = [123, 456, 789]
+  /// Expect: Option.Some(value: 123)
+  println(intArr.find(i => i == 123))
+  /// Expect: Option.None
+  println(intArr.find(i => i == 10))
 
-//   val empty: Int[] = []
-//   /// Expect: Option.None
-//   println(empty.find(i => i == 123))
+  val empty: Int[] = []
+  /// Expect: Option.None
+  println(empty.find(i => i == 123))
 
-//   val strArr = ["hello", "world"]
-//   /// Expect: Option.Some(value: "hello")
-//   println(strArr.find(s => s == "hello"))
-//   /// Expect: Option.None
-//   println(strArr.find(s => s == "HELLO"))
-// })()
+  val strArr = ["hello", "world"]
+  /// Expect: Option.Some(value: "hello")
+  println(strArr.find(s => s == "hello"))
+  /// Expect: Option.None
+  println(strArr.find(s => s == "HELLO"))
+})()
 
-// // Array#findIndex
-// (() => {
-//   val intArr = [123, 456, 789]
-//   /// Expect: Option.Some(value: (123, 0))
-//   println(intArr.findIndex(i => i == 123))
-//   /// Expect: Option.None
-//   println(intArr.findIndex(i => i == 10))
+// Array#findIndex
+(() => {
+  val intArr = [123, 456, 789]
+  /// Expect: Option.Some(value: (123, 0))
+  println(intArr.findIndex(i => i == 123))
+  /// Expect: Option.None
+  println(intArr.findIndex(i => i == 10))
 
-//   val empty: Int[] = []
-//   /// Expect: Option.None
-//   println(empty.findIndex(i => i == 123))
+  val empty: Int[] = []
+  /// Expect: Option.None
+  println(empty.findIndex(i => i == 123))
 
-//   val strArr = ["hello", "world"]
-//   /// Expect: Option.Some(value: ("hello", 0))
-//   println(strArr.findIndex(s => s == "hello"))
-//   /// Expect: Option.None
-//   println(strArr.findIndex(s => s == "HELLO"))
-// })()
+  val strArr = ["hello", "world"]
+  /// Expect: Option.Some(value: ("hello", 0))
+  println(strArr.findIndex(s => s == "hello"))
+  /// Expect: Option.None
+  println(strArr.findIndex(s => s == "HELLO"))
+})()
 
-// // Array#any
-// (() => {
-//   val intArr = [123, 456, 789]
-//   /// Expect: true
-//   println(intArr.any(i => i == 123))
-//   /// Expect: false
-//   println(intArr.any(i => i == 10))
+// Array#any
+(() => {
+  val intArr = [123, 456, 789]
+  /// Expect: true
+  println(intArr.any(i => i == 123))
+  /// Expect: false
+  println(intArr.any(i => i == 10))
 
-//   val empty: Int[] = []
-//   /// Expect: false
-//   println(empty.any(i => i == 123))
+  val empty: Int[] = []
+  /// Expect: false
+  println(empty.any(i => i == 123))
 
-//   val strArr = ["hello", "world"]
-//   /// Expect: true
-//   println(strArr.any(s => s == "hello"))
-//   /// Expect: false
-//   println(strArr.any(s => s == "HELLO"))
-// })()
+  val strArr = ["hello", "world"]
+  /// Expect: true
+  println(strArr.any(s => s == "hello"))
+  /// Expect: false
+  println(strArr.any(s => s == "HELLO"))
+})()
 
-// // Array#all
-// (() => {
-//   val intArr = [123, 456, 789]
-//   /// Expect: true
-//   println(intArr.all(i => i > 0))
-//   /// Expect: false
-//   println(intArr.all(i => i == 10))
+// Array#all
+(() => {
+  val intArr = [123, 456, 789]
+  /// Expect: true
+  println(intArr.all(i => i > 0))
+  /// Expect: false
+  println(intArr.all(i => i == 10))
 
-//   val empty: Int[] = []
-//   /// Expect: true
-//   println(empty.all(i => i == 123))
+  val empty: Int[] = []
+  /// Expect: true
+  println(empty.all(i => i == 123))
 
-//   val strArr = ["hello", "world"]
-//   /// Expect: true
-//   println(strArr.all(s => s.length > 0))
-//   /// Expect: false
-//   println(strArr.all(s => s == "HELLO"))
-// })()
+  val strArr = ["hello", "world"]
+  /// Expect: true
+  println(strArr.all(s => s.length > 0))
+  /// Expect: false
+  println(strArr.all(s => s == "HELLO"))
+})()
 
-// // Array#sortBy
-// (() => {
-//   val strings = ["abc", "d", "efgh", "ij", "k", "lm", "nopqr", "stu", "v", "wxyz"]
-//   val sorted = strings.sortBy(s => s.length)
-//   /// Expect: [abc, d, efgh, ij, k, lm, nopqr, stu, v, wxyz]
-//   println(strings) // original should be unmodified
-//   /// Expect: [d, k, v, ij, lm, stu, abc, efgh, wxyz, nopqr]
-//   println(sorted)
+// Array#sortBy
+(() => {
+  val strings = ["abc", "d", "efgh", "ij", "k", "lm", "nopqr", "stu", "v", "wxyz"]
+  val sorted = strings.sortBy(s => s.length)
+  /// Expect: [abc, d, efgh, ij, k, lm, nopqr, stu, v, wxyz]
+  println(strings) // original should be unmodified
+  /// Expect: [d, k, v, ij, lm, stu, abc, efgh, wxyz, nopqr]
+  println(sorted)
 
-//   val arrays = [[1, 2], [], [3, 4, 5], [6], [7, 8, 9, 10]]
-//   val sortedRev = arrays.sortBy(fn: a => a.length, reverse: true)
-//   /// Expect: [[1, 2], [], [3, 4, 5], [6], [7, 8, 9, 10]]
-//   println(arrays) // original should be unmodified
-//   /// Expect: [[7, 8, 9, 10], [3, 4, 5], [1, 2], [6], []]
-//   println(sortedRev)
-// })()
+  val arrays = [[1, 2], [], [3, 4, 5], [6], [7, 8, 9, 10]]
+  val sortedRev = arrays.sortBy(fn: a => a.length, reverse: true)
+  /// Expect: [[1, 2], [], [3, 4, 5], [6], [7, 8, 9, 10]]
+  println(arrays) // original should be unmodified
+  /// Expect: [[7, 8, 9, 10], [3, 4, 5], [1, 2], [6], []]
+  println(sortedRev)
+})()
 
-// // Array#keyBy
-// (() => {
-//   val empty: String[] = []
-//   /// Expect: {}
-//   println(empty.keyBy(s => s.length))
+// Array#keyBy
+(() => {
+  val empty: String[] = []
+  /// Expect: {}
+  println(empty.keyBy(s => s.length))
 
-//   val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
-//   /// Expect: { 3: dog, 4: lazy, 5: brown, 6: jumped }
-//   println(strArr.keyBy(s => s.length))
-// })()
+  val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
+  /// Expect: { 3: dog, 4: lazy, 5: brown, 6: jumped }
+  println(strArr.keyBy(s => s.length))
+})()
 
-// // Array#indexBy
-// (() => {
-//   val empty: String[] = []
-//   /// Expect: {}
-//   println(empty.indexBy(s => s.length))
+// Array#indexBy
+(() => {
+  val empty: String[] = []
+  /// Expect: {}
+  println(empty.indexBy(s => s.length))
 
-//   val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
-//   /// Expect: { 3: [The, fox, the, dog], 4: [over, lazy], 5: [quick, brown], 6: [jumped] }
-//   println(strArr.indexBy(s => s.length))
-// })()
+  val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
+  /// Expect: { 3: [The, fox, the, dog], 4: [over, lazy], 5: [quick, brown], 6: [jumped] }
+  println(strArr.indexBy(s => s.length))
+})()
 
-// // Array#asSet
-// (() => {
-//   val empty: String[] = []
-//   val emptySet: Set<String> = #{}
-//   /// Expect: true
-//   println(empty.asSet() == emptySet)
+// Array#asSet
+(() => {
+  val empty: String[] = []
+  val emptySet: Set<String> = #{}
+  /// Expect: true
+  println(empty.asSet() == emptySet)
 
-//   val arr = [1, 2, 3, 4, 3, 2, 1]
-//   /// Expect: true
-//   println(arr.asSet() == #{1, 2, 3, 4})
-// })()
+  val arr = [1, 2, 3, 4, 3, 2, 1]
+  /// Expect: true
+  println(arr.asSet() == #{1, 2, 3, 4})
+})()

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -3,3 +3,290 @@ func foo(a: Int, b = bar(a), c = bar(a, b), arr = [a, b, c]): Int = a + b + c + 
 func bar(x: Int, y = 10): Int = x + y
 /// Expect: 31
 println(foo(2))
+
+// // Variadic parameters
+// func variadic(*items: Int[]) = println(items)
+// /// Expect: [1, 2, 3]
+// variadic(1, 2, 3)
+// /// Expect: []
+// variadic()
+
+// Functions and closures as value (lambdas too)
+func abc(): Int = 24
+/// Expect: <#function>
+println(abc)
+val abcVal = abc
+/// Expect: <#function> 24
+println(abcVal, abcVal())
+
+func def(a: Int): Int = a + 1
+val defVal = def
+/// Expect: 24
+println(defVal(23))
+
+func ghi(a: Int, b: Int): Int = a + b
+val ghiVal = ghi
+/// Expect: 24
+println(ghiVal(11, 13))
+
+func callFn(fn: (Int) => Int) = println(fn(16))
+func callFn2(fn: (Int, Int, Int) => Int) = println(fn(16, 17, 18))
+func callFn3(fn: (Int, Int, Int, Int) => Int) = println(fn(16, 17, 18, 19))
+
+// val xyz = "xyz"
+
+func f0(x: Int): Int = x
+// func f0Closure(x: Int): Int = x + xyz.length
+/// Expect: 16
+callFn(f0)
+// /// Expect: 16
+// callFn(x => x)
+// /// Expect: 19
+// callFn(f0Closure)
+// /// Expect: 19
+// callFn(x => x + xyz.length)
+
+// func f1(x = 12): Int = x
+// func f1Closure(x = 12): Int = x + xyz.length
+// /// Expect: 16
+// callFn(f1)
+// /// Expect: 16
+// callFn((x = 12) => x)
+// /// Expect: 19
+// callFn(f1Closure)
+// /// Expect: 19
+// callFn((x = 12) => x + xyz.length)
+
+// func f2(x: Int, y = 6): Int = x + y
+// func f2Closure(x: Int, y = 6): Int = x + y + xyz.length
+// /// Expect: 22
+// callFn(f2)
+// /// Expect: 22
+// callFn((x, y = 6) => x + y)
+// /// Expect: 25
+// callFn(f2Closure)
+// /// Expect: 25
+// callFn((x, y = 6) => x + y + xyz.length)
+
+// func f3(x = 12, y = 6): Int = x + y
+// func f3Closure(x = 12, y = 6): Int = x + y + xyz.length
+// /// Expect: 22
+// callFn(f3)
+// /// Expect: 22
+// callFn((x = 12, y = 6) => x + y)
+// /// Expect: 25
+// callFn(f3Closure)
+// /// Expect: 25
+// callFn((x = 12, y = 6) => x + y + xyz.length)
+
+// func f4(x: Int): Int = x
+// func f4Closure(x: Int): Int = x + xyz.length
+// /// Expect: 16
+// callFn2(f4)
+// /// Expect: 16
+// callFn2(x => x)
+// /// Expect: 19
+// callFn2(f4Closure)
+// /// Expect: 19
+// callFn2(x => x + xyz.length)
+
+// func f5(x: Int, y: Int): Int = x + y
+// func f5Closure(x: Int, y: Int): Int = x + y + xyz.length
+// /// Expect: 33
+// callFn2(f5)
+// /// Expect: 33
+// callFn2((x, y) => x + y)
+// /// Expect: 36
+// callFn2(f5Closure)
+// /// Expect: 36
+// callFn2((x, y) => x + y + xyz.length)
+
+// func f6(x: Int, y = 12): Int = x + y
+// func f6Closure(x: Int, y = 12): Int = x + y + xyz.length
+// /// Expect: 33
+// callFn2(f6)
+// /// Expect: 33
+// callFn2((x, y = 12) => x + y)
+// /// Expect: 36
+// callFn2(f6Closure)
+// /// Expect: 36
+// callFn2((x, y = 12) => x + y + xyz.length)
+
+// func f7(x: Int, y = 12, z = 100): Int = x + y + z
+// func f7Closure(x: Int, y = 12, z = 100): Int = x + y + z + xyz.length
+// /// Expect: 51
+// callFn3(f7)
+// /// Expect: 51
+// callFn3((x, y = 12, z = 100) => x + y + z)
+// /// Expect: 54
+// callFn3(f7Closure)
+// /// Expect: 54
+// callFn3((x, y = 12, z = 100) => x + y + z + xyz.length)
+
+// // Closures
+// var capturedFloat = 1.1
+// func closure1(one: Int): Float {
+//   capturedFloat += 1.1
+//   val x = capturedFloat + one
+//   x
+// }
+// /// Expect: 1.1
+// println(capturedFloat)
+// /// Expect: 3.2
+// println(closure1(one: 1))
+// /// Expect: 2.2
+// println(capturedFloat)
+
+// capturedFloat = 10.1
+// /// Expect: 10.1
+// println(capturedFloat)
+// /// Expect: 12.2
+// println(closure1(one: 1))
+// /// Expect: 11.2
+// println(capturedFloat)
+
+// val capturedArray = [1, 2, 3]
+// func closure2(zero = 0): Int {
+//   capturedArray.pop()
+//   capturedArray.length + zero
+// }
+// /// Expect: [1, 2, 3]
+// println(capturedArray)
+// /// Expect: 2
+// println(closure2())
+// /// Expect: [1, 2]
+// println(capturedArray)
+// capturedArray.push(3)
+// /// Expect: [1, 2, 3]
+// println(capturedArray)
+
+// var capturedInt = 1
+// func closure3<T>(arr: T[], extra = 0) {
+//   capturedInt += arr.length + extra
+// }
+
+// /// Expect: 1
+// println(capturedInt)
+// closure3([1, 2, 3])
+// /// Expect: 4
+// println(capturedInt)
+// capturedInt = 1
+// closure3(["a", "b"], 12)
+// /// Expect: 15
+// println(capturedInt)
+
+// func closure4(a: Int, b = a + capturedInt): Int = a + b
+// /// Expect: 3
+// println(closure4(1, 2))
+// /// Expect: 16
+// capturedInt = 14
+// println(closure4(1))
+
+// capturedInt = 1
+// func closure5() { capturedInt += 2 }
+// func containsClosures1() { closure5() }
+// func containsClosures2() { containsClosures1() }
+
+// /// Expect: 1
+// println(capturedInt)
+// containsClosures2()
+// /// Expect: 3
+// println(capturedInt)
+// containsClosures2()
+// /// Expect: 5
+// println(capturedInt)
+
+// // Returning a function/closure value
+// func makeNonClosure(): (Int) => Int = i => i + 1
+// val nonClosure = makeNonClosure()
+// /// Expect: 12
+// println(nonClosure(11))
+
+// val one = 1
+// func makeClosureCapturingOutside(): (Int) => Int {
+//   i => i + one
+// }
+// val closureCapturingOutside = makeClosureCapturingOutside()
+// /// Expect: 12
+// println(closureCapturingOutside(11))
+
+// func makeAdder(x: Int): (Int) => Int {
+//   i => i + x
+// }
+// val addOne = makeAdder(1)
+// /// Expect: 12
+// println(addOne(11))
+
+// val capturedArr = [1, 2, 3]
+// func makeClosureCapturingOutsideAndParam(arr: Int[]): (Int) => Int {
+//   val f = (i: Int) => i + arr.length + one
+//   arr.pop()
+//   f
+// }
+// val closureCapturingOutsideAndParam = makeClosureCapturingOutsideAndParam(capturedArr)
+// /// Expect: [1, 2]
+// println(capturedArr)
+// capturedArr.push(3)
+// /// Expect: [1, 2, 3]
+// println(capturedArr)
+// /// Expect: 15
+// println(closureCapturingOutsideAndParam(11))
+
+// // This is a pretty cool stress-test for closures and functions as values
+// type JankInstance<A, B> {
+//   a: A
+//   b: B
+//   setA: (A) => A
+//   setB: (B) => B
+//   toString: () => String
+// }
+// func makeJankClass(className: String, a: Int, b: Float[]): JankInstance<Int, Float[]> {
+//   var selfA = a
+//   var selfB = b
+
+//   JankInstance(
+//     a: a,
+//     b: b,
+//     setA: a => selfA = a,
+//     setB: b => selfB = b,
+//     toString: () => "$className(a: $selfA, b: $selfB)"
+//   )
+// }
+// val jank = makeJankClass("Wow", 1, [2.3, 4.5])
+// /// Expect: Wow(a: 1, b: [2.3, 4.5])
+// println(jank.toString())
+
+// jank.setA(0)
+// jank.setB([1.2, 3.4])
+// /// Expect: Wow(a: 0, b: [1.2, 3.4])
+// println(jank.toString())
+
+// // Return statements in if-expressions
+// func returnExprInArr(i: Int): Int[] {
+//   val arr = [
+//     1,
+//     if i == 0 { return [] } else 2,
+//     3
+//   ]
+
+//   arr
+// }
+// /// Expect: []
+// println(returnExprInArr(0))
+// /// Expect: [1, 2, 3]
+// println(returnExprInArr(1))
+
+// func returnInVarDecl(i: Int): Int {
+//   val a = if i == 100 {
+//     17
+//   } else {
+//     return -1
+//   }
+
+//   return a
+// }
+
+// /// Expect: 17
+// println(returnInVarDecl(100))
+// /// Expect: -1
+// println(returnInVarDecl(0))

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -182,19 +182,19 @@ println(closure4(1, 2))
 capturedInt = 14
 println(closure4(1))
 
-// capturedInt = 1
-// func closure5() { capturedInt += 2 }
-// func containsClosures1() { closure5() }
-// func containsClosures2() { containsClosures1() }
+capturedInt = 1
+func closure5() { capturedInt += 2 }
+func containsClosures1() { closure5() }
+func containsClosures2() { containsClosures1() }
 
-// /// Expect: 1
-// println(capturedInt)
-// containsClosures2()
-// /// Expect: 3
-// println(capturedInt)
-// containsClosures2()
-// /// Expect: 5
-// println(capturedInt)
+/// Expect: 1
+println(capturedInt)
+containsClosures2()
+/// Expect: 3
+println(capturedInt)
+containsClosures2()
+/// Expect: 5
+println(capturedInt)
 
 // Returning a function/closure value
 func makeNonClosure(): (Int) => Int = i => i + 1
@@ -210,13 +210,21 @@ val closure = makeClosure()
 /// Expect: 134
 println(closure(11))
 
-// val one = 1
-// func makeClosureCapturingOutside(): (Int) => Int {
-//   i => i + one
-// }
-// val closureCapturingOutside = makeClosureCapturingOutside()
-// /// Expect: 12
-// println(closureCapturingOutside(11))
+val one = 1
+func makeClosureCapturingOutside(): (Int) => Int {
+  i => i + one
+}
+val closureCapturingOutside1 = makeClosureCapturingOutside()
+/// Expect: 12
+println(closureCapturingOutside1(11))
+// Even more ridiculous example
+func getClosureCapturingOutside(): (Int) => Int {
+  val fn = () => makeClosureCapturingOutside()
+  fn()
+}
+val closureCapturingOutside2 = getClosureCapturingOutside()
+/// Expect: 12
+println(closureCapturingOutside2(11))
 
 func makeAdder(x: Int): (Int) => Int {
   i => i + x
@@ -225,49 +233,60 @@ val addOne = makeAdder(1)
 /// Expect: 12
 println(addOne(11))
 
-// val capturedArr = [1, 2, 3]
-// func makeClosureCapturingOutsideAndParam(arr: Int[]): (Int) => Int {
-//   val f = (i: Int) => i + arr.length + one
-//   arr.pop()
-//   f
-// }
-// val closureCapturingOutsideAndParam = makeClosureCapturingOutsideAndParam(capturedArr)
-// /// Expect: [1, 2]
-// println(capturedArr)
-// capturedArr.push(3)
-// /// Expect: [1, 2, 3]
-// println(capturedArr)
-// /// Expect: 15
-// println(closureCapturingOutsideAndParam(11))
+val capturedArr = [1, 2, 3]
+func makeClosureCapturingOutsideAndParam(arr: Int[]): (Int) => Int {
+  val f = (i: Int) => i + arr.length + one
+  arr.pop()
+  f
+}
+val closureCapturingOutsideAndParam = makeClosureCapturingOutsideAndParam(capturedArr)
+/// Expect: [1, 2]
+println(capturedArr)
+capturedArr.push(3)
+/// Expect: [1, 2, 3]
+println(capturedArr)
+/// Expect: 15
+println(closureCapturingOutsideAndParam(11))
 
-// // This is a pretty cool stress-test for closures and functions as values
+// This is a pretty cool stress-test for closures and functions as values
+// TODO: there's some issue here with the generics. the error is: "unexpected generic 'A' at this point"
 // type JankInstance<A, B> {
 //   a: A
 //   b: B
-//   setA: (A) => A
-//   setB: (B) => B
+//   setA: (A) => Unit
+//   setB: (B) => Unit
 //   toString: () => String
 // }
-// func makeJankClass(className: String, a: Int, b: Float[]): JankInstance<Int, Float[]> {
-//   var selfA = a
-//   var selfB = b
+type JankInstance {
+  a: Int
+  b: Float[]
+  setA: (Int) => Unit
+  setB: (Float[]) => Unit
+  toString: () => String
+}
+func makeJankClass(className: String, a: Int, b: Float[]): JankInstance {
+  var selfA = a
+  var selfB = b
 
-//   JankInstance(
-//     a: a,
-//     b: b,
-//     setA: a => selfA = a,
-//     setB: b => selfB = b,
-//     toString: () => "$className(a: $selfA, b: $selfB)"
-//   )
-// }
-// val jank = makeJankClass("Wow", 1, [2.3, 4.5])
-// /// Expect: Wow(a: 1, b: [2.3, 4.5])
-// println(jank.toString())
-
-// jank.setA(0)
-// jank.setB([1.2, 3.4])
-// /// Expect: Wow(a: 0, b: [1.2, 3.4])
-// println(jank.toString())
+  JankInstance(
+    a: a,
+    b: b,
+    setA: a => selfA = a,
+    setB: b => selfB = b,
+    toString: () => className + "(a: " + selfA + ", b: " + selfB + ")" //"$className(a: $selfA, b: $selfB)"
+  )
+}
+val jank = makeJankClass("Wow", 1, [2.3, 4.5])
+/// Expect: Wow(a: 1, b: [2.3, 4.5])
+println(jank.toString())
+jank.setA(2)
+jank.b.push(6.7)
+/// Expect: Wow(a: 2, b: [2.3, 4.5, 6.7])
+println(jank.toString())
+jank.setA(0)
+jank.setB([1.2, 3.4])
+/// Expect: Wow(a: 0, b: [1.2, 3.4])
+println(jank.toString())
 
 // // Return statements in if-expressions
 // func returnExprInArr(i: Int): Int[] {

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -4,12 +4,12 @@ func bar(x: Int, y = 10): Int = x + y
 /// Expect: 31
 println(foo(2))
 
-// // Variadic parameters
-// func variadic(*items: Int[]) = println(items)
-// /// Expect: [1, 2, 3]
-// variadic(1, 2, 3)
-// /// Expect: []
-// variadic()
+// Variadic parameters
+func variadic(*items: Int[]) = println(items)
+/// Expect: [1, 2, 3]
+variadic(1, 2, 3)
+/// Expect: []
+variadic()
 
 // Functions and closures as value (lambdas too)
 func abc(): Int = 24
@@ -123,64 +123,64 @@ callFn3((x, y = 12, z = 100) => x + y + z)
 // /// Expect: 54
 // callFn3((x, y = 12, z = 100) => x + y + z + xyz.length)
 
-// // Closures
-// var capturedFloat = 1.1
-// func closure1(one: Int): Float {
-//   capturedFloat += 1.1
-//   val x = capturedFloat + one
-//   x
-// }
-// /// Expect: 1.1
-// println(capturedFloat)
-// /// Expect: 3.2
-// println(closure1(one: 1))
-// /// Expect: 2.2
-// println(capturedFloat)
+// Closures
+var capturedFloat = 1.1
+func closure1(one: Int): Float {
+  capturedFloat += 1.1
+  val x = capturedFloat + one
+  x
+}
+/// Expect: 1.1
+println(capturedFloat)
+/// Expect: 3.2
+println(closure1(one: 1))
+/// Expect: 2.2
+println(capturedFloat)
 
-// capturedFloat = 10.1
-// /// Expect: 10.1
-// println(capturedFloat)
-// /// Expect: 12.2
-// println(closure1(one: 1))
-// /// Expect: 11.2
-// println(capturedFloat)
+capturedFloat = 10.1
+/// Expect: 10.1
+println(capturedFloat)
+/// Expect: 12.2
+println(closure1(one: 1))
+/// Expect: 11.2
+println(capturedFloat)
 
-// val capturedArray = [1, 2, 3]
-// func closure2(zero = 0): Int {
-//   capturedArray.pop()
-//   capturedArray.length + zero
-// }
-// /// Expect: [1, 2, 3]
-// println(capturedArray)
-// /// Expect: 2
-// println(closure2())
-// /// Expect: [1, 2]
-// println(capturedArray)
-// capturedArray.push(3)
-// /// Expect: [1, 2, 3]
-// println(capturedArray)
+val capturedArray = [1, 2, 3]
+func closure2(zero = 0): Int {
+  capturedArray.pop()
+  capturedArray.length + zero
+}
+/// Expect: [1, 2, 3]
+println(capturedArray)
+/// Expect: 2
+println(closure2())
+/// Expect: [1, 2]
+println(capturedArray)
+capturedArray.push(3)
+/// Expect: [1, 2, 3]
+println(capturedArray)
 
-// var capturedInt = 1
-// func closure3<T>(arr: T[], extra = 0) {
-//   capturedInt += arr.length + extra
-// }
+var capturedInt = 1
+func closure3<T>(arr: T[], extra = 0) {
+  capturedInt += arr.length + extra
+}
 
-// /// Expect: 1
-// println(capturedInt)
-// closure3([1, 2, 3])
-// /// Expect: 4
-// println(capturedInt)
-// capturedInt = 1
-// closure3(["a", "b"], 12)
-// /// Expect: 15
-// println(capturedInt)
+/// Expect: 1
+println(capturedInt)
+closure3([1, 2, 3])
+/// Expect: 4
+println(capturedInt)
+capturedInt = 1
+closure3(["a", "b"], 12)
+/// Expect: 15
+println(capturedInt)
 
-// func closure4(a: Int, b = a + capturedInt): Int = a + b
-// /// Expect: 3
-// println(closure4(1, 2))
-// /// Expect: 16
-// capturedInt = 14
-// println(closure4(1))
+func closure4(a: Int, b = a + capturedInt): Int = a + b
+/// Expect: 3
+println(closure4(1, 2))
+/// Expect: 16
+capturedInt = 14
+println(closure4(1))
 
 // capturedInt = 1
 // func closure5() { capturedInt += 2 }

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -196,11 +196,19 @@ println(closure4(1))
 // /// Expect: 5
 // println(capturedInt)
 
-// // Returning a function/closure value
-// func makeNonClosure(): (Int) => Int = i => i + 1
-// val nonClosure = makeNonClosure()
-// /// Expect: 12
-// println(nonClosure(11))
+// Returning a function/closure value
+func makeNonClosure(): (Int) => Int = i => i + 1
+val nonClosure = makeNonClosure()
+/// Expect: 12
+println(nonClosure(11))
+
+func makeClosure(): (Int) => Int {
+  val x = 123
+  i => i + x
+}
+val closure = makeClosure()
+/// Expect: 134
+println(closure(11))
 
 // val one = 1
 // func makeClosureCapturingOutside(): (Int) => Int {
@@ -210,12 +218,12 @@ println(closure4(1))
 // /// Expect: 12
 // println(closureCapturingOutside(11))
 
-// func makeAdder(x: Int): (Int) => Int {
-//   i => i + x
-// }
-// val addOne = makeAdder(1)
-// /// Expect: 12
-// println(addOne(11))
+func makeAdder(x: Int): (Int) => Int {
+  i => i + x
+}
+val addOne = makeAdder(1)
+/// Expect: 12
+println(addOne(11))
 
 // val capturedArr = [1, 2, 3]
 // func makeClosureCapturingOutsideAndParam(arr: Int[]): (Int) => Int {

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -39,8 +39,8 @@ func f0(x: Int): Int = x
 // func f0Closure(x: Int): Int = x + xyz.length
 /// Expect: 16
 callFn(f0)
-// /// Expect: 16
-// callFn(x => x)
+/// Expect: 16
+callFn(x => x)
 // /// Expect: 19
 // callFn(f0Closure)
 // /// Expect: 19
@@ -50,8 +50,8 @@ func f1(x = 12): Int = x
 // func f1Closure(x = 12): Int = x + xyz.length
 /// Expect: 16
 callFn(f1)
-// /// Expect: 16
-// callFn((x = 12) => x)
+/// Expect: 16
+callFn((x = 12) => x)
 // /// Expect: 19
 // callFn(f1Closure)
 // /// Expect: 19
@@ -61,8 +61,8 @@ func f2(x: Int, y = 6): Int = x + y
 // func f2Closure(x: Int, y = 6): Int = x + y + xyz.length
 /// Expect: 22
 callFn(f2)
-// /// Expect: 22
-// callFn((x, y = 6) => x + y)
+/// Expect: 22
+callFn((x, y = 6) => x + y)
 // /// Expect: 25
 // callFn(f2Closure)
 // /// Expect: 25
@@ -72,8 +72,8 @@ func f3(x = 12, y = 6): Int = x + y
 // func f3Closure(x = 12, y = 6): Int = x + y + xyz.length
 /// Expect: 22
 callFn(f3)
-// /// Expect: 22
-// callFn((x = 12, y = 6) => x + y)
+/// Expect: 22
+callFn((x = 12, y = 6) => x + y)
 // /// Expect: 25
 // callFn(f3Closure)
 // /// Expect: 25
@@ -83,8 +83,8 @@ func f4(x: Int): Int = x
 // func f4Closure(x: Int): Int = x + xyz.length
 /// Expect: 16
 callFn2(f4)
-// /// Expect: 16
-// callFn2(x => x)
+/// Expect: 16
+callFn2(x => x)
 // /// Expect: 19
 // callFn2(f4Closure)
 // /// Expect: 19
@@ -94,8 +94,8 @@ func f5(x: Int, y: Int): Int = x + y
 // func f5Closure(x: Int, y: Int): Int = x + y + xyz.length
 /// Expect: 33
 callFn2(f5)
-// /// Expect: 33
-// callFn2((x, y) => x + y)
+/// Expect: 33
+callFn2((x, y) => x + y)
 // /// Expect: 36
 // callFn2(f5Closure)
 // /// Expect: 36
@@ -105,8 +105,8 @@ func f6(x: Int, y = 12): Int = x + y
 // func f6Closure(x: Int, y = 12): Int = x + y + xyz.length
 /// Expect: 33
 callFn2(f6)
-// /// Expect: 33
-// callFn2((x, y = 12) => x + y)
+/// Expect: 33
+callFn2((x, y = 12) => x + y)
 // /// Expect: 36
 // callFn2(f6Closure)
 // /// Expect: 36
@@ -116,8 +116,8 @@ func f7(x: Int, y = 12, z = 100): Int = x + y + z
 // func f7Closure(x: Int, y = 12, z = 100): Int = x + y + z + xyz.length
 /// Expect: 51
 callFn3(f7)
-// /// Expect: 51
-// callFn3((x, y = 12, z = 100) => x + y + z)
+/// Expect: 51
+callFn3((x, y = 12, z = 100) => x + y + z)
 // /// Expect: 54
 // callFn3(f7Closure)
 // /// Expect: 54

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -101,10 +101,10 @@ callFn2(f5)
 // /// Expect: 36
 // callFn2((x, y) => x + y + xyz.length)
 
-// func f6(x: Int, y = 12): Int = x + y
+func f6(x: Int, y = 12): Int = x + y
 // func f6Closure(x: Int, y = 12): Int = x + y + xyz.length
-// /// Expect: 33
-// callFn2(f6)
+/// Expect: 33
+callFn2(f6)
 // /// Expect: 33
 // callFn2((x, y = 12) => x + y)
 // /// Expect: 36
@@ -112,10 +112,10 @@ callFn2(f5)
 // /// Expect: 36
 // callFn2((x, y = 12) => x + y + xyz.length)
 
-// func f7(x: Int, y = 12, z = 100): Int = x + y + z
+func f7(x: Int, y = 12, z = 100): Int = x + y + z
 // func f7Closure(x: Int, y = 12, z = 100): Int = x + y + z + xyz.length
-// /// Expect: 51
-// callFn3(f7)
+/// Expect: 51
+callFn3(f7)
 // /// Expect: 51
 // callFn3((x, y = 12, z = 100) => x + y + z)
 // /// Expect: 54

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -79,10 +79,10 @@ callFn(f0)
 // /// Expect: 25
 // callFn((x = 12, y = 6) => x + y + xyz.length)
 
-// func f4(x: Int): Int = x
+func f4(x: Int): Int = x
 // func f4Closure(x: Int): Int = x + xyz.length
-// /// Expect: 16
-// callFn2(f4)
+/// Expect: 16
+callFn2(f4)
 // /// Expect: 16
 // callFn2(x => x)
 // /// Expect: 19
@@ -90,10 +90,10 @@ callFn(f0)
 // /// Expect: 19
 // callFn2(x => x + xyz.length)
 
-// func f5(x: Int, y: Int): Int = x + y
+func f5(x: Int, y: Int): Int = x + y
 // func f5Closure(x: Int, y: Int): Int = x + y + xyz.length
-// /// Expect: 33
-// callFn2(f5)
+/// Expect: 33
+callFn2(f5)
 // /// Expect: 33
 // callFn2((x, y) => x + y)
 // /// Expect: 36

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -33,95 +33,95 @@ func callFn(fn: (Int) => Int) = println(fn(16))
 func callFn2(fn: (Int, Int, Int) => Int) = println(fn(16, 17, 18))
 func callFn3(fn: (Int, Int, Int, Int) => Int) = println(fn(16, 17, 18, 19))
 
-// val xyz = "xyz"
+val xyz = "xyz"
 
 func f0(x: Int): Int = x
-// func f0Closure(x: Int): Int = x + xyz.length
+func f0Closure(x: Int): Int = x + xyz.length
 /// Expect: 16
 callFn(f0)
 /// Expect: 16
 callFn(x => x)
-// /// Expect: 19
-// callFn(f0Closure)
-// /// Expect: 19
-// callFn(x => x + xyz.length)
+/// Expect: 19
+callFn(f0Closure)
+/// Expect: 19
+callFn(x => x + xyz.length)
 
 func f1(x = 12): Int = x
-// func f1Closure(x = 12): Int = x + xyz.length
+func f1Closure(x = 12): Int = x + xyz.length
 /// Expect: 16
 callFn(f1)
 /// Expect: 16
 callFn((x = 12) => x)
-// /// Expect: 19
-// callFn(f1Closure)
-// /// Expect: 19
-// callFn((x = 12) => x + xyz.length)
+/// Expect: 19
+callFn(f1Closure)
+/// Expect: 19
+callFn((x = 12) => x + xyz.length)
 
 func f2(x: Int, y = 6): Int = x + y
-// func f2Closure(x: Int, y = 6): Int = x + y + xyz.length
+func f2Closure(x: Int, y = 6): Int = x + y + xyz.length
 /// Expect: 22
 callFn(f2)
 /// Expect: 22
 callFn((x, y = 6) => x + y)
-// /// Expect: 25
-// callFn(f2Closure)
-// /// Expect: 25
-// callFn((x, y = 6) => x + y + xyz.length)
+/// Expect: 25
+callFn(f2Closure)
+/// Expect: 25
+callFn((x, y = 6) => x + y + xyz.length)
 
 func f3(x = 12, y = 6): Int = x + y
-// func f3Closure(x = 12, y = 6): Int = x + y + xyz.length
+func f3Closure(x = 12, y = 6): Int = x + y + xyz.length
 /// Expect: 22
 callFn(f3)
 /// Expect: 22
 callFn((x = 12, y = 6) => x + y)
-// /// Expect: 25
-// callFn(f3Closure)
-// /// Expect: 25
-// callFn((x = 12, y = 6) => x + y + xyz.length)
+/// Expect: 25
+callFn(f3Closure)
+/// Expect: 25
+callFn((x = 12, y = 6) => x + y + xyz.length)
 
 func f4(x: Int): Int = x
-// func f4Closure(x: Int): Int = x + xyz.length
+func f4Closure(x: Int): Int = x + xyz.length
 /// Expect: 16
 callFn2(f4)
 /// Expect: 16
 callFn2(x => x)
-// /// Expect: 19
-// callFn2(f4Closure)
-// /// Expect: 19
-// callFn2(x => x + xyz.length)
+/// Expect: 19
+callFn2(f4Closure)
+/// Expect: 19
+callFn2(x => x + xyz.length)
 
 func f5(x: Int, y: Int): Int = x + y
-// func f5Closure(x: Int, y: Int): Int = x + y + xyz.length
+func f5Closure(x: Int, y: Int): Int = x + y + xyz.length
 /// Expect: 33
 callFn2(f5)
 /// Expect: 33
 callFn2((x, y) => x + y)
-// /// Expect: 36
-// callFn2(f5Closure)
-// /// Expect: 36
-// callFn2((x, y) => x + y + xyz.length)
+/// Expect: 36
+callFn2(f5Closure)
+/// Expect: 36
+callFn2((x, y) => x + y + xyz.length)
 
 func f6(x: Int, y = 12): Int = x + y
-// func f6Closure(x: Int, y = 12): Int = x + y + xyz.length
+func f6Closure(x: Int, y = 12): Int = x + y + xyz.length
 /// Expect: 33
 callFn2(f6)
 /// Expect: 33
 callFn2((x, y = 12) => x + y)
-// /// Expect: 36
-// callFn2(f6Closure)
-// /// Expect: 36
-// callFn2((x, y = 12) => x + y + xyz.length)
+/// Expect: 36
+callFn2(f6Closure)
+/// Expect: 36
+callFn2((x, y = 12) => x + y + xyz.length)
 
 func f7(x: Int, y = 12, z = 100): Int = x + y + z
-// func f7Closure(x: Int, y = 12, z = 100): Int = x + y + z + xyz.length
+func f7Closure(x: Int, y = 12, z = 100): Int = x + y + z + xyz.length
 /// Expect: 51
 callFn3(f7)
 /// Expect: 51
 callFn3((x, y = 12, z = 100) => x + y + z)
-// /// Expect: 54
-// callFn3(f7Closure)
-// /// Expect: 54
-// callFn3((x, y = 12, z = 100) => x + y + z + xyz.length)
+/// Expect: 54
+callFn3(f7Closure)
+/// Expect: 54
+callFn3((x, y = 12, z = 100) => x + y + z + xyz.length)
 
 // Closures
 var capturedFloat = 1.1

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -46,10 +46,10 @@ callFn(f0)
 // /// Expect: 19
 // callFn(x => x + xyz.length)
 
-// func f1(x = 12): Int = x
+func f1(x = 12): Int = x
 // func f1Closure(x = 12): Int = x + xyz.length
-// /// Expect: 16
-// callFn(f1)
+/// Expect: 16
+callFn(f1)
 // /// Expect: 16
 // callFn((x = 12) => x)
 // /// Expect: 19
@@ -57,10 +57,10 @@ callFn(f0)
 // /// Expect: 19
 // callFn((x = 12) => x + xyz.length)
 
-// func f2(x: Int, y = 6): Int = x + y
+func f2(x: Int, y = 6): Int = x + y
 // func f2Closure(x: Int, y = 6): Int = x + y + xyz.length
-// /// Expect: 22
-// callFn(f2)
+/// Expect: 22
+callFn(f2)
 // /// Expect: 22
 // callFn((x, y = 6) => x + y)
 // /// Expect: 25
@@ -68,10 +68,10 @@ callFn(f0)
 // /// Expect: 25
 // callFn((x, y = 6) => x + y + xyz.length)
 
-// func f3(x = 12, y = 6): Int = x + y
+func f3(x = 12, y = 6): Int = x + y
 // func f3Closure(x = 12, y = 6): Int = x + y + xyz.length
-// /// Expect: 22
-// callFn(f3)
+/// Expect: 22
+callFn(f3)
 // /// Expect: 22
 // callFn((x = 12, y = 6) => x + y)
 // /// Expect: 25

--- a/selfhost/test/typechecker/lambda/lambda.1.out.json
+++ b/selfhost/test/typechecker/lambda/lambda.1.out.json
@@ -81,9 +81,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_0", "position": [1, 37] },
+              "label": { "name": "lambda_3_1", "position": [1, 37] },
               "scope": {
-                "name": "$root::module_3::lambda_0",
+                "name": "$root::module_3::lambda_3_1",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [1, 31] },
@@ -267,9 +267,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_1", "position": [2, 28] },
+              "label": { "name": "lambda_3_2", "position": [2, 28] },
               "scope": {
-                "name": "$root::module_3::lambda_1",
+                "name": "$root::module_3::lambda_3_2",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [2, 12] },
@@ -451,9 +451,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_2", "position": [3, 20] },
+              "label": { "name": "lambda_3_3", "position": [3, 20] },
               "scope": {
-                "name": "$root::module_3::lambda_2",
+                "name": "$root::module_3::lambda_3_3",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [3, 12] },
@@ -690,9 +690,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_3", "position": [4, 33] },
+              "label": { "name": "lambda_3_4", "position": [4, 33] },
               "scope": {
-                "name": "$root::module_3::lambda_3",
+                "name": "$root::module_3::lambda_3_4",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [4, 26] },
@@ -868,9 +868,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_4", "position": [5, 36] },
+              "label": { "name": "lambda_3_5", "position": [5, 36] },
               "scope": {
-                "name": "$root::module_3::lambda_4",
+                "name": "$root::module_3::lambda_3_5",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [5, 26] },
@@ -1052,9 +1052,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5", "position": [7, 27] },
+              "label": { "name": "lambda_3_6", "position": [7, 27] },
               "scope": {
-                "name": "$root::module_3::lambda_5",
+                "name": "$root::module_3::lambda_3_6",
                 "variables": [],
                 "functions": [],
                 "types": []
@@ -1174,9 +1174,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_6", "position": [8, 28] },
+              "label": { "name": "lambda_3_7", "position": [8, 28] },
               "scope": {
-                "name": "$root::module_3::lambda_6",
+                "name": "$root::module_3::lambda_3_7",
                 "variables": [],
                 "functions": [],
                 "types": []
@@ -1332,9 +1332,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_7", "position": [9, 28] },
+              "label": { "name": "lambda_3_8", "position": [9, 28] },
               "scope": {
-                "name": "$root::module_3::lambda_7",
+                "name": "$root::module_3::lambda_3_8",
                 "variables": [],
                 "functions": [],
                 "types": []

--- a/selfhost/test/typechecker/lambda/lambda.2.out.json
+++ b/selfhost/test/typechecker/lambda/lambda.2.out.json
@@ -502,6 +502,7 @@
               {
                 "label": { "name": "fn", "position": [8, 30] },
                 "mutable": false,
+                "isCaptured": true,
                 "type": {
                   "kind": "function",
                   "parameters": [
@@ -760,6 +761,29 @@
                           "kind": "primitive",
                           "primitive": "Unit"
                         },
+                        "captures": [
+                          {
+                            "label": { "name": "fn", "position": [8, 30] },
+                            "mutable": false,
+                            "isCaptured": true,
+                            "type": {
+                              "kind": "function",
+                              "parameters": [
+                                {
+                                  "required": true,
+                                  "type": {
+                                    "kind": "generic",
+                                    "name": "T"
+                                  }
+                                }
+                              ],
+                              "returnType": {
+                                "kind": "primitive",
+                                "primitive": "Unit"
+                              }
+                            }
+                          }
+                        ],
                         "body": [
                           {
                             "token": {
@@ -870,6 +894,7 @@
               {
                 "label": { "name": "fn", "position": [11, 26] },
                 "mutable": false,
+                "isCaptured": true,
                 "type": {
                   "kind": "function",
                   "parameters": [
@@ -1160,6 +1185,29 @@
                               "kind": "generic",
                               "name": "U"
                             },
+                            "captures": [
+                              {
+                                "label": { "name": "fn", "position": [11, 26] },
+                                "mutable": false,
+                                "isCaptured": true,
+                                "type": {
+                                  "kind": "function",
+                                  "parameters": [
+                                    {
+                                      "required": true,
+                                      "type": {
+                                        "kind": "generic",
+                                        "name": "T"
+                                      }
+                                    }
+                                  ],
+                                  "returnType": {
+                                    "kind": "generic",
+                                    "name": "U"
+                                  }
+                                }
+                              }
+                            ],
                             "body": [
                               {
                                 "token": {

--- a/selfhost/test/typechecker/lambda/lambda.2.out.json
+++ b/selfhost/test/typechecker/lambda/lambda.2.out.json
@@ -316,9 +316,9 @@
                 "node": {
                   "kind": "lambda",
                   "function": {
-                    "label": { "name": "lambda_0", "position": [4, 25] },
+                    "label": { "name": "lambda_3_1", "position": [4, 25] },
                     "scope": {
-                      "name": "$root::module_3::lambda_0",
+                      "name": "$root::module_3::lambda_3_1",
                       "variables": [
                         {
                           "label": { "name": "x", "position": [4, 22] },
@@ -727,9 +727,9 @@
                     "node": {
                       "kind": "lambda",
                       "function": {
-                        "label": { "name": "lambda_0", "position": [9, 24] },
+                        "label": { "name": "lambda_3_2", "position": [9, 24] },
                         "scope": {
-                          "name": "$root::module_3::forEach::lambda_0",
+                          "name": "$root::module_3::forEach::lambda_3_2",
                           "variables": [
                             {
                               "label": { "name": "key", "position": [9, 20] },
@@ -1127,9 +1127,9 @@
                         "node": {
                           "kind": "lambda",
                           "function": {
-                            "label": { "name": "lambda_0", "position": [12, 26] },
+                            "label": { "name": "lambda_3_3", "position": [12, 26] },
                             "scope": {
-                              "name": "$root::module_3::map::lambda_0",
+                              "name": "$root::module_3::map::lambda_3_3",
                               "variables": [
                                 {
                                   "label": { "name": "v", "position": [12, 24] },

--- a/selfhost/test/typechecker/lambda/lambda_generic_inference.1.out.json
+++ b/selfhost/test/typechecker/lambda/lambda_generic_inference.1.out.json
@@ -419,9 +419,9 @@
                 "node": {
                   "kind": "lambda",
                   "function": {
-                    "label": { "name": "lambda_0", "position": [8, 16] },
+                    "label": { "name": "lambda_3_1", "position": [8, 16] },
                     "scope": {
-                      "name": "$root::module_3::lambda_0",
+                      "name": "$root::module_3::lambda_3_1",
                       "variables": [],
                       "functions": [],
                       "types": []

--- a/selfhost/test/typechecker/lambda/lambda_generic_inference.2.out.json
+++ b/selfhost/test/typechecker/lambda/lambda_generic_inference.2.out.json
@@ -71,9 +71,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_0", "position": [1, 14] },
+              "label": { "name": "lambda_3_1", "position": [1, 14] },
               "scope": {
-                "name": "$root::module_3::lambda_0",
+                "name": "$root::module_3::lambda_3_1",
                 "variables": [],
                 "functions": [],
                 "types": []
@@ -442,9 +442,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_1", "position": [8, 14] },
+              "label": { "name": "lambda_3_2", "position": [8, 14] },
               "scope": {
-                "name": "$root::module_3::lambda_1",
+                "name": "$root::module_3::lambda_3_2",
                 "variables": [],
                 "functions": [],
                 "types": []
@@ -810,9 +810,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_2", "position": [11, 14] },
+              "label": { "name": "lambda_3_3", "position": [11, 14] },
               "scope": {
-                "name": "$root::module_3::lambda_2",
+                "name": "$root::module_3::lambda_3_3",
                 "variables": [],
                 "functions": [],
                 "types": []


### PR DESCRIPTION
Expand upon the current `#buildCall` methods to accept an arbitrary `Value` as opposed to a `QbeFunction` instance. This allows instances of Functions (represented as structs, similar to tuples) to be passed around as arbitrary values, and invoked using the stored function pointer within.