### PR TITLE
Selfhost: compiling string literals with escapes

### DIFF
--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -345,7 +345,55 @@ type String {
     newString
   }
 
-  @Stub func replaceAll(self, pattern: String, replacement: String): String
+  func replaceAll(self, pattern: String, replacement: String): String {
+    if pattern.isEmpty() && replacement.isEmpty() return self
+
+    var cursor = 0
+    var replacementIndices: Int[] = []
+    if pattern.isEmpty() {
+      while cursor < self.length {
+        replacementIndices.push(cursor)
+        cursor += 1
+      }
+      replacementIndices.push(cursor)
+    } else {
+      while cursor < self.length {
+        if self.getRange(cursor, cursor + pattern.length) == pattern {
+          replacementIndices.push(cursor)
+          cursor += pattern.length
+        } else {
+          cursor += 1
+        }
+      }
+    }
+
+    val numReplacements = replacementIndices.length
+    if numReplacements == 0 return self
+
+    val newStringLength = self.length + (numReplacements * (replacement.length - pattern.length))
+    val newString = String.withLength(newStringLength)
+
+    val selfBuf = self._buffer
+    var resCursor = 0
+    var selfCursor = 0
+    for idx in replacementIndices {
+      if selfCursor < idx {
+        newString._buffer.offset(resCursor).copyFrom(selfBuf.offset(selfCursor), idx - selfCursor)
+        resCursor += (idx - selfCursor)
+      }
+      selfCursor = idx + pattern.length
+      if replacement.length != 0 {
+        newString._buffer.offset(resCursor).copyFrom(replacement._buffer, replacement.length)
+      }
+      resCursor += replacement.length
+    }
+
+    if selfCursor < self.length {
+      newString._buffer.offset(resCursor).copyFrom(selfBuf.offset(selfCursor), self.length - selfCursor)
+    }
+
+    newString
+  }
 
   func get(self, index: Int): String {
     var idx = if index < 0 index + self.length else index

--- a/selfhost/abra
+++ b/selfhost/abra
@@ -12,6 +12,8 @@ else
   $(echo "$COMPILER_BIN $1")
 fi
 
+shift 1
+
 qbe -o ./._abra/_main.s ./._abra/_main.ssa
 
 CFLAGS="-Wno-override-module"

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,10 +1,1 @@
-val a = 123
-val b = [1, 2, 3]
-
-val s = "$a + ${b.length} = ${a + b.length}"
-// val s = "$a ${a + 1}!"
-println(s)
-
-val array = [1, 2, 3]
-/// Expect: length of [1, 2, 3] is 3
-println("length of $array is ${array.length}")
+println("\"hello\"".replaceAll("\"", "\\\""))

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1846,7 +1846,7 @@ export type Compiler {
       LiteralAstNode.Float(f) => (Value.Float(f), Type(kind: TypeKind.PrimitiveFloat))
       LiteralAstNode.Bool(b) => (Value.Int32(if b 1 else 0), Type(kind: TypeKind.PrimitiveBool))
       LiteralAstNode.String(s) => {
-        val dataPtr = self._builder.buildGlobalString(s)
+        val dataPtr = self._builder.buildGlobalString(s.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n"))
         val instancePtr = match self._constructString(dataPtr, Value.Int(s.length)) { Ok(v) => v, Err(e) => return Err(e) }
         (instancePtr, Type(kind: TypeKind.PrimitiveString))
       }

--- a/selfhost/test/compiler/process.abra
+++ b/selfhost/test/compiler/process.abra
@@ -3,7 +3,7 @@
 val args = Process.args()
 
 /// Expect: [-f, bar, --baz, qux]
-println(args[2:])
+println(args[1:])
 
 val bogusEnvVar = Process.getEnvVar("BOGUS")
 /// Expect: Option.None

--- a/selfhost/test/compiler/strings.abra
+++ b/selfhost/test/compiler/strings.abra
@@ -60,6 +60,45 @@ println("hello")
   println("length of $array is ${array.length}")
 })()
 
+// String#replaceAll(pattern: String, replacement: String)
+(() => {
+  /// Expect: LLaaLLa
+  println("laala".replaceAll("l", "LL"))
+
+  /// Expect: aaLLaLL
+  println("aalal".replaceAll("l", "LL"))
+
+  /// Expect: LLaaLLaLL
+  println("laalal".replaceAll("l", "LL"))
+
+  /// Expect: feebar
+  println("foobar".replaceAll("o", "e"))
+
+  /// Expect: fexexbar
+  println("foobar".replaceAll("o", "ex"))
+
+  /// Expect: foobar
+  println("foobar".replaceAll("x", "yz"))
+
+  /// Expect: -ä
+  println("/ä".replaceAll("/", "-"))
+
+  /// Expect: xfxoxox
+  println("foo".replaceAll("", "x"))
+
+  /// Expect: x
+  println("".replaceAll("", "x"))
+
+  /// Expect: abcd
+  println("abcd".replaceAll("", ""))
+
+  /// Expect: fa bar baaz
+  println("foo boor booooz".replaceAll("oo", "a"))
+
+  // /// Expect: "hello"
+  // println("\"hello\"".replaceAll("\"", "\\\""))
+})()
+
 // Indexing (also String#get(index: Int))
 (() => {
   val s1 = "abc"


### PR DESCRIPTION
Add an implementation of the String#replaceAll method in the prelude, along with tests. This method is then used within the compiler to properly emit string values that contain characters that need to be escaped.