### PR TITLE
Selfhost: compiling imports and exports

### DIFF
--- a/abra_cli/abra-files/example.abra
+++ b/abra_cli/abra-files/example.abra
@@ -51,4 +51,4 @@
 //  Some(123)
 //}
 //println(x)
-val x = None
+val x: Int? = None

--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -3,8 +3,7 @@ import Pointer, Byte from "./_intrinsics"
 import "libc" as libc
 
 func stdoutWrite(str: String) {
-  // libc.STDOUT_FILENO = 1
-  libc.write(1, str._buffer, str.length)
+  libc.write(libc.STDOUT_FILENO, str._buffer, str.length)
 }
 
 func print(*items: Any[]) {

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,5 +1,9 @@
-// import abc from "./example2" //as ex2
-import "./example2" as ex2
+// import abc from "./example2"
+// // import "./example2" as ex2
 
-//println(abc)
-ex2.abc = 432
+// println(abc)
+
+val arr: Int[] = []
+arr.push(1)
+
+println(arr)

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,4 +1,5 @@
-import "fs" as fs
+// import abc from "./example2" //as ex2
+import "./example2" as ex2
 
-val res = fs.readFile("asdf")
-println(res)
+//println(abc)
+ex2.abc = 432

--- a/selfhost/example2.abra
+++ b/selfhost/example2.abra
@@ -1,0 +1,1 @@
+export var abc = 123

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1,7 +1,7 @@
 import "fs" as fs
 import Position from "./lexer"
 import LiteralAstNode, UnaryOp, BinaryOp, AssignOp, BindingPattern, IndexingMode from "./parser"
-import Project, TypedModule, Scope, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind from "./typechecker"
+import Project, TypedModule, Scope, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind, BuiltinModule from "./typechecker"
 import ModuleBuilder, QbeType, Dest, QbeFunction, Value, Label, Callable, QbeData, QbeDataKind from "./qbe"
 
 type CompilationError {
@@ -530,7 +530,11 @@ export type Compiler {
 
         if bindingDeclNode.expr |expr| {
           val res = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
-          if variable.isCaptured {
+          if variable.isExported {
+            val name = "mod${self._currentModule.id}exp_$slotName"
+            val slot = self._builder.addData(QbeData(name: name, kind: QbeDataKind.Constants([(varTy, varTy.zeroValue())])))
+            self._currentFn.block.buildStore(varTy, res, slot)
+          } else if variable.isCaptured {
             self._currentFn.block.addComment("move captured '${variable.label.name}' to heap")
             val size = varTy.size()
             val heapMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -978,7 +982,7 @@ export type Compiler {
         }
       }
       TypedAstNodeKind.Grouped(inner) => self._compileExpression(inner, resultLocalName)
-      TypedAstNodeKind.Identifier(name, variable, fnAliasTypeHint) => {
+      TypedAstNodeKind.Identifier(name, variable, fnAliasTypeHint, varImportModule) => {
         // If a variable is function parameter, it can just be referenced by name as a temporary/local, otherwise it can be obtained by
         // loading the value pointed to by the temporary/local with that name.
         // TODO: handle captured variables in closures, global variables, etc).
@@ -1015,7 +1019,12 @@ export type Compiler {
               self._compileFunctionValue(node.token.position, fn, fnValBase, targetParamTypes, capturesMem, None)
             }
             _ => {
-              if variable.isCaptured {
+              if varImportModule |mod| {
+                val name = "mod${mod.id}exp_$name.slot"
+                val slot = Value.Global(name, QbeType.Pointer)
+                val res = self._currentFn.block.buildLoad(varTy, slot)
+                Ok(res)
+              } else if variable.isCaptured {
                 val ptr = match self._getCapturedVarPtr(variable.label.name) { Ok(v) => v, Err(e) => return Err(e) }
                 self._currentFn.block.addComment("deref ptr to captured '${variable.label.name}'")
                 val res = self._currentFn.block.buildLoad(varTy, ptr)
@@ -2382,8 +2391,7 @@ export type Compiler {
             if struct == self._project.preludeIntStruct return Ok(Some(QbeType.U64))
             if struct == self._project.preludeFloatStruct return Ok(Some(QbeType.F64))
 
-            // moduleId == 1 -> "_intrinsics" module
-            if struct.moduleId == 1 {
+            if struct.builtin == Some(BuiltinModule.Intrinsics) {
               if struct.label.name == "Byte" return Ok(Some(QbeType.U64))
               if struct.label.name == "Pointer" return Ok(Some(QbeType.Pointer))
             }
@@ -2792,8 +2800,7 @@ export type Compiler {
       TypeKind.Instance(structOrEnum, generics) => {
         match structOrEnum {
           StructOrEnum.Struct(struct) => {
-            // moduleId == 1 -> "_intrinsics" module
-            if struct.moduleId == 1 && struct.label.name == "Byte" 1 else 8
+            if struct.builtin == Some(BuiltinModule.Intrinsics) && struct.label.name == "Byte" 1 else 8
           }
           _ => 8
         }
@@ -2939,7 +2946,7 @@ export type Compiler {
         val isByte = match innerTy.kind {
           TypeKind.Instance(structOrEnum, _) => {
             val r = match structOrEnum {
-              StructOrEnum.Struct(struct) => struct.moduleId == 1 && struct.label.name == "Byte"
+              StructOrEnum.Struct(struct) => struct.builtin == Some(BuiltinModule.Intrinsics) && struct.label.name == "Byte"
               _ => false
             }
             r

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1,7 +1,7 @@
 import "fs" as fs
 import Position from "./lexer"
 import LiteralAstNode, UnaryOp, BinaryOp, AssignOp, BindingPattern, IndexingMode from "./parser"
-import Project, TypedModule, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind from "./typechecker"
+import Project, TypedModule, Scope, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind from "./typechecker"
 import ModuleBuilder, QbeType, Dest, QbeFunction, Value, Label, Callable, QbeData, QbeDataKind from "./qbe"
 
 type CompilationError {
@@ -181,7 +181,7 @@ export type Compiler {
   _tupleStructs: Map<String, Struct> = {}
   _functionStructs: Map<String, Struct> = {}
 
-  func compile(project: Project, entry: TypedModule): Result<ModuleBuilder, CompilationError> {
+  func compile(project: Project): Result<ModuleBuilder, CompilationError> {
     val builder = ModuleBuilder()
 
     val mainFn = builder.buildFunction(name: "main", returnType: Some(QbeType.U32), exported: true)
@@ -196,17 +196,22 @@ export type Compiler {
 
     mainFn.block.buildVoidCallRaw("GC_init", [])
 
-    val compiler = Compiler(_project: project, _builder: builder, _currentModule: entry, _currentFn: mainFn, _currentFunction: None, _currentNode: None, _argcPtr: argcPtr, _argvPtr: argvPtr)
+    val dummyMod = TypedModule(id: -1, name: "dummy", code: [], rootScope: Scope.bogus())
+    val compiler = Compiler(_project: project, _builder: builder, _currentModule: dummyMod, _currentFn: mainFn, _currentFunction: None, _currentNode: None, _argcPtr: argcPtr, _argvPtr: argvPtr)
 
-    val moduleFn = match compiler._compileModule(entry) { Ok(v) => v, Err(e) => {
-      // println(compiler._currentNode?.token)
-      return Err(CompilationError(modulePath: entry.name, error: e))
-    }}
+    val allModules = project.modules.values().sortBy(m => m.id)
+    for mod in allModules {
+      val moduleFn = match compiler._compileModule(mod) { Ok(v) => v, Err(e) => {
+        // println(compiler._currentNode?.token)
+        return Err(CompilationError(modulePath: mod.name, error: e))
+      }}
+      match moduleFn.block.verify() { Ok(v) => v, Err(e) => return Err(CompilationError(modulePath: mod.name, error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e)))) }
+      mainFn.block.buildVoidCall(Callable.Function(moduleFn), [])
+    }
 
-    mainFn.block.buildVoidCall(Callable.Function(moduleFn), [])
     mainFn.block.buildReturn(Some(Value.Int(0)))
 
-    match mainFn.block.verify() { Ok(v) => v, Err(e) => return Err(CompilationError(modulePath: entry.name, error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e)))) }
+    match mainFn.block.verify() { Ok(v) => v, Err(e) => return Err(CompilationError(modulePath: "<entrypoint>", error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e)))) }
 
     Ok(builder)
   }

--- a/selfhost/src/compiler.test.abra
+++ b/selfhost/src/compiler.test.abra
@@ -30,15 +30,15 @@ func main() {
     val project = Project()
     val typechecker = Typechecker(moduleLoader: moduleLoader, project: project)
 
-    val entryMod = match typechecker.typecheckEntrypoint(filePathAbs) {
+    match typechecker.typecheckEntrypoint(filePathAbs) {
       Err(e) => {
         println(e.getMessage())
         return
       }
-      Ok(mod) => mod
+      Ok(_) => {}
     }
 
-    val builder = match Compiler.compile(project, entryMod) {
+    val builder = match Compiler.compile(project) {
       Ok(v) => v
       Err(e) => {
         println(e.getMessage())

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -169,6 +169,11 @@ export type Scope {
   }
 }
 
+export enum BuiltinModule {
+  Prelude
+  Intrinsics
+}
+
 export type Field {
   name: Label
   ty: Type
@@ -183,6 +188,7 @@ export type Struct {
   fields: Field[] = []
   instanceMethods: Function[] = []
   staticMethods: Function[] = []
+  builtin: BuiltinModule? = None
 
   // Override eq method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
   func eq(self, other: Struct): Bool = self.moduleId == other.moduleId && self.label == other.label
@@ -234,6 +240,7 @@ export type Enum {
   variants: TypedEnumVariant[] = []
   instanceMethods: Function[] = []
   staticMethods: Function[] = []
+  builtin: BuiltinModule? = None
 
   func toString(self): String = "Enum(moduleId: ${self.moduleId}, label: ${self.label})"
 
@@ -359,7 +366,7 @@ export type Type {
       TypeKind.Instance(structOrEnum, typeParams) => {
         match structOrEnum {
           StructOrEnum.Struct(struct) => {
-            if struct.moduleId == 0 && struct.label.name == "Array" {
+            if struct.builtin == Some(BuiltinModule.Prelude) && struct.label.name == "Array" {
               val innerRepr = typeParams[0]?.repr() ?: "<unknown>"
               "$innerRepr[]"
             } else {
@@ -371,7 +378,7 @@ export type Type {
             }
           }
           StructOrEnum.Enum(enum_) => {
-            if enum_.moduleId == 0 && enum_.label.name == "Option" {
+            if enum_.builtin == Some(BuiltinModule.Prelude) && enum_.label.name == "Option" {
               val innerRepr = typeParams[0]?.repr() ?: "<unknown>"
               "$innerRepr?"
             } else {
@@ -827,7 +834,7 @@ type TypeError {
   func _typeIsOption(self, ty: Type): Type? {
     match ty.kind {
       TypeKind.Instance(structOrEnum, generics) => match structOrEnum {
-        StructOrEnum.Enum(enum_) => if enum_.moduleId == 0 && enum_.label.name == "Option" {
+        StructOrEnum.Enum(enum_) => if enum_.builtin == Some(BuiltinModule.Prelude) && enum_.label.name == "Option" {
           generics[0]
         } else {
           None
@@ -1390,6 +1397,7 @@ export type Typechecker {
   isStructOrEnumValueAllowed: Bool = false
   isEnumContainerValueAllowed: Bool = false
   numLambdas: Int = 0
+  typecheckingBuiltin: BuiltinModule? = None
 
   func typecheckEntrypoint(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
     val preludeModulePathSegs = getAbsolutePath(self.moduleLoader.stdRoot + "/prelude.abra")
@@ -2016,19 +2024,23 @@ export type Typechecker {
 
 
   func _typecheckModule(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
-    val moduleId = self.project.modules.size
-    self.currentModuleId = moduleId
-
-    val moduleScope = self.currentScope.makeChild("module_$moduleId", ScopeKind.Module)
-    if moduleId == 0 {
-      self.project.preludeScope = moduleScope
+    self.typecheckingBuiltin = if modulePathAbs == self.moduleLoader.stdRoot + "/prelude.abra" {
+      self.project.preludeScope = self.currentScope.makeChild("module_prelude", ScopeKind.Module)
+      Some(BuiltinModule.Prelude)
+    } else if modulePathAbs == self.moduleLoader.stdRoot + "/_intrinsics.abra" {
+      Some(BuiltinModule.Intrinsics)
+    } else {
+      None
     }
-    val prevScope = self.currentScope
-    self.currentScope = moduleScope
-    val mod = TypedModule(id: moduleId, name: modulePathAbs, code: [], rootScope: moduleScope)
+
+    // Insert module with placeholder scope and moduleId. These values will be filled in after typechecking
+    // this module's imports; this ensures that sorting the final list of modules by id results in a resolved
+    // dependency graph.
+    val mod = TypedModule(id: -1, name: modulePathAbs, code: [], rootScope: Scope.bogus())
     self.project.modules[modulePathAbs] = mod
 
     val parsedModule = match self._tokenizeAndParse(modulePathAbs) { Ok(v) => v, Err(e) => return Err(e) }
+    val imports: (TypedModule, ImportNode)[] = []
     for importNode in parsedModule.imports {
       var importNodePath = importNode.moduleName.name
       val isRelativeImport = importNodePath.startsWith(".")
@@ -2073,6 +2085,26 @@ export type Typechecker {
         typedImportModule
       }
 
+      imports.push((typedImportModule, importNode))
+    }
+
+    val moduleId = self.project.modules.values().filter(m => m.id != -1).length
+    self.currentModuleId = moduleId
+
+    val moduleScope = if self.typecheckingBuiltin == Some(BuiltinModule.Prelude) {
+      self.project.preludeScope
+    } else {
+      self.currentScope.makeChild("module_$moduleId", ScopeKind.Module)
+    }
+    val prevScope = self.currentScope
+    self.currentScope = moduleScope
+    mod.id = moduleId
+    mod.rootScope = moduleScope
+
+    for _p in imports {
+      // TODO: destructuring
+      val typedImportModule = _p[0]
+      val importNode = _p[1]
       match self._typecheckImport(typedImportModule, importNode) {
         Ok(v) => v
         Err(e) => return Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(e)))
@@ -2093,6 +2125,11 @@ export type Typechecker {
     self.currentScope = prevScope
 
     mod.complete = true
+
+    if self.typecheckingBuiltin {
+      self.typecheckingBuiltin = None
+    }
+
     Ok(mod)
   }
 
@@ -2417,7 +2454,7 @@ export type Typechecker {
 
     self.currentScope = prevScope
 
-    val struct = Struct(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams)
+    val struct = Struct(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
     match self._addStructToScope(struct, isExported) { Ok(v) => v, Err(e) => return Err(e) }
 
     Ok(struct)
@@ -2619,7 +2656,7 @@ export type Typechecker {
 
     self.currentScope = prevScope
 
-    val enum_ = Enum(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams)
+    val enum_ = Enum(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
     match self._addEnumToScope(enum_, isExported) { Ok(v) => v, Err(e) => return Err(e) }
 
     Ok(enum_)
@@ -2805,10 +2842,11 @@ export type Typechecker {
 
     // --- Pass 1 for types, enums, and functions
 
+    val typecheckingPrelude = self.typecheckingBuiltin == Some(BuiltinModule.Prelude)
     val structsPass1: (Struct, TypeDeclarationNode)[] = []
     for node in typeDecls {
       val struct = match self._typecheckStructPass1(node) { Ok(v) => v, Err(e) => return Err(e) }
-      if self.currentModuleId == 0 {
+      if typecheckingPrelude {
         match struct.label.name {
           "Int" => self.project.preludeIntStruct = struct
           "Float" => self.project.preludeFloatStruct = struct
@@ -2826,9 +2864,10 @@ export type Typechecker {
     val enumsPass1: (Enum, EnumDeclarationNode)[] = []
     for node in enumDecls {
       val enum_ = match self._typecheckEnumPass1(node) { Ok(v) => v, Err(e) => return Err(e) }
-      if self.currentModuleId == 0 {
+      if typecheckingPrelude {
         match enum_.label.name {
           "Option" => self.project.preludeOptionEnum = enum_
+          // "Result" => self.project.preludeResultEnum = enum_
           _ => {}
         }
       }

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -738,7 +738,7 @@ export enum TypedAstNodeKind {
   Unary(op: UnaryOp, expr: TypedAstNode)
   Binary(left: TypedAstNode, op: BinaryOp, right: TypedAstNode)
   Grouped(inner: TypedAstNode)
-  Identifier(name: String, variable: Variable, fnAliasTypeHint: Type?)
+  Identifier(name: String, variable: Variable, fnAliasTypeHint: Type?, varImportModule: TypedModule?)
   Accessor(head: TypedAstNode, middle: AccessorPathSegment[], tail: AccessorPathSegment)
   Invocation(invokee: TypedInvokee, arguments: TypedAstNode?[], resolvedGenerics: Map<String, Type>)
   Array(items: TypedAstNode[])
@@ -1181,6 +1181,7 @@ type TypeError {
           IllegalAssignmentReason.EnumVariant => lines.push("'$name' is an enum variant, which cannot be overwritten")
           IllegalAssignmentReason.Method => lines.push("'$name' is a method, which cannot be overwritten")
           IllegalAssignmentReason.StaticMethod => lines.push("'$name' is a static method, which cannot be overwritten")
+          IllegalAssignmentReason.Import => lines.push("'$name' is an import, which cannot be overwritten")
         }
       }
       TypeErrorKind.UnknownModule(modulePath, isRelativeImport) => {
@@ -1309,6 +1310,7 @@ enum IllegalAssignmentReason {
   EnumVariant
   Method
   StaticMethod
+  Import
 }
 
 enum UnreachableMatchCaseReason {
@@ -1793,7 +1795,7 @@ export type Typechecker {
     }
   }
 
-  func _resolveIdentifier(self, ident: String): Variable? {
+  func _resolveIdentifier(self, ident: String): (Variable, TypedModule?)? {
     val currentFnScope = self.currentFunction?.scope
     var scope: Scope? = Some(self.currentScope)
     var fnBarrierBreached = false
@@ -1810,7 +1812,7 @@ export type Typechecker {
             }
           }
 
-          return Some(v)
+          return Some((v, None))
         }
       }
 
@@ -1833,11 +1835,13 @@ export type Typechecker {
           }
         }
 
-        return Some(v)
+        return Some((v, None))
       }
     }
 
-    for importedModule in self.currentModuleImports.values() {
+    for _m in self.currentModuleImports {
+      val name = _m[0]
+      val importedModule = _m[1]
       for _p in importedModule.imports {
         // TODO: destructuring
         val importedName = _p[0]
@@ -1859,7 +1863,8 @@ export type Typechecker {
             TypedImportKind.Function(aliasVar) => aliasVar
             TypedImportKind.Type(_, aliasVar) => aliasVar
           }
-          return Some(v)
+
+          return Some((v, self.project.modules[name]))
         }
       }
     }
@@ -2744,8 +2749,8 @@ export type Typechecker {
   }
 
   func _typecheckImport(self, mod: TypedModule, node: ImportNode): Result<Int, TypeError> {
+    // TODO: better API for this (Map#getOrInsert?)
     val importedModule = if self.currentModuleImports[mod.name] |importedModule| importedModule else {
-      // TODO: better API for this
       val importedModule = ImportedModule()
       self.currentModuleImports[mod.name] = importedModule
       importedModule
@@ -3054,7 +3059,14 @@ export type Typechecker {
       AssignmentMode.Variable(name, varToken) => {
         val pos = varToken.position
 
-        val variable = if self._resolveIdentifier(name) |variable| variable else {
+        val variable = if self._resolveIdentifier(name) |_v| {
+          // TODO: destructuring
+          val v = _v[0]
+          val modExportedFrom = _v[1]
+          if modExportedFrom return Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "variable", name: name, reason: IllegalAssignmentReason.Import)))
+
+          v
+        } else {
           return Err(TypeError(position: pos, kind: TypeErrorKind.UnknownName(name, "variable")))
         }
         match variable.alias {
@@ -3114,6 +3126,11 @@ export type Typechecker {
               }
             }
             t
+          }
+          TypedAstNodeKind.Identifier(name, _, _, varImportMod) => {
+            val pos = typedLhs.token.position
+            if varImportMod return Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "member", name: name, reason: IllegalAssignmentReason.Import)))
+            return unreachable(pos, "_typecheckAccessor returned unexpected TypedAstNodeKind")
           }
           _ => return unreachable(typedLhs.token.position, "_typecheckAccessor returned unexpected TypedAstNodeKind")
         }
@@ -3869,12 +3886,13 @@ export type Typechecker {
   func _typecheckIdentifier(self, token: Token, kind: IdentifierKind, typeHint: Type?): Result<TypedAstNode, TypeError> {
     val _p = match kind {
       IdentifierKind.Named(name) => {
-        val variable = if self._resolveIdentifier(name) |variable| variable else {
+        val resolvedIdentifier = if self._resolveIdentifier(name) |_v| _v else {
           if self.paramDefaultValueContext |ctx| {
             ctx.exprContainsVariableRef = true
           }
           return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName(name, "variable")))
         }
+        val variable = resolvedIdentifier[0]
         val fnTypeHint = match variable.alias {
           VariableAlias.Function(fn) => {
             if fn.isClosure() {
@@ -3890,7 +3908,8 @@ export type Typechecker {
           _ => None
         }
 
-        (variable.ty, name, variable, fnTypeHint)
+        // (variable.ty, name, variable, fnTypeHint)
+        (resolvedIdentifier, name, fnTypeHint)
       }
       IdentifierKind.Discard => return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName("_", "variable")))
       IdentifierKind.None_ => {
@@ -3906,18 +3925,23 @@ export type Typechecker {
         return Ok(e)
       }
       IdentifierKind.Self => {
-        val variable = if self._resolveIdentifier("self") |variable| variable else {
+        val resolvedIdentifier = if self._resolveIdentifier("self") |_v| _v else {
           if self.paramDefaultValueContext |ctx| {
             ctx.exprContainsVariableRef = true
           }
           return Err(TypeError(position: token.position, kind: TypeErrorKind.UnknownName("self", "variable")))
         }
-        (variable.ty, "self", variable, None)
+        (resolvedIdentifier, "self", None)
       }
     }
-
     // TODO: destructuring
-    Ok(TypedAstNode(token: token, ty: _p[0], kind: TypedAstNodeKind.Identifier(_p[1], _p[2], _p[3])))
+    val _v = _p[0]
+    val name = _p[1]
+    val fnTypeHint = _p[2]
+    val variable = _v[0]
+    val varImportMod = _v[1]
+
+    Ok(TypedAstNode(token: token, ty: variable.ty, kind: TypedAstNodeKind.Identifier(name, variable, fnTypeHint, varImportMod)))
   }
 
   func _resolveAccessorPathSegmentAny(self, label: Label, optSafe: Bool, typeHint: Type?): AccessorPathSegment? {
@@ -4079,7 +4103,7 @@ export type Typechecker {
       }
 
       val token = Token(position: label.position, kind: TokenKind.Ident(label.name))
-      Some(TypedAstNode(token: token, ty: exportVar.ty, kind: TypedAstNodeKind.Identifier(label.name, exportVar, None)))
+      Some(TypedAstNode(token: token, ty: exportVar.ty, kind: TypedAstNodeKind.Identifier(label.name, exportVar, None, Some(mod))))
     } else {
       None
     }
@@ -4200,7 +4224,7 @@ export type Typechecker {
     self.isStructOrEnumValueAllowed = false
 
     match invokee.kind {
-      TypedAstNodeKind.Identifier(name, variable) => {
+      TypedAstNodeKind.Identifier(name, variable, _, _) => {
         match variable.alias {
           VariableAlias.Function(fn) => self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint)
           VariableAlias.Struct(struct) => {

--- a/selfhost/src/typechecker.test.abra
+++ b/selfhost/src/typechecker.test.abra
@@ -43,9 +43,9 @@ func main() {
       Ok => {
         val allModules = project.modules.values().sortBy(m => m.id)
 
-        if !verifyStdModule(allModules, 0, "prelude") return
-        if !verifyStdModule(allModules, 1, "_intrinsics") return
-        if !verifyStdModule(allModules, 2, "libc") return
+        if !verifyStdModule(allModules, 0, "_intrinsics") return
+        if !verifyStdModule(allModules, 1, "libc") return
+        if !verifyStdModule(allModules, 2, "prelude") return
 
         val userModules = allModules[3:]
         val json = Jsonifier()

--- a/selfhost/test/typechecker/accessor/accessor.2.out.json
+++ b/selfhost/test/typechecker/accessor/accessor.2.out.json
@@ -222,7 +222,7 @@
             "mutable": true,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
@@ -259,7 +259,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -278,7 +278,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -298,7 +298,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
@@ -318,7 +318,7 @@
                 "name": "bar",
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
@@ -334,7 +334,7 @@
               "name": "str",
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -370,7 +370,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -390,7 +390,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/array/array.out.json
+++ b/selfhost/test/typechecker/array/array.out.json
@@ -11,7 +11,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -85,11 +85,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -111,7 +111,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -168,7 +168,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -242,7 +242,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -261,7 +261,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -299,7 +299,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -318,7 +318,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -408,11 +408,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -433,11 +433,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -459,7 +459,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -500,7 +500,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -520,7 +520,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -543,7 +543,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -603,11 +603,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -628,11 +628,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -654,7 +654,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -674,7 +674,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -697,7 +697,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -738,7 +738,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -784,11 +784,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -810,7 +810,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -867,7 +867,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -889,7 +889,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -949,11 +949,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -975,7 +975,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1016,7 +1016,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1057,7 +1057,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1077,7 +1077,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
+                  "enum": { "moduleId": 2, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1100,7 +1100,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1144,15 +1144,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1176,11 +1176,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1203,7 +1203,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1263,11 +1263,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1290,7 +1290,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1350,11 +1350,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1376,7 +1376,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
+                  "enum": { "moduleId": 2, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1399,11 +1399,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1426,7 +1426,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1503,15 +1503,15 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1534,15 +1534,15 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1567,11 +1567,11 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1593,7 +1593,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Option" },
+                        "enum": { "moduleId": 2, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1613,7 +1613,7 @@
                           },
                           "type": {
                             "kind": "enum",
-                            "enum": { "moduleId": 0, "name": "Option" }
+                            "enum": { "moduleId": 2, "name": "Option" }
                           },
                           "node": {
                             "kind": "identifier",
@@ -1644,11 +1644,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1670,7 +1670,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1692,7 +1692,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1749,7 +1749,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1809,11 +1809,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Set" },
+            "struct": { "moduleId": 2, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1835,7 +1835,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1857,7 +1857,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1914,7 +1914,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1974,15 +1974,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Set" },
+                "struct": { "moduleId": 2, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2006,11 +2006,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2033,7 +2033,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2058,11 +2058,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2084,7 +2084,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
+                  "enum": { "moduleId": 2, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -2107,11 +2107,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2134,7 +2134,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2197,15 +2197,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Array" },
+        "struct": { "moduleId": 2, "name": "Array" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Set" },
+                "struct": { "moduleId": 2, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2229,11 +2229,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2256,7 +2256,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2281,11 +2281,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2308,7 +2308,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/selfhost/test/typechecker/assignment/assignment_accessor.out.json
+++ b/selfhost/test/typechecker/assignment/assignment_accessor.out.json
@@ -32,7 +32,7 @@
               "name": { "name": "b", "position": [1, 20] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -184,7 +184,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -339,7 +339,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -379,7 +379,7 @@
             "name": "b",
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/selfhost/test/typechecker/assignment/assignment_indexing.out.json
+++ b/selfhost/test/typechecker/assignment/assignment_indexing.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -156,7 +156,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -224,7 +224,7 @@
                 },
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -256,7 +256,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -312,7 +312,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -405,7 +405,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -447,7 +447,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "tuple",
@@ -479,7 +479,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "tuple",
@@ -711,7 +711,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Map" },
+                "struct": { "moduleId": 2, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "tuple",

--- a/selfhost/test/typechecker/assignment/assignment_variable.out.json
+++ b/selfhost/test/typechecker/assignment/assignment_variable.out.json
@@ -115,7 +115,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -134,7 +134,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -223,7 +223,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -244,7 +244,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/selfhost/test/typechecker/binary/coalesce.1.out.json
+++ b/selfhost/test/typechecker/binary/coalesce.1.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -129,7 +129,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/selfhost/test/typechecker/binary/coalesce.2.out.json
+++ b/selfhost/test/typechecker/binary/coalesce.2.out.json
@@ -25,11 +25,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -50,11 +50,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -77,7 +77,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -136,7 +136,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -155,7 +155,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -176,11 +176,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -204,7 +204,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -244,7 +244,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -264,7 +264,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/binary/eq.1.out.json
+++ b/selfhost/test/typechecker/binary/eq.1.out.json
@@ -75,7 +75,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -149,7 +149,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/binary/eq.2.out.json
+++ b/selfhost/test/typechecker/binary/eq.2.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -102,7 +102,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -124,7 +124,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -144,7 +144,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 0, "name": "Option" }
+                "enum": { "moduleId": 2, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",

--- a/selfhost/test/typechecker/binary/neq.1.out.json
+++ b/selfhost/test/typechecker/binary/neq.1.out.json
@@ -75,7 +75,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -149,7 +149,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/binary/neq.2.out.json
+++ b/selfhost/test/typechecker/binary/neq.2.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -102,7 +102,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -124,7 +124,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -144,7 +144,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 0, "name": "Option" }
+                "enum": { "moduleId": 2, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",

--- a/selfhost/test/typechecker/bindingdecl/bindingdecl.out.json
+++ b/selfhost/test/typechecker/bindingdecl/bindingdecl.out.json
@@ -209,7 +209,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -228,7 +228,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -248,7 +248,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 0, "name": "Option" }
+                "enum": { "moduleId": 2, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",
@@ -287,7 +287,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -306,7 +306,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/enumdecl/enumdecl_Result_shorthand.out.json
+++ b/selfhost/test/typechecker/enumdecl/enumdecl_Result_shorthand.out.json
@@ -28,7 +28,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Result" },
+            "enum": { "moduleId": 2, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -50,7 +50,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -93,7 +93,7 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Result" },
+                      "enum": { "moduleId": 2, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -122,7 +122,7 @@
                           ],
                           "returnType": {
                             "kind": "enumInstance",
-                            "enum": { "moduleId": 0, "name": "Result" },
+                            "enum": { "moduleId": 2, "name": "Result" },
                             "typeParams": [
                               {
                                 "kind": "generic",
@@ -168,7 +168,7 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Result" },
+                      "enum": { "moduleId": 2, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -197,7 +197,7 @@
                           ],
                           "returnType": {
                             "kind": "enumInstance",
-                            "enum": { "moduleId": 0, "name": "Result" },
+                            "enum": { "moduleId": 2, "name": "Result" },
                             "typeParams": [
                               {
                                 "kind": "generic",
@@ -265,7 +265,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Result" },
+            "enum": { "moduleId": 2, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -332,7 +332,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -361,7 +361,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Result" },
+                                "enum": { "moduleId": 2, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -455,7 +455,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -484,7 +484,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Result" },
+                                "enum": { "moduleId": 2, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -544,7 +544,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -573,7 +573,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Result" },
+                                "enum": { "moduleId": 2, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",

--- a/selfhost/test/typechecker/for/for.1.out.json
+++ b/selfhost/test/typechecker/for/for.1.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/for/for.2.out.json
+++ b/selfhost/test/typechecker/for/for.2.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/funcdecl/default_param_value_call.7.out.json
+++ b/selfhost/test/typechecker/funcdecl/default_param_value_call.7.out.json
@@ -116,7 +116,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -316,7 +316,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -334,7 +334,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/selfhost/test/typechecker/funcdecl/funcdecl.3.out.json
+++ b/selfhost/test/typechecker/funcdecl/funcdecl.3.out.json
@@ -25,7 +25,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -44,7 +44,7 @@
                       "required": true,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -71,7 +71,7 @@
               "label": { "name": "a", "position": [2, 8] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -116,7 +116,7 @@
                           "required": true,
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 0, "name": "Array" },
+                            "struct": { "moduleId": 2, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "primitive",
@@ -148,7 +148,7 @@
                         "required": true,
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",

--- a/selfhost/test/typechecker/funcdecl/funcdecl.5.out.json
+++ b/selfhost/test/typechecker/funcdecl/funcdecl.5.out.json
@@ -28,7 +28,7 @@
           "parameters": [],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -46,7 +46,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -89,11 +89,11 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -113,11 +113,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -158,11 +158,11 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -185,7 +185,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 0, "name": "Array" },
+                            "struct": { "moduleId": 2, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "primitive",
@@ -212,11 +212,11 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -238,7 +238,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 0, "name": "Option" }
+                          "enum": { "moduleId": 2, "name": "Option" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -285,11 +285,11 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -309,11 +309,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -354,11 +354,11 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -380,7 +380,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 0, "name": "Option" }
+                          "enum": { "moduleId": 2, "name": "Option" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -405,11 +405,11 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -432,7 +432,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 0, "name": "Array" },
+                            "struct": { "moduleId": 2, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "primitive",
@@ -481,15 +481,15 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -511,15 +511,15 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Option" },
+                        "enum": { "moduleId": 2, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -562,15 +562,15 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 0, "name": "Option" },
+                              "enum": { "moduleId": 2, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -594,7 +594,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 0, "name": "Option" }
+                          "enum": { "moduleId": 2, "name": "Option" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -619,15 +619,15 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 0, "name": "Option" },
+                              "enum": { "moduleId": 2, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -652,11 +652,11 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 0, "name": "Array" },
+                            "struct": { "moduleId": 2, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Option" },
+                                "enum": { "moduleId": 2, "name": "Option" },
                                 "typeParams": [
                                   {
                                     "kind": "primitive",
@@ -707,15 +707,15 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -737,15 +737,15 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Option" },
+                        "enum": { "moduleId": 2, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -788,15 +788,15 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 0, "name": "Option" },
+                              "enum": { "moduleId": 2, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -820,7 +820,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 0, "name": "Option" }
+                          "enum": { "moduleId": 2, "name": "Option" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -845,15 +845,15 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 0, "name": "Option" },
+                              "enum": { "moduleId": 2, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -878,11 +878,11 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 0, "name": "Array" },
+                            "struct": { "moduleId": 2, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Option" },
+                                "enum": { "moduleId": 2, "name": "Option" },
                                 "typeParams": [
                                   {
                                     "kind": "primitive",
@@ -904,7 +904,7 @@
                                 },
                                 "type": {
                                   "kind": "enumInstance",
-                                  "enum": { "moduleId": 0, "name": "Option" },
+                                  "enum": { "moduleId": 2, "name": "Option" },
                                   "typeParams": [
                                     {
                                       "kind": "primitive",
@@ -924,7 +924,7 @@
                                     },
                                     "type": {
                                       "kind": "enum",
-                                      "enum": { "moduleId": 0, "name": "Option" }
+                                      "enum": { "moduleId": 2, "name": "Option" }
                                     },
                                     "node": {
                                       "kind": "identifier",

--- a/selfhost/test/typechecker/funcdecl/funcdecl.6.out.json
+++ b/selfhost/test/typechecker/funcdecl/funcdecl.6.out.json
@@ -25,7 +25,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -82,11 +82,11 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -108,7 +108,7 @@
               "label": { "name": "arrs", "position": [3, 12] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/selfhost/test/typechecker/funcdecl/funcdecl.7.out.json
+++ b/selfhost/test/typechecker/funcdecl/funcdecl.7.out.json
@@ -33,7 +33,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -87,7 +87,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -106,7 +106,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/selfhost/test/typechecker/identifier/identifier.out.json
+++ b/selfhost/test/typechecker/identifier/identifier.out.json
@@ -133,7 +133,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -152,7 +152,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -172,7 +172,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 0, "name": "Option" }
+                "enum": { "moduleId": 2, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",

--- a/selfhost/test/typechecker/identifier/identifier_transform_OptionNone.out.json
+++ b/selfhost/test/typechecker/identifier/identifier_transform_OptionNone.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -64,7 +64,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 0, "name": "Option" }
+                "enum": { "moduleId": 2, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",

--- a/selfhost/test/typechecker/if/expr.out.json
+++ b/selfhost/test/typechecker/if/expr.out.json
@@ -172,7 +172,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -191,7 +191,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -276,7 +276,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -318,7 +318,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -359,7 +359,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -379,7 +379,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -417,7 +417,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -436,7 +436,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -475,7 +475,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -545,7 +545,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -604,7 +604,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -624,7 +624,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -662,11 +662,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -687,11 +687,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -732,11 +732,11 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -758,7 +758,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -829,11 +829,11 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -856,7 +856,7 @@
                       },
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -918,11 +918,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -944,11 +944,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -988,11 +988,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1013,11 +1013,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1104,11 +1104,11 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1131,7 +1131,7 @@
                       },
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1176,11 +1176,11 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1202,7 +1202,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1244,11 +1244,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1270,11 +1270,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1314,7 +1314,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1333,7 +1333,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1372,7 +1372,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1415,7 +1415,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1435,7 +1435,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1477,7 +1477,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1497,7 +1497,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1535,7 +1535,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1554,7 +1554,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1593,7 +1593,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1613,7 +1613,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1638,7 +1638,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1698,7 +1698,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1718,7 +1718,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1756,7 +1756,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1775,7 +1775,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1814,7 +1814,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1853,7 +1853,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Option" },
+                        "enum": { "moduleId": 2, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1896,7 +1896,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Option" },
+                        "enum": { "moduleId": 2, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1942,7 +1942,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1962,7 +1962,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -2004,7 +2004,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -2024,7 +2024,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -2116,7 +2116,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Option" },
+                        "enum": { "moduleId": 2, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "hole"
@@ -2135,7 +2135,7 @@
                           },
                           "type": {
                             "kind": "enum",
-                            "enum": { "moduleId": 0, "name": "Option" }
+                            "enum": { "moduleId": 2, "name": "Option" }
                           },
                           "node": {
                             "kind": "identifier",
@@ -2304,7 +2304,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -2323,7 +2323,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -2408,7 +2408,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/selfhost/test/typechecker/import/error_assignment_to_aliased_imported_variable.abra
+++ b/selfhost/test/typechecker/import/error_assignment_to_aliased_imported_variable.abra
@@ -1,0 +1,3 @@
+import "./_exports" as exp
+
+exp.a = 456

--- a/selfhost/test/typechecker/import/error_assignment_to_aliased_imported_variable.out
+++ b/selfhost/test/typechecker/import/error_assignment_to_aliased_imported_variable.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:3:5
+Cannot assign to member 'a'
+  |  exp.a = 456
+         ^
+'a' is an import, which cannot be overwritten

--- a/selfhost/test/typechecker/import/error_assignment_to_imported_variable.abra
+++ b/selfhost/test/typechecker/import/error_assignment_to_imported_variable.abra
@@ -1,0 +1,3 @@
+import a from "./_exports"
+
+a = 456

--- a/selfhost/test/typechecker/import/error_assignment_to_imported_variable.out
+++ b/selfhost/test/typechecker/import/error_assignment_to_imported_variable.out
@@ -1,0 +1,5 @@
+Error at %FILE_NAME%:3:1
+Cannot assign to variable 'a'
+  |  a = 456
+     ^
+'a' is an import, which cannot be overwritten

--- a/selfhost/test/typechecker/import/import.1.out.json
+++ b/selfhost/test/typechecker/import/import.1.out.json
@@ -1,6 +1,562 @@
 [
   {
     "id": 3,
+    "name": "%TEST_DIR%/typechecker/import/_exports.abra",
+    "exports": [
+      {
+        "kind": "function",
+        "name": "add"
+      },
+      {
+        "kind": "type",
+        "name": "Foo"
+      },
+      {
+        "kind": "variable",
+        "name": "foo"
+      },
+      {
+        "kind": "type",
+        "name": "Color"
+      },
+      {
+        "kind": "variable",
+        "name": "a"
+      }
+    ],
+    "code": [
+      {
+        "token": {
+          "position": [1, 8],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "a", "position": [1, 12] }
+          },
+          "variables": [
+            {
+              "label": { "name": "a", "position": [1, 12] },
+              "mutable": false,
+              "type": {
+                "kind": "primitive",
+                "primitive": "Int"
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [1, 16],
+              "kind": {
+                "name": "Int",
+                "value": 123
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Int"
+            },
+            "node": {
+              "kind": "literal",
+              "value": 123
+            }
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [3, 8],
+          "kind": {
+            "name": "Func"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "functionDeclaration",
+          "function": {
+            "label": { "name": "add", "position": [3, 13] },
+            "scope": {
+              "name": "$root::module_3::add",
+              "variables": [
+                {
+                  "label": { "name": "a", "position": [3, 17] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                },
+                {
+                  "label": { "name": "b", "position": [3, 25] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                }
+              ],
+              "functions": [],
+              "types": []
+            },
+            "kind": "FunctionKind.Standalone",
+            "typeParameters": [],
+            "parameters": [
+              {
+                "label": { "name": "a", "position": [3, 17] },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "defaultValue": null,
+                "isVariadic": false
+              },
+              {
+                "label": { "name": "b", "position": [3, 25] },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "defaultValue": null,
+                "isVariadic": false
+              }
+            ],
+            "returnType": {
+              "kind": "primitive",
+              "primitive": "Int"
+            },
+            "body": [
+              {
+                "token": {
+                  "position": [3, 42],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [3, 40],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "a"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "a"
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [3, 44],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "b"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "b"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [5, 8],
+          "kind": {
+            "name": "Type"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "typeDeclaration",
+          "struct": {
+            "moduleId": 3,
+            "name": { "name": "Foo", "position": [5, 13] },
+            "typeParams": [],
+            "fields": [
+              {
+                "name": { "name": "color", "position": [6, 3] },
+                "type": {
+                  "kind": "enumInstance",
+                  "enum": { "moduleId": 3, "name": "Color" },
+                  "typeParams": []
+                },
+                "initializer": null
+              }
+            ],
+            "instanceMethods": [
+              {
+                "label": { "name": "toString", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Foo::toString",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "hash", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Foo::hash",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "eq", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Foo::eq",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [
+                  {
+                    "label": { "name": "other", "position": [0, 0] },
+                    "type": {
+                      "kind": "instance",
+                      "struct": { "moduleId": 3, "name": "Foo" },
+                      "typeParams": []
+                    },
+                    "defaultValue": null,
+                    "isVariadic": false
+                  }
+                ],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "foo", "position": [8, 8] },
+                "scope": {
+                  "name": "$root::module_3::Foo::foo",
+                  "variables": [
+                    {
+                      "label": { "name": "self", "position": [8, 12] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "instance",
+                        "struct": { "moduleId": 3, "name": "Foo" },
+                        "typeParams": []
+                      }
+                    }
+                  ],
+                  "functions": [],
+                  "types": []
+                },
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "body": [
+                  {
+                    "token": {
+                      "position": [8, 25],
+                      "kind": {
+                        "name": "Int",
+                        "value": 123
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "literal",
+                      "value": 123
+                    }
+                  }
+                ]
+              }
+            ],
+            "staticMethods": []
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [10, 8],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "foo", "position": [10, 12] }
+          },
+          "variables": [
+            {
+              "label": { "name": "foo", "position": [10, 12] },
+              "mutable": false,
+              "type": {
+                "kind": "instance",
+                "struct": { "moduleId": 3, "name": "Foo" },
+                "typeParams": []
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [10, 21],
+              "kind": {
+                "name": "LParen"
+              }
+            },
+            "type": {
+              "kind": "instance",
+              "struct": { "moduleId": 3, "name": "Foo" },
+              "typeParams": []
+            },
+            "node": {
+              "kind": "invocation",
+              "invokee": { "moduleId": 3, "name": "Foo" },
+              "arguments": [
+                {
+                  "token": {
+                    "position": [10, 34],
+                    "kind": {
+                      "name": "Dot"
+                    }
+                  },
+                  "type": {
+                    "kind": "enumInstance",
+                    "enum": { "moduleId": 3, "name": "Color" },
+                    "typeParams": []
+                  },
+                  "node": {
+                    "kind": "accessor",
+                    "head": {
+                      "token": {
+                        "position": [10, 29],
+                        "kind": {
+                          "name": "Ident",
+                          "value": "Color"
+                        }
+                      },
+                      "type": {
+                        "kind": "enum",
+                        "enum": { "moduleId": 3, "name": "Color" }
+                      },
+                      "node": {
+                        "kind": "identifier",
+                        "name": "Color"
+                      }
+                    },
+                    "middle": [],
+                    "tail": {
+                      "kind": "enumVariant",
+                      "name": "Color.Green"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [12, 8],
+          "kind": {
+            "name": "Enum"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "enumDeclaration",
+          "enum": {
+            "moduleId": 3,
+            "name": { "name": "Color", "position": [12, 13] },
+            "typeParams": [],
+            "variants": [
+              {
+                "label": { "name": "Red", "position": [13, 3] },
+                "kind": "constant"
+              },
+              {
+                "label": { "name": "Green", "position": [14, 3] },
+                "kind": "constant"
+              },
+              {
+                "label": { "name": "Blue", "position": [15, 3] },
+                "kind": "constant"
+              },
+              {
+                "label": { "name": "RGB", "position": [16, 3] },
+                "kind": "container",
+                "fields": [
+                  {
+                    "name": { "name": "r", "position": [16, 7] },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "initializer": null
+                  },
+                  {
+                    "name": { "name": "g", "position": [16, 15] },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "initializer": null
+                  },
+                  {
+                    "name": { "name": "b", "position": [16, 23] },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "initializer": null
+                  }
+                ]
+              }
+            ],
+            "instanceMethods": [
+              {
+                "label": { "name": "toString", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Color::toString",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "hash", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Color::hash",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "eq", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Color::eq",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [
+                  {
+                    "label": { "name": "other", "position": [0, 0] },
+                    "type": {
+                      "kind": "enumInstance",
+                      "enum": { "moduleId": 3, "name": "Color" },
+                      "typeParams": []
+                    },
+                    "defaultValue": null,
+                    "isVariadic": false
+                  }
+                ],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "body": []
+              }
+            ],
+            "staticMethods": []
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": 4,
     "name": "%TEST_DIR%/typechecker/import/import.1.abra",
     "code": [
       {
@@ -211,7 +767,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Color" },
+                "enum": { "moduleId": 3, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -225,7 +781,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Color" },
+              "enum": { "moduleId": 3, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -311,7 +867,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Foo" },
+                "struct": { "moduleId": 3, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -325,12 +881,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Foo" },
+              "struct": { "moduleId": 3, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 4, "name": "Foo" },
+              "invokee": { "moduleId": 3, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -342,7 +898,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Color" },
+                    "enum": { "moduleId": 3, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {
@@ -352,562 +908,6 @@
                 }
               ]
             }
-          }
-        }
-      }
-    ]
-  },
-  {
-    "id": 4,
-    "name": "%TEST_DIR%/typechecker/import/_exports.abra",
-    "exports": [
-      {
-        "kind": "function",
-        "name": "add"
-      },
-      {
-        "kind": "type",
-        "name": "Foo"
-      },
-      {
-        "kind": "variable",
-        "name": "foo"
-      },
-      {
-        "kind": "type",
-        "name": "Color"
-      },
-      {
-        "kind": "variable",
-        "name": "a"
-      }
-    ],
-    "code": [
-      {
-        "token": {
-          "position": [1, 8],
-          "kind": {
-            "name": "Val"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "bindingDeclaration",
-          "pattern": {
-            "kind": "variable",
-            "label": { "name": "a", "position": [1, 12] }
-          },
-          "variables": [
-            {
-              "label": { "name": "a", "position": [1, 12] },
-              "mutable": false,
-              "type": {
-                "kind": "primitive",
-                "primitive": "Int"
-              }
-            }
-          ],
-          "expr": {
-            "token": {
-              "position": [1, 16],
-              "kind": {
-                "name": "Int",
-                "value": 123
-              }
-            },
-            "type": {
-              "kind": "primitive",
-              "primitive": "Int"
-            },
-            "node": {
-              "kind": "literal",
-              "value": 123
-            }
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [3, 8],
-          "kind": {
-            "name": "Func"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "functionDeclaration",
-          "function": {
-            "label": { "name": "add", "position": [3, 13] },
-            "scope": {
-              "name": "$root::module_4::add",
-              "variables": [
-                {
-                  "label": { "name": "a", "position": [3, 17] },
-                  "mutable": false,
-                  "type": {
-                    "kind": "primitive",
-                    "primitive": "Int"
-                  }
-                },
-                {
-                  "label": { "name": "b", "position": [3, 25] },
-                  "mutable": false,
-                  "type": {
-                    "kind": "primitive",
-                    "primitive": "Int"
-                  }
-                }
-              ],
-              "functions": [],
-              "types": []
-            },
-            "kind": "FunctionKind.Standalone",
-            "typeParameters": [],
-            "parameters": [
-              {
-                "label": { "name": "a", "position": [3, 17] },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "defaultValue": null,
-                "isVariadic": false
-              },
-              {
-                "label": { "name": "b", "position": [3, 25] },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "defaultValue": null,
-                "isVariadic": false
-              }
-            ],
-            "returnType": {
-              "kind": "primitive",
-              "primitive": "Int"
-            },
-            "body": [
-              {
-                "token": {
-                  "position": [3, 42],
-                  "kind": {
-                    "name": "Plus"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "node": {
-                  "kind": "binary",
-                  "op": "BinaryOp.Add",
-                  "left": {
-                    "token": {
-                      "position": [3, 40],
-                      "kind": {
-                        "name": "Ident",
-                        "value": "a"
-                      }
-                    },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "node": {
-                      "kind": "identifier",
-                      "name": "a"
-                    }
-                  },
-                  "right": {
-                    "token": {
-                      "position": [3, 44],
-                      "kind": {
-                        "name": "Ident",
-                        "value": "b"
-                      }
-                    },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "node": {
-                      "kind": "identifier",
-                      "name": "b"
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [5, 8],
-          "kind": {
-            "name": "Type"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "typeDeclaration",
-          "struct": {
-            "moduleId": 4,
-            "name": { "name": "Foo", "position": [5, 13] },
-            "typeParams": [],
-            "fields": [
-              {
-                "name": { "name": "color", "position": [6, 3] },
-                "type": {
-                  "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Color" },
-                  "typeParams": []
-                },
-                "initializer": null
-              }
-            ],
-            "instanceMethods": [
-              {
-                "label": { "name": "toString", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Foo::toString",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "String"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "hash", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Foo::hash",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "eq", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Foo::eq",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "label": { "name": "other", "position": [0, 0] },
-                    "type": {
-                      "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Foo" },
-                      "typeParams": []
-                    },
-                    "defaultValue": null,
-                    "isVariadic": false
-                  }
-                ],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Bool"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "foo", "position": [8, 8] },
-                "scope": {
-                  "name": "$root::module_4::Foo::foo",
-                  "variables": [
-                    {
-                      "label": { "name": "self", "position": [8, 12] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Foo" },
-                        "typeParams": []
-                      }
-                    }
-                  ],
-                  "functions": [],
-                  "types": []
-                },
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "body": [
-                  {
-                    "token": {
-                      "position": [8, 25],
-                      "kind": {
-                        "name": "Int",
-                        "value": 123
-                      }
-                    },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "node": {
-                      "kind": "literal",
-                      "value": 123
-                    }
-                  }
-                ]
-              }
-            ],
-            "staticMethods": []
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [10, 8],
-          "kind": {
-            "name": "Val"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "bindingDeclaration",
-          "pattern": {
-            "kind": "variable",
-            "label": { "name": "foo", "position": [10, 12] }
-          },
-          "variables": [
-            {
-              "label": { "name": "foo", "position": [10, 12] },
-              "mutable": false,
-              "type": {
-                "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Foo" },
-                "typeParams": []
-              }
-            }
-          ],
-          "expr": {
-            "token": {
-              "position": [10, 21],
-              "kind": {
-                "name": "LParen"
-              }
-            },
-            "type": {
-              "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Foo" },
-              "typeParams": []
-            },
-            "node": {
-              "kind": "invocation",
-              "invokee": { "moduleId": 4, "name": "Foo" },
-              "arguments": [
-                {
-                  "token": {
-                    "position": [10, 34],
-                    "kind": {
-                      "name": "Dot"
-                    }
-                  },
-                  "type": {
-                    "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Color" },
-                    "typeParams": []
-                  },
-                  "node": {
-                    "kind": "accessor",
-                    "head": {
-                      "token": {
-                        "position": [10, 29],
-                        "kind": {
-                          "name": "Ident",
-                          "value": "Color"
-                        }
-                      },
-                      "type": {
-                        "kind": "enum",
-                        "enum": { "moduleId": 4, "name": "Color" }
-                      },
-                      "node": {
-                        "kind": "identifier",
-                        "name": "Color"
-                      }
-                    },
-                    "middle": [],
-                    "tail": {
-                      "kind": "enumVariant",
-                      "name": "Color.Green"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [12, 8],
-          "kind": {
-            "name": "Enum"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "enumDeclaration",
-          "enum": {
-            "moduleId": 4,
-            "name": { "name": "Color", "position": [12, 13] },
-            "typeParams": [],
-            "variants": [
-              {
-                "label": { "name": "Red", "position": [13, 3] },
-                "kind": "constant"
-              },
-              {
-                "label": { "name": "Green", "position": [14, 3] },
-                "kind": "constant"
-              },
-              {
-                "label": { "name": "Blue", "position": [15, 3] },
-                "kind": "constant"
-              },
-              {
-                "label": { "name": "RGB", "position": [16, 3] },
-                "kind": "container",
-                "fields": [
-                  {
-                    "name": { "name": "r", "position": [16, 7] },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "initializer": null
-                  },
-                  {
-                    "name": { "name": "g", "position": [16, 15] },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "initializer": null
-                  },
-                  {
-                    "name": { "name": "b", "position": [16, 23] },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "initializer": null
-                  }
-                ]
-              }
-            ],
-            "instanceMethods": [
-              {
-                "label": { "name": "toString", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Color::toString",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "String"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "hash", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Color::hash",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "eq", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Color::eq",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "label": { "name": "other", "position": [0, 0] },
-                    "type": {
-                      "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Color" },
-                      "typeParams": []
-                    },
-                    "defaultValue": null,
-                    "isVariadic": false
-                  }
-                ],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Bool"
-                },
-                "body": []
-              }
-            ],
-            "staticMethods": []
           }
         }
       }

--- a/selfhost/test/typechecker/import/import.2.out.json
+++ b/selfhost/test/typechecker/import/import.2.out.json
@@ -1,6 +1,562 @@
 [
   {
     "id": 3,
+    "name": "%TEST_DIR%/typechecker/import/_exports.abra",
+    "exports": [
+      {
+        "kind": "function",
+        "name": "add"
+      },
+      {
+        "kind": "type",
+        "name": "Foo"
+      },
+      {
+        "kind": "variable",
+        "name": "foo"
+      },
+      {
+        "kind": "type",
+        "name": "Color"
+      },
+      {
+        "kind": "variable",
+        "name": "a"
+      }
+    ],
+    "code": [
+      {
+        "token": {
+          "position": [1, 8],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "a", "position": [1, 12] }
+          },
+          "variables": [
+            {
+              "label": { "name": "a", "position": [1, 12] },
+              "mutable": false,
+              "type": {
+                "kind": "primitive",
+                "primitive": "Int"
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [1, 16],
+              "kind": {
+                "name": "Int",
+                "value": 123
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Int"
+            },
+            "node": {
+              "kind": "literal",
+              "value": 123
+            }
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [3, 8],
+          "kind": {
+            "name": "Func"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "functionDeclaration",
+          "function": {
+            "label": { "name": "add", "position": [3, 13] },
+            "scope": {
+              "name": "$root::module_3::add",
+              "variables": [
+                {
+                  "label": { "name": "a", "position": [3, 17] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                },
+                {
+                  "label": { "name": "b", "position": [3, 25] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                }
+              ],
+              "functions": [],
+              "types": []
+            },
+            "kind": "FunctionKind.Standalone",
+            "typeParameters": [],
+            "parameters": [
+              {
+                "label": { "name": "a", "position": [3, 17] },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "defaultValue": null,
+                "isVariadic": false
+              },
+              {
+                "label": { "name": "b", "position": [3, 25] },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "defaultValue": null,
+                "isVariadic": false
+              }
+            ],
+            "returnType": {
+              "kind": "primitive",
+              "primitive": "Int"
+            },
+            "body": [
+              {
+                "token": {
+                  "position": [3, 42],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [3, 40],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "a"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "a"
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [3, 44],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "b"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "b"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [5, 8],
+          "kind": {
+            "name": "Type"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "typeDeclaration",
+          "struct": {
+            "moduleId": 3,
+            "name": { "name": "Foo", "position": [5, 13] },
+            "typeParams": [],
+            "fields": [
+              {
+                "name": { "name": "color", "position": [6, 3] },
+                "type": {
+                  "kind": "enumInstance",
+                  "enum": { "moduleId": 3, "name": "Color" },
+                  "typeParams": []
+                },
+                "initializer": null
+              }
+            ],
+            "instanceMethods": [
+              {
+                "label": { "name": "toString", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Foo::toString",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "hash", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Foo::hash",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "eq", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Foo::eq",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [
+                  {
+                    "label": { "name": "other", "position": [0, 0] },
+                    "type": {
+                      "kind": "instance",
+                      "struct": { "moduleId": 3, "name": "Foo" },
+                      "typeParams": []
+                    },
+                    "defaultValue": null,
+                    "isVariadic": false
+                  }
+                ],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "foo", "position": [8, 8] },
+                "scope": {
+                  "name": "$root::module_3::Foo::foo",
+                  "variables": [
+                    {
+                      "label": { "name": "self", "position": [8, 12] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "instance",
+                        "struct": { "moduleId": 3, "name": "Foo" },
+                        "typeParams": []
+                      }
+                    }
+                  ],
+                  "functions": [],
+                  "types": []
+                },
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "body": [
+                  {
+                    "token": {
+                      "position": [8, 25],
+                      "kind": {
+                        "name": "Int",
+                        "value": 123
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "literal",
+                      "value": 123
+                    }
+                  }
+                ]
+              }
+            ],
+            "staticMethods": []
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [10, 8],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "foo", "position": [10, 12] }
+          },
+          "variables": [
+            {
+              "label": { "name": "foo", "position": [10, 12] },
+              "mutable": false,
+              "type": {
+                "kind": "instance",
+                "struct": { "moduleId": 3, "name": "Foo" },
+                "typeParams": []
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [10, 21],
+              "kind": {
+                "name": "LParen"
+              }
+            },
+            "type": {
+              "kind": "instance",
+              "struct": { "moduleId": 3, "name": "Foo" },
+              "typeParams": []
+            },
+            "node": {
+              "kind": "invocation",
+              "invokee": { "moduleId": 3, "name": "Foo" },
+              "arguments": [
+                {
+                  "token": {
+                    "position": [10, 34],
+                    "kind": {
+                      "name": "Dot"
+                    }
+                  },
+                  "type": {
+                    "kind": "enumInstance",
+                    "enum": { "moduleId": 3, "name": "Color" },
+                    "typeParams": []
+                  },
+                  "node": {
+                    "kind": "accessor",
+                    "head": {
+                      "token": {
+                        "position": [10, 29],
+                        "kind": {
+                          "name": "Ident",
+                          "value": "Color"
+                        }
+                      },
+                      "type": {
+                        "kind": "enum",
+                        "enum": { "moduleId": 3, "name": "Color" }
+                      },
+                      "node": {
+                        "kind": "identifier",
+                        "name": "Color"
+                      }
+                    },
+                    "middle": [],
+                    "tail": {
+                      "kind": "enumVariant",
+                      "name": "Color.Green"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [12, 8],
+          "kind": {
+            "name": "Enum"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "enumDeclaration",
+          "enum": {
+            "moduleId": 3,
+            "name": { "name": "Color", "position": [12, 13] },
+            "typeParams": [],
+            "variants": [
+              {
+                "label": { "name": "Red", "position": [13, 3] },
+                "kind": "constant"
+              },
+              {
+                "label": { "name": "Green", "position": [14, 3] },
+                "kind": "constant"
+              },
+              {
+                "label": { "name": "Blue", "position": [15, 3] },
+                "kind": "constant"
+              },
+              {
+                "label": { "name": "RGB", "position": [16, 3] },
+                "kind": "container",
+                "fields": [
+                  {
+                    "name": { "name": "r", "position": [16, 7] },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "initializer": null
+                  },
+                  {
+                    "name": { "name": "g", "position": [16, 15] },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "initializer": null
+                  },
+                  {
+                    "name": { "name": "b", "position": [16, 23] },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "initializer": null
+                  }
+                ]
+              }
+            ],
+            "instanceMethods": [
+              {
+                "label": { "name": "toString", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Color::toString",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "hash", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Color::hash",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "body": []
+              },
+              {
+                "label": { "name": "eq", "position": [0, 0] },
+                "scope": {
+                  "name": "$root::module_3::Color::eq",
+                  "variables": [],
+                  "functions": [],
+                  "types": []
+                },
+                "isGenerated": true,
+                "kind": "FunctionKind.InstanceMethod",
+                "typeParameters": [],
+                "parameters": [
+                  {
+                    "label": { "name": "other", "position": [0, 0] },
+                    "type": {
+                      "kind": "enumInstance",
+                      "enum": { "moduleId": 3, "name": "Color" },
+                      "typeParams": []
+                    },
+                    "defaultValue": null,
+                    "isVariadic": false
+                  }
+                ],
+                "returnType": {
+                  "kind": "primitive",
+                  "primitive": "Bool"
+                },
+                "body": []
+              }
+            ],
+            "staticMethods": []
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": 4,
     "name": "%TEST_DIR%/typechecker/import/import.2.abra",
     "code": [
       {
@@ -105,7 +661,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Color" },
+                "enum": { "moduleId": 3, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -119,7 +675,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Color" },
+              "enum": { "moduleId": 3, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -134,7 +690,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Foo" },
+                  "struct": { "moduleId": 3, "name": "Foo" },
                   "typeParams": []
                 },
                 "node": {
@@ -148,7 +704,7 @@
                 "name": "color",
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Color" },
+                  "enum": { "moduleId": 3, "name": "Color" },
                   "typeParams": []
                 }
               }
@@ -391,7 +947,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Color" },
+                "enum": { "moduleId": 3, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -405,7 +961,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Color" },
+              "enum": { "moduleId": 3, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -420,7 +976,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Color" }
+                  "enum": { "moduleId": 3, "name": "Color" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -459,7 +1015,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Color" },
+                "enum": { "moduleId": 3, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -473,7 +1029,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Color" },
+              "enum": { "moduleId": 3, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -488,7 +1044,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Color" }
+                  "enum": { "moduleId": 3, "name": "Color" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -527,7 +1083,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Color" },
+                "enum": { "moduleId": 3, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -541,7 +1097,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Color" },
+              "enum": { "moduleId": 3, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -556,7 +1112,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Color" }
+                  "enum": { "moduleId": 3, "name": "Color" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -595,7 +1151,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Color" },
+                "enum": { "moduleId": 3, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -609,7 +1165,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Color" },
+              "enum": { "moduleId": 3, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -695,7 +1251,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Foo" },
+                "struct": { "moduleId": 3, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -709,12 +1265,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Foo" },
+              "struct": { "moduleId": 3, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 4, "name": "Foo" },
+              "invokee": { "moduleId": 3, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -726,7 +1282,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Color" },
+                    "enum": { "moduleId": 3, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {
@@ -736,562 +1292,6 @@
                 }
               ]
             }
-          }
-        }
-      }
-    ]
-  },
-  {
-    "id": 4,
-    "name": "%TEST_DIR%/typechecker/import/_exports.abra",
-    "exports": [
-      {
-        "kind": "function",
-        "name": "add"
-      },
-      {
-        "kind": "type",
-        "name": "Foo"
-      },
-      {
-        "kind": "variable",
-        "name": "foo"
-      },
-      {
-        "kind": "type",
-        "name": "Color"
-      },
-      {
-        "kind": "variable",
-        "name": "a"
-      }
-    ],
-    "code": [
-      {
-        "token": {
-          "position": [1, 8],
-          "kind": {
-            "name": "Val"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "bindingDeclaration",
-          "pattern": {
-            "kind": "variable",
-            "label": { "name": "a", "position": [1, 12] }
-          },
-          "variables": [
-            {
-              "label": { "name": "a", "position": [1, 12] },
-              "mutable": false,
-              "type": {
-                "kind": "primitive",
-                "primitive": "Int"
-              }
-            }
-          ],
-          "expr": {
-            "token": {
-              "position": [1, 16],
-              "kind": {
-                "name": "Int",
-                "value": 123
-              }
-            },
-            "type": {
-              "kind": "primitive",
-              "primitive": "Int"
-            },
-            "node": {
-              "kind": "literal",
-              "value": 123
-            }
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [3, 8],
-          "kind": {
-            "name": "Func"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "functionDeclaration",
-          "function": {
-            "label": { "name": "add", "position": [3, 13] },
-            "scope": {
-              "name": "$root::module_4::add",
-              "variables": [
-                {
-                  "label": { "name": "a", "position": [3, 17] },
-                  "mutable": false,
-                  "type": {
-                    "kind": "primitive",
-                    "primitive": "Int"
-                  }
-                },
-                {
-                  "label": { "name": "b", "position": [3, 25] },
-                  "mutable": false,
-                  "type": {
-                    "kind": "primitive",
-                    "primitive": "Int"
-                  }
-                }
-              ],
-              "functions": [],
-              "types": []
-            },
-            "kind": "FunctionKind.Standalone",
-            "typeParameters": [],
-            "parameters": [
-              {
-                "label": { "name": "a", "position": [3, 17] },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "defaultValue": null,
-                "isVariadic": false
-              },
-              {
-                "label": { "name": "b", "position": [3, 25] },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "defaultValue": null,
-                "isVariadic": false
-              }
-            ],
-            "returnType": {
-              "kind": "primitive",
-              "primitive": "Int"
-            },
-            "body": [
-              {
-                "token": {
-                  "position": [3, 42],
-                  "kind": {
-                    "name": "Plus"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "node": {
-                  "kind": "binary",
-                  "op": "BinaryOp.Add",
-                  "left": {
-                    "token": {
-                      "position": [3, 40],
-                      "kind": {
-                        "name": "Ident",
-                        "value": "a"
-                      }
-                    },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "node": {
-                      "kind": "identifier",
-                      "name": "a"
-                    }
-                  },
-                  "right": {
-                    "token": {
-                      "position": [3, 44],
-                      "kind": {
-                        "name": "Ident",
-                        "value": "b"
-                      }
-                    },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "node": {
-                      "kind": "identifier",
-                      "name": "b"
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [5, 8],
-          "kind": {
-            "name": "Type"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "typeDeclaration",
-          "struct": {
-            "moduleId": 4,
-            "name": { "name": "Foo", "position": [5, 13] },
-            "typeParams": [],
-            "fields": [
-              {
-                "name": { "name": "color", "position": [6, 3] },
-                "type": {
-                  "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Color" },
-                  "typeParams": []
-                },
-                "initializer": null
-              }
-            ],
-            "instanceMethods": [
-              {
-                "label": { "name": "toString", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Foo::toString",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "String"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "hash", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Foo::hash",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "eq", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Foo::eq",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "label": { "name": "other", "position": [0, 0] },
-                    "type": {
-                      "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Foo" },
-                      "typeParams": []
-                    },
-                    "defaultValue": null,
-                    "isVariadic": false
-                  }
-                ],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Bool"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "foo", "position": [8, 8] },
-                "scope": {
-                  "name": "$root::module_4::Foo::foo",
-                  "variables": [
-                    {
-                      "label": { "name": "self", "position": [8, 12] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Foo" },
-                        "typeParams": []
-                      }
-                    }
-                  ],
-                  "functions": [],
-                  "types": []
-                },
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "body": [
-                  {
-                    "token": {
-                      "position": [8, 25],
-                      "kind": {
-                        "name": "Int",
-                        "value": 123
-                      }
-                    },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "node": {
-                      "kind": "literal",
-                      "value": 123
-                    }
-                  }
-                ]
-              }
-            ],
-            "staticMethods": []
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [10, 8],
-          "kind": {
-            "name": "Val"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "bindingDeclaration",
-          "pattern": {
-            "kind": "variable",
-            "label": { "name": "foo", "position": [10, 12] }
-          },
-          "variables": [
-            {
-              "label": { "name": "foo", "position": [10, 12] },
-              "mutable": false,
-              "type": {
-                "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Foo" },
-                "typeParams": []
-              }
-            }
-          ],
-          "expr": {
-            "token": {
-              "position": [10, 21],
-              "kind": {
-                "name": "LParen"
-              }
-            },
-            "type": {
-              "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Foo" },
-              "typeParams": []
-            },
-            "node": {
-              "kind": "invocation",
-              "invokee": { "moduleId": 4, "name": "Foo" },
-              "arguments": [
-                {
-                  "token": {
-                    "position": [10, 34],
-                    "kind": {
-                      "name": "Dot"
-                    }
-                  },
-                  "type": {
-                    "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Color" },
-                    "typeParams": []
-                  },
-                  "node": {
-                    "kind": "accessor",
-                    "head": {
-                      "token": {
-                        "position": [10, 29],
-                        "kind": {
-                          "name": "Ident",
-                          "value": "Color"
-                        }
-                      },
-                      "type": {
-                        "kind": "enum",
-                        "enum": { "moduleId": 4, "name": "Color" }
-                      },
-                      "node": {
-                        "kind": "identifier",
-                        "name": "Color"
-                      }
-                    },
-                    "middle": [],
-                    "tail": {
-                      "kind": "enumVariant",
-                      "name": "Color.Green"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [12, 8],
-          "kind": {
-            "name": "Enum"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "enumDeclaration",
-          "enum": {
-            "moduleId": 4,
-            "name": { "name": "Color", "position": [12, 13] },
-            "typeParams": [],
-            "variants": [
-              {
-                "label": { "name": "Red", "position": [13, 3] },
-                "kind": "constant"
-              },
-              {
-                "label": { "name": "Green", "position": [14, 3] },
-                "kind": "constant"
-              },
-              {
-                "label": { "name": "Blue", "position": [15, 3] },
-                "kind": "constant"
-              },
-              {
-                "label": { "name": "RGB", "position": [16, 3] },
-                "kind": "container",
-                "fields": [
-                  {
-                    "name": { "name": "r", "position": [16, 7] },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "initializer": null
-                  },
-                  {
-                    "name": { "name": "g", "position": [16, 15] },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "initializer": null
-                  },
-                  {
-                    "name": { "name": "b", "position": [16, 23] },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "Int"
-                    },
-                    "initializer": null
-                  }
-                ]
-              }
-            ],
-            "instanceMethods": [
-              {
-                "label": { "name": "toString", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Color::toString",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "String"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "hash", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Color::hash",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Int"
-                },
-                "body": []
-              },
-              {
-                "label": { "name": "eq", "position": [0, 0] },
-                "scope": {
-                  "name": "$root::module_4::Color::eq",
-                  "variables": [],
-                  "functions": [],
-                  "types": []
-                },
-                "isGenerated": true,
-                "kind": "FunctionKind.InstanceMethod",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "label": { "name": "other", "position": [0, 0] },
-                    "type": {
-                      "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Color" },
-                      "typeParams": []
-                    },
-                    "defaultValue": null,
-                    "isVariadic": false
-                  }
-                ],
-                "returnType": {
-                  "kind": "primitive",
-                  "primitive": "Bool"
-                },
-                "body": []
-              }
-            ],
-            "staticMethods": []
           }
         }
       }

--- a/selfhost/test/typechecker/import/import_type_identifier.1.out.json
+++ b/selfhost/test/typechecker/import/import_type_identifier.1.out.json
@@ -1,172 +1,6 @@
 [
   {
     "id": 3,
-    "name": "%TEST_DIR%/typechecker/import/import_type_identifier.1.abra",
-    "code": [
-      {
-        "token": {
-          "position": [3, 1],
-          "kind": {
-            "name": "Val"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "bindingDeclaration",
-          "pattern": {
-            "kind": "variable",
-            "label": { "name": "_", "position": [3, 5] }
-          },
-          "variables": [
-            {
-              "label": { "name": "_", "position": [3, 5] },
-              "mutable": false,
-              "type": {
-                "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
-                "typeParams": [
-                  {
-                    "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Foo" },
-                    "typeParams": []
-                  }
-                ]
-              }
-            }
-          ],
-          "expr": {
-            "token": {
-              "position": [3, 15],
-              "kind": {
-                "name": "None"
-              }
-            },
-            "type": {
-              "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
-              "typeParams": [
-                {
-                  "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Foo" },
-                  "typeParams": []
-                }
-              ]
-            },
-            "node": {
-              "kind": "accessor",
-              "head": {
-                "token": {
-                  "position": [3, 15],
-                  "kind": {
-                    "name": "Ident",
-                    "value": "Option"
-                  }
-                },
-                "type": {
-                  "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
-                },
-                "node": {
-                  "kind": "identifier",
-                  "name": "Option"
-                }
-              },
-              "middle": [],
-              "tail": {
-                "kind": "enumVariant",
-                "name": "Option.None"
-              }
-            }
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [4, 1],
-          "kind": {
-            "name": "Val"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "bindingDeclaration",
-          "pattern": {
-            "kind": "variable",
-            "label": { "name": "_", "position": [4, 5] }
-          },
-          "variables": [
-            {
-              "label": { "name": "_", "position": [4, 5] },
-              "mutable": false,
-              "type": {
-                "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
-                "typeParams": [
-                  {
-                    "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Color" },
-                    "typeParams": []
-                  }
-                ]
-              }
-            }
-          ],
-          "expr": {
-            "token": {
-              "position": [4, 17],
-              "kind": {
-                "name": "None"
-              }
-            },
-            "type": {
-              "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
-              "typeParams": [
-                {
-                  "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Color" },
-                  "typeParams": []
-                }
-              ]
-            },
-            "node": {
-              "kind": "accessor",
-              "head": {
-                "token": {
-                  "position": [4, 17],
-                  "kind": {
-                    "name": "Ident",
-                    "value": "Option"
-                  }
-                },
-                "type": {
-                  "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
-                },
-                "node": {
-                  "kind": "identifier",
-                  "name": "Option"
-                }
-              },
-              "middle": [],
-              "tail": {
-                "kind": "enumVariant",
-                "name": "Option.None"
-              }
-            }
-          }
-        }
-      }
-    ]
-  },
-  {
-    "id": 4,
     "name": "%TEST_DIR%/typechecker/import/_exports.abra",
     "exports": [
       {
@@ -253,7 +87,7 @@
           "function": {
             "label": { "name": "add", "position": [3, 13] },
             "scope": {
-              "name": "$root::module_4::add",
+              "name": "$root::module_3::add",
               "variables": [
                 {
                   "label": { "name": "a", "position": [3, 17] },
@@ -370,7 +204,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 4,
+            "moduleId": 3,
             "name": { "name": "Foo", "position": [5, 13] },
             "typeParams": [],
             "fields": [
@@ -378,7 +212,7 @@
                 "name": { "name": "color", "position": [6, 3] },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Color" },
+                  "enum": { "moduleId": 3, "name": "Color" },
                   "typeParams": []
                 },
                 "initializer": null
@@ -388,7 +222,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Foo::toString",
+                  "name": "$root::module_3::Foo::toString",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -406,7 +240,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Foo::hash",
+                  "name": "$root::module_3::Foo::hash",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -424,7 +258,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Foo::eq",
+                  "name": "$root::module_3::Foo::eq",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -437,7 +271,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Foo" },
+                      "struct": { "moduleId": 3, "name": "Foo" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -453,14 +287,14 @@
               {
                 "label": { "name": "foo", "position": [8, 8] },
                 "scope": {
-                  "name": "$root::module_4::Foo::foo",
+                  "name": "$root::module_3::Foo::foo",
                   "variables": [
                     {
                       "label": { "name": "self", "position": [8, 12] },
                       "mutable": false,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Foo" },
+                        "struct": { "moduleId": 3, "name": "Foo" },
                         "typeParams": []
                       }
                     }
@@ -523,7 +357,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Foo" },
+                "struct": { "moduleId": 3, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -537,12 +371,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Foo" },
+              "struct": { "moduleId": 3, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 4, "name": "Foo" },
+              "invokee": { "moduleId": 3, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -553,7 +387,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Color" },
+                    "enum": { "moduleId": 3, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {
@@ -568,7 +402,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 4, "name": "Color" }
+                        "enum": { "moduleId": 3, "name": "Color" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -601,7 +435,7 @@
         "node": {
           "kind": "enumDeclaration",
           "enum": {
-            "moduleId": 4,
+            "moduleId": 3,
             "name": { "name": "Color", "position": [12, 13] },
             "typeParams": [],
             "variants": [
@@ -652,7 +486,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Color::toString",
+                  "name": "$root::module_3::Color::toString",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -670,7 +504,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Color::hash",
+                  "name": "$root::module_3::Color::hash",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -688,7 +522,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Color::eq",
+                  "name": "$root::module_3::Color::eq",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -701,7 +535,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Color" },
+                      "enum": { "moduleId": 3, "name": "Color" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -716,6 +550,172 @@
               }
             ],
             "staticMethods": []
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": 4,
+    "name": "%TEST_DIR%/typechecker/import/import_type_identifier.1.abra",
+    "code": [
+      {
+        "token": {
+          "position": [3, 1],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "_", "position": [3, 5] }
+          },
+          "variables": [
+            {
+              "label": { "name": "_", "position": [3, 5] },
+              "mutable": false,
+              "type": {
+                "kind": "enumInstance",
+                "enum": { "moduleId": 2, "name": "Option" },
+                "typeParams": [
+                  {
+                    "kind": "instance",
+                    "struct": { "moduleId": 3, "name": "Foo" },
+                    "typeParams": []
+                  }
+                ]
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [3, 15],
+              "kind": {
+                "name": "None"
+              }
+            },
+            "type": {
+              "kind": "enumInstance",
+              "enum": { "moduleId": 2, "name": "Option" },
+              "typeParams": [
+                {
+                  "kind": "instance",
+                  "struct": { "moduleId": 3, "name": "Foo" },
+                  "typeParams": []
+                }
+              ]
+            },
+            "node": {
+              "kind": "accessor",
+              "head": {
+                "token": {
+                  "position": [3, 15],
+                  "kind": {
+                    "name": "Ident",
+                    "value": "Option"
+                  }
+                },
+                "type": {
+                  "kind": "enum",
+                  "enum": { "moduleId": 2, "name": "Option" }
+                },
+                "node": {
+                  "kind": "identifier",
+                  "name": "Option"
+                }
+              },
+              "middle": [],
+              "tail": {
+                "kind": "enumVariant",
+                "name": "Option.None"
+              }
+            }
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [4, 1],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "_", "position": [4, 5] }
+          },
+          "variables": [
+            {
+              "label": { "name": "_", "position": [4, 5] },
+              "mutable": false,
+              "type": {
+                "kind": "enumInstance",
+                "enum": { "moduleId": 2, "name": "Option" },
+                "typeParams": [
+                  {
+                    "kind": "enumInstance",
+                    "enum": { "moduleId": 3, "name": "Color" },
+                    "typeParams": []
+                  }
+                ]
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [4, 17],
+              "kind": {
+                "name": "None"
+              }
+            },
+            "type": {
+              "kind": "enumInstance",
+              "enum": { "moduleId": 2, "name": "Option" },
+              "typeParams": [
+                {
+                  "kind": "enumInstance",
+                  "enum": { "moduleId": 3, "name": "Color" },
+                  "typeParams": []
+                }
+              ]
+            },
+            "node": {
+              "kind": "accessor",
+              "head": {
+                "token": {
+                  "position": [4, 17],
+                  "kind": {
+                    "name": "Ident",
+                    "value": "Option"
+                  }
+                },
+                "type": {
+                  "kind": "enum",
+                  "enum": { "moduleId": 2, "name": "Option" }
+                },
+                "node": {
+                  "kind": "identifier",
+                  "name": "Option"
+                }
+              },
+              "middle": [],
+              "tail": {
+                "kind": "enumVariant",
+                "name": "Option.None"
+              }
+            }
           }
         }
       }

--- a/selfhost/test/typechecker/import/import_type_identifier.2.out.json
+++ b/selfhost/test/typechecker/import/import_type_identifier.2.out.json
@@ -1,151 +1,6 @@
 [
   {
     "id": 3,
-    "name": "%TEST_DIR%/typechecker/import/import_type_identifier.2.abra",
-    "code": [
-      {
-        "token": {
-          "position": [3, 1],
-          "kind": {
-            "name": "Val"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "bindingDeclaration",
-          "pattern": {
-            "kind": "variable",
-            "label": { "name": "_", "position": [3, 5] }
-          },
-          "variables": [
-            {
-              "label": { "name": "_", "position": [3, 5] },
-              "mutable": false,
-              "type": {
-                "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
-                "typeParams": [
-                  {
-                    "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Foo" },
-                    "typeParams": []
-                  }
-                ]
-              }
-            }
-          ],
-          "expr": {
-            "token": {
-              "position": [3, 17],
-              "kind": {
-                "name": "None"
-              }
-            },
-            "type": {
-              "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
-              "typeParams": [
-                {
-                  "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Foo" },
-                  "typeParams": []
-                }
-              ]
-            },
-            "node": {
-              "kind": "accessor",
-              "head": {
-                "token": {
-                  "position": [3, 17],
-                  "kind": {
-                    "name": "Ident",
-                    "value": "Option"
-                  }
-                },
-                "type": {
-                  "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
-                },
-                "node": {
-                  "kind": "identifier",
-                  "name": "Option"
-                }
-              },
-              "middle": [],
-              "tail": {
-                "kind": "enumVariant",
-                "name": "Option.None"
-              }
-            }
-          }
-        }
-      },
-      {
-        "token": {
-          "position": [4, 1],
-          "kind": {
-            "name": "Val"
-          }
-        },
-        "type": {
-          "kind": "primitive",
-          "primitive": "Unit"
-        },
-        "node": {
-          "kind": "bindingDeclaration",
-          "pattern": {
-            "kind": "variable",
-            "label": { "name": "_", "position": [4, 5] }
-          },
-          "variables": [
-            {
-              "label": { "name": "_", "position": [4, 5] },
-              "mutable": false,
-              "type": {
-                "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
-                "typeParams": [
-                  {
-                    "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Color" },
-                    "typeParams": []
-                  }
-                ]
-              }
-            }
-          ],
-          "expr": {
-            "token": {
-              "position": [4, 20],
-              "kind": {
-                "name": "LBrack"
-              }
-            },
-            "type": {
-              "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
-              "typeParams": [
-                {
-                  "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Color" },
-                  "typeParams": []
-                }
-              ]
-            },
-            "node": {
-              "kind": "array",
-              "items": []
-            }
-          }
-        }
-      }
-    ]
-  },
-  {
-    "id": 4,
     "name": "%TEST_DIR%/typechecker/import/_exports.abra",
     "exports": [
       {
@@ -232,7 +87,7 @@
           "function": {
             "label": { "name": "add", "position": [3, 13] },
             "scope": {
-              "name": "$root::module_4::add",
+              "name": "$root::module_3::add",
               "variables": [
                 {
                   "label": { "name": "a", "position": [3, 17] },
@@ -349,7 +204,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 4,
+            "moduleId": 3,
             "name": { "name": "Foo", "position": [5, 13] },
             "typeParams": [],
             "fields": [
@@ -357,7 +212,7 @@
                 "name": { "name": "color", "position": [6, 3] },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Color" },
+                  "enum": { "moduleId": 3, "name": "Color" },
                   "typeParams": []
                 },
                 "initializer": null
@@ -367,7 +222,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Foo::toString",
+                  "name": "$root::module_3::Foo::toString",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -385,7 +240,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Foo::hash",
+                  "name": "$root::module_3::Foo::hash",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -403,7 +258,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Foo::eq",
+                  "name": "$root::module_3::Foo::eq",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -416,7 +271,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Foo" },
+                      "struct": { "moduleId": 3, "name": "Foo" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -432,14 +287,14 @@
               {
                 "label": { "name": "foo", "position": [8, 8] },
                 "scope": {
-                  "name": "$root::module_4::Foo::foo",
+                  "name": "$root::module_3::Foo::foo",
                   "variables": [
                     {
                       "label": { "name": "self", "position": [8, 12] },
                       "mutable": false,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Foo" },
+                        "struct": { "moduleId": 3, "name": "Foo" },
                         "typeParams": []
                       }
                     }
@@ -502,7 +357,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Foo" },
+                "struct": { "moduleId": 3, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -516,12 +371,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Foo" },
+              "struct": { "moduleId": 3, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 4, "name": "Foo" },
+              "invokee": { "moduleId": 3, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -532,7 +387,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Color" },
+                    "enum": { "moduleId": 3, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {
@@ -547,7 +402,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 4, "name": "Color" }
+                        "enum": { "moduleId": 3, "name": "Color" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -580,7 +435,7 @@
         "node": {
           "kind": "enumDeclaration",
           "enum": {
-            "moduleId": 4,
+            "moduleId": 3,
             "name": { "name": "Color", "position": [12, 13] },
             "typeParams": [],
             "variants": [
@@ -631,7 +486,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Color::toString",
+                  "name": "$root::module_3::Color::toString",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -649,7 +504,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Color::hash",
+                  "name": "$root::module_3::Color::hash",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -667,7 +522,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_4::Color::eq",
+                  "name": "$root::module_3::Color::eq",
                   "variables": [],
                   "functions": [],
                   "types": []
@@ -680,7 +535,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Color" },
+                      "enum": { "moduleId": 3, "name": "Color" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -695,6 +550,151 @@
               }
             ],
             "staticMethods": []
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": 4,
+    "name": "%TEST_DIR%/typechecker/import/import_type_identifier.2.abra",
+    "code": [
+      {
+        "token": {
+          "position": [3, 1],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "_", "position": [3, 5] }
+          },
+          "variables": [
+            {
+              "label": { "name": "_", "position": [3, 5] },
+              "mutable": false,
+              "type": {
+                "kind": "enumInstance",
+                "enum": { "moduleId": 2, "name": "Option" },
+                "typeParams": [
+                  {
+                    "kind": "instance",
+                    "struct": { "moduleId": 3, "name": "Foo" },
+                    "typeParams": []
+                  }
+                ]
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [3, 17],
+              "kind": {
+                "name": "None"
+              }
+            },
+            "type": {
+              "kind": "enumInstance",
+              "enum": { "moduleId": 2, "name": "Option" },
+              "typeParams": [
+                {
+                  "kind": "instance",
+                  "struct": { "moduleId": 3, "name": "Foo" },
+                  "typeParams": []
+                }
+              ]
+            },
+            "node": {
+              "kind": "accessor",
+              "head": {
+                "token": {
+                  "position": [3, 17],
+                  "kind": {
+                    "name": "Ident",
+                    "value": "Option"
+                  }
+                },
+                "type": {
+                  "kind": "enum",
+                  "enum": { "moduleId": 2, "name": "Option" }
+                },
+                "node": {
+                  "kind": "identifier",
+                  "name": "Option"
+                }
+              },
+              "middle": [],
+              "tail": {
+                "kind": "enumVariant",
+                "name": "Option.None"
+              }
+            }
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [4, 1],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "_", "position": [4, 5] }
+          },
+          "variables": [
+            {
+              "label": { "name": "_", "position": [4, 5] },
+              "mutable": false,
+              "type": {
+                "kind": "instance",
+                "struct": { "moduleId": 2, "name": "Array" },
+                "typeParams": [
+                  {
+                    "kind": "enumInstance",
+                    "enum": { "moduleId": 3, "name": "Color" },
+                    "typeParams": []
+                  }
+                ]
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [4, 20],
+              "kind": {
+                "name": "LBrack"
+              }
+            },
+            "type": {
+              "kind": "instance",
+              "struct": { "moduleId": 2, "name": "Array" },
+              "typeParams": [
+                {
+                  "kind": "enumInstance",
+                  "enum": { "moduleId": 3, "name": "Color" },
+                  "typeParams": []
+                }
+              ]
+            },
+            "node": {
+              "kind": "array",
+              "items": []
+            }
           }
         }
       }

--- a/selfhost/test/typechecker/indexing/indexing_array.out.json
+++ b/selfhost/test/typechecker/indexing/indexing_array.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -153,7 +153,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -175,7 +175,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -233,7 +233,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -253,7 +253,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -383,7 +383,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -402,7 +402,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -424,7 +424,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -499,7 +499,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -519,7 +519,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -557,7 +557,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -576,7 +576,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -598,7 +598,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -657,7 +657,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -677,7 +677,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -715,7 +715,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -734,7 +734,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -756,7 +756,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -831,7 +831,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -851,7 +851,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/indexing/indexing_map.out.json
+++ b/selfhost/test/typechecker/indexing/indexing_map.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -48,7 +48,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -163,7 +163,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -182,7 +182,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -204,7 +204,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Map" },
+                  "struct": { "moduleId": 2, "name": "Map" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -266,7 +266,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -286,7 +286,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -324,7 +324,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -347,7 +347,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -528,7 +528,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -547,7 +547,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -569,7 +569,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Map" },
+                  "struct": { "moduleId": 2, "name": "Map" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -631,7 +631,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -651,7 +651,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/indexing/indexing_tuple.out.json
+++ b/selfhost/test/typechecker/indexing/indexing_tuple.out.json
@@ -36,7 +36,7 @@
                 },
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -68,7 +68,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -124,7 +124,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -224,7 +224,7 @@
                     },
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -354,7 +354,7 @@
                     },
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -443,7 +443,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -462,7 +462,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -496,7 +496,7 @@
                     },
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -539,7 +539,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -559,7 +559,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/invocation/invocation.5.out.json
+++ b/selfhost/test/typechecker/invocation/invocation.5.out.json
@@ -25,7 +25,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -39,7 +39,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -59,7 +59,7 @@
               "label": { "name": "a", "position": [1, 10] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -74,7 +74,7 @@
               "label": { "name": "b", "position": [1, 20] },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -116,7 +116,7 @@
                 "required": true,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -129,7 +129,7 @@
                 "required": true,
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -155,7 +155,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -177,7 +177,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -234,7 +234,7 @@
                 "required": true,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -247,7 +247,7 @@
                 "required": true,
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -273,7 +273,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -330,7 +330,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -350,7 +350,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
+                  "enum": { "moduleId": 2, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",

--- a/selfhost/test/typechecker/invocation/invocation_enum_variant.4.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_enum_variant.4.out.json
@@ -30,7 +30,7 @@
                   "name": { "name": "a", "position": [2, 7] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -177,7 +177,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",

--- a/selfhost/test/typechecker/invocation/invocation_field_generics.1.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_field_generics.1.out.json
@@ -10,14 +10,13 @@
         }
       },
       "type": {
-        "nullable": false,
         "kind": "primitive",
         "primitive": "Unit"
       },
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 1,
+          "moduleId": 3,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [
             "T"
@@ -26,20 +25,17 @@
             {
               "name": { "name": "fn", "position": [1, 15] },
               "type": {
-                "nullable": false,
                 "kind": "function",
                 "parameters": [
                   {
                     "required": true,
                     "type": {
-                      "nullable": false,
                       "kind": "generic",
                       "name": "T"
                     }
                   }
                 ],
                 "returnType": {
-                  "nullable": false,
                   "kind": "generic",
                   "name": "T"
                 }
@@ -51,7 +47,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_1::Foo::toString",
+                "name": "$root::module_3::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "types": []
@@ -61,7 +57,6 @@
               "typeParameters": [],
               "parameters": [],
               "returnType": {
-                "nullable": false,
                 "kind": "primitive",
                 "primitive": "String"
               },
@@ -70,7 +65,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_1::Foo::hash",
+                "name": "$root::module_3::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "types": []
@@ -80,7 +75,6 @@
               "typeParameters": [],
               "parameters": [],
               "returnType": {
-                "nullable": false,
                 "kind": "primitive",
                 "primitive": "Int"
               },
@@ -89,7 +83,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_1::Foo::eq",
+                "name": "$root::module_3::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "types": []
@@ -101,17 +95,20 @@
                 {
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
-                    "nullable": false,
                     "kind": "instance",
-                    "struct": { "moduleId": 1, "name": "Foo" },
-                    "typeParams": []
+                    "struct": { "moduleId": 3, "name": "Foo" },
+                    "typeParams": [
+                      {
+                        "kind": "generic",
+                        "name": "T"
+                      }
+                    ]
                   },
                   "defaultValue": null,
                   "isVariadic": false
                 }
               ],
               "returnType": {
-                "nullable": false,
                 "kind": "primitive",
                 "primitive": "Bool"
               },
@@ -130,7 +127,6 @@
         }
       },
       "type": {
-        "nullable": false,
         "kind": "primitive",
         "primitive": "Unit"
       },
@@ -139,13 +135,12 @@
         "function": {
           "label": { "name": "identity", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_1::identity",
+            "name": "$root::module_3::identity",
             "variables": [
               {
                 "label": { "name": "i", "position": [3, 15] },
                 "mutable": false,
                 "type": {
-                  "nullable": false,
                   "kind": "primitive",
                   "primitive": "Int"
                 }
@@ -160,7 +155,6 @@
             {
               "label": { "name": "i", "position": [3, 15] },
               "type": {
-                "nullable": false,
                 "kind": "primitive",
                 "primitive": "Int"
               },
@@ -169,7 +163,6 @@
             }
           ],
           "returnType": {
-            "nullable": false,
             "kind": "primitive",
             "primitive": "Int"
           },
@@ -183,7 +176,6 @@
                 }
               },
               "type": {
-                "nullable": false,
                 "kind": "primitive",
                 "primitive": "Int"
               },
@@ -204,7 +196,6 @@
         }
       },
       "type": {
-        "nullable": false,
         "kind": "primitive",
         "primitive": "Unit"
       },
@@ -219,12 +210,10 @@
             "label": { "name": "f", "position": [5, 5] },
             "mutable": false,
             "type": {
-              "nullable": false,
               "kind": "instance",
-              "struct": { "moduleId": 1, "name": "Foo" },
+              "struct": { "moduleId": 3, "name": "Foo" },
               "typeParams": [
                 {
-                  "nullable": false,
                   "kind": "primitive",
                   "primitive": "Int"
                 }
@@ -240,12 +229,10 @@
             }
           },
           "type": {
-            "nullable": false,
             "kind": "instance",
-            "struct": { "moduleId": 1, "name": "Foo" },
+            "struct": { "moduleId": 3, "name": "Foo" },
             "typeParams": [
               {
-                "nullable": false,
                 "kind": "primitive",
                 "primitive": "Int"
               }
@@ -253,7 +240,7 @@
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 1, "name": "Foo" },
+            "invokee": { "moduleId": 3, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -264,20 +251,17 @@
                   }
                 },
                 "type": {
-                  "nullable": false,
                   "kind": "function",
                   "parameters": [
                     {
                       "required": true,
                       "type": {
-                        "nullable": false,
                         "kind": "primitive",
                         "primitive": "Int"
                       }
                     }
                   ],
                   "returnType": {
-                    "nullable": false,
                     "kind": "primitive",
                     "primitive": "Int"
                   }
@@ -300,7 +284,6 @@
         }
       },
       "type": {
-        "nullable": false,
         "kind": "primitive",
         "primitive": "Unit"
       },
@@ -315,7 +298,6 @@
             "label": { "name": "int", "position": [6, 5] },
             "mutable": false,
             "type": {
-              "nullable": false,
               "kind": "primitive",
               "primitive": "Int"
             }
@@ -329,7 +311,6 @@
             }
           },
           "type": {
-            "nullable": false,
             "kind": "primitive",
             "primitive": "Int"
           },
@@ -343,20 +324,17 @@
                 }
               },
               "type": {
-                "nullable": false,
                 "kind": "function",
                 "parameters": [
                   {
                     "required": true,
                     "type": {
-                      "nullable": false,
                       "kind": "primitive",
                       "primitive": "Int"
                     }
                   }
                 ],
                 "returnType": {
-                  "nullable": false,
                   "kind": "primitive",
                   "primitive": "Int"
                 }
@@ -372,12 +350,10 @@
                     }
                   },
                   "type": {
-                    "nullable": false,
                     "kind": "instance",
-                    "struct": { "moduleId": 1, "name": "Foo" },
+                    "struct": { "moduleId": 3, "name": "Foo" },
                     "typeParams": [
                       {
-                        "nullable": false,
                         "kind": "primitive",
                         "primitive": "Int"
                       }
@@ -391,7 +367,23 @@
                 "middle": [],
                 "tail": {
                   "kind": "field",
-                  "name": "fn"
+                  "name": "fn",
+                  "type": {
+                    "kind": "function",
+                    "parameters": [
+                      {
+                        "required": true,
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        }
+                      }
+                    ],
+                    "returnType": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    }
+                  }
                 }
               }
             },
@@ -405,7 +397,6 @@
                   }
                 },
                 "type": {
-                  "nullable": false,
                   "kind": "primitive",
                   "primitive": "Int"
                 },
@@ -427,7 +418,6 @@
         }
       },
       "type": {
-        "nullable": false,
         "kind": "primitive",
         "primitive": "Unit"
       },
@@ -442,7 +432,6 @@
             "label": { "name": "_", "position": [7, 5] },
             "mutable": false,
             "type": {
-              "nullable": false,
               "kind": "primitive",
               "primitive": "Int"
             }
@@ -457,7 +446,6 @@
             }
           },
           "type": {
-            "nullable": false,
             "kind": "primitive",
             "primitive": "Int"
           },

--- a/selfhost/test/typechecker/invocation/invocation_generics.2.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_generics.2.out.json
@@ -25,7 +25,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -58,7 +58,7 @@
               "label": { "name": "t", "position": [1, 14] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -72,7 +72,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -91,7 +91,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -131,7 +131,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -150,7 +150,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -169,7 +169,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -181,7 +181,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -201,7 +201,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -260,7 +260,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -280,7 +280,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -318,7 +318,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -337,7 +337,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -356,7 +356,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -368,7 +368,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -388,7 +388,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -447,7 +447,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -467,7 +467,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -540,7 +540,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -558,7 +558,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -616,7 +616,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -635,7 +635,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -660,7 +660,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -716,7 +716,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -736,7 +736,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -774,7 +774,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -793,7 +793,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -818,7 +818,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -874,7 +874,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -894,7 +894,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/invocation/invocation_generics.3.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_generics.3.out.json
@@ -25,7 +25,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -66,7 +66,7 @@
               "label": { "name": "arr", "position": [1, 13] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -89,7 +89,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -108,7 +108,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -148,7 +148,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -167,7 +167,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -186,7 +186,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -205,7 +205,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -225,7 +225,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -283,7 +283,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -303,7 +303,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/invocation/invocation_generics.4.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_generics.4.out.json
@@ -25,7 +25,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -39,7 +39,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -72,7 +72,7 @@
               "label": { "name": "arr1", "position": [1, 13] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -87,7 +87,7 @@
               "label": { "name": "arr2", "position": [1, 24] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -101,7 +101,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -120,7 +120,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -160,7 +160,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -179,7 +179,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -198,7 +198,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -211,7 +211,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -223,7 +223,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -243,7 +243,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -265,7 +265,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -306,7 +306,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -326,7 +326,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/invocation/invocation_generics.5.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_generics.5.out.json
@@ -25,7 +25,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -89,7 +89,7 @@
               "label": { "name": "arr", "position": [1, 21] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -124,11 +124,11 @@
           ],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -148,11 +148,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -175,7 +175,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -287,11 +287,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -312,11 +312,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -337,7 +337,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -368,11 +368,11 @@
                 ],
                 "returnType": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -394,7 +394,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -516,11 +516,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -542,11 +542,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/selfhost/test/typechecker/invocation/invocation_instantiation_generics.2.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_instantiation_generics.2.out.json
@@ -35,7 +35,7 @@
               "name": { "name": "u", "position": [3, 3] },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -52,7 +52,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -72,7 +72,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",

--- a/selfhost/test/typechecker/invocation/invocation_method_generics.1.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_method_generics.1.out.json
@@ -148,7 +148,7 @@
               ],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -166,7 +166,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -349,7 +349,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -368,7 +368,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -393,7 +393,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -473,7 +473,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -493,7 +493,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/invocation/invocation_variadic.1.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_variadic.1.out.json
@@ -33,7 +33,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -96,7 +96,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -116,7 +116,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -201,7 +201,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -318,7 +318,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -400,7 +400,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -482,7 +482,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -582,7 +582,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/selfhost/test/typechecker/invocation/invocation_variadic.2.out.json
+++ b/selfhost/test/typechecker/invocation/invocation_variadic.2.out.json
@@ -33,7 +33,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -109,7 +109,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -129,7 +129,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -214,7 +214,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -331,7 +331,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -413,7 +413,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -495,7 +495,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -595,7 +595,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/selfhost/test/typechecker/lambda/lambda.1.out.json
+++ b/selfhost/test/typechecker/lambda/lambda.1.out.json
@@ -408,7 +408,7 @@
               ],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -439,7 +439,7 @@
             ],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -482,7 +482,7 @@
               ],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -500,7 +500,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -539,7 +539,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Option" },
+                          "enum": { "moduleId": 2, "name": "Option" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -559,7 +559,7 @@
                             },
                             "type": {
                               "kind": "enum",
-                              "enum": { "moduleId": 0, "name": "Option" }
+                              "enum": { "moduleId": 2, "name": "Option" }
                             },
                             "node": {
                               "kind": "identifier",
@@ -584,7 +584,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Option" },
+                          "enum": { "moduleId": 2, "name": "Option" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -1017,7 +1017,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1040,7 +1040,7 @@
             "parameters": [],
             "returnType": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1064,7 +1064,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1082,7 +1082,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1127,11 +1127,11 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1156,11 +1156,11 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1186,11 +1186,11 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1210,11 +1210,11 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1237,7 +1237,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -1285,11 +1285,11 @@
               "parameters": [],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1314,11 +1314,11 @@
             "parameters": [],
             "returnType": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1344,11 +1344,11 @@
               "parameters": [],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1368,11 +1368,11 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Option" },
+                        "enum": { "moduleId": 2, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",

--- a/selfhost/test/typechecker/lambda/lambda.2.out.json
+++ b/selfhost/test/typechecker/lambda/lambda.2.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -154,7 +154,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -192,7 +192,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -211,7 +211,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -255,7 +255,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -275,7 +275,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -432,7 +432,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -452,7 +452,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -490,7 +490,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -544,7 +544,7 @@
               "label": { "name": "set", "position": [8, 17] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Set" },
+                "struct": { "moduleId": 2, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -642,7 +642,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Map" },
+                      "struct": { "moduleId": 2, "name": "Map" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -666,7 +666,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Set" },
+                          "struct": { "moduleId": 2, "name": "Set" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -685,7 +685,7 @@
                         "name": "_map",
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Map" },
+                          "struct": { "moduleId": 2, "name": "Map" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -882,7 +882,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -917,7 +917,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -961,7 +961,7 @@
               "label": { "name": "arr", "position": [11, 16] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -996,7 +996,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -1028,7 +1028,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -1047,7 +1047,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -1091,7 +1091,7 @@
                         ],
                         "returnType": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -1111,7 +1111,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -1291,7 +1291,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",

--- a/selfhost/test/typechecker/lambda/lambda_generic_inference.1.out.json
+++ b/selfhost/test/typechecker/lambda/lambda_generic_inference.1.out.json
@@ -28,7 +28,7 @@
                   "parameters": [],
                   "returnType": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -43,7 +43,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -79,7 +79,7 @@
                 "parameters": [],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -94,7 +94,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -126,7 +126,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -145,7 +145,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -168,7 +168,7 @@
                         "parameters": [],
                         "returnType": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -209,7 +209,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -254,7 +254,7 @@
           "parameters": [],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -272,7 +272,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -330,7 +330,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -349,7 +349,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -371,7 +371,7 @@
                       "parameters": [],
                       "returnType": {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "generic",
@@ -384,7 +384,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -407,7 +407,7 @@
                   "parameters": [],
                   "returnType": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -431,7 +431,7 @@
                     "parameters": [],
                     "returnType": {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -449,7 +449,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -466,7 +466,7 @@
                               "parameters": [],
                               "returnType": {
                                 "kind": "instance",
-                                "struct": { "moduleId": 0, "name": "Array" },
+                                "struct": { "moduleId": 2, "name": "Array" },
                                 "typeParams": [
                                   {
                                     "kind": "primitive",
@@ -511,7 +511,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -531,7 +531,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/lambda/lambda_generic_inference.2.out.json
+++ b/selfhost/test/typechecker/lambda/lambda_generic_inference.2.out.json
@@ -28,7 +28,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -55,7 +55,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Result" },
+              "enum": { "moduleId": 2, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -83,7 +83,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -150,7 +150,7 @@
                             },
                             "type": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 0, "name": "Result" },
+                              "enum": { "moduleId": 2, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -179,7 +179,7 @@
                                   ],
                                   "returnType": {
                                     "kind": "enumInstance",
-                                    "enum": { "moduleId": 0, "name": "Result" },
+                                    "enum": { "moduleId": 2, "name": "Result" },
                                     "typeParams": [
                                       {
                                         "kind": "generic",
@@ -229,7 +229,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Result" },
+                    "enum": { "moduleId": 2, "name": "Result" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -258,7 +258,7 @@
                         ],
                         "returnType": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -325,7 +325,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -353,7 +353,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Result" },
+              "enum": { "moduleId": 2, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -399,7 +399,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -426,7 +426,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Result" },
+              "enum": { "moduleId": 2, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -454,7 +454,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -476,7 +476,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Result" },
+                    "enum": { "moduleId": 2, "name": "Result" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -519,7 +519,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -548,7 +548,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Result" },
+                                "enum": { "moduleId": 2, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -594,7 +594,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -623,7 +623,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Result" },
+                                "enum": { "moduleId": 2, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -693,7 +693,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -721,7 +721,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Result" },
+              "enum": { "moduleId": 2, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -767,7 +767,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -794,7 +794,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Result" },
+              "enum": { "moduleId": 2, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -822,7 +822,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -844,7 +844,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Result" },
+                    "enum": { "moduleId": 2, "name": "Result" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -887,7 +887,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -916,7 +916,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Result" },
+                                "enum": { "moduleId": 2, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -962,7 +962,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -991,7 +991,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 0, "name": "Result" },
+                                "enum": { "moduleId": 2, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -1061,7 +1061,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1089,7 +1089,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Result" },
+              "enum": { "moduleId": 2, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/selfhost/test/typechecker/literals/string_interpolation.out.json
+++ b/selfhost/test/typechecker/literals/string_interpolation.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -315,7 +315,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -397,7 +397,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -496,7 +496,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/selfhost/test/typechecker/map/map.out.json
+++ b/selfhost/test/typechecker/map/map.out.json
@@ -11,7 +11,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Map" },
+        "struct": { "moduleId": 2, "name": "Map" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -110,7 +110,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Map" },
+        "struct": { "moduleId": 2, "name": "Map" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -118,7 +118,7 @@
           },
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -126,7 +126,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -168,7 +168,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Map" },
+                "struct": { "moduleId": 2, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -176,7 +176,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -216,7 +216,7 @@
                       },
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -296,7 +296,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Map" },
+                "struct": { "moduleId": 2, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -304,7 +304,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -332,7 +332,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Map" },
+        "struct": { "moduleId": 2, "name": "Map" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -340,7 +340,7 @@
           },
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -348,7 +348,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Array" },
+                "struct": { "moduleId": 2, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -390,7 +390,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Map" },
+                "struct": { "moduleId": 2, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -398,7 +398,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -441,7 +441,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Map" },
+                "struct": { "moduleId": 2, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -449,7 +449,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -489,7 +489,7 @@
                       },
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -568,7 +568,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -591,7 +591,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -633,7 +633,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -656,7 +656,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -735,11 +735,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -764,11 +764,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -812,11 +812,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -841,11 +841,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -872,7 +872,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -932,7 +932,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -952,7 +952,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 0, "name": "Option" }
+                        "enum": { "moduleId": 2, "name": "Option" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -1012,11 +1012,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1026,11 +1026,11 @@
                 },
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1053,11 +1053,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1067,11 +1067,11 @@
               },
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1096,7 +1096,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1137,11 +1137,11 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1164,7 +1164,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -1191,7 +1191,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1211,7 +1211,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 0, "name": "Option" }
+                        "enum": { "moduleId": 2, "name": "Option" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -1234,11 +1234,11 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1260,7 +1260,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 0, "name": "Option" }
+                        "enum": { "moduleId": 2, "name": "Option" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -1285,7 +1285,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1326,11 +1326,11 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 0, "name": "Array" },
+                        "struct": { "moduleId": 2, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1353,7 +1353,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 0, "name": "Array" },
+                          "struct": { "moduleId": 2, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -1433,11 +1433,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Map" },
+              "struct": { "moduleId": 2, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1447,11 +1447,11 @@
                 },
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 0, "name": "Array" },
+                      "struct": { "moduleId": 2, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1475,11 +1475,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Map" },
+            "struct": { "moduleId": 2, "name": "Map" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1489,11 +1489,11 @@
               },
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Array" },
+                    "struct": { "moduleId": 2, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/selfhost/test/typechecker/match/match_Result.out.json
+++ b/selfhost/test/typechecker/match/match_Result.out.json
@@ -25,7 +25,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Result" },
+                  "enum": { "moduleId": 2, "name": "Result" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -57,7 +57,7 @@
               "label": { "name": "res", "position": [1, 13] },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -75,7 +75,7 @@
           ],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Result" },
+            "enum": { "moduleId": 2, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -139,7 +139,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Result" },
+                        "enum": { "moduleId": 2, "name": "Result" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -161,7 +161,7 @@
                         "kind": {
                           "kind": "enumVariant",
                           "variantIdx": 0,
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "destructuredVariables": [
                             {
                               "label": { "name": "v", "position": [2, 26] },
@@ -198,7 +198,7 @@
                         "kind": {
                           "kind": "enumVariant",
                           "variantIdx": 1,
-                          "enum": { "moduleId": 0, "name": "Result" },
+                          "enum": { "moduleId": 2, "name": "Result" },
                           "destructuredVariables": [
                             {
                               "label": { "name": "e", "position": [2, 38] },
@@ -233,7 +233,7 @@
                                 },
                                 "type": {
                                   "kind": "enumInstance",
-                                  "enum": { "moduleId": 0, "name": "Result" },
+                                  "enum": { "moduleId": 2, "name": "Result" },
                                   "typeParams": [
                                     {
                                       "kind": "primitive",
@@ -262,7 +262,7 @@
                                       ],
                                       "returnType": {
                                         "kind": "enumInstance",
-                                        "enum": { "moduleId": 0, "name": "Result" },
+                                        "enum": { "moduleId": 2, "name": "Result" },
                                         "typeParams": [
                                           {
                                             "kind": "generic",
@@ -315,7 +315,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Result" },
+                "enum": { "moduleId": 2, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -344,7 +344,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Result" },
+                      "enum": { "moduleId": 2, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",

--- a/selfhost/test/typechecker/match/match_expr.out.json
+++ b/selfhost/test/typechecker/match/match_expr.out.json
@@ -158,7 +158,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -177,7 +177,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -267,7 +267,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -286,7 +286,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -308,7 +308,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -394,7 +394,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -596,7 +596,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -864,7 +864,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1069,7 +1069,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1351,7 +1351,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
@@ -1371,7 +1371,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "enumInstance",
@@ -1525,7 +1525,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
@@ -1545,7 +1545,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "enumInstance",
@@ -1568,7 +1568,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Array" },
+                  "struct": { "moduleId": 2, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
@@ -1657,7 +1657,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",

--- a/selfhost/test/typechecker/set/set.out.json
+++ b/selfhost/test/typechecker/set/set.out.json
@@ -11,7 +11,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -85,11 +85,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Set" },
+            "struct": { "moduleId": 2, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -111,7 +111,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -168,7 +168,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -242,7 +242,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -261,7 +261,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Set" },
+            "struct": { "moduleId": 2, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -299,7 +299,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -318,7 +318,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Set" },
+            "struct": { "moduleId": 2, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -408,11 +408,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -433,11 +433,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Set" },
+            "struct": { "moduleId": 2, "name": "Set" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -459,7 +459,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -500,7 +500,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -520,7 +520,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -543,7 +543,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -603,11 +603,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -628,11 +628,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Set" },
+            "struct": { "moduleId": 2, "name": "Set" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -654,7 +654,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -674,7 +674,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -697,7 +697,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -738,7 +738,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -784,11 +784,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Set" },
+            "struct": { "moduleId": 2, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -810,7 +810,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -867,7 +867,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -889,7 +889,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -949,11 +949,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -975,7 +975,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1016,7 +1016,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1057,7 +1057,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1077,7 +1077,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
+                  "enum": { "moduleId": 2, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1100,7 +1100,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1144,15 +1144,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Set" },
+                "struct": { "moduleId": 2, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1176,11 +1176,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1203,7 +1203,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1263,11 +1263,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1290,7 +1290,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1350,11 +1350,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1376,7 +1376,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
+                  "enum": { "moduleId": 2, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1399,11 +1399,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1426,7 +1426,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1503,15 +1503,15 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1534,15 +1534,15 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Set" },
+                "struct": { "moduleId": 2, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 0, "name": "Option" },
+                    "enum": { "moduleId": 2, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1567,11 +1567,11 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 0, "name": "Option" },
+                      "enum": { "moduleId": 2, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1593,7 +1593,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 0, "name": "Option" },
+                        "enum": { "moduleId": 2, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1613,7 +1613,7 @@
                           },
                           "type": {
                             "kind": "enum",
-                            "enum": { "moduleId": 0, "name": "Option" }
+                            "enum": { "moduleId": 2, "name": "Option" }
                           },
                           "node": {
                             "kind": "identifier",
@@ -1644,11 +1644,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Array" },
+            "struct": { "moduleId": 2, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1670,7 +1670,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1692,7 +1692,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1749,7 +1749,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Array" },
+              "struct": { "moduleId": 2, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1809,11 +1809,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 0, "name": "Set" },
+            "struct": { "moduleId": 2, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1835,7 +1835,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1857,7 +1857,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1914,7 +1914,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 0, "name": "Set" },
+              "struct": { "moduleId": 2, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1974,15 +1974,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Set" },
+                "struct": { "moduleId": 2, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2006,11 +2006,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2033,7 +2033,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2058,11 +2058,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2084,7 +2084,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 0, "name": "Option" }
+                  "enum": { "moduleId": 2, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -2107,11 +2107,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2134,7 +2134,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2197,15 +2197,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 0, "name": "Set" },
+        "struct": { "moduleId": 2, "name": "Set" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 0, "name": "Set" },
+                "struct": { "moduleId": 2, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2229,11 +2229,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2256,7 +2256,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2281,11 +2281,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 0, "name": "Set" },
+                  "struct": { "moduleId": 2, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2308,7 +2308,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 0, "name": "Set" },
+                    "struct": { "moduleId": 2, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/selfhost/test/typechecker/tuple/tuple.out.json
+++ b/selfhost/test/typechecker/tuple/tuple.out.json
@@ -151,7 +151,7 @@
               "types": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -179,7 +179,7 @@
             "types": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 0, "name": "Option" },
+                "enum": { "moduleId": 2, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -205,7 +205,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 0, "name": "Option" },
+                  "enum": { "moduleId": 2, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -225,7 +225,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 0, "name": "Option" }
+                      "enum": { "moduleId": 2, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",

--- a/selfhost/test/typechecker/while/while.2.out.json
+++ b/selfhost/test/typechecker/while/while.2.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -64,7 +64,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 0, "name": "Option" }
+                "enum": { "moduleId": 2, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",
@@ -103,7 +103,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost/test/typechecker/while/while.3.out.json
+++ b/selfhost/test/typechecker/while/while.3.out.json
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 0, "name": "Option" },
+              "enum": { "moduleId": 2, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -64,7 +64,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 0, "name": "Option" }
+                "enum": { "moduleId": 2, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",
@@ -103,7 +103,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 0, "name": "Option" },
+            "enum": { "moduleId": 2, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -500,6 +500,7 @@ fn typechecker_tests() {
         .add_test_vs_txt("typechecker/invocation/invocation_enum_variant.2.abra", "typechecker/invocation/invocation_enum_variant.2.out.json")
         .add_test_vs_txt("typechecker/invocation/invocation_enum_variant.3.abra", "typechecker/invocation/invocation_enum_variant.3.out.json")
         .add_test_vs_txt("typechecker/invocation/invocation_enum_variant.4.abra", "typechecker/invocation/invocation_enum_variant.4.out.json")
+        .add_test_vs_txt("typechecker/invocation/invocation_field_generics.1.abra", "typechecker/invocation/invocation_field_generics.1.out.json")
         .add_test_vs_txt("typechecker/invocation/error_variadic_generic_type_mismatch.abra", "typechecker/invocation/error_variadic_generic_type_mismatch.out")
         .add_test_vs_txt("typechecker/invocation/error_variadic_labeled_generic_type_mismatch.abra", "typechecker/invocation/error_variadic_labeled_generic_type_mismatch.out")
         .add_test_vs_txt("typechecker/invocation/error_variadic_labeled_too_many_args.abra", "typechecker/invocation/error_variadic_labeled_too_many_args.out")

--- a/selfhost_test/src/tests.rs
+++ b/selfhost_test/src/tests.rs
@@ -711,6 +711,9 @@ fn typechecker_tests() {
         // Imports
         .add_test_vs_txt("typechecker/import/import.1.abra", "typechecker/import/import.1.out.json")
         .add_test_vs_txt("typechecker/import/import.2.abra", "typechecker/import/import.2.out.json")
+        .add_test_vs_txt("typechecker/import/error_assignment_to_aliased_imported_variable.abra", "typechecker/import/error_assignment_to_aliased_imported_variable.out")
+        .add_test_vs_txt("typechecker/import/error_assignment_to_imported_variable.abra", "typechecker/import/error_assignment_to_imported_variable.out")
+
         .add_test_vs_txt("typechecker/import/error_no_file_exists.abra", "typechecker/import/error_no_file_exists.out")
         .add_test_vs_txt("typechecker/import/error_nonrelative_not_found.abra", "typechecker/import/error_nonrelative_not_found.out")
         .add_test_vs_txt("typechecker/import/error_circular_dependency.1/mod.1.abra", "typechecker/import/error_circular_dependency.1/mod.1.out")


### PR DESCRIPTION
This first pass does two things. Firstly, it removes the need for a designated "entry" module when compiling; it just uses the dependency-ordered module list that's built during typechecking (by sorting the TypedModules by `id` we essentially obtain a list of modules in the order that they need to be evaluated for the program to work). Secondly, it adds an optional TypedModule field onto the TypedAstNodeKind.Identifier variant, which will be used in the compilation step to determine whether the identifier is an exported value or not. But for now, I add some additional error reporting to raise a typechecker error if the user attempts to reassign an imported variable (or an aliased imported value).