### PR TITLE
Selfhost: compiling the parser

### DIFF
--- a/abra_core/std/libc.abra
+++ b/abra_core/std/libc.abra
@@ -46,3 +46,6 @@ export func strlen(s: Pointer<Byte>): Int
 
 @CBinding("uname")
 export func uname(utsnameBuf: Pointer<Byte>): Int
+
+@CBinding("rand")
+export func rand(): Int

--- a/abra_core/std/prelude.abra
+++ b/abra_core/std/prelude.abra
@@ -157,6 +157,20 @@ type String {
     String(length: length, _buffer: Pointer.malloc(length + 1))
   }
 
+  func random(length: Int, choices = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"): String {
+    // TODO: this implementation is pretty bad, and it also relies on using `%` with libc.rand() which allows for skew.
+    //       But it's fine for now.
+
+    val str = String.withLength(length)
+
+    for i in range(0, length) {
+      val ch = choices._buffer.offset(libc.rand() % choices.length).load()
+      str._buffer.offset(i).store(ch)
+    }
+
+    str
+  }
+
   func hash(self): Int {
     var hash = 31 * self.length
     for i in range(0, self.length) {

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,1 +1,52 @@
-println(String.random(60))
+type Foo {
+  func number(self): Int = 123
+
+  func printNumber(self, arr: Int[]) {
+    val n = plusOne(() => {
+      val num = self.number()
+      arr.push(num)
+      num
+    })
+    println("number:", n)
+  }
+}
+
+func plusOne(fn: () => Int): Int = fn() + 1
+
+val f = Foo()
+val arr = [1, 2, 3]
+f.printNumber(arr)
+println(arr)
+
+// func foo() {
+//   var arr = [1, 2, 3]
+
+//   val five = plusOne(() => {
+//     arr = [1]
+//     arr.push(4)
+//     arr.length
+//   })
+//   println(five)
+//   println(arr)
+// }
+
+// foo()
+
+// func makeAdder(b: Bool, x: Int): (Int) => Int {
+//   i => i + ((if b 1 else -1) * x)
+// }
+// // func makeAdder(f: Float, x: Int): (Int) => Int {
+// //   i => i + (f.floor() * x)
+// // }
+// val addOne = makeAdder(false, 1)
+// /// Expect: 12
+// println(addOne(11))
+
+// val bang = "!"
+// func bangbang(): String = bang + "!"
+// func functionReferencingClosureAsValue() {
+//   val fn = bangbang
+//   println(fn())
+// }
+// /// Expect: !!
+// functionReferencingClosureAsValue()

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,11 +1,1 @@
-func foo(b: Bool) {
-  val a = "hello"
-
-  if b {
-    val a = [1, 2, 3]
-  }
-
-  println(a)
-}
-
-foo(true)
+println(String.random(60))

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -13,40 +13,23 @@ type Foo {
 
 func plusOne(fn: () => Int): Int = fn() + 1
 
-val f = Foo()
-val arr = [1, 2, 3]
-f.printNumber(arr)
-println(arr)
+// // val f = Foo()
+// // val arr = [1, 2, 3]
+// // f.printNumber(arr)
+// // println(arr)
 
-// func foo() {
-//   var arr = [1, 2, 3]
-
-//   val five = plusOne(() => {
-//     arr = [1]
-//     arr.push(4)
-//     arr.length
-//   })
-//   println(five)
-//   println(arr)
+// enum Foo {
+//   Bar(arr: Int[], name: String)
 // }
 
-// foo()
-
-// func makeAdder(b: Bool, x: Int): (Int) => Int {
-//   i => i + ((if b 1 else -1) * x)
+// val f = Foo.Bar(arr: [1, 2, 3], name: "hello")
+// match f {
+//   Foo.Bar(arr, name) => {
+//     println(arr, name)
+//   }
 // }
-// // func makeAdder(f: Float, x: Int): (Int) => Int {
-// //   i => i + (f.floor() * x)
-// // }
-// val addOne = makeAdder(false, 1)
-// /// Expect: 12
-// println(addOne(11))
 
-// val bang = "!"
-// func bangbang(): String = bang + "!"
-// func functionReferencingClosureAsValue() {
-//   val fn = bangbang
-//   println(fn())
+// val arr = ["a", "b", "c"]
+// if arr[0] |item| {
+//   println(item.length)
 // }
-// /// Expect: !!
-// functionReferencingClosureAsValue()

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -182,6 +182,7 @@ export type Compiler {
   _realloc: QbeFunction = QbeFunction.spec(name: "GC_realloc", returnType: Some(QbeType.Pointer))
   _tupleStructs: Map<String, Struct> = {}
   _functionStructs: Map<String, Struct> = {}
+  _aliasedTypeNames: Map<String, String> = {}
 
   func compile(project: Project): Result<ModuleBuilder, CompilationError> {
     val builder = ModuleBuilder()
@@ -195,6 +196,10 @@ export type Compiler {
     mainFn.block.buildStoreL(argcParam, argcPtr)
     val argvPtr = builder.addData(QbeData(name: "__argv", kind: QbeDataKind.Constants([(QbeType.U64, Value.Int(0))])))
     mainFn.block.buildStoreL(argvParam, argvPtr)
+
+    // Seed the RNG, for any future calls to `libc.rand()`
+    val timeVal = match mainFn.block.buildCallRaw("time", QbeType.U64, [Value.Int(0)]) { Ok(v) => v, Err(e) => return Err(CompilationError(modulePath: "<entrypoint>", error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e)))) }
+    mainFn.block.buildVoidCallRaw("srand", [timeVal])
 
     mainFn.block.buildVoidCallRaw("GC_init", [])
 
@@ -4332,7 +4337,7 @@ export type Compiler {
 
   func _structTypeName(self, struct: Struct): Result<String, CompileError> {
     val base = ".${struct.moduleId}.${struct.label.name}"
-    if !struct.typeParams.isEmpty() {
+    val name = if !struct.typeParams.isEmpty() {
       val parts: String[] = []
       for name in struct.typeParams {
         val repr = if self._resolvedGenerics.resolveGeneric(name) |ty| {
@@ -4343,9 +4348,24 @@ export type Compiler {
         }
         parts.push(repr)
       }
-      Ok("$base.${parts.join(".")}")
+      "$base.${parts.join(".")}"
     } else {
-      Ok(base)
+      base
+    }
+
+    // qbe limits its identifiers to 80 chars, so if the resulting type name is long, we instead use a randomly-generated alias
+    // in place of the type. 16 chars seems like a good balance between long enough that there won't be any conflicts, but also
+    // short enough that there's enough room for this type to be used as a generic in other types without making that type's or
+    // function's identifier too long.
+    if name.length >= 80 {
+      val alias = if self._aliasedTypeNames[name] |alias| alias else {
+        val replacement = String.random(16)
+        self._aliasedTypeNames[name] = replacement
+        replacement
+      }
+      Ok(alias)
+    } else {
+      Ok(name)
     }
   }
   func _structInitializerFnName(self, struct: Struct): Result<String, CompileError> {
@@ -4355,20 +4375,35 @@ export type Compiler {
 
   func _enumTypeName(self, enum_: Enum): Result<String, CompileError> {
     val base = ".${enum_.moduleId}.${enum_.label.name}"
-    if !enum_.typeParams.isEmpty() {
+    val name = if !enum_.typeParams.isEmpty() {
       val parts: String[] = []
       for name in enum_.typeParams {
         val repr = if self._resolvedGenerics.resolveGeneric(name) |ty| {
           val r = match self._getNameForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
           r
         } else {
-          return unreachable("here1: could not resolve '$name'")
+          return unreachable("could not resolve '$name'")
         }
         parts.push(repr)
       }
-      Ok("$base.${parts.join(".")}")
+      "$base.${parts.join(".")}"
     } else {
-      Ok(base)
+      base
+    }
+
+    // qbe limits its identifiers to 80 chars, so if the resulting type name is long, we instead use a randomly-generated alias
+    // in place of the type. 16 chars seems like a good balance between long enough that there won't be any conflicts, but also
+    // short enough that there's enough room for this type to be used as a generic in other types without making that type's or
+    // function's identifier too long.
+    if name.length >= 80 {
+      val alias = if self._aliasedTypeNames[name] |alias| alias else {
+        val replacement = String.random(40)
+        self._aliasedTypeNames[name] = replacement
+        replacement
+      }
+      Ok(alias)
+    } else {
+      Ok(name)
     }
   }
   func _enumVariantFnName(self, enum_: Enum, variant: TypedEnumVariant): Result<String, CompileError> {

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -535,8 +535,10 @@ export type Compiler {
             val name = self._exportedVarName(self._currentModule.id, variable.label.name)
             val slot = self._builder.addData(QbeData(name: name, kind: QbeDataKind.Constants([(varTy, varTy.zeroValue())])))
             self._currentFn.block.buildStore(varTy, res, slot)
-          } else if variable.isCaptured {
-            self._currentFn.block.addComment("move captured '${variable.label.name}' to heap")
+          } else if variable.isCaptured && variable.mutable {
+            // Only move captured variables to the heap if they're mutable - captured immutable variables can just have their value present in
+            // a closure's captures array, but a mutable variable needs an additional layer of indirection to handle possible reassignment.
+            self._currentFn.block.addComment("move captured mutable '${variable.label.name}' to heap")
             val size = varTy.size()
             val heapMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
             self._currentFn.block.buildStore(varTy, res, heapMem)
@@ -1054,10 +1056,9 @@ export type Compiler {
         val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
         if variable.isParameter {
           if variable.isCaptured {
-            val ptr = match self._getCapturedVarPtr(variable) { Ok(v) => v, Err(e) => return Err(e) }
-            self._currentFn.block.addComment("deref ptr to captured '${variable.label.name}'")
-            val res = self._currentFn.block.buildLoad(varTy, ptr)
-            Ok(res)
+            if variable.mutable return unreachable("parameters cannot be mutable", node.token.position)
+            val value = match self._getCapturedVarPtr(variable) { Ok(v) => v, Err(e) => return Err(e) }
+            Ok(value)
           } else {
             val varName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'", node.token.position)
             Ok(Value.Ident(varName, varTy))
@@ -1092,8 +1093,12 @@ export type Compiler {
                 Ok(res)
               } else if variable.isCaptured {
                 val ptr = match self._getCapturedVarPtr(variable) { Ok(v) => v, Err(e) => return Err(e) }
-                self._currentFn.block.addComment("deref ptr to captured '${variable.label.name}'")
-                val res = self._currentFn.block.buildLoad(varTy, ptr)
+                val res = if variable.mutable {
+                  self._currentFn.block.addComment("deref ptr to captured mutable '${variable.label.name}'")
+                  self._currentFn.block.buildLoad(varTy, ptr)
+                } else {
+                  ptr
+                }
                 Ok(res)
               } else {
                 val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'")
@@ -2047,22 +2052,49 @@ export type Compiler {
       if self._currentFn._env |env| {
         for v, idx in fn.captures {
           if v.label.name == variable.label.name {
-            self._currentFn.block.addComment("get ptr to captured '${variable.label.name}'")
+            // When loading the captured variable from the closure env, if the captured variable is immutable then we
+            // don't need to dereference the value of `env[idx]`; only mutable variables need to be stored using an
+            // additional indirection layer to account for reassignment.
             val captureSlot = match self._currentFn.block.buildAdd(Value.Int(idx * QbeType.Pointer.size()), env) { Ok(v) => v, Err(e) => return qbeError(e) }
-            val ptr = self._currentFn.block.buildLoad(QbeType.Pointer, captureSlot)
-            return Ok(ptr)
+            var varTy = if variable.mutable {
+              self._currentFn.block.addComment("get ptr to captured mutable '${variable.label.name}'")
+              QbeType.Pointer
+            } else {
+              self._currentFn.block.addComment("get captured '${variable.label.name}'")
+              val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+              varTy
+            }
+            val ptrOrValue = self._currentFn.block.buildLoad(varTy, captureSlot)
+            return Ok(ptrOrValue)
           }
         }
       }
     }
 
+    // If the captured variable is a parameter but we're not currently referencing it from a closure, then it can be resolved as any ordinary
+    // parameter (simply by name) since it's an immutable variable that has not been moved to the heap.
+    if variable.isParameter {
+      val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'")
+      val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+      return Ok(Value.Ident(slotName, varTy))
+    }
+
     // If we're not currently in a function body, or if the captured variable is not a capture of the current function, then
-    // we need to undo the extra layer of pointer indirection which comes as a result of being captured by some other function.
-    self._currentFn.block.addComment("get ptr to captured '${variable.label.name}'")
+    // we may need to undo the extra layer of pointer indirection which comes as a result of being captured by some other function,
+    // if the captured variable is mutable. If it's not mutable then it will not have been moved to the heap, so no additional pointer
+    // needs to be dereferenced.
     val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'")
     val slot = Value.Ident(slotName, QbeType.Pointer)
-    val res = self._currentFn.block.buildLoad(QbeType.Pointer, slot)
-    Ok(res)
+    var varTy = if variable.mutable {
+      self._currentFn.block.addComment("get ptr to captured mutable '${variable.label.name}'")
+      QbeType.Pointer
+    } else {
+      self._currentFn.block.addComment("get captured '${variable.label.name}'")
+      val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+      varTy
+    }
+    val ptrOrValue = self._currentFn.block.buildLoad(varTy, slot)
+    Ok(ptrOrValue)
   }
 
   func _createClosureCaptures(self, fn: Function): Result<Value, CompileError> {
@@ -2072,7 +2104,15 @@ export type Compiler {
 
     for variable in fn.captures {
       val ptr = match self._getCapturedVarPtr(variable) { Ok(v) => v, Err(e) => return Err(e) }
-      self._currentFn.block.buildStore(QbeType.Pointer, ptr, cursor)
+      var varTy = if variable.mutable {
+        self._currentFn.block.addComment("store ptr to captured mutable '${variable.label.name}' in captures")
+        QbeType.Pointer
+      } else {
+        self._currentFn.block.addComment("store captured mutable '${variable.label.name}' in captures")
+        val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+        varTy
+      }
+      self._currentFn.block.buildStore(varTy, ptr, cursor)
       if fn.captures.length > 1 || fn.capturedClosures.length > 0 {
         cursor = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), cursor) { Ok(v) => v, Err(e) => return qbeError(e) }
       }
@@ -3270,18 +3310,7 @@ export type Compiler {
         fnVal.addParameter(param.label.name, paramTy)
       }
 
-      if param.variable.isCaptured {
-        self._currentFn.block.addComment("move param '${param.label.name}' to heap")
-        val size = paramTy.size()
-        val heapMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
-        self._currentFn.block.buildStore(paramTy, Value.Ident(param.label.name, paramTy), heapMem)
-
-        val slotName = self._currentFn.block.addVar(variableToVar(param.variable))
-        val slot = self._buildStackAllocForQbeType(QbeType.Pointer, Some(slotName))
-        self._currentFn.block.buildStore(QbeType.Pointer, heapMem, slot)
-      } else {
-        self._currentFn.block.addVar(variableToVar(param.variable), Some(param.label.name))
-      }
+      self._currentFn.block.addVar(variableToVar(param.variable), Some(param.label.name))
     }
     if addMaskParam {
       fnVal.addParameter("__default_params_mask__", QbeType.U32)

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -298,7 +298,7 @@ export type Compiler {
           } else {
             val boolTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
             val slot = self._buildStackAllocForQbeType(boolTypeQbe, Some(slotName))
-            self._currentFn.block.buildStore(boolTypeQbe, Value.Int32(1), slot)
+            self._currentFn.block.buildStore(boolTypeQbe, Value.Int(1), slot)
           }
         }
         for node in ifBlock {
@@ -359,7 +359,7 @@ export type Compiler {
           } else {
             val boolTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
             val slot = self._buildStackAllocForQbeType(boolTypeQbe, Some(slotName))
-            self._currentFn.block.buildStore(boolTypeQbe, Value.Int32(1), slot)
+            self._currentFn.block.buildStore(boolTypeQbe, Value.Int(1), slot)
           }
         }
 
@@ -767,10 +767,11 @@ export type Compiler {
             val exprIsOpt = self._typeIsOption(expr.ty)
             if exprIsOpt {
               val variantIsNotOptionSome = match self._emitOptValueIsSomeVariant(exprVal: exprVal, negate: true) { Ok(v) => v, Err(e) => return Err(e) }
-              Ok(variantIsNotOptionSome)
+              val res = self._currentFn.block.buildExt(variantIsNotOptionSome, false)
+              Ok(res)
             } else {
-              val plusOneVal = match self._currentFn.block.buildAdd(Value.Int32(1), exprVal) { Ok(v) => v, Err(e) => return qbeError(e) }
-              val res = match self._currentFn.block.buildRem(plusOneVal, Value.Int32(2)) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val plusOneVal = match self._currentFn.block.buildAdd(Value.Int(1), exprVal) { Ok(v) => v, Err(e) => return qbeError(e) }
+              val res = match self._currentFn.block.buildRem(plusOneVal, Value.Int(2)) { Ok(v) => v, Err(e) => return qbeError(e) }
               Ok(res)
             }
           }
@@ -1015,12 +1016,12 @@ export type Compiler {
           BinaryOp.LT => {
             val vals = match self._compileBinaryOperands(left, right, "<") { Ok(v) => v, Err(e) => return Err(e) }
             val res = match self._currentFn.block.buildCompareLt(vals[0], vals[1], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
-            Ok(res)
+            Ok(self._currentFn.block.buildExt(res, false))
           }
           BinaryOp.LTE => {
             val vals = match self._compileBinaryOperands(left, right, "<=") { Ok(v) => v, Err(e) => return Err(e) }
             val res = match self._currentFn.block.buildCompareLte(vals[0], vals[1], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
-            Ok(res)
+            Ok(self._currentFn.block.buildExt(res, false))
           }
           BinaryOp.Shl => {
             val leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
@@ -1032,12 +1033,12 @@ export type Compiler {
           BinaryOp.GT => {
             val vals = match self._compileBinaryOperands(left, right, ">") { Ok(v) => v, Err(e) => return Err(e) }
             val res = match self._currentFn.block.buildCompareGt(vals[0], vals[1], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
-            Ok(res)
+            Ok(self._currentFn.block.buildExt(res, false))
           }
           BinaryOp.GTE => {
             val vals = match self._compileBinaryOperands(left, right, ">=") { Ok(v) => v, Err(e) => return Err(e) }
             val res = match self._currentFn.block.buildCompareGte(vals[0], vals[1], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
-            Ok(res)
+            Ok(self._currentFn.block.buildExt(res, false))
           }
           BinaryOp.Shr => {
             val leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
@@ -1787,7 +1788,7 @@ export type Compiler {
           } else {
             val boolTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
             val slot = self._buildStackAllocForQbeType(boolTypeQbe, Some(slotName))
-            self._currentFn.block.buildStore(boolTypeQbe, Value.Int32(1), slot)
+            self._currentFn.block.buildStore(boolTypeQbe, Value.Int(1), slot)
           }
         }
         for node, idx in ifBlock {
@@ -1849,7 +1850,7 @@ export type Compiler {
     Ok(match lit {
       LiteralAstNode.Int(v) => (Value.Int(v), Type(kind: TypeKind.PrimitiveInt))
       LiteralAstNode.Float(f) => (Value.Float(f), Type(kind: TypeKind.PrimitiveFloat))
-      LiteralAstNode.Bool(b) => (Value.Int32(if b 1 else 0), Type(kind: TypeKind.PrimitiveBool))
+      LiteralAstNode.Bool(b) => (Value.Int(if b 1 else 0), Type(kind: TypeKind.PrimitiveBool))
       LiteralAstNode.String(s) => {
         val dataPtr = self._builder.buildGlobalString(s.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n"))
         val instancePtr = match self._constructString(dataPtr, Value.Int(s.length)) { Ok(v) => v, Err(e) => return Err(e) }
@@ -2108,7 +2109,7 @@ export type Compiler {
         self._currentFn.block.addComment("store ptr to captured mutable '${variable.label.name}' in captures")
         QbeType.Pointer
       } else {
-        self._currentFn.block.addComment("store captured mutable '${variable.label.name}' in captures")
+        self._currentFn.block.addComment("store captured '${variable.label.name}' in captures")
         val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
         varTy
       }
@@ -2209,10 +2210,10 @@ export type Compiler {
     if self._typeIsInt(ty) || self._typeIsFloat(ty) || self._typeIsBool(ty) {
       val res = if negate {
         val res = match self._currentFn.block.buildCompareNeq(leftVal, rightVal, localName) { Ok(v) => v, Err(e) => return qbeError(e) }
-        res
+        self._currentFn.block.buildExt(res, false)
       } else {
         val res = match self._currentFn.block.buildCompareEq(leftVal, rightVal, localName) { Ok(v) => v, Err(e) => return qbeError(e) }
-        res
+        self._currentFn.block.buildExt(res, false)
       }
       return Ok(res)
     }
@@ -2223,8 +2224,8 @@ export type Compiler {
 
     val res = match self._currentFn.block.buildCall(Callable.Function(eqFnVal), [leftVal, rightVal], localName) { Ok(v) => v, Err(e) => return qbeError(e) }
     if negate {
-      val plusOneVal = match self._currentFn.block.buildAdd(Value.Int32(1), res) { Ok(v) => v, Err(e) => return qbeError(e) }
-      val res = match self._currentFn.block.buildRem(plusOneVal, Value.Int32(2)) { Ok(v) => v, Err(e) => return qbeError(e) }
+      val plusOneVal = match self._currentFn.block.buildAdd(Value.Int(1), res) { Ok(v) => v, Err(e) => return qbeError(e) }
+      val res = match self._currentFn.block.buildRem(plusOneVal, Value.Int(2)) { Ok(v) => v, Err(e) => return qbeError(e) }
       Ok(res)
     } else {
       Ok(res)
@@ -2483,7 +2484,7 @@ export type Compiler {
       TypeKind.PrimitiveUnit => Ok(None)
       TypeKind.PrimitiveInt => Ok(Some(QbeType.U64))
       TypeKind.PrimitiveFloat => Ok(Some(QbeType.F64))
-      TypeKind.PrimitiveBool => Ok(Some(QbeType.U32))
+      TypeKind.PrimitiveBool => Ok(Some(QbeType.U64))
       TypeKind.PrimitiveString => Ok(Some(QbeType.Pointer))
       TypeKind.Never => Ok(None)
       TypeKind.Any => todo("TypeKind.Any")
@@ -2950,10 +2951,10 @@ export type Compiler {
         self._currentFn.block.buildJnz(ptrVal, labelIsNotNull, labelIsNull)
 
         self._currentFn.block.registerLabel(labelIsNotNull)
-        val f = Value.Int32(0)
+        val f = Value.Int(0)
         self._currentFn.block.buildJmp(labelCont)
         self._currentFn.block.registerLabel(labelIsNull)
-        val t = Value.Int32(1)
+        val t = Value.Int(1)
         self._currentFn.block.buildJmp(labelCont)
         self._currentFn.block.registerLabel(labelCont)
 
@@ -3715,7 +3716,7 @@ export type Compiler {
           val selfParam = fnVal.addParameter("self", intTypeQbe)
           val otherParam = fnVal.addParameter("other", intTypeQbe)
           val res = match self._currentFn.block.buildCompareEq(selfParam, otherParam) { Ok(v) => v, Err(e) => return qbeError(e) }
-          fnVal.block.buildReturn(Some(res))
+          fnVal.block.buildReturn(Some(self._currentFn.block.buildExt(res, false)))
 
           match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
@@ -3737,7 +3738,7 @@ export type Compiler {
           val selfParam = fnVal.addParameter("self", floatTypeQbe)
           val otherParam = fnVal.addParameter("other", floatTypeQbe)
           val res = match self._currentFn.block.buildCompareEq(selfParam, otherParam) { Ok(v) => v, Err(e) => return qbeError(e) }
-          fnVal.block.buildReturn(Some(res))
+          fnVal.block.buildReturn(Some(self._currentFn.block.buildExt(res, false)))
 
           match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
@@ -3757,7 +3758,7 @@ export type Compiler {
           val selfParam = fnVal.addParameter("self", boolTypeQbe)
           val otherParam = fnVal.addParameter("other", boolTypeQbe)
           val res = match self._currentFn.block.buildCompareEq(selfParam, otherParam) { Ok(v) => v, Err(e) => return qbeError(e) }
-          fnVal.block.buildReturn(Some(res))
+          fnVal.block.buildReturn(Some(self._currentFn.block.buildExt(res, false)))
 
           match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
@@ -3833,7 +3834,7 @@ export type Compiler {
 
         self._currentFn.block.registerLabel(labelVariantsNeq)
         self._currentFn.block.addComment("return false")
-        self._currentFn.block.buildReturn(Some(Value.Int32(0)))
+        self._currentFn.block.buildReturn(Some(Value.Int(0)))
 
         self._currentFn.block.registerLabel(labelVariantsEq)
 
@@ -3859,7 +3860,7 @@ export type Compiler {
           match variant.kind {
             EnumVariantKind.Constant => {
               self._currentFn.block.addComment("return true")
-              self._currentFn.block.buildReturn(Some(Value.Int32(1)))
+              self._currentFn.block.buildReturn(Some(Value.Int(1)))
             }
             EnumVariantKind.Container(fields) => {
               val data: (String, Position, Type)[] = []
@@ -3911,7 +3912,7 @@ export type Compiler {
 
       self._currentFn.block.registerLabel(labelNeq)
       self._currentFn.block.addComment("return false")
-      self._currentFn.block.buildReturn(Some(Value.Int32(0)))
+      self._currentFn.block.buildReturn(Some(Value.Int(0)))
 
       self._currentFn.block.registerLabel(labelEq)
 
@@ -3919,7 +3920,7 @@ export type Compiler {
     }
 
     self._currentFn.block.addComment("return true")
-    self._currentFn.block.buildReturn(Some(Value.Int32(1)))
+    self._currentFn.block.buildReturn(Some(Value.Int(1)))
 
     Ok(0)
   }

--- a/selfhost_test/src/test_utils.rs
+++ b/selfhost_test/src/test_utils.rs
@@ -25,7 +25,7 @@ impl TestRunner {
     }
 
     pub fn parser_test_runner() -> Self {
-        Self::test_runner("parser", "parser.test.abra", "parser_test", false)
+        Self::test_runner("parser", "parser.test.abra", "parser_test", true)
     }
 
     pub fn typechecker_test_runner() -> Self {
@@ -40,7 +40,7 @@ impl TestRunner {
         let bin_path = build_test_runner(&src_file, &output_bin_file);
 
         let selfhosted_bin_path = if test_selfhosted {
-            let selfhosted_compiler_bin = build_test_runner("compiler.test.abra", "selfhosted_compiler");
+            let selfhosted_compiler_bin = build_test_runner("compiler.test.abra", &format!("selfhosted_compiler_for_{}", runner_name));
 
             let project_root = get_project_root().unwrap();
             let selfhost_dir = project_root.join("selfhost");


### PR DESCRIPTION
When compiling the `src/parser.test.abra` file, there were some function invocations whose identifiers exceeded the length limit for qbe identifiers. To fix this, I generate a randomized name to act as an alias in place of that long type name. In order to perform the randomization, I added an implementation of `rand` to the `libc` module (and also added `srand(time(NULL))` to the `main` method. This is a suboptimal solution, but it's good enough for now. As of this change, the `src/parser.test.abra` file compiles using the selfhosted compiler! However, that binary produces a segfault when run on even a basic input, so I'll need ot dive in and debug.