### PR TITLE
Selfhost: compiling string interpolation

### DIFF
--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -909,8 +909,7 @@ type Set<T> {
     }
 
     val items = reprs.join(", ")
-    // "#{${items}}"
-    "#{" + items + "}"
+    "#{$items}"
   }
 
   func eq(self, other: Set<T>): Bool {
@@ -1064,8 +1063,7 @@ type Map<K, V> {
           //       then have `toString` called on it after the fact. I don't know what the issue was but there
           //       was some problem with llvm generation (likely generic resolution) which led to a bug. Explicitly
           //       calling `toString()` here seems to fix it.
-          // val item = "${cur.key}: ${cur.value.toString()}"
-          val item = cur.key + ": " + cur.value
+          val item = "${cur.key}: ${cur.value.toString()}"
           reprs.push(item)
           cursor = cur.next
         }
@@ -1073,8 +1071,7 @@ type Map<K, V> {
     }
 
     val items = reprs.join(", ")
-    // "{ ${items} }"
-    "{ " + items + " }"
+    "{ $items }"
   }
 
   func eq(self, other: Map<K, V>): Bool {

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,23 +1,10 @@
-// import abc from "./example2"
-// // import "./example2" as ex2
+val a = 123
+val b = [1, 2, 3]
 
-// println(abc)
+val s = "$a + ${b.length} = ${a + b.length}"
+// val s = "$a ${a + 1}!"
+println(s)
 
-/// Expect: 34.2968
-println(2 ** 5.1)
-/// Expect: 43.9864
-println(2.1 ** 5.1)
-/// Expect: 40.841
-println(2.1 ** 5)
-/// Expect: -34.2968
-println(-2 ** 5.1)
-/// Expect: -43.9864
-println(-2.1 ** 5.1)
-/// Expect: -40.841
-println(-2.1 ** 5)
-/// Expect: 0.0291573
-println(2 ** -5.1)
-/// Expect: 0.0227343
-println(2.1 ** -5.1)
-/// Expect: 0.0244852
-println(2.1 ** -5)
+val array = [1, 2, 3]
+/// Expect: length of [1, 2, 3] is 3
+println("length of $array is ${array.length}")

--- a/selfhost/example2.abra
+++ b/selfhost/example2.abra
@@ -1,1 +1,0 @@
-export var abc = 123

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -713,7 +713,44 @@ export type Compiler {
         // TODO: destructuring
         Ok(_p[0])
       }
-      TypedAstNodeKind.StringInterpolation => todo("compiling string interpolation expression", node.token.position)
+      TypedAstNodeKind.StringInterpolation(exprs) => {
+        self._currentFn.block.addComment("begin string interpolation...")
+
+        val strVals: Value[] = []
+        var lenVal = Value.Int(0)
+        for item in exprs {
+          val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
+
+          val itemInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(item.ty, "toString", item.token.position) { Ok(v) => v, Err(e) => return Err(e) }
+          val itemToStringFnVal = match self._getOrCompileToStringMethod(itemInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
+          self._resolvedGenerics.popLayer()
+
+          val toStringVal = match self._currentFn.block.buildCall(Callable.Function(itemToStringFnVal), [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+          strVals.push(toStringVal)
+
+          val stringLength = self._currentFn.block.buildLoadL(toStringVal)
+          lenVal = match self._currentFn.block.buildAdd(lenVal, stringLength) { Ok(v) => v, Err(e) => return qbeError(e) }
+        }
+
+        val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
+        val stringWithLengthFnVal = match self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val newString = match self._currentFn.block.buildCall(Callable.Function(stringWithLengthFnVal), [lenVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
+        var newBuffer = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), newString) { Ok(v) => v, Err(e) => return qbeError(e) })
+
+        for strVal, idx in strVals {
+          val strValLen = self._currentFn.block.buildLoadL(strVal)
+          val strValBuf = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), strVal) { Ok(v) => v, Err(e) => return qbeError(e) })
+
+          self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [newBuffer, strValBuf, strValLen])
+          if idx != strVals.length {
+            newBuffer = match self._currentFn.block.buildAdd(newBuffer, strValLen) { Ok(v) => v, Err(e) => return qbeError(e) }
+          }
+        }
+
+        self._currentFn.block.addComment("...string interpolation end")
+
+        Ok(newString)
+      }
       TypedAstNodeKind.Unary(op, expr) => {
         match op {
           UnaryOp.Minus => {
@@ -1077,8 +1114,8 @@ export type Compiler {
           TypedInvokee.Function(fn) => {
             match self._resolvedGenerics.addLayer(fn.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: fn.label.name, message: e))) }
 
-            if fn.label.name == "println" {
-              val res = self._invokePrintln(arguments)
+            if fn.label.name == "println" || fn.label.name == "print" {
+              val res = self._invokePrint(arguments: arguments, withNewline: fn.label.name == "println")
               self._resolvedGenerics.popLayer()
               return res
             }
@@ -2751,16 +2788,17 @@ export type Compiler {
     Ok(fn)
   }
 
-  func _invokePrintln(self, arguments: TypedAstNode?[]): Result<Value, CompileError> {
-    self._currentFn.block.addComment("begin println...")
+  func _invokePrint(self, arguments: TypedAstNode?[], withNewline = false): Result<Value, CompileError> {
+    val fnName = if withNewline "println" else "print"
+    self._currentFn.block.addComment("begin $fnName...")
     val varargItems = if arguments[0] |node| {
       if node |node| {
         val items = match node.kind {
           TypedAstNodeKind.Array(items) => items
-          _ => return unreachable("`println` receives an array of its variadic arguments")
+          _ => return unreachable("`$fnName` receives an array of its variadic arguments")
         }
         items
-      } else return unreachable("`println` receives an array of its variadic arguments")
+      } else return unreachable("`$fnName` receives an array of its variadic arguments")
     } else []
 
     val stdoutWriteFn = if self._project.preludeScope.functions.find(fn => fn.label.name == "stdoutWrite") |fn| fn else return unreachable("`stdoutWrite` must exist in prelude")
@@ -2768,8 +2806,6 @@ export type Compiler {
 
     val space = self._builder.buildGlobalString(" ")
     val spaceStr = match self._constructString(space, Value.Int(1)) { Ok(v) => v, Err(e) => return Err(e) }
-    val newline = self._builder.buildGlobalString("\\n")
-    val newlineStr = match self._constructString(newline, Value.Int(1)) { Ok(v) => v, Err(e) => return Err(e) }
 
     for item, idx in varargItems {
       val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
@@ -2782,13 +2818,18 @@ export type Compiler {
 
       self._currentFn.block.buildVoidCall(Callable.Function(stdoutWriteFnVal), [toStringVal])
 
-      if idx == varargItems.length - 1 {
-        self._currentFn.block.buildVoidCall(Callable.Function(stdoutWriteFnVal), [newlineStr])
-      } else {
+      if idx != varargItems.length - 1 {
         self._currentFn.block.buildVoidCall(Callable.Function(stdoutWriteFnVal), [spaceStr])
       }
     }
-    self._currentFn.block.addComment("...println end")
+
+    if withNewline {
+      val newline = self._builder.buildGlobalString("\\n")
+      val newlineStr = match self._constructString(newline, Value.Int(1)) { Ok(v) => v, Err(e) => return Err(e) }
+      self._currentFn.block.buildVoidCall(Callable.Function(stdoutWriteFnVal), [newlineStr])
+    }
+
+    self._currentFn.block.addComment("...$fnName end")
 
     Ok(Value.Ident("bogus", QbeType.F32))
   }

--- a/selfhost/src/lexer.abra
+++ b/selfhost/src/lexer.abra
@@ -506,7 +506,7 @@ export type Lexer {
             }
           }
           val chunks = [initialChunk, StringInterpolationChunk.Interpolation(interpolatedTokens)]
-          interpolationChunks = Some(chunks)
+          interpolationChunks = Some(if interpolationChunks |existingChunks| { existingChunks.concat(chunks) } else { chunks })
           start = self._cursor
           startPos = self._curPos()
           continue

--- a/selfhost/test/compiler/strings.abra
+++ b/selfhost/test/compiler/strings.abra
@@ -53,12 +53,12 @@ println("hello")
 //   println(s1 == { (1): "a", (2): "b" })
 })()
 
-// // Interpolation (also String#concat<T>(other: T, *others: Any[]))
-// (() => {
-//   val array = [1, 2, 3]
-//   /// Expect: length of [1, 2, 3] is 3
-//   println("length of $array is ${array.length}")
-// })()
+// Interpolation
+(() => {
+  val array = [1, 2, 3]
+  /// Expect: length of [1, 2, 3] is 3
+  println("length of $array is ${array.length}")
+})()
 
 // Indexing (also String#get(index: Int))
 (() => {


### PR DESCRIPTION
Actually, before I could write code to compile string interpolation, I needed to fix it! I had apparently not noticed a bug in the lexer (!) for string interpolation expressions, which resulted in incorrect sub-expressions being output.
Once that was fixed, emitting the proper code for string interpolation was straightforward since it's very similar to the existing code for string concatenation. Interpolation is a more efficient form of concatenation because it doesn't allocate intermediate strings for each binary sub-expression of concatenation.
I also added builtin support for calling the `print` function, much like how the `println` function is handled. I did this in my quest to be able to compile the selfhosted compiler with itself, and I noticed this was missing.