### PR TITLE
Selfhost: compiling the typechecker

### DIFF
--- a/selfhost/example.abra
+++ b/selfhost/example.abra
@@ -1,4 +1,1 @@
-import "fs" as fs
-
-val cwd = fs.getCurrentWorkingDirectory()
-println(cwd)
+println("hello")

--- a/selfhost/src/compiler.abra
+++ b/selfhost/src/compiler.abra
@@ -540,7 +540,7 @@ export type Compiler {
             // a closure's captures array, but a mutable variable needs an additional layer of indirection to handle possible reassignment.
             self._currentFn.block.addComment("move captured mutable '${variable.label.name}' to heap")
             val size = varTy.size()
-            val heapMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+            val heapMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("${variable.label.name}.mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
             self._currentFn.block.buildStore(varTy, res, heapMem)
 
             val slot = self._buildStackAllocForQbeType(QbeType.Pointer, Some(slotName))
@@ -2100,7 +2100,7 @@ export type Compiler {
 
   func _createClosureCaptures(self, fn: Function): Result<Value, CompileError> {
     val size = QbeType.Pointer.size() * (fn.captures.length + fn.capturedClosures.length)
-    val capturesMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val capturesMem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("${fn.label.name}_captures.mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
     var cursor = capturesMem
 
     for variable in fn.captures {
@@ -2755,7 +2755,7 @@ export type Compiler {
       fnVal.addParameter("__default_params_mask__", QbeType.U32)
     }
 
-    val memLocal = match fnVal.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val memLocal = match fnVal.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("struct.mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     var offset = 0
     for field in struct.fields {
@@ -2801,7 +2801,7 @@ export type Compiler {
       _ => {}
     }
 
-    val memLocal = match fn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val memLocal = match fn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("enum_variant.mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     val variantIdx = if enum_.variants.findIndex(v => v.label.name == variant.label.name) |_v| _v[1] else return unreachable("variant '${variant.label.name}' must exist")
     fn.block.buildStoreW(Value.Int(variantIdx), memLocal) // Store variant idx at designated slot
@@ -2976,7 +2976,7 @@ export type Compiler {
         val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
         val sizeVal = match self._currentFn.block.buildMul(Value.Int(innerTySize), countVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-        val mem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [sizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+        val mem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [sizeVal], Some("ptr.mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
         self._currentFn.block.addComment("...pointer_malloc end")
 
@@ -3589,7 +3589,7 @@ export type Compiler {
     val sizeVal = match fnVal.block.buildCall(Callable.Function(self._snprintf), [Value.Int(0), Value.Int(0), intFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
     val mallocSizeVal = match fnVal.block.buildAdd(Value.Int(1), sizeVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-    val mem = match fnVal.block.buildCall(Callable.Function(self._malloc), [mallocSizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val mem = match fnVal.block.buildCall(Callable.Function(self._malloc), [mallocSizeVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
     match fnVal.block.buildCall(Callable.Function(self._snprintf), [mem, mallocSizeVal, intFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     val str = match self._constructString(mem, sizeVal) { Ok(v) => v, Err(e) => return Err(e) }
@@ -3621,7 +3621,7 @@ export type Compiler {
     val sizeVal = match fnVal.block.buildCall(Callable.Function(self._snprintf), [Value.Int(0), Value.Int(0), floatFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
     val mallocSizeVal = match fnVal.block.buildAdd(Value.Int(1), sizeVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-    val mem = match fnVal.block.buildCall(Callable.Function(self._malloc), [mallocSizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
+    val mem = match fnVal.block.buildCall(Callable.Function(self._malloc), [mallocSizeVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
     match fnVal.block.buildCall(Callable.Function(self._snprintf), [mem, mallocSizeVal, floatFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     val str = match self._constructString(mem, sizeVal) { Ok(v) => v, Err(e) => return Err(e) }
@@ -4517,7 +4517,10 @@ export type Compiler {
     parts.push("(")
 
     val args: String[] = []
-    if fn.kind == FunctionKind.InstanceMethod args.push("self")
+    match fn.kind {
+      FunctionKind.InstanceMethod => args.push("self")
+      _ => {}
+    }
     for param in fn.params {
       val paramTyRepr = match self._getReprForType(param.ty) { Ok(v) => v, Err(e) => return Err(e) }
       val defaultExpr = if param.defaultValue " = ..." else ""

--- a/selfhost/src/qbe.abra
+++ b/selfhost/src/qbe.abra
@@ -26,7 +26,7 @@ export type ModuleBuilder {
 
     val block = Block.new(name: name)
 
-    val fn = QbeFunction(exported: exported, name: name, returnType: returnType, _parameters: [], block: block, variadicIdx: None, _comments: [], _env: None)
+    val fn = QbeFunction(exported: exported, name: name, block: block, returnType: returnType, _parameters: [], variadicIdx: None, _comments: [], _env: None)
     self._functions.push(fn)
     self._functionsByName[name] = fn
     fn
@@ -604,7 +604,7 @@ export type Block {
           self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnIdent, args: arguments, env: envPtr))
         }
       }
-      Callable.Value(fnValue) => {
+      Callable.Value(fnValue, _) => {
         self.append(Instruction.Call(dst: Some(Dest(name: local.repr(), ty: fnReturnType)), fn: fnValue, args: arguments, env: envPtr))
       }
     }
@@ -631,7 +631,7 @@ export type Block {
           self.append(Instruction.Call(dst: None, fn: fnIdent, args: arguments, env: envPtr))
         }
       }
-      Callable.Value(fnValue) => {
+      Callable.Value(fnValue, _) => {
         self.append(Instruction.Call(dst: None, fn: fnValue, args: arguments, env: envPtr))
       }
     }


### PR DESCRIPTION
With this commit, the selfhosted compiler can compile the selfhosted compiler, and pass all of the tests that the reference-compiled selfhosted compiler passes! What a mouthful.

Anyway, the main change here was to not use the name `mem` for internal locals after allocating memory, as that would interfere with parameters named `mem` (what a niche corner case that was, but I'm glad it happened and I was able to catch it; it took a while though). With this change, I also updated the test runner to be able to run all of the compiler tests against the compiler as compiled by itself, and they all pass! I'm very proud of this accomplishment, as I've now implemented a fully selfhosted compiler!