### PR TITLE
Selfhost: compiling `uname` function

### DIFF
--- a/abra_core/std/libc.abra
+++ b/abra_core/std/libc.abra
@@ -43,3 +43,14 @@ export func getcwd(buf: Pointer<Byte>, count: Int): String
 
 @CBinding("strlen")
 export func strlen(s: Pointer<Byte>): Int
+
+// type _utsname {
+//   sysname: Pointer<Byte>
+//   nodename: Pointer<Byte>
+//   release: Pointer<Byte>
+//   version: Pointer<Byte>
+//   machine: Pointer<Byte>
+//   domainname: Pointer<Byte>
+// }
+@CBinding("uname")
+export func uname(utsnameBuf: Pointer<Byte>): Int

--- a/abra_core/std/libc.abra
+++ b/abra_core/std/libc.abra
@@ -44,13 +44,5 @@ export func getcwd(buf: Pointer<Byte>, count: Int): String
 @CBinding("strlen")
 export func strlen(s: Pointer<Byte>): Int
 
-// type _utsname {
-//   sysname: Pointer<Byte>
-//   nodename: Pointer<Byte>
-//   release: Pointer<Byte>
-//   version: Pointer<Byte>
-//   machine: Pointer<Byte>
-//   domainname: Pointer<Byte>
-// }
 @CBinding("uname")
 export func uname(utsnameBuf: Pointer<Byte>): Int

--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -795,6 +795,14 @@ type Array<T> {
   @Stub func reversed(self): T[]
 }
 
