### PR TITLE
Selfhost: compiling methods as values

### DIFF
--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,75 +1,12 @@
-// val set = #{17, 18, 19}
-// println(set)
+val bang = "!"
 
-// func callFn(fn: (Int) => Int, a: Int): Int {
-//   fn(a)
-// }
+type Foo<A> {
+  a: A
 
-// val res = callFn//(x => x + 1, 7)
-// println(res)
-
-// func add_(a: Int, b: Int): Int = a + b
-
-// val add = add_
-// println(add(1, 2))
-
-// val fn: (Int, Int) => Int = (x) => x + 10
-// println(fn(23, 24))
-
-// val arr = [1]
-// // println(arr)
-
-// // func foo(b: Int): Int = arr.length + b
-// val foo: (Int) => Int = b => b + 1
-// println(foo(23))
-
-// func makeAdder(x: Int): (Int) => Int {
-//   i => i + x
-// }
-// val addOne = makeAdder(1)
-// /// Expect: 12
-// println(addOne(11))
-
-// var capturedInt = 1
-// func closure5() { capturedInt += 2 }
-// func containsClosures1() { closure5() }
-// containsClosures1()
-
-// println(capturedInt)
-
-// val one = 1
-// func makeClosureCapturingOutside(): (Int) => Int {
-//   i => i + one
-// }
-// func getClosureCapturingOutside(): (Int) => Int {
-//   val f = () => makeClosureCapturingOutside()
-//   f()
-// }
-// val closureCapturingOutside = getClosureCapturingOutside()
-// /// Expect: 12
-// println(closureCapturingOutside(11))
-
-func makeClosure(): (Int) => Int {
-  val x = 123
-  i => i + x
+  func echo(self) { println(self.a + bang) }
+  func printA(self, bang = "!") { println(self.a + bang) }
 }
-val closure = makeClosure()
-/// Expect: 134
-println(closure(11))
 
-// arr.push(2)
-// println(arr)
-// println(foo(23))
-
-// func callFn1(fn: (Int, String) => Int) {
-//   println(fn(24, "abc"))
-// }
-// // func callFn2(fn: (String) => Int) {
-// //   println(fn("abc"))
-// // }
-// // func foo(a: Int, b: Int): Int = a + b
-// func foo(a: Int, s = "qwer", d = 1): Int = a + s.length + d
-// // func foo(): Int = 12
-// callFn1(foo)
-// // callFn2(foo)
-
+val foo = Foo(a: 11)
+val printA: () => Unit = foo.printA
+printA()

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -540,7 +540,27 @@ export type Compiler {
 
         Ok(None)
       }
-      TypedAstNodeKind.TypeDeclaration => Ok(None)
+      TypedAstNodeKind.TypeDeclaration(struct) => {
+        for fn in struct.instanceMethods {
+          if fn.isClosure() {
+            val capturesMem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+            val methodName = "${struct.label.name}..${fn.label.name}"
+            val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some("$methodName.captures"))
+            self._currentFn.block.buildStore(QbeType.Pointer, capturesMem, capturesSlot)
+          }
+        }
+
+        for fn in struct.staticMethods {
+          if fn.isClosure() {
+            val capturesMem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+            val methodName = "${struct.label.name}.${fn.label.name}"
+            val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some("$methodName.captures"))
+            self._currentFn.block.buildStore(QbeType.Pointer, capturesMem, capturesSlot)
+          }
+        }
+
+        Ok(None)
+      }
       TypedAstNodeKind.EnumDeclaration => Ok(None)
       TypedAstNodeKind.Break => {
         if self._loopStack[-1] |currentLoop| {
@@ -960,11 +980,12 @@ export type Compiler {
               }
 
               val capturesMem = if !fn.isClosure() None else {
-                val mem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+                val mem = match self._getCapturesArrForClosure(fn) { Ok(v) => v, Err(e) => return Err(e) }
                 Some(mem)
               }
 
-              self._compileFunctionValue(node.token.position, fn, targetParamTypes, capturesMem)
+              val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
+              self._compileFunctionValue(node.token.position, fn, fnValBase, targetParamTypes, capturesMem, None)
             }
             _ => {
               if variable.isCaptured {
@@ -987,6 +1008,7 @@ export type Compiler {
         var fnHasOptionalParameters = false
         var optSafeCtx: (Label, Value?, QbeFunction, Label)? = None
         var closureEnvCtx: (Value, Bool)? = None
+        var closureSelfCtx: Value? = None
 
         val _p = match invokee {
           TypedInvokee.Function(fn) => {
@@ -1130,6 +1152,10 @@ export type Compiler {
             val envPtr = self._currentFn.block.buildLoadL(fnObj)
             closureEnvCtx = Some((envPtr, true))
 
+            val selfPtrSlot = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size() * 2), fnObj) { Ok(v) => v, Err(e) => return qbeError(e) }
+            val selfPtr = self._currentFn.block.buildLoadL(selfPtrSlot)
+            closureSelfCtx = Some(selfPtr)
+
             val fnValPtrSlot = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), fnObj) { Ok(v) => v, Err(e) => return qbeError(e) }
             val fnValPtr = self._currentFn.block.buildLoadL(fnValPtrSlot)
 
@@ -1178,6 +1204,7 @@ export type Compiler {
           args.push(Value.Int32(defaultValueFlags))
         }
 
+        // TODO: yikes...
         var res = if fnVal.returnType() {
           if closureEnvCtx |_ctx| {
             // TODO: destructuring
@@ -1191,12 +1218,62 @@ export type Compiler {
               self._currentFn.block.buildJnz(closureEnvPtr, labelCallWithEnv, labelCallWithoutEnv)
 
               self._currentFn.block.registerLabel(labelCallWithEnv)
-              val resWithEnv = match self._currentFn.block.buildCall(fnVal, args, resultLocalName, Some(closureEnvPtr)) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val resWithEnv = if closureSelfCtx |selfVal| {
+                val labelCallWithSelf = self._currentFn.block.addLabel("call_fn_val_with_env_with_self")
+                val labelCallWithoutSelf = self._currentFn.block.addLabel("call_fn_val_with_env_without_self")
+                val labelCont = self._currentFn.block.addLabel("call_fn_val_cont_with_env")
+
+                self._currentFn.block.buildJnz(selfVal, labelCallWithSelf, labelCallWithoutSelf)
+
+                self._currentFn.block.registerLabel(labelCallWithSelf)
+                val resWithSelf = match self._currentFn.block.buildCall(fnVal, [selfVal].concat(args), resultLocalName, Some(closureEnvPtr)) { Ok(v) => v, Err(e) => return qbeError(e) }
+                val resWithSelfLabel = self._currentFn.block.currentLabel
+                self._currentFn.block.buildJmp(labelCont)
+
+                self._currentFn.block.registerLabel(labelCallWithoutSelf)
+                val resWithoutSelf = match self._currentFn.block.buildCall(fnVal, args, resultLocalName, Some(closureEnvPtr)) { Ok(v) => v, Err(e) => return qbeError(e) }
+                val resWithoutSelfLabel = self._currentFn.block.currentLabel
+                self._currentFn.block.buildJmp(labelCont)
+
+                self._currentFn.block.registerLabel(labelCont)
+
+                val phiCases = [(resWithSelfLabel, resWithSelf), (resWithoutSelfLabel, resWithoutSelf)]
+                val res = match self._currentFn.block.buildPhi(phiCases) { Ok(v) => v, Err(e) => return qbeError(e) }
+                res
+              } else {
+                val res = match self._currentFn.block.buildCall(fnVal, args, resultLocalName, Some(closureEnvPtr)) { Ok(v) => v, Err(e) => return qbeError(e) }
+                res
+              }
               val resWithEnvLabel = self._currentFn.block.currentLabel
               self._currentFn.block.buildJmp(labelCont)
 
               self._currentFn.block.registerLabel(labelCallWithoutEnv)
-              val resWithoutEnv = match self._currentFn.block.buildCall(fnVal, args, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val resWithoutEnv = if closureSelfCtx |selfVal| {
+                val labelCallWithSelf = self._currentFn.block.addLabel("call_fn_val_without_env_with_self")
+                val labelCallWithoutSelf = self._currentFn.block.addLabel("call_fn_val_without_env_without_self")
+                val labelCont = self._currentFn.block.addLabel("call_fn_val_cont_without_env")
+
+                self._currentFn.block.buildJnz(selfVal, labelCallWithSelf, labelCallWithoutSelf)
+
+                self._currentFn.block.registerLabel(labelCallWithSelf)
+                val resWithSelf = match self._currentFn.block.buildCall(fnVal, [selfVal].concat(args), resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+                val resWithSelfLabel = self._currentFn.block.currentLabel
+                self._currentFn.block.buildJmp(labelCont)
+
+                self._currentFn.block.registerLabel(labelCallWithoutSelf)
+                val resWithoutSelf = match self._currentFn.block.buildCall(fnVal, args, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+                val resWithoutSelfLabel = self._currentFn.block.currentLabel
+                self._currentFn.block.buildJmp(labelCont)
+
+                self._currentFn.block.registerLabel(labelCont)
+
+                val phiCases = [(resWithSelfLabel, resWithSelf), (resWithoutSelfLabel, resWithoutSelf)]
+                val res = match self._currentFn.block.buildPhi(phiCases) { Ok(v) => v, Err(e) => return qbeError(e) }
+                res
+              } else {
+                val res = match self._currentFn.block.buildCall(fnVal, args, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
+                res
+              }
               val resWithoutEnvLabel = self._currentFn.block.currentLabel
               self._currentFn.block.buildJmp(labelCont)
 
@@ -1228,11 +1305,47 @@ export type Compiler {
               self._currentFn.block.buildJnz(closureEnvPtr, labelCallWithEnv, labelCallWithoutEnv)
 
               self._currentFn.block.registerLabel(labelCallWithEnv)
-              self._currentFn.block.buildVoidCall(fnVal, args, Some(closureEnvPtr))
+              if closureSelfCtx |selfVal| {
+                val labelCallWithSelf = self._currentFn.block.addLabel("call_fn_val_with_env_with_self")
+                val labelCallWithoutSelf = self._currentFn.block.addLabel("call_fn_val_with_env_without_self")
+                val labelCont = self._currentFn.block.addLabel("call_fn_val_cont_with_env")
+
+                self._currentFn.block.buildJnz(selfVal, labelCallWithSelf, labelCallWithoutSelf)
+
+                self._currentFn.block.registerLabel(labelCallWithSelf)
+                self._currentFn.block.buildVoidCall(fnVal, [selfVal].concat(args), Some(closureEnvPtr))
+                self._currentFn.block.buildJmp(labelCont)
+
+                self._currentFn.block.registerLabel(labelCallWithoutSelf)
+                self._currentFn.block.buildVoidCall(fnVal, args, Some(closureEnvPtr))
+                self._currentFn.block.buildJmp(labelCont)
+
+                self._currentFn.block.registerLabel(labelCont)
+              } else {
+                self._currentFn.block.buildVoidCall(fnVal, args, Some(closureEnvPtr))
+              }
               self._currentFn.block.buildJmp(labelCont)
 
               self._currentFn.block.registerLabel(labelCallWithoutEnv)
-              self._currentFn.block.buildVoidCall(fnVal, args)
+              if closureSelfCtx |selfVal| {
+                val labelCallWithSelf = self._currentFn.block.addLabel("call_fn_val_without_env_with_self")
+                val labelCallWithoutSelf = self._currentFn.block.addLabel("call_fn_val_without_env_without_self")
+                val labelCont = self._currentFn.block.addLabel("call_fn_val_cont_without_env")
+
+                self._currentFn.block.buildJnz(selfVal, labelCallWithSelf, labelCallWithoutSelf)
+
+                self._currentFn.block.registerLabel(labelCallWithSelf)
+                self._currentFn.block.buildVoidCall(fnVal, [selfVal].concat(args))
+                self._currentFn.block.buildJmp(labelCont)
+
+                self._currentFn.block.registerLabel(labelCallWithoutSelf)
+                self._currentFn.block.buildVoidCall(fnVal, args)
+                self._currentFn.block.buildJmp(labelCont)
+
+                self._currentFn.block.registerLabel(labelCont)
+              } else {
+                self._currentFn.block.buildVoidCall(fnVal, args, Some(closureEnvPtr))
+              }
               self._currentFn.block.buildJmp(labelCont)
 
               self._currentFn.block.registerLabel(labelCont)
@@ -1240,7 +1353,25 @@ export type Compiler {
               self._currentFn.block.buildVoidCall(fnVal, args, Some(closureEnvPtr))
             }
           } else {
-            self._currentFn.block.buildVoidCall(fnVal, args)
+            if closureSelfCtx |selfVal| {
+              val labelCallWithSelf = self._currentFn.block.addLabel("call_fn_val_with_env_with_self")
+              val labelCallWithoutSelf = self._currentFn.block.addLabel("call_fn_val_with_env_without_self")
+              val labelCont = self._currentFn.block.addLabel("call_fn_val_cont_with_env")
+
+              self._currentFn.block.buildJnz(selfVal, labelCallWithSelf, labelCallWithoutSelf)
+
+              self._currentFn.block.registerLabel(labelCallWithSelf)
+              self._currentFn.block.buildVoidCall(fnVal, [selfVal].concat(args))
+              self._currentFn.block.buildJmp(labelCont)
+
+              self._currentFn.block.registerLabel(labelCallWithoutSelf)
+              self._currentFn.block.buildVoidCall(fnVal, args)
+              self._currentFn.block.buildJmp(labelCont)
+
+              self._currentFn.block.registerLabel(labelCont)
+            } else {
+              self._currentFn.block.buildVoidCall(fnVal, args)
+            }
           }
 
           Value.Ident("bogus", QbeType.F32)
@@ -1509,7 +1640,8 @@ export type Compiler {
           Some(mem)
         }
 
-        self._compileFunctionValue(node.token.position, fn, targetParamTypes, capturesMem)
+        val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
+        self._compileFunctionValue(node.token.position, fn, fnValBase, targetParamTypes, capturesMem, None)
       }
       TypedAstNodeKind.If(isStatement, cond, conditionBinding, ifBlock, ifBlockTerminator, elseBlock, elseBlockTerminator) => {
         if isStatement return unreachable("if-statements are handled elsewhere", node.token.position)
@@ -1664,7 +1796,27 @@ export type Compiler {
       self._currentFn.block.buildLoadL(ptr)
     } else {
       // If the closure is being called in the same scope in which it was declared, then the `*.captures` value is visible as a stack local.
-      val capturesName = "${fn.label.name}.captures"
+      val prefix = match fn.kind {
+        FunctionKind.InstanceMethod(structOrEnum) => {
+          val v = if structOrEnum |structOrEnum| {
+            val typeName = match structOrEnum {
+              StructOrEnum.Struct(struct) => struct.label.name
+              StructOrEnum.Enum(enum_) => enum_.label.name
+            }
+            "$typeName.."
+          } else return unreachable("an instance method should have a structOrEnum", fn.label.position)
+          v
+        }
+        FunctionKind.StaticMethod(structOrEnum) => {
+          val typeName = match structOrEnum {
+            StructOrEnum.Struct(struct) => struct.label.name
+            StructOrEnum.Enum(enum_) => enum_.label.name
+          }
+          "$typeName."
+        }
+        _ => ""
+      }
+      val capturesName = "$prefix${fn.label.name}.captures"
       self._currentFn.block.buildLoadL(Value.Ident(capturesName, QbeType.Pointer))
     }
 
@@ -1725,8 +1877,27 @@ export type Compiler {
     }
   }
 
-  func _compileFunctionValue(self, position: Position, fn: Function, targetParamTypes: (Type, Bool)[]?, capturesPtr: Value?): Result<Value, CompileError> {
+  func _compileFunctionValue(
+    self,
+    position: Position,
+    fn: Function,
+    fnValBase: QbeFunction,
+    targetParamTypes: (Type, Bool)[]?,
+    capturesPtr: Value?,
+    capturedSelf: (Value, Type)?,
+  ): Result<Value, CompileError> {
     val closureEnvPtr = capturesPtr ?: Value.Int(0)
+
+    val _s = if capturedSelf |_p| {
+      val selfVal = _p[0]
+      val selfTy = match self._getQbeTypeForTypeExpect(_p[1], "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+      (selfVal, Some(selfTy))
+    } else {
+      (Value.Int(0), None)
+    }
+    // TODO: destructuring
+    val selfVal = _s[0]
+    val selfTy = _s[1]
 
     val numParams = fn.params.length
     var fnNumReqParams = 0
@@ -1751,7 +1922,8 @@ export type Compiler {
       if targetArity == numParams {
         // If the referenced function's arity matches the required arity, and it has no optional parameters,
         // then we don't need to create a wrapper for it.
-        self._getOrCompileFunction(fn)
+        val res: Result<QbeFunction, CompileError> = Ok(fnValBase)
+        res
       } else if targetArity < numParams {
         // In this case, consider the following example:
         //   func foo(a: Int, b: Int): Int = ...
@@ -1764,7 +1936,7 @@ export type Compiler {
         //   callFn(foo)
         // Create a wrapper of higher arity which discards parameters (and which doesn't consider default-valued parameters, since we
         // know the wrapped function does not have any).
-        self._compileParamDiscardingFunctionWrapper(fnValParamTypes, fn, position, false)
+        self._compileParamDiscardingFunctionWrapper(fnValParamTypes, fn, fnValBase, position, false, selfTy)
       }
     } else if targetArity < fnNumReqParams {
       // In this case, consider the following example:
@@ -1801,7 +1973,7 @@ export type Compiler {
         val prevFn = self._currentFn
         self._currentFn = wrapperFnVal
 
-        val args: Value[] = []
+        val args = if selfTy |selfTy| [wrapperFnVal.addParameter("self", selfTy)] else []
         for paramType, idx in fnValParamTypes {
           val paramTy = match self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
           if fn.params[idx] |param| {
@@ -1819,7 +1991,6 @@ export type Compiler {
         }
         args.push(Value.Int32(defaultMaskFlag))
 
-        val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
         val ret = if fn.returnType.kind != TypeKind.PrimitiveUnit {
           val res = match self._currentFn.block.buildCall(Callable.Function(fnValBase), args) { Ok(v) => v, Err(e) => return qbeError(e) }
           Some(res)
@@ -1841,7 +2012,7 @@ export type Compiler {
       //   callFn2(foo)
       // Create a wrapper function of higher arity which discards parameters and _also_ passes 0 to the optional params flag; we know we can do this
       // because in order to reach this case, it must be the case that all of the optional parameters are passed a value.
-      self._compileParamDiscardingFunctionWrapper(fnValParamTypes, fn, position, true)
+      self._compileParamDiscardingFunctionWrapper(fnValParamTypes, fn, fnValBase, position, true, selfTy)
     } else {
       return unreachable("All valid cases exhausted above", position)
     }
@@ -1862,12 +2033,20 @@ export type Compiler {
 
     self._resolvedGenerics.popLayer()
 
-    val initArgs = [closureEnvPtr, Value.Global(fnVal.name, QbeType.Pointer)]
+    val initArgs = [closureEnvPtr, Value.Global(fnVal.name, QbeType.Pointer), selfVal]
     val res = match self._currentFn.block.buildCall(Callable.Function(initFnVal), initArgs) { Ok(v) => v, Err(e) => return qbeError(e) }
     Ok(res)
   }
 
-  func _compileParamDiscardingFunctionWrapper(self, fnValParamTypes: Type[], fn: Function, position: Position, passDefaultParamMask: Bool): Result<QbeFunction, CompileError> {
+  func _compileParamDiscardingFunctionWrapper(
+    self,
+    fnValParamTypes: Type[],
+    fn: Function,
+    fnValBase: QbeFunction,
+    position: Position,
+    passDefaultParamMask: Bool,
+    selfInstTy: QbeType?,
+  ): Result<QbeFunction, CompileError> {
     var wrapperSuffix = "..w"
     val numParams = fn.params.length
     val discardedParamTypeReprs: String[] = []
@@ -1899,6 +2078,7 @@ export type Compiler {
 
       wrapperSuffix += "D${idx + 1}$paramTypeName"
     }
+    // TODO: if `fn` is a method then the wrapper name should include the parent type as well
     val wrapperFnName = self._fnName(fn) + wrapperSuffix
 
     if self._builder.getFunction(wrapperFnName) |wrapperFnVal| return Ok(wrapperFnVal)
@@ -1909,7 +2089,7 @@ export type Compiler {
     val prevFn = self._currentFn
     self._currentFn = wrapperFnVal
 
-    val args: Value[] = []
+    val args = if selfInstTy |selfInstTy| [wrapperFnVal.addParameter("self", selfInstTy)] else []
     for paramType, idx in fnValParamTypes {
       val paramTy = match self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
       if fn.params[idx] |param| {
@@ -1920,7 +2100,6 @@ export type Compiler {
     }
     if passDefaultParamMask args.push(Value.Int32(0))
 
-    val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
     val ret = if fn.returnType.kind != TypeKind.PrimitiveUnit {
       val res = match self._currentFn.block.buildCall(Callable.Function(fnValBase), args) { Ok(v) => v, Err(e) => return qbeError(e) }
       Some(res)
@@ -1988,26 +2167,40 @@ export type Compiler {
 
   func _followAccessorPath(self, head: TypedAstNode, middle: AccessorPathSegment[], tail: AccessorPathSegment, loadFinal: Bool, localName: String? = None): Result<Value, CompileError> {
     val segs = middle.concat([tail])
-    val _p = match segs[0] {
+    // val bogusValue = (StructOrEnum.Struct(self._project.preludeBoolStruct), Type(kind: TypeKind.Instance(StructOrEnum.Struct(self._project.preludeBoolStruct), [])), Value.Ident("bogus", QbeType.F32))
+    var instTy = StructOrEnum.Struct(self._project.preludeBoolStruct)
+    var instType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self._project.preludeBoolStruct), []))
+    var curVal = Value.Ident("bogus", QbeType.F32)
+    match segs[0] {
       AccessorPathSegment.Field => {
         // TODO: assert that `head.ty` is a pointer type (attempting to do pointer arithmetic later on will fail otherwise)
         val _t = match self._getInstanceTypeForType(head.ty) { Ok(v) => v, Err(e) => return Err(e) }
         // TODO: destructuring
-        val instTy = _t[0]
+        instTy = _t[0]
         val typeArgs = _t[1]
-        val instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
+        instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
 
-        val curVal = match self._compileExpression(head) { Ok(v) => v, Err(e) => return Err(e) }
+        curVal = match self._compileExpression(head) { Ok(v) => v, Err(e) => return Err(e) }
         self._currentFn.block.addCommentBefore("${curVal.repr()}: ${head.ty.repr()}")
-
-        (instTy, instType, curVal)
       }
-      _ => (StructOrEnum.Struct(self._project.preludeBoolStruct), Type(kind: TypeKind.Instance(StructOrEnum.Struct(self._project.preludeBoolStruct), [])), Value.Ident("bogus", QbeType.F32))
+      AccessorPathSegment.Method(_, fn, _, _) => {
+        match fn.kind {
+          FunctionKind.InstanceMethod => {
+            // TODO: assert that `head.ty` is a pointer type (attempting to do pointer arithmetic later on will fail otherwise)
+            val _t = match self._getInstanceTypeForType(head.ty) { Ok(v) => v, Err(e) => return Err(e) }
+            // TODO: destructuring
+            instTy = _t[0]
+            val typeArgs = _t[1]
+            instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
+
+            curVal = match self._compileExpression(head) { Ok(v) => v, Err(e) => return Err(e) }
+            self._currentFn.block.addCommentBefore("${curVal.repr()}: ${head.ty.repr()}")
+          }
+          _ => {}
+        }
+      }
+      _ => {}
     }
-    // TODO: destructuring
-    var instTy = _p[0]
-    var instType = _p[1]
-    var curVal = _p[2]
 
     for seg, idx in segs {
       match seg {
@@ -2019,7 +2212,41 @@ export type Compiler {
 
           instTy = StructOrEnum.Enum(enum_)
         }
-        AccessorPathSegment.Method(label, fn, _) => return todo("method accessor")
+        AccessorPathSegment.Method(label, fn, isOptSafe, fnAliasTypeHint) => {
+          if isOptSafe return todo("opt-safe method accessor", label.position)
+
+          val selfInstType = match fn.kind {
+            FunctionKind.InstanceMethod => {
+              val selfInstType = match self._addResolvedGenericsLayerForInstanceMethod(instType, fn.label.name, label.position) { Ok(v) => v, Err(e) => return Err(e) }
+              Some(selfInstType)
+            }
+            _ => None
+          }
+          val fnBaseVal = match self._getOrCompileMethod(instType, fn) { Ok(v) => v, Err(e) => return Err(e) }
+
+          val capturesMem = if fn.isClosure() {
+            val capturesArr = match self._getCapturesArrForClosure(fn) { Ok(v) => v, Err(e) => return Err(e) }
+            Some(capturesArr)
+          } else {
+            None
+          }
+
+          val targetParamTypes = if fnAliasTypeHint |hint| {
+            val paramTypes = match hint.kind {
+              TypeKind.Func(paramTypes, _) => Some(paramTypes)
+              TypeKind.Any => None // if the function value is being treated as an Any, then no param type info needs to be known later anyway
+              _ => return unreachable("fnAliasTypeKind must be TypeKind.Func", label.position)
+            }
+            paramTypes
+          } else {
+            None
+          }
+
+          self._resolvedGenerics.popLayer()
+
+          val selfVal = if selfInstType |selfInstType| Some((curVal, selfInstType)) else None
+          curVal = match self._compileFunctionValue(label.position, fn, fnBaseVal, targetParamTypes, capturesMem, selfVal) { Ok(v) => v, Err(e) => return Err(e) }
+        }
         AccessorPathSegment.Field(label, ty, field, isOptSafe) => {
           var optSafeCtx: (Label, Value, QbeFunction, Label)? = None
 
@@ -2605,14 +2832,12 @@ export type Compiler {
     val selfTy = _t[0]
     val _typeArgs = _t[1]
 
-    val methodName = match selfTy {
-      StructOrEnum.Struct(struct) => match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }
-      StructOrEnum.Enum(enum_) => match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }
-    }
+    val methodName = match self._methodFnName(selfTy, fn) { Ok(v) => v, Err(e) => return Err(e) }
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
 
     val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
     val fnVal = self._builder.buildFunction(name: methodName, returnType: returnTypeQbe)
+    if fn.isClosure() fnVal.addEnv()
 
     if isInstanceMethod {
       val selfTyQbe = match self._getQbeTypeForTypeExpect(selfType, "unacceptable type for self") { Ok(v) => v, Err(e) => return Err(e) }
@@ -2742,10 +2967,7 @@ export type Compiler {
     val typeArgs = _t[1]
     val selfInstanceTy = Type(kind: TypeKind.Instance(selfTy, typeArgs))
 
-    val methodName = match selfTy {
-      StructOrEnum.Struct(struct) => match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }
-      StructOrEnum.Enum(enum_) => match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }
-    }
+    val methodName = match self._methodFnName(selfTy, fn) { Ok(v) => v, Err(e) => return Err(e) }
 
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(stringTypeQbe))
     val prevFn = self._currentFn
@@ -3165,10 +3387,7 @@ export type Compiler {
     val typeArgs = _t[1]
     val selfInstanceTy = Type(kind: TypeKind.Instance(selfTy, typeArgs))
 
-    val methodName = match selfTy {
-      StructOrEnum.Struct(struct) => match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }
-      StructOrEnum.Enum(enum_) => match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }
-    }
+    val methodName = match self._methodFnName(selfTy, fn) { Ok(v) => v, Err(e) => return Err(e) }
 
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(boolTypeQbe))
     val prevFn = self._currentFn
@@ -3398,10 +3617,7 @@ export type Compiler {
     val typeArgs = _t[1]
     val selfInstanceTy = Type(kind: TypeKind.Instance(selfTy, typeArgs))
 
-    val methodName = match selfTy {
-      StructOrEnum.Struct(struct) => match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }
-      StructOrEnum.Enum(enum_) => match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }
-    }
+    val methodName = match self._methodFnName(selfTy, fn) { Ok(v) => v, Err(e) => return Err(e) }
 
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(intTypeQbe))
     val prevFn = self._currentFn
@@ -3602,7 +3818,7 @@ export type Compiler {
       val dummyModuleId = 0
       val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       val typeParams = (if hasReturnType { ["_R"] } else []).concat(alphabet[:arity].split(""))
-      val fields = [("_env", Type(kind: TypeKind.PrimitiveInt)), ("_ptr", Type(kind: TypeKind.PrimitiveInt))]
+      val fields = [("_env", Type(kind: TypeKind.PrimitiveInt)), ("_ptr", Type(kind: TypeKind.PrimitiveInt)), ("_self", Type(kind: TypeKind.PrimitiveInt))]
       val struct = Struct.makeDummy(moduleId: dummyModuleId, name: name, typeParams: typeParams, fields: fields)
 
       self._functionStructs[name] = struct
@@ -3799,6 +4015,14 @@ export type Compiler {
       _ => "."
     }
     Ok("${typeName}${sep}${fn.label.name}")
+  }
+
+  func _methodFnName(self, structOrEnum: StructOrEnum, fn: Function): Result<String, CompileError> {
+    val methodName = match structOrEnum {
+      StructOrEnum.Struct(struct) => match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }
+      StructOrEnum.Enum(enum_) => match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }
+    }
+    Ok(methodName)
   }
 
   func _fnSignature(self, structOrEnum: StructOrEnum?, fn: Function): Result<String, CompileError> {

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -687,7 +687,10 @@ export type Function {
       returnType: returnType,
       body: self.body,
       isGenerated: self.isGenerated,
+      isLambda: self.isLambda,
       decorators: self.decorators,
+      captures: self.captures,
+      capturedClosures: self.capturedClosures,
     )
   }
 
@@ -761,13 +764,13 @@ export enum TypedAstNodeKind {
 
 export enum AccessorPathSegment {
   EnumVariant(label: Label, ty: Type, enum_: Enum, variant: TypedEnumVariant)
-  Method(label: Label, fn: Function, optSafe: Bool)
+  Method(label: Label, fn: Function, optSafe: Bool, typeHint: Type?)
   Field(label: Label, ty: Type, f: Field, optSafe: Bool)
 
   func getType(self): Type {
     match self {
       AccessorPathSegment.EnumVariant(_, ty, _, _) => ty
-      AccessorPathSegment.Method(_, fn, _) => fn.getType()
+      AccessorPathSegment.Method(_, fn, _, _) => fn.getType()
       AccessorPathSegment.Field(_, ty, _, _) => ty
     }
   }
@@ -3093,7 +3096,7 @@ export type Typechecker {
               AccessorPathSegment.EnumVariant(label, _, _, variant) => {
                 return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAssignment("enum variant", variant.label.name, IllegalAssignmentReason.EnumVariant)))
               }
-              AccessorPathSegment.Method(label, fn, _) => {
+              AccessorPathSegment.Method(label, fn, _, _) => {
                 val _p = match fn.kind {
                   FunctionKind.StaticMethod => ("static method", IllegalAssignmentReason.StaticMethod)
                   _ => ("method", IllegalAssignmentReason.Method)
@@ -3870,7 +3873,17 @@ export type Typechecker {
           return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName(name, "variable")))
         }
         val fnTypeHint = match variable.alias {
-          VariableAlias.Function(fn) => typeHint
+          VariableAlias.Function(fn) => {
+            if fn.isClosure() {
+              if self.currentFunction |currentFn| {
+                if !currentFn.capturedClosures.find(f => f.label.name == fn.label.name) {
+                  currentFn.capturedClosures.push(fn)
+                }
+              }
+            }
+
+            typeHint
+          }
           _ => None
         }
 
@@ -3904,7 +3917,7 @@ export type Typechecker {
     Ok(TypedAstNode(token: token, ty: _p[0], kind: TypedAstNodeKind.Identifier(_p[1], _p[2], _p[3])))
   }
 
-  func _resolveAccessorPathSegmentAny(self, label: Label, optSafe: Bool): AccessorPathSegment? {
+  func _resolveAccessorPathSegmentAny(self, label: Label, optSafe: Bool, typeHint: Type?): AccessorPathSegment? {
     val scope = self.project.preludeScope.makeChild("Any", ScopeKind.Type)
     val method: Function? = if label.name == "toString" {
       Some(Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(None)))
@@ -3917,7 +3930,7 @@ export type Typechecker {
     }
 
     if method |method| {
-      Some(AccessorPathSegment.Method(label, method, optSafe))
+      Some(AccessorPathSegment.Method(label, method, optSafe, typeHint))
     } else {
       None
     }
@@ -3925,14 +3938,14 @@ export type Typechecker {
 
   func _resolveAccessorPathSegment(self, ty: Type, label: Label, typeHint: Type?, optSafe = false): Result<AccessorPathSegment?, TypeError> {
     val foundSegment = match ty.kind {
-      TypeKind.Any => self._resolveAccessorPathSegmentAny(label, optSafe)
+      TypeKind.Any => self._resolveAccessorPathSegmentAny(label, optSafe, typeHint)
       TypeKind.PrimitiveUnit => None
       TypeKind.PrimitiveInt => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeIntStruct), [])), label, None, optSafe)
       TypeKind.PrimitiveFloat => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeFloatStruct), [])), label, None, optSafe)
       TypeKind.PrimitiveBool => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeBoolStruct), [])), label, None, optSafe)
       TypeKind.PrimitiveString => return self._resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeStringStruct), [])), label, None, optSafe)
       TypeKind.Never => None
-      TypeKind.Generic => self._resolveAccessorPathSegmentAny(label, optSafe)
+      TypeKind.Generic => self._resolveAccessorPathSegmentAny(label, optSafe, typeHint)
       TypeKind.Instance(structOrEnum, generics) => {
         val _p = match structOrEnum {
           StructOrEnum.Struct(struct) => {
@@ -3965,7 +3978,7 @@ export type Typechecker {
               resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
             }
             val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true, genericsInScope: #{})
-            return Ok(Some(AccessorPathSegment.Method(label, method, optSafe)))
+            return Ok(Some(AccessorPathSegment.Method(label, method, optSafe, typeHint)))
           }
         }
 
@@ -4019,7 +4032,7 @@ export type Typechecker {
         }
 
         for method in staticMethods {
-          if method.label.name == label.name return Ok(Some(AccessorPathSegment.Method(label, method, optSafe)))
+          if method.label.name == label.name return Ok(Some(AccessorPathSegment.Method(label, method, optSafe, typeHint)))
         }
 
         None
@@ -4113,6 +4126,19 @@ export type Typechecker {
       if seg |seg| {
         val nextTy = seg.getType()
 
+        match seg {
+          AccessorPathSegment.Method(_, fn, _, _) => {
+            if fn.isClosure() {
+              if self.currentFunction |currentFn| {
+                if !currentFn.capturedClosures.find(f => f.label.name == fn.label.name) {
+                  currentFn.capturedClosures.push(fn)
+                }
+              }
+            }
+          }
+          _ => {}
+        }
+
         path.push(seg)
         ty = if isOptSafe {
           match seg {
@@ -4194,7 +4220,7 @@ export type Typechecker {
 
             self._typecheckInvocationOfFunction(token, invokee, enumVariantAsFn, node, typeHint, None, Some(Instantiatable.EnumContainerVariant(enum_, variant, fields)))
           }
-          AccessorPathSegment.Method(l, fn, optSafe) => {
+          AccessorPathSegment.Method(l, fn, optSafe, _) => {
             match fn.kind {
               FunctionKind.InstanceMethod => {
                 val selfVal = if mid[-1] |newTail| {

--- a/selfhost/test/compiler/functions.abra
+++ b/selfhost/test/compiler/functions.abra
@@ -29,6 +29,18 @@ val ghiVal = ghi
 /// Expect: 24
 println(ghiVal(11, 13))
 
+// Test reference to closure as value, from a nested scope
+val bang = "!"
+func bangbang(): String = bang + "!"
+func functionReferencingClosureAsValue() {
+  val fn = bangbang
+  println(fn())
+}
+/// Expect: !!
+functionReferencingClosureAsValue()
+
+// Test passing function/closure values as parameters
+
 func callFn(fn: (Int) => Int) = println(fn(16))
 func callFn2(fn: (Int, Int, Int) => Int) = println(fn(16, 17, 18))
 func callFn3(fn: (Int, Int, Int, Int) => Int) = println(fn(16, 17, 18, 19))

--- a/selfhost/test/compiler/types.abra
+++ b/selfhost/test/compiler/types.abra
@@ -70,38 +70,168 @@ println(f)
 /// Expect: true
 println(f.hash() == Foo().hash())
 
-// // Methods that capture variables
-// var capturedInt = 11
-// type FooWithCaptures {
-//   i: Int
+// Methods that capture variables
+var capturedInt = 11
+type FooWithCaptures {
+  i: Int
 
-//   func foo(self): Int = self.i + capturedInt
-//   func foo2(self, a = capturedInt): Int = self.i + a
-//   func fooStatic(): Int = capturedInt
-// }
+  func foo(self): Int = self.i + capturedInt
+  func foo2(self, a = capturedInt): Int = self.i + a
+  func fooStatic(): Int = capturedInt
+}
 
-// val fooWithCaptures = FooWithCaptures(i: 12)
-// /// Expect: 23
-// println(fooWithCaptures.foo())
-// capturedInt = 17
-// /// Expect: 29
-// println(fooWithCaptures.foo())
+val fooWithCaptures = FooWithCaptures(i: 12)
+/// Expect: 23
+println(fooWithCaptures.foo())
+capturedInt = 17
+/// Expect: 29
+println(fooWithCaptures.foo())
 
-// capturedInt = 17
-// /// Expect: 29
-// println(fooWithCaptures.foo2())
-// capturedInt = 17
-// /// Expect: 15
-// println(fooWithCaptures.foo2(3))
-// /// Expect: 17
-// println(FooWithCaptures.fooStatic())
+capturedInt = 17
+/// Expect: 29
+println(fooWithCaptures.foo2())
+capturedInt = 17
+/// Expect: 15
+println(fooWithCaptures.foo2(3))
+/// Expect: 17
+println(FooWithCaptures.fooStatic())
 
-// capturedInt = 11
-// func wrapper() {
-//   val f = FooWithCaptures(i: 12)
-//   /// Expect: 23
-//   println(f.foo())
-//   /// Expect: 11
-//   println(FooWithCaptures.fooStatic())
-// }
-// wrapper()
+val foo1Ref1 = fooWithCaptures.foo
+func wrapper1() {
+  val foo1Ref2 = fooWithCaptures.foo
+
+  /// Expect: 29
+  println(fooWithCaptures.foo())
+  /// Expect: 29
+  println(foo1Ref1())
+  /// Expect: 29
+  println(foo1Ref2())
+}
+wrapper1()
+
+capturedInt = 11
+func wrapper() {
+  val f = FooWithCaptures(i: 12)
+  /// Expect: 23
+  println(f.foo())
+  /// Expect: 11
+  println(FooWithCaptures.fooStatic())
+}
+wrapper()
+
+// Test passing function/closure values as parameters
+// This is similar to the suite of tests in `functions.abra`, but for references to methods instead
+func callFn(fn: (Int) => Int) = println(fn(16))
+func callFn2(fn: (Int, Int, Int) => Int) = println(fn(16, 17, 18))
+func callFn3(fn: (Int, Int, Int, Int) => Int) = println(fn(16, 17, 18, 19))
+
+val xyz = "xyz"
+type Foo2 {
+  a: Int
+
+  func f0(self, x: Int): Int = self.a + x
+  func f0Closure(self, x: Int): Int = self.a + x + xyz.length
+  func f0Static(x: Int): Int = x
+  func f0ClosureStatic(x: Int): Int = x + xyz.length
+
+  func f1(self, x = 12): Int = self.a + x
+  func f1Closure(self, x = 12): Int = self.a + x + xyz.length
+  func f1Static(x = 12): Int = x
+  func f1ClosureStatic(x = 12): Int = x + xyz.length
+
+  func f2(self, x: Int, y = 6): Int = self.a + x + y
+  func f2Closure(self, x: Int, y = 6): Int = self.a + x + y + xyz.length
+  func f2Static(x: Int, y = 6): Int = x + y
+  func f2ClosureStatic(x: Int, y = 6): Int =  x + y + xyz.length
+
+  func f3(self, x = 12, y = 6): Int = self.a + x + y
+  func f3Closure(self, x = 12, y = 6): Int = self.a + x + y + xyz.length
+  func f3Static(x = 12, y = 6): Int = x + y
+  func f3ClosureStatic(x = 12, y = 6): Int = x + y + xyz.length
+
+  func f4(self, x: Int): Int = self.a + x
+  func f4Closure(self, x: Int): Int = self.a + x + xyz.length
+  func f4Static(x: Int): Int = x
+  func f4ClosureStatic(x: Int): Int = x + xyz.length
+
+  func f5(self, x: Int, y: Int): Int = self.a + x + y
+  func f5Closure(self, x: Int, y: Int): Int = self.a + x + y + xyz.length
+  func f5Static(x: Int, y: Int): Int = x + y
+  func f5ClosureStatic(x: Int, y: Int): Int = x + y + xyz.length
+
+  func f6(self, x: Int, y = 12): Int = self.a + x + y
+  func f6Closure(self, x: Int, y = 12): Int = self.a + x + y + xyz.length
+  func f6Static(x: Int, y = 12): Int = x + y
+  func f6ClosureStatic(x: Int, y = 12): Int = x + y + xyz.length
+
+  func f7(self, x: Int, y = 12, z = 100): Int = self.a + x + y + z
+  func f7Closure(self, x: Int, y = 12, z = 100): Int = self.a + x + y + z + xyz.length
+  func f7Static(x: Int, y = 12, z = 100): Int = x + y + z
+  func f7ClosureStatic(x: Int, y = 12, z = 100): Int = x + y + z + xyz.length
+}
+val foo2 = Foo2(a: 1)
+
+/// Expect: 17
+callFn(foo2.f0)
+/// Expect: 20
+callFn(foo2.f0Closure)
+/// Expect: 16
+callFn(Foo2.f0Static)
+/// Expect: 19
+callFn(Foo2.f0ClosureStatic)
+/// Expect: 17
+callFn(foo2.f1)
+/// Expect: 20
+callFn(foo2.f1Closure)
+/// Expect: 16
+callFn(Foo2.f1Static)
+/// Expect: 19
+callFn(Foo2.f1ClosureStatic)
+/// Expect: 23
+callFn(foo2.f2)
+/// Expect: 26
+callFn(foo2.f2Closure)
+/// Expect: 22
+callFn(Foo2.f2Static)
+/// Expect: 25
+callFn(Foo2.f2ClosureStatic)
+/// Expect: 23
+callFn(foo2.f3)
+/// Expect: 26
+callFn(foo2.f3Closure)
+/// Expect: 22
+callFn(Foo2.f3Static)
+/// Expect: 25
+callFn(Foo2.f3ClosureStatic)
+/// Expect: 17
+callFn2(foo2.f4)
+/// Expect: 20
+callFn2(foo2.f4Closure)
+/// Expect: 16
+callFn2(Foo2.f4Static)
+/// Expect: 19
+callFn2(Foo2.f4ClosureStatic)
+/// Expect: 34
+callFn2(foo2.f5)
+/// Expect: 37
+callFn2(foo2.f5Closure)
+/// Expect: 33
+callFn2(Foo2.f5Static)
+/// Expect: 36
+callFn2(Foo2.f5ClosureStatic)
+/// Expect: 34
+callFn2(foo2.f6)
+/// Expect: 37
+callFn2(foo2.f6Closure)
+/// Expect: 33
+callFn2(Foo2.f6Static)
+/// Expect: 36
+callFn2(Foo2.f6ClosureStatic)
+/// Expect: 52
+callFn3(foo2.f7)
+/// Expect: 55
+callFn3(foo2.f7Closure)
+/// Expect: 51
+callFn3(Foo2.f7Static)
+/// Expect: 54
+callFn3(Foo2.f7ClosureStatic)


### PR DESCRIPTION
This is similar to functions-as-values, except when a method is referenced as a value we need to ensure that the `self` value is captured by the closure. Everything else should be the same as functions-as-values.