### PR TITLE
Selfhost: compiling errno

### DIFF
--- a/abra_core/std/fs.abra
+++ b/abra_core/std/fs.abra
@@ -11,27 +11,27 @@ export enum ReadFileError {
 export func readFile(path: String): Result<String, ReadFileError> {
   val fd = libc.open(path._buffer, libc.O_RDONLY)
   if fd == -1 {
-    val errMsg = libc.strerror(libc.errno())
+    val errMsg = _strerror(libc.errno())
     return Err(error: ReadFileError.CouldNotOpen(message: errMsg))
   }
 
   val len = libc.lseek(fd, 0, libc.SEEK_END)
   if len == -1 {
-    val errMsg = libc.strerror(libc.errno())
+    val errMsg = _strerror(libc.errno())
     return Err(error: ReadFileError.CouldNotSeek(message: errMsg))
   }
   if libc.lseek(fd, 0, libc.SEEK_SET) == -1 {
-    val errMsg = libc.strerror(libc.errno())
+    val errMsg = _strerror(libc.errno())
     return Err(error: ReadFileError.CouldNotSeek(message: errMsg))
   }
 
   val str = String.withLength(len)
   if libc.read(fd, str._buffer, len) == -1 {
-    val errMsg = libc.strerror(libc.errno())
+    val errMsg = _strerror(libc.errno())
     return Err(error: ReadFileError.CouldNotRead(message: errMsg))
   }
   if libc.close(fd) == -1 {
-    val errMsg = libc.strerror(libc.errno())
+    val errMsg = _strerror(libc.errno())
     return Err(error: ReadFileError.CouldNotClose(message: errMsg))
   }
 
@@ -50,7 +50,7 @@ export type File {
 
   func close(self): Result<Int, ReadFileError> {
     if libc.close(self._fd) == -1 {
-      val errMsg = libc.strerror(libc.errno())
+      val errMsg = _strerror(libc.errno())
       // TODO: change ReadFileError to FileError (?)
       return Err(error: ReadFileError.CouldNotClose(message: errMsg))
     }
@@ -78,7 +78,7 @@ export func openFile(path: String, accessMode: AccessMode): Result<File, ReadFil
   }
   val fd = libc.open(path._buffer, oflag)
   if fd == -1 {
-    val errMsg = libc.strerror(libc.errno())
+    val errMsg = _strerror(libc.errno())
     return Err(error: ReadFileError.CouldNotOpen(message: errMsg))
   }
 
@@ -91,6 +91,14 @@ export func getCurrentWorkingDirectory(): String {
   val cwd = libc.getcwd(buf, libc.PATH_MAX)
   val len = libc.strlen(cwd._buffer)
 
+  val str = String.withLength(len)
+  str._buffer.copyFrom(buf, len)
+  str
+}
+
+func _strerror(errno: Int): String {
+  val buf = libc.strerror(errno)
+  val len = libc.strlen(buf)
   val str = String.withLength(len)
   str._buffer.copyFrom(buf, len)
   str

--- a/abra_core/std/libc.abra
+++ b/abra_core/std/libc.abra
@@ -7,7 +7,7 @@ export func getenv(name: Pointer<Byte>): Pointer<Byte>
 export func errno(): Int
 
 @CBinding("strerror")
-export func strerror(errno: Int): String
+export func strerror(errno: Int): Pointer<Byte>
 
 export val O_RDONLY = 0
 export val O_WRONLY = 1

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,2 +1,4 @@
-println(Process.uname())
-// println("hello")
+import "fs" as fs
+
+val res = fs.readFile("asdf")
+println(res)

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -2977,6 +2977,22 @@ export type Compiler {
 
         Ok(Value.Ident("bogus", QbeType.F32))
       }
+      "errno" => {
+        self._currentFn.block.addComment("begin errno...")
+
+        val errnoFnName = match Process.uname().sysname {
+          "Linux" => "__errno_location"
+          "Darwin" => "__error"
+          _ sysname => return todo("[errno] unsupported system " + sysname)
+        }
+        val errnoPtr = match self._currentFn.block.buildCallRaw(errnoFnName, QbeType.Pointer, []) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val errnoVal = self._currentFn.block.buildLoadW(errnoPtr)
+        val res = self._currentFn.block.buildExt(value: errnoVal, signed: false)
+
+        self._currentFn.block.addComment("...errno end")
+
+        Ok(res)
+      }
       "byte_from_int" => {
         self._currentFn.block.addComment("begin byte_from_int...")
 


### PR DESCRIPTION
Add support for the `errno` intrinsic, now that `uname` exists and allows for runtime OS detection (since the mechanism for fetching the errno value differs per-platform). Also, this fixes the libc function `strerror` which incorrectly had the `String` return type and it should have had `Pointer<Byte>` in order to be compatible with C (I'm not really sure how this worked in the reference implementation).