+type Uname {
+  sysname: String
+  nodename: String
+  release: String
+  version: String
+  machine: String
+}
+
 type Process {
   func args(): String[] {
     val argc = intrinsics.argc()
@@ -816,6 +824,50 @@ type Process {
 
     val len = libc.strlen(str)
     Some(String(length: len, _buffer: str))
+  }
+
+  func uname(): Uname {
+    // On macOS, each field in the utsname struct is a char[256]; on other platforms it's different, so
+    // this can be wasteful of memory.
+    var utsnameBuf = Pointer.malloc<Byte>(256 * 5)
+    val res = libc.uname(utsnameBuf)
+    if res != 0 { /* todo: handle error code */ }
+
+    val sysnameLen = libc.strlen(utsnameBuf)
+    val sysname = String.withLength(sysnameLen)
+    sysname._buffer.copyFrom(utsnameBuf, sysnameLen)
+
+    // The utsname struct has 5 fields (6 on some platforms), of constant and equal sizes, but the size of
+    // each field differs per platform. After extracting the first string, skip over the \0 bytes until we
+    // reach the start of the next string. From that offset, we can determine the size of each field, and
+    // extract the remaining fields more efficiently.
+    var offset = sysnameLen
+    utsnameBuf = utsnameBuf.offset(offset)
+    while utsnameBuf.load().asInt() == 0 {
+      utsnameBuf = utsnameBuf.offset(1)
+      offset += 1
+    }
+
+    val nodenameLen = libc.strlen(utsnameBuf)
+    val nodename = String.withLength(nodenameLen)
+    nodename._buffer.copyFrom(utsnameBuf, nodenameLen)
+    utsnameBuf = utsnameBuf.offset(offset)
+
+    val releaseLen = libc.strlen(utsnameBuf)
+    val release = String.withLength(releaseLen)
+    release._buffer.copyFrom(utsnameBuf, releaseLen)
+    utsnameBuf = utsnameBuf.offset(offset)
+
+    val versionLen = libc.strlen(utsnameBuf)
+    val version = String.withLength(versionLen)
+    version._buffer.copyFrom(utsnameBuf, versionLen)
+    utsnameBuf = utsnameBuf.offset(offset)
+
+    val machineLen = libc.strlen(utsnameBuf)
+    val machine = String.withLength(machineLen)
+    machine._buffer.copyFrom(utsnameBuf, machineLen)
+
+    Uname(sysname: sysname, nodename: nodename, release: release, version: version, machine: machine)
   }
 }
 

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,2 +1,2 @@
-println(Process.args())
+println(Process.uname())
 // println("hello")

--- a/selfhost/src/test_utils.abra
+++ b/selfhost/src/test_utils.abra
@@ -580,7 +580,7 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
       println(",\n$fieldsIndent\"op\": \"$op\",")
       print("$fieldsIndent\"mode\": ")
       match mode {
-        AssignmentMode.Variable(name) => {
+        AssignmentMode.Variable(name, _) => {
           println("{\n$fieldsIndent  \"mode\": \"variable\",")
           println("$fieldsIndent  \"variable\": \"$name\"")
           println("$fieldsIndent}")

--- a/selfhost/test/compiler/process_linux.abra
+++ b/selfhost/test/compiler/process_linux.abra
@@ -1,4 +1,10 @@
 // This file is run on linux only
+// These tests are difficult by nature since there's not many assumptions which will hold 100% of the time.
+// Verify the sysname and machine per-platform should be sufficient to prove that it's working correctly.
 
-/// Expect: Uname(sysname: "Darwin", nodename: "Kens-MBP", release: "23.6.0", version: "Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000", machine: "arm64")
-println(Process.uname())
+val uname = Process.uname()
+
+/// Expect: Linux
+println(uname.sysname)
+/// Expect: x86_64
+println(uname.machine)

--- a/selfhost/test/compiler/process_linux.abra
+++ b/selfhost/test/compiler/process_linux.abra
@@ -1,0 +1,4 @@
+// This file is run on linux only
+
+/// Expect: Uname(sysname: "Darwin", nodename: "Kens-MBP", release: "23.6.0", version: "Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000", machine: "arm64")
+println(Process.uname())

--- a/selfhost/test/compiler/process_macos.abra
+++ b/selfhost/test/compiler/process_macos.abra
@@ -1,4 +1,10 @@
 // This file is run on macos only
+// These tests are difficult by nature since there's not many assumptions which will hold 100% of the time.
+// Verify the sysname and machine per-platform should be sufficient to prove that it's working correctly.
 
-/// Expect: Uname(sysname: "Darwin", nodename: "Kens-MBP", release: "23.6.0", version: "Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000", machine: "arm64")
-println(Process.uname())
+val uname = Process.uname()
+
+/// Expect: Darwin
+println(uname.sysname)
+/// Expect: arm64
+println(uname.machine)

--- a/selfhost/test/compiler/process_macos.abra
+++ b/selfhost/test/compiler/process_macos.abra
@@ -1,0 +1,4 @@
+// This file is run on macos only
+
+/// Expect: Uname(sysname: "Darwin", nodename: "Kens-MBP", release: "23.6.0", version: "Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000", machine: "arm64")
+println(Process.uname())

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -749,7 +749,7 @@ fn typechecker_tests() {
 
 #[test]
 fn compiler_tests() {
-    TestRunner::compiler_test_runner()
+    let mut test_runner = TestRunner::compiler_test_runner()
         .add_test("compiler/ints.abra")
         .add_test("compiler/floats.abra")
         .add_test("compiler/bools.abra")
@@ -764,7 +764,15 @@ fn compiler_tests() {
         .add_test("compiler/maps.abra")
         .add_test("compiler/sets.abra")
         .add_test("compiler/match.abra")
-        .add_test_with_args_and_env("compiler/process.abra", &["-f", "bar", "--baz", "qux"], &[("FOO", "bar")])
+        .add_test_with_args_and_env("compiler/process.abra", &["-f", "bar", "--baz", "qux"], &[("FOO", "bar")]);
 
-        .run_tests();
+    test_runner = if cfg!(target_os = "linux") {
+        test_runner.add_test("compiler/process_linus.abra")
+    } else if cfg!(target_os = "macos") {
+        test_runner.add_test("compiler/process_macos.abra")
+    } else {
+        unreachable!("unsupported operating system {}", std::env::consts::OS)
+    };
+
+    test_runner.run_tests();
 }

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -767,7 +767,7 @@ fn compiler_tests() {
         .add_test_with_args_and_env("compiler/process.abra", &["-f", "bar", "--baz", "qux"], &[("FOO", "bar")]);
 
     test_runner = if cfg!(target_os = "linux") {
-        test_runner.add_test("compiler/process_linus.abra")
+        test_runner.add_test("compiler/process_linux.abra")
     } else if cfg!(target_os = "macos") {
         test_runner.add_test("compiler/process_macos.abra")
     } else {


### PR DESCRIPTION
This also adds per-OS capabilities, which can be used to implement platform-specific things like `errno`.