### PR TITLE
Selfhost: compiling the typechecker

### DIFF
--- a/abra_core/std/fs.abra
+++ b/abra_core/std/fs.abra
@@ -86,8 +86,8 @@ export func openFile(path: String, accessMode: AccessMode): Result<File, FileIOE
 export func getCurrentWorkingDirectory(): String {
   val buf = Pointer.malloc<Byte>(libc.PATH_MAX)
 
-  val cwd = libc.getcwd(buf, libc.PATH_MAX)
-  val len = libc.strlen(cwd._buffer)
+  libc.getcwd(buf, libc.PATH_MAX)
+  val len = libc.strlen(buf)
 
   val str = String.withLength(len)
   str._buffer.copyFrom(buf, len)

--- a/abra_core/std/libc.abra
+++ b/abra_core/std/libc.abra
@@ -39,7 +39,7 @@ export func write(fd: Int, buf: Pointer<Byte>, count: Int): Int
 export val PATH_MAX = 4096
 
 @CBinding("getcwd")
-export func getcwd(buf: Pointer<Byte>, count: Int): String
+export func getcwd(buf: Pointer<Byte>, count: Int): Pointer<Byte>
 
 @CBinding("strlen")
 export func strlen(s: Pointer<Byte>): Int

--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,35 +1,4 @@
-type Foo {
-  func number(self): Int = 123
+import "fs" as fs
 
-  func printNumber(self, arr: Int[]) {
-    val n = plusOne(() => {
-      val num = self.number()
-      arr.push(num)
-      num
-    })
-    println("number:", n)
-  }
-}
-
-func plusOne(fn: () => Int): Int = fn() + 1
-
-// // val f = Foo()
-// // val arr = [1, 2, 3]
-// // f.printNumber(arr)
-// // println(arr)
-
-// enum Foo {
-//   Bar(arr: Int[], name: String)
-// }
-
-// val f = Foo.Bar(arr: [1, 2, 3], name: "hello")
-// match f {
-//   Foo.Bar(arr, name) => {
-//     println(arr, name)
-//   }
-// }
-
-// val arr = ["a", "b", "c"]
-// if arr[0] |item| {
-//   println(item.length)
-// }
+val cwd = fs.getCurrentWorkingDirectory()
+println(cwd)

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -1,7 +1,7 @@
 import "fs" as fs
 import Position from "./lexer"
 import LiteralAstNode, UnaryOp, BinaryOp, AssignOp, BindingPattern, IndexingMode from "./parser"
-import Project, TypedModule, Scope, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind, BuiltinModule, Variable from "./typechecker"
+import Project, TypedModule, Scope, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind, BuiltinModule, Variable, Terminator from "./typechecker"
 import ModuleBuilder, QbeType, Dest, QbeFunction, Value, Label, Callable, QbeData, QbeDataKind, Var from "./qbe"
 
 type CompilationError {
@@ -1852,7 +1852,7 @@ export type Compiler {
       LiteralAstNode.Float(f) => (Value.Float(f), Type(kind: TypeKind.PrimitiveFloat))
       LiteralAstNode.Bool(b) => (Value.Int(if b 1 else 0), Type(kind: TypeKind.PrimitiveBool))
       LiteralAstNode.String(s) => {
-        val dataPtr = self._builder.buildGlobalString(s.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n"))
+        val dataPtr = self._builder.buildGlobalString(s.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n").replaceAll("\r", "\\r"))
         val instancePtr = match self._constructString(dataPtr, Value.Int(s.length)) { Ok(v) => v, Err(e) => return Err(e) }
         (instancePtr, Type(kind: TypeKind.PrimitiveString))
       }
@@ -1869,7 +1869,7 @@ export type Compiler {
 
     val resValSlotCtx = if !isStatement {
       val slotName = "${matchLabelPrefix}_result.slot"
-      val nodeTypeQbe = match self._getQbeTypeForTypeExpect(node.ty, "qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+      val nodeTypeQbe = match self._getQbeTypeForTypeExpect(node.ty, "qbe type should exist", Some(node.token.position)) { Ok(v) => v, Err(e) => return Err(e) }
       val slot = self._buildStackAllocForQbeType(nodeTypeQbe, Some(slotName))
       Some((slot, nodeTypeQbe))
     } else None
@@ -2007,7 +2007,7 @@ export type Compiler {
 
       if case.binding |v| {
         val slotName = self._currentFn.block.addVar(variableToVar(v))
-        val bindingTypeQbe = match self._getQbeTypeForTypeExpect(exprType, "qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+        val bindingTypeQbe = match self._getQbeTypeForTypeExpect(exprType, "qbe type should exist", Some(v.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
         val slot = self._buildStackAllocForQbeType(bindingTypeQbe, Some(slotName))
         self._currentFn.block.buildStore(bindingTypeQbe, exprVal, slot)
       }
@@ -3324,7 +3324,8 @@ export type Compiler {
         retVal = res
       }
     }
-    if !fn.scope.terminator {
+
+    if fn.scope.terminator != Some(Terminator.Returning) {
       fnVal.block.buildReturn(retVal)
     }
 

--- a/selfhost/src/typechecker.abra
+++ b/selfhost/src/typechecker.abra
@@ -3159,7 +3159,7 @@ export type Typechecker {
 
                 return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAssignment(kind, fn.label.name, reason)))
               }
-              AccessorPathSegment.Field(label, _, field) => {
+              AccessorPathSegment.Field(label, _, field, _) => {
                 val mode = TypedAssignmentMode.Accessor(head, mid, tail)
                 (mode, label, field)
               }
@@ -3726,8 +3726,8 @@ export type Typechecker {
       Type(kind: TypeKind.PrimitiveUnit)
     }
 
-    // If the resulting type is Unit after visiting all the cases' blocks, then treat this as a statement
-    val isStmt = isStatement || ty.kind == TypeKind.PrimitiveUnit
+    // If the resulting type is Unit or Never after visiting all the cases' blocks, then treat this as a statement
+    val isStmt = isStatement || ty.kind == TypeKind.PrimitiveUnit || ty.kind == TypeKind.Never
     val kind = TypedAstNodeKind.Match(isStmt, typedExpr, typedCases)
     Ok(TypedAstNode(token: token, ty: ty, kind: kind))
   }
@@ -4305,7 +4305,7 @@ export type Typechecker {
               _ => self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint)
             }
           }
-          AccessorPathSegment.Field(label, _, _) => self._typecheckInvocationOfExpression(token, invokee, label.position, node)
+          AccessorPathSegment.Field(label, _, _, _) => self._typecheckInvocationOfExpression(token, invokee, label.position, node)
         }
       }
       _ => self._typecheckInvocationOfExpression(token, invokee, invokee.token.position, node)

--- a/selfhost/src/typechecker_test_utils.abra
+++ b/selfhost/src/typechecker_test_utils.abra
@@ -368,7 +368,7 @@ export type Jsonifier {
         self.printNode(inner)
         println()
       }
-      TypedAstNodeKind.Identifier(name, _) => {
+      TypedAstNodeKind.Identifier(name, _, _, _) => {
         self.println("\"kind\": \"identifier\",")
 
         self.print("\"name\": \"$name\"")
@@ -391,11 +391,11 @@ export type Jsonifier {
               self.println("\"kind\": \"enumVariant\",")
               self.println("\"name\": \"${enum_.label.name}.${variant.label.name}\"")
             }
-            AccessorPathSegment.Method(_, f) => {
+            AccessorPathSegment.Method(_, f, _, _) => {
               self.println("\"kind\": \"method\",")
               self.println("\"name\": \"${f.label.name}\"")
             }
-            AccessorPathSegment.Field(_, ty, f) => {
+            AccessorPathSegment.Field(_, ty, f, _) => {
               self.println("\"kind\": \"field\",")
               self.println("\"name\": \"${f.name.name}\",")
               self.print("\"type\": ")
@@ -416,11 +416,11 @@ export type Jsonifier {
             self.println("\"kind\": \"enumVariant\",")
             self.println("\"name\": \"${enum_.label.name}.${variant.label.name}\"")
           }
-          AccessorPathSegment.Method(_, f) => {
+          AccessorPathSegment.Method(_, f, _, _) => {
             self.println("\"kind\": \"method\",")
             self.println("\"name\": \"${f.label.name}\"")
           }
-          AccessorPathSegment.Field(_, ty, f) => {
+          AccessorPathSegment.Field(_, ty, f, _) => {
             self.println("\"kind\": \"field\",")
             self.println("\"name\": \"${f.name.name}\",")
             self.print("\"type\": ")
@@ -431,7 +431,7 @@ export type Jsonifier {
         self.indentDec()
         self.println("}")
       }
-      TypedAstNodeKind.Invocation(invokee, arguments) => {
+      TypedAstNodeKind.Invocation(invokee, arguments, _) => {
         self.println("\"kind\": \"invocation\",")
 
         self.print("\"invokee\": ")
@@ -514,7 +514,7 @@ export type Jsonifier {
         self.printTypedIndexingNode(node)
         println()
       }
-      TypedAstNodeKind.Lambda(fn) => {
+      TypedAstNodeKind.Lambda(fn, _) => {
         self.println("\"kind\": \"lambda\",")
         self.print("\"function\": ")
         self.printFunc(fn)
@@ -679,7 +679,7 @@ export type Jsonifier {
       }
 
       // Statements
-      TypedAstNodeKind.While(condition, conditionBindingPattern, block) => {
+      TypedAstNodeKind.While(condition, conditionBindingPattern, block, _) => {
         self.println("\"kind\": \"while\",")
 
         self.print("\"condition\": ")
@@ -977,9 +977,9 @@ export type Jsonifier {
 
   func indent(self) = print("  ".repeat(self.indentLevel))
 
-  func indentInc(self) = self.indentLevel += 1
+  func indentInc(self) { self.indentLevel += 1 }
 
-  func indentDec(self) = self.indentLevel -= 1
+  func indentDec(self) { self.indentLevel -= 1 }
 
   func print(self, str: String) {
     self.indent()

--- a/selfhost_test/src/test_utils.rs
+++ b/selfhost_test/src/test_utils.rs
@@ -29,7 +29,7 @@ impl TestRunner {
     }
 
     pub fn typechecker_test_runner() -> Self {
-        Self::test_runner("typechecker", "typechecker.test.abra", "typechecker_test", false)
+        Self::test_runner("typechecker", "typechecker.test.abra", "typechecker_test", true)
     }
 
     pub fn compiler_test_runner() -> CompilerTestRunner {


### PR DESCRIPTION
With this commit, the selfhosted compiler can compile the selfhosted typechecker, and pass all of the tests that the reference-compiled selfhosted typechecker passes!

Much like the prior commits, there were a few things I needed to fix up that were only uncovered when attempting to compile the typechecker.
  1. I needed to fix up usages of the `getcwd` function, since having `String` as a return type in the `libc` module is nonsensical (it should be a `Pointer<Byte>` as that's the low-level C equivalent); also callers of that function can, at the moment, just use the `buf` that's passed as the first argument rather than using the return value.
  2. was the proper handling of terminators within while-loops in functions (the function should only cease to be emitted when a _returning_ terminator is seen, not just any terminator (eg. `break`)).
  3. Match expressions that have a type of `Never` (meaning that all of the arms' blocks result in a terminator (for now) should just be handled as if they were _statements_ instead.
  4. Lastly, ensure all destructuring has the correct arity (which is now a requirement, unlike in the reference typechecker implementation).