### PR TITLE
Using `try` expressions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
           tar -xf qbe-1.2.tar.xz
           cd qbe-1.2
           make
-        if: steps.cache-qbe.outputs.cache-hit != 'true'
       - name: Setup QBE
         run: |
           echo "PATH=$(pwd)/qbe/qbe-1.2:$PATH" >> $GITHUB_ENV

--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -115,24 +115,24 @@ type ResolvedGenerics {
       TypeKind.Instance(structOrEnum, typeArgs) => {
         val resolvedGenerics: Type[] = []
         for typeArg in typeArgs {
-          resolvedGenerics.push(match self._resolveType(typeArg) { Ok(v) => v, Err(e) => return Err(e) })
+          resolvedGenerics.push(try self._resolveType(typeArg))
         }
         Ok(Type(kind: TypeKind.Instance(structOrEnum, resolvedGenerics)))
       }
       TypeKind.Tuple(typeArgs) => {
         val resolvedGenerics: Type[] = []
         for typeArg in typeArgs {
-          resolvedGenerics.push(match self._resolveType(typeArg) { Ok(v) => v, Err(e) => return Err(e) })
+          resolvedGenerics.push(try self._resolveType(typeArg))
         }
         Ok(Type(kind: TypeKind.Tuple(resolvedGenerics)))
       }
       TypeKind.Func(paramTypes, returnType) => {
         val resolvedParams: (Type, Bool)[] = []
         for (paramType, paramIsRequired) in paramTypes {
-          val ty = match self._resolveType(paramType) { Ok(v) => v, Err(e) => return Err(e) }
+          val ty = try self._resolveType(paramType)
           resolvedParams.push((ty, paramIsRequired))
         }
-        val resolvedReturn = match self._resolveType(returnType) { Ok(v) => v, Err(e) => return Err(e) }
+        val resolvedReturn = try self._resolveType(returnType)
 
         Ok(Type(kind: TypeKind.Func(resolvedParams, resolvedReturn)))
       }
@@ -143,7 +143,7 @@ type ResolvedGenerics {
   func addLayer(self, context: String, given: Map<String, Type>): Result<Int, String> {
     val newLayer: Map<String, Type> = {}
     for (name, ty) in given {
-      newLayer[name] = match self._resolveType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+      newLayer[name] = try self._resolveType(ty)
     }
 
     self._layers.push((context, newLayer))
@@ -203,17 +203,26 @@ export type Compiler {
 
     val allModules = project.modules.values().sortBy(m => m.id)
     for mod in allModules {
-      val moduleFn = match compiler._compileModule(mod) { Ok(v) => v, Err(e) => {
-        // println(compiler._currentNode?.token)
-        return Err(CompilationError(modulePath: mod.name, error: e))
-      }}
-      match moduleFn.block.verify() { Ok(v) => v, Err(e) => return Err(CompilationError(modulePath: mod.name, error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e)))) }
+      val moduleFn = match compiler._compileModule(mod) {
+        Ok(v) => v
+        Err(e) => {
+          // println(compiler._currentNode?.token)
+          return Err(CompilationError(modulePath: mod.name, error: e))
+        }
+      }
+      match moduleFn.block.verify() {
+        Ok(v) => v
+        Err(e) => return Err(CompilationError(modulePath: mod.name, error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e))))
+      }
       mainFn.block.buildVoidCall(Callable.Function(moduleFn), [])
     }
 
     mainFn.block.buildReturn(Some(Value.Int(0)))
 
-    match mainFn.block.verify() { Ok(v) => v, Err(e) => return Err(CompilationError(modulePath: "<entrypoint>", error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e)))) }
+    match mainFn.block.verify() {
+      Ok(v) => v
+      Err(e) => return Err(CompilationError(modulePath: "<entrypoint>", error: CompileError(position: Position(line: 0, col: 0), kind: CompileErrorKind.QbeError(e))))
+    }
 
     Ok(builder)
   }
@@ -228,13 +237,13 @@ export type Compiler {
     self._currentFn = fn
 
     for node, idx in module.code {
-      val value = match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+      val value = try self._compileStatement(node)
       // If the last statement in the module is an expression, call the `toString` method on that expression, and print the result using `printf`.
       if idx == module.code.length - 1 && node.ty.kind != TypeKind.PrimitiveUnit {
         if value |v| {
           self._currentFn.block.addComment("call `toString` on final expression, and `printf` the String's chars")
           val dataPtr = self._builder.buildGlobalString("%s\\n")
-          val tostringMethod = match self._getOrCompileToStringMethod(node.ty) { Ok(v) => v, Err(e) => return Err(e) }
+          val tostringMethod = try self._getOrCompileToStringMethod(node.ty)
 
           val tostringRepr = match self._currentFn.block.buildCall(Callable.Function(tostringMethod), [v], Some("_to_string_repr")) { Ok(v) => v, Err(e) => return qbeError(e) }
           val reprCharsPtr = match self._currentFn.block.buildAdd(Value.Int(8), tostringRepr, Some("_repr_chars_ptr")) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -258,7 +267,7 @@ export type Compiler {
     val res: Result<Value?, CompileError> = match node.kind {
       TypedAstNodeKind.If(isStatement, cond, conditionBinding, ifBlock, ifBlockTerminator, elseBlock, elseBlockTerminator) => {
         if !isStatement {
-          val res = match self._compileExpression(node) { Ok(v) => v, Err(e) => return Err(e) }
+          val res = try self._compileExpression(node)
           return Ok(Some(res))
         }
 
@@ -266,11 +275,11 @@ export type Compiler {
         val labelElse = self._currentFn.block.addLabel("else")
         val labelCont = self._currentFn.block.addLabel("cont")
 
-        val condVal = match self._compileExpression(cond) { Ok(v) => v, Err(e) => return Err(e) }
+        val condVal = try self._compileExpression(cond)
         val condExprIsOpt = self._typeIsOption(cond.ty)
 
         if condExprIsOpt {
-          val variantIsOptionSome = match self._emitOptValueIsSomeVariant(condVal) { Ok(v) => v, Err(e) => return Err(e) }
+          val variantIsOptionSome = try self._emitOptValueIsSomeVariant(condVal)
           self._currentFn.block.buildJnz(variantIsOptionSome, labelThen, if elseBlock.isEmpty() labelCont else labelElse)
         } else {
           self._currentFn.block.buildJnz(condVal, labelThen, if elseBlock.isEmpty() labelCont else labelElse)
@@ -281,17 +290,16 @@ export type Compiler {
           val variables = vars.keyBy(v => v.label.name)
 
           val bindingVal = if condExprIsOpt |innerTy| {
-            val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
-            val optInnerValue = match self._emitOptValueGetValue(innerQbeType, condVal) { Ok(v) => v, Err(e) => return Err(e) }
-            optInnerValue
+            val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+            try self._emitOptValueGetValue(innerQbeType, condVal)
           } else {
             Value.Int(1)
           }
-          match self._compileBindingPattern(bindingPattern, variables, Some(bindingVal)) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._compileBindingPattern(bindingPattern, variables, Some(bindingVal))
         }
 
         for node in ifBlock {
-          match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._compileStatement(node)
         }
         if !ifBlockTerminator {
           self._currentFn.block.buildJmp(labelCont)
@@ -300,7 +308,7 @@ export type Compiler {
         if !elseBlock.isEmpty() {
           self._currentFn.block.registerLabel(labelElse)
           for node in elseBlock {
-            match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+            try self._compileStatement(node)
           }
           if !elseBlockTerminator {
             self._currentFn.block.buildJmp(labelCont)
@@ -320,11 +328,11 @@ export type Compiler {
         self._loopStack.push((loopStartLabel, loopEndLabel))
 
         self._currentFn.block.registerLabel(loopStartLabel)
-        val condVal = match self._compileExpression(cond) { Ok(v) => v, Err(e) => return Err(e) }
+        val condVal = try self._compileExpression(cond)
         val condExprIsOpt = self._typeIsOption(cond.ty)
 
         if condExprIsOpt {
-          val variantIsOptionSome = match self._emitOptValueIsSomeVariant(condVal) { Ok(v) => v, Err(e) => return Err(e) }
+          val variantIsOptionSome = try self._emitOptValueIsSomeVariant(condVal)
           self._currentFn.block.buildJnz(variantIsOptionSome, loopBodyLabel, loopEndLabel)
         } else {
           self._currentFn.block.buildJnz(condVal, loopBodyLabel, loopEndLabel)
@@ -335,17 +343,16 @@ export type Compiler {
           val variables = vars.keyBy(v => v.label.name)
 
           val bindingVal = if condExprIsOpt |innerTy| {
-            val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
-            val optInnerValue = match self._emitOptValueGetValue(innerQbeType, condVal) { Ok(v) => v, Err(e) => return Err(e) }
-            optInnerValue
+            val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+            try self._emitOptValueGetValue(innerQbeType, condVal)
           } else {
             Value.Int(1)
           }
-          match self._compileBindingPattern(bindingPattern, variables, Some(bindingVal)) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._compileBindingPattern(bindingPattern, variables, Some(bindingVal))
         }
 
         for node in block {
-          match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._compileStatement(node)
         }
         if !blockTerminator {
           self._currentFn.block.buildJmp(loopStartLabel)
@@ -359,7 +366,7 @@ export type Compiler {
       }
       TypedAstNodeKind.For(typedIterator, itemBindingPattern, indexBinding, block) => {
         val forLabelPrefix = "for_${node.token.position.line}_${node.token.position.col}"
-        val (instTy, typeArgs) = match self._getInstanceTypeForType(typedIterator.ty) { Ok(v) => v, Err(e) => return Err(e) }
+        val (instTy, typeArgs) = try self._getInstanceTypeForType(typedIterator.ty)
 
         val (iterVal, iterTy, nextFn, popAdditionalResolvedGenericsLayer) = match instTy {
           StructOrEnum.Struct(s) => {
@@ -367,15 +374,15 @@ export type Compiler {
               val innerTy = if typeArgs[0] |t| t else return unreachable("Array has 1 required type argument")
               match self._resolvedGenerics.addLayer("array literal", { "T": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "array literal", message: e))) }
 
-              val arrayVal = match self._compileExpression(typedIterator) { Ok(v) => v, Err(e) => return Err(e) }
-              val instType = match self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position) { Ok(v) => v, Err(e) => return Err(e) }
+              val arrayVal = try self._compileExpression(typedIterator)
+              val instType = try self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position)
               val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else return unreachable("Array#iterator must exist")
-              val iteratorFnVal = match self._getOrCompileMethod(instType, iteratorFn) { Ok(v) => v, Err(e) => return Err(e) }
+              val iteratorFnVal = try self._getOrCompileMethod(instType, iteratorFn)
               self._resolvedGenerics.popLayer()
 
               val iter = match self._currentFn.block.buildCall(Callable.Function(iteratorFnVal), [arrayVal], Some("${forLabelPrefix}_iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-              val (structOrEnum, typeArgs) = match self._getInstanceTypeForType(iteratorFn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+              val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
               val instanceMethods = match structOrEnum {
                 StructOrEnum.Struct(s) => s.instanceMethods
                 StructOrEnum.Enum(e) => e.instanceMethods
@@ -388,15 +395,15 @@ export type Compiler {
               val innerTy = if typeArgs[0] |t| t else return unreachable("Set has 1 required type argument")
               match self._resolvedGenerics.addLayer("set literal", { "T": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "set literal", message: e))) }
 
-              val mapVal = match self._compileExpression(typedIterator) { Ok(v) => v, Err(e) => return Err(e) }
-              val instType = match self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position) { Ok(v) => v, Err(e) => return Err(e) }
+              val mapVal = try self._compileExpression(typedIterator)
+              val instType = try self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position)
               val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else return unreachable("Set#iterator must exist")
-              val iteratorFnVal = match self._getOrCompileMethod(instType, iteratorFn) { Ok(v) => v, Err(e) => return Err(e) }
+              val iteratorFnVal = try self._getOrCompileMethod(instType, iteratorFn)
               self._resolvedGenerics.popLayer()
 
               val iter = match self._currentFn.block.buildCall(Callable.Function(iteratorFnVal), [mapVal], Some("${forLabelPrefix}_iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-              val (structOrEnum, typeArgs) = match self._getInstanceTypeForType(iteratorFn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+              val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
               val instanceMethods = match structOrEnum {
                 StructOrEnum.Struct(s) => s.instanceMethods
                 StructOrEnum.Enum(e) => e.instanceMethods
@@ -410,15 +417,15 @@ export type Compiler {
               val valTy = if typeArgs[1] |t| t else return unreachable("Map has 2 required type arguments")
               match self._resolvedGenerics.addLayer("map literal", { "K": keyTy, "V": valTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "map literal", message: e))) }
 
-              val mapVal = match self._compileExpression(typedIterator) { Ok(v) => v, Err(e) => return Err(e) }
-              val instType = match self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position) { Ok(v) => v, Err(e) => return Err(e) }
+              val mapVal = try self._compileExpression(typedIterator)
+              val instType = try self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position)
               val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else return unreachable("Map#iterator must exist")
-              val iteratorFnVal = match self._getOrCompileMethod(instType, iteratorFn) { Ok(v) => v, Err(e) => return Err(e) }
+              val iteratorFnVal = try self._getOrCompileMethod(instType, iteratorFn)
               self._resolvedGenerics.popLayer()
 
               val iter = match self._currentFn.block.buildCall(Callable.Function(iteratorFnVal), [mapVal], Some("${forLabelPrefix}_iterator")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-              val (structOrEnum, typeArgs) = match self._getInstanceTypeForType(iteratorFn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+              val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
               val instanceMethods = match structOrEnum {
                 StructOrEnum.Struct(s) => s.instanceMethods
                 StructOrEnum.Enum(e) => e.instanceMethods
@@ -428,7 +435,7 @@ export type Compiler {
               val iterTy = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
               (iter, iterTy, nextFn, true)
             } else {
-              val iter = match self._compileExpression(typedIterator) { Ok(v) => v, Err(e) => return Err(e) }
+              val iter = try self._compileExpression(typedIterator)
               val nextFn = if s.instanceMethods.find(m => m.label.name == "next") |fn| fn else return unreachable("a type must have a 'next' method if it's to be iterable")
 
               (iter, typedIterator.ty, nextFn, false)
@@ -438,10 +445,10 @@ export type Compiler {
         }
 
         val nextItemTy = if self._typeIsOption(nextFn.returnType) |innerTy| innerTy else return unreachable("a 'next' method must return an Option type")
-        val iterInstTy = match self._addResolvedGenericsLayerForInstanceMethod(iterTy, "next", node.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-        val nextItemQbeTy = match self._getQbeTypeForTypeExpect(nextItemTy, "unacceptable type for 'next' method return type") { Ok(v) => v, Err(e) => return Err(e) }
+        val iterInstTy = try self._addResolvedGenericsLayerForInstanceMethod(iterTy, "next", node.token.position)
+        val nextItemQbeTy = try self._getQbeTypeForTypeExpect(nextItemTy, "unacceptable type for 'next' method return type")
 
-        val nextFnVal = match self._getOrCompileMethod(iterInstTy, nextFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val nextFnVal = try self._getOrCompileMethod(iterInstTy, nextFn)
         self._resolvedGenerics.popLayer()
         if popAdditionalResolvedGenericsLayer self._resolvedGenerics.popLayer()
 
@@ -465,12 +472,12 @@ export type Compiler {
         val iterateeBindingVariables = iterateeBindingVars.keyBy(v => v.label.name)
         val nextRet = match self._currentFn.block.buildCall(Callable.Function(nextFnVal), [iterVal], Some("next_ret")) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-        val variantIsOptionSome = match self._emitOptValueIsSomeVariant(nextRet) { Ok(v) => v, Err(e) => return Err(e) }
+        val variantIsOptionSome = try self._emitOptValueIsSomeVariant(nextRet)
         self._currentFn.block.buildJnz(variantIsOptionSome, loopBodyLabel, loopEndLabel)
 
         self._currentFn.block.registerLabel(loopBodyLabel)
-        val optInnerValue = match self._emitOptValueGetValue(nextItemQbeTy, nextRet) { Ok(v) => v, Err(e) => return Err(e) }
-        match self._compileBindingPattern(iterateePattern, iterateeBindingVariables, Some(optInnerValue)) { Ok(v) => v, Err(e) => return Err(e) }
+        val optInnerValue = try self._emitOptValueGetValue(nextItemQbeTy, nextRet)
+        try self._compileBindingPattern(iterateePattern, iterateeBindingVariables, Some(optInnerValue))
         if indexBindingSlot |idxSlot| {
           val idxVal = self._currentFn.block.buildLoadL(idxSlot)
           val idxIncrVal = match self._currentFn.block.buildAdd(Value.Int(1), idxVal) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -478,7 +485,7 @@ export type Compiler {
         }
 
         for node in block {
-          match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._compileStatement(node)
         }
         self._currentFn.block.buildJmp(loopStartLabel)
 
@@ -491,18 +498,17 @@ export type Compiler {
       TypedAstNodeKind.BindingDeclaration(bindingDeclNode) => {
         val variables = bindingDeclNode.variables.keyBy(v => v.label.name)
         val exprVal = if bindingDeclNode.expr |expr| {
-          val res = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
-          Some(res)
+          Some(try self._compileExpression(expr))
         } else {
           None
         }
-        match self._compileBindingPattern(bindingDeclNode.bindingPattern, variables, exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+        try self._compileBindingPattern(bindingDeclNode.bindingPattern, variables, exprVal)
 
         Ok(None)
       }
       TypedAstNodeKind.FunctionDeclaration(fn) => {
         if fn.isClosure() {
-          val capturesMem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+          val capturesMem = try self._createClosureCaptures(fn)
           val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some("${fn.label.name}.captures"))
           self._currentFn.block.buildStore(QbeType.Pointer, capturesMem, capturesSlot)
         }
@@ -512,7 +518,7 @@ export type Compiler {
       TypedAstNodeKind.TypeDeclaration(struct) => {
         for fn in struct.instanceMethods {
           if fn.isClosure() {
-            val capturesMem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+            val capturesMem = try self._createClosureCaptures(fn)
             val methodName = "${struct.label.name}..${fn.label.name}"
             val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some("$methodName.captures"))
             self._currentFn.block.buildStore(QbeType.Pointer, capturesMem, capturesSlot)
@@ -521,7 +527,7 @@ export type Compiler {
 
         for fn in struct.staticMethods {
           if fn.isClosure() {
-            val capturesMem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+            val capturesMem = try self._createClosureCaptures(fn)
             val methodName = "${struct.label.name}.${fn.label.name}"
             val capturesSlot = self._buildStackAllocForQbeType(QbeType.Pointer, Some("$methodName.captures"))
             self._currentFn.block.buildStore(QbeType.Pointer, capturesMem, capturesSlot)
@@ -551,7 +557,7 @@ export type Compiler {
       }
       TypedAstNodeKind.Return(expr) => {
         if expr |expr| {
-          val retVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
+          val retVal = try self._compileExpression(expr)
           self._currentFn.block.buildReturn(Some(retVal))
         } else {
           self._currentFn.block.buildReturn(None)
@@ -561,15 +567,15 @@ export type Compiler {
       }
       TypedAstNodeKind.Placeholder => unreachable("placeholder ast node emitted from typechecker", node.token.position)
       TypedAstNodeKind.Assignment(mode, op, expr) => {
-        val res = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
+        val res = try self._compileExpression(expr)
 
         match mode {
           TypedAssignmentMode.Variable(variable) => {
             if variable.isParameter return unreachable("parameters cannot be reassigned to", node.token.position)
 
-            val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+            val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
             if variable.isCaptured {
-              val ptr = match self._getCapturedVarPtr(variable) { Ok(v) => v, Err(e) => return Err(e) }
+              val ptr = try self._getCapturedVarPtr(variable)
               self._currentFn.block.addComment("overwrite ptr to captured '${variable.label.name}'")
               self._currentFn.block.buildStore(varTy, res, ptr)
             } else {
@@ -583,11 +589,11 @@ export type Compiler {
               TypedIndexingNode.ArrayLike(expr, indexingMode) => {
                 match indexingMode {
                   IndexingMode.Single(idxExpr) => {
-                    val exprVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
-                    val idxExprVal = match self._compileExpression(idxExpr) { Ok(v) => v, Err(e) => return Err(e) }
+                    val exprVal = try self._compileExpression(expr)
+                    val idxExprVal = try self._compileExpression(idxExpr)
 
-                    val instType = match self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "set", expr.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-                    val (structOrEnum, _) = match self._getInstanceTypeForType(expr.ty) { Ok(v) => v, Err(e) => return Err(e) }
+                    val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "set", expr.token.position)
+                    val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
                     val struct = match structOrEnum {
                       StructOrEnum.Struct(struct) => struct
                       StructOrEnum.Enum => return unreachable("index-assignment only implemented for arrays")
@@ -595,7 +601,7 @@ export type Compiler {
                     if struct != self._project.preludeArrayStruct return unreachable("index-assignment only implemented for arrays")
 
                     val setFn = if self._project.preludeArrayStruct.instanceMethods.find(m => m.label.name == "set") |fn| fn else return unreachable("Array#set must exist")
-                    val setFnVal = match self._getOrCompileMethod(instType, setFn) { Ok(v) => v, Err(e) => return Err(e) }
+                    val setFnVal = try self._getOrCompileMethod(instType, setFn)
                     self._resolvedGenerics.popLayer()
 
                     match self._currentFn.block.buildCall(Callable.Function(setFnVal), [exprVal, idxExprVal, res]) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -604,11 +610,11 @@ export type Compiler {
                 }
               }
               TypedIndexingNode.Map(expr, idxExpr) => {
-                val exprVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
-                val idxExprVal = match self._compileExpression(idxExpr) { Ok(v) => v, Err(e) => return Err(e) }
+                val exprVal = try self._compileExpression(expr)
+                val idxExprVal = try self._compileExpression(idxExpr)
 
-                val instType = match self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "set", expr.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-                val (structOrEnum, _) = match self._getInstanceTypeForType(expr.ty) { Ok(v) => v, Err(e) => return Err(e) }
+                val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "set", expr.token.position)
+                val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
                 val struct = match structOrEnum {
                   StructOrEnum.Struct(struct) => struct
                   StructOrEnum.Enum => return unreachable("index-assignment only implemented for maps")
@@ -616,7 +622,7 @@ export type Compiler {
                 if struct != self._project.preludeMapStruct return unreachable("index-assignment only implemented for map")
 
                 val insertFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else return unreachable("Map#insert must exist")
-                val insertFnVal = match self._getOrCompileMethod(instType, insertFn) { Ok(v) => v, Err(e) => return Err(e) }
+                val insertFnVal = try self._getOrCompileMethod(instType, insertFn)
                 self._resolvedGenerics.popLayer()
 
                 match self._currentFn.block.buildCall(Callable.Function(insertFnVal), [exprVal, idxExprVal, res]) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -625,7 +631,7 @@ export type Compiler {
             }
           }
           TypedAssignmentMode.Accessor(head, middle, tail) => {
-            val ptr = match self._followAccessorPath(head: head, middle: middle, tail: tail, loadFinal: false) { Ok(v) => v, Err(e) => return Err(e) }
+            val ptr = try self._followAccessorPath(head: head, middle: middle, tail: tail, loadFinal: false)
             self._currentFn.block.buildStore(res.ty(), res, ptr)
           }
         }
@@ -633,7 +639,7 @@ export type Compiler {
         Ok(None)
       }
       _ => {
-        val v = match self._compileExpression(node) { Ok(v) => v, Err(e) => return Err(e) }
+        val v = try self._compileExpression(node)
         if node.ty.kind == TypeKind.PrimitiveUnit {
           Ok(None)
         } else {
@@ -653,7 +659,7 @@ export type Compiler {
 
     val res: Result<Value, CompileError> = match node.kind {
       TypedAstNodeKind.Literal(lit) => {
-        val (value, _) = match self._compileLiteral(lit) { Ok(v) => v, Err(e) => return Err(e) }
+        val (value, _) = try self._compileLiteral(lit)
         Ok(value)
       }
       TypedAstNodeKind.StringInterpolation(exprs) => {
@@ -662,10 +668,10 @@ export type Compiler {
         val strVals: Value[] = []
         var lenVal = Value.Int(0)
         for item in exprs {
-          val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
+          val itemVal = try self._compileExpression(item)
 
-          val itemInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(item.ty, "toString", item.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-          val itemToStringFnVal = match self._getOrCompileToStringMethod(itemInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
+          val itemInstanceType = try self._addResolvedGenericsLayerForInstanceMethod(item.ty, "toString", item.token.position)
+          val itemToStringFnVal = try self._getOrCompileToStringMethod(itemInstanceType)
           self._resolvedGenerics.popLayer()
 
           val toStringVal = match self._currentFn.block.buildCall(Callable.Function(itemToStringFnVal), [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -676,7 +682,7 @@ export type Compiler {
         }
 
         val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
-        val stringWithLengthFnVal = match self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
         val newString = match self._currentFn.block.buildCall(Callable.Function(stringWithLengthFnVal), [lenVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
         var newBuffer = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), newString) { Ok(v) => v, Err(e) => return qbeError(e) })
 
@@ -697,16 +703,16 @@ export type Compiler {
       TypedAstNodeKind.Unary(op, expr) => {
         match op {
           UnaryOp.Minus => {
-            val exprVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
+            val exprVal = try self._compileExpression(expr)
             val res = match self._currentFn.block.buildNeg(exprVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
             Ok(res)
           }
           UnaryOp.Negate => {
-            val exprVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
+            val exprVal = try self._compileExpression(expr)
             val exprIsOpt = self._typeIsOption(expr.ty)
             if exprIsOpt {
-              val variantIsNotOptionSome = match self._emitOptValueIsSomeVariant(exprVal: exprVal, negate: true) { Ok(v) => v, Err(e) => return Err(e) }
+              val variantIsNotOptionSome = try self._emitOptValueIsSomeVariant(exprVal: exprVal, negate: true)
               val res = self._currentFn.block.buildExt(variantIsNotOptionSome, false)
               Ok(res)
             } else {
@@ -725,26 +731,26 @@ export type Compiler {
 
             if leftIsString || rightIsString {
               self._currentFn.block.addComment("begin string concatenation...")
-              var leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
+              var leftVal = try self._compileExpression(left)
               if !leftIsString {
-                val leftInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(left.ty, "toString", left.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-                val leftToStringFnVal = match self._getOrCompileToStringMethod(leftInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
+                val leftInstanceType = try self._addResolvedGenericsLayerForInstanceMethod(left.ty, "toString", left.token.position)
+                val leftToStringFnVal = try self._getOrCompileToStringMethod(leftInstanceType)
                 self._resolvedGenerics.popLayer()
 
                 leftVal = match self._currentFn.block.buildCall(Callable.Function(leftToStringFnVal), [leftVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
               }
 
-              var rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+              var rightVal = try self._compileExpression(right)
               if !rightIsString {
-                val rightInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(right.ty, "toString", right.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-                val rightToStringFnVal = match self._getOrCompileToStringMethod(rightInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
+                val rightInstanceType = try self._addResolvedGenericsLayerForInstanceMethod(right.ty, "toString", right.token.position)
+                val rightToStringFnVal = try self._getOrCompileToStringMethod(rightInstanceType)
                 self._resolvedGenerics.popLayer()
 
                 rightVal = match self._currentFn.block.buildCall(Callable.Function(rightToStringFnVal), [rightVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
               }
 
               val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
-              val stringWithLengthFnVal = match self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn) { Ok(v) => v, Err(e) => return Err(e) }
+              val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
               val leftLength = self._currentFn.block.buildLoadL(leftVal)
               val rightLength = self._currentFn.block.buildLoadL(rightVal)
               val totalLength = match self._currentFn.block.buildAdd(leftLength, rightLength) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -764,23 +770,23 @@ export type Compiler {
               return Ok(newString)
             }
 
-            val (lval, rval) = match self._compileBinaryOperands(left, right, "+") { Ok(v) => v, Err(e) => return Err(e) }
+            val (lval, rval) = try self._compileBinaryOperands(left, right, "+")
             val res = match self._currentFn.block.buildAdd(lval, rval, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(res)
           }
           BinaryOp.Sub => {
-            val (lval, rval) = match self._compileBinaryOperands(left, right, "-") { Ok(v) => v, Err(e) => return Err(e) }
+            val (lval, rval) = try self._compileBinaryOperands(left, right, "-")
             val res = match self._currentFn.block.buildSub(lval, rval, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(res)
           }
           BinaryOp.Mul => {
-            val (lval, rval) = match self._compileBinaryOperands(left, right, "*") { Ok(v) => v, Err(e) => return Err(e) }
+            val (lval, rval) = try self._compileBinaryOperands(left, right, "*")
             val res = match self._currentFn.block.buildMul(lval, rval, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(res)
           }
           BinaryOp.Div => {
-            var leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
-            var rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+            var leftVal = try self._compileExpression(left)
+            var rightVal = try self._compileExpression(right)
 
             if !self._typeIsFloat(left.ty)
               leftVal = self._currentFn.block.buildLToF(leftVal)
@@ -791,8 +797,8 @@ export type Compiler {
             Ok(res)
           }
           BinaryOp.Mod => {
-            var leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
-            var rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+            var leftVal = try self._compileExpression(left)
+            var rightVal = try self._compileExpression(right)
 
             if self._typeIsInt(left.ty) && self._typeIsInt(right.ty) {
               val res = match self._currentFn.block.buildRem(leftVal, rightVal, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -808,8 +814,8 @@ export type Compiler {
             }
           }
           BinaryOp.Pow => {
-            var leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
-            var rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+            var leftVal = try self._compileExpression(left)
+            var rightVal = try self._compileExpression(right)
 
             if self._typeIsInt(left.ty) && self._typeIsInt(right.ty) {
               leftVal = self._currentFn.block.buildLToF(leftVal)
@@ -848,10 +854,10 @@ export type Compiler {
             }
           }
           BinaryOp.And => {
-            val leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
+            val leftVal = try self._compileExpression(left)
 
             if self._typeIsInt(left.ty) && self._typeIsInt(right.ty) {
-              val rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+              val rightVal = try self._compileExpression(right)
 
               val res = match self._currentFn.block.buildAnd(leftVal, rightVal, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
               Ok(res)
@@ -863,7 +869,7 @@ export type Compiler {
               self._currentFn.block.buildJnz(leftVal, labelThen, labelElse)
 
               self._currentFn.block.registerLabel(labelThen)
-              val rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+              val rightVal = try self._compileExpression(right)
               val rightLabel = self._currentFn.block.currentLabel
               self._currentFn.block.buildJmp(labelCont)
 
@@ -879,10 +885,10 @@ export type Compiler {
             }
           }
           BinaryOp.Or => {
-            val leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
+            val leftVal = try self._compileExpression(left)
 
             if self._typeIsInt(left.ty) && self._typeIsInt(right.ty) {
-              val rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+              val rightVal = try self._compileExpression(right)
 
               val res = match self._currentFn.block.buildOr(leftVal, rightVal, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
               Ok(res)
@@ -897,7 +903,7 @@ export type Compiler {
               self._currentFn.block.buildJmp(labelCont)
 
               self._currentFn.block.registerLabel(labelElse)
-              val rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+              val rightVal = try self._compileExpression(right)
               val rightLabel = self._currentFn.block.currentLabel
               self._currentFn.block.buildJmp(labelCont)
 
@@ -910,8 +916,8 @@ export type Compiler {
             }
           }
           BinaryOp.Xor => {
-            val leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
-            val rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+            val leftVal = try self._compileExpression(left)
+            val rightVal = try self._compileExpression(right)
 
             if self._typeIsInt(left.ty) && self._typeIsInt(right.ty) || self._typeIsBool(left.ty) && self._typeIsBool(right.ty) {
               val res = match self._currentFn.block.buildXor(leftVal, rightVal, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -921,25 +927,25 @@ export type Compiler {
             }
           }
           BinaryOp.Coalesce => {
-            val leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
+            val leftVal = try self._compileExpression(left)
 
             val labelThen = self._currentFn.block.addLabel("coalesce_then")
             val labelElse = self._currentFn.block.addLabel("coalesce_else")
             val labelCont = self._currentFn.block.addLabel("coalesce_cont")
 
-            val isSome = match self._emitOptValueIsSomeVariant(leftVal) { Ok(v) => v, Err(e) => return Err(e) }
+            val isSome = try self._emitOptValueIsSomeVariant(leftVal)
 
             self._currentFn.block.buildJnz(isSome, labelThen, labelElse)
 
             self._currentFn.block.registerLabel(labelThen)
             val innerTy = if self._typeIsOption(left.ty) |innerTy| innerTy else return unreachable("", node.token.position)
-            val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
-            val innerVal = match self._emitOptValueGetValue(innerQbeType, leftVal) { Ok(v) => v, Err(e) => return Err(e) }
+            val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+            val innerVal = try self._emitOptValueGetValue(innerQbeType, leftVal)
             val leftLabel = self._currentFn.block.currentLabel
             self._currentFn.block.buildJmp(labelCont)
 
             self._currentFn.block.registerLabel(labelElse)
-            val rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+            val rightVal = try self._compileExpression(right)
             val rightLabel = self._currentFn.block.currentLabel
             self._currentFn.block.buildJmp(labelCont)
 
@@ -953,35 +959,35 @@ export type Compiler {
           BinaryOp.Eq => self._compileBinaryEq(left, right)
           BinaryOp.Neq => self._compileBinaryEq(left: left, right: right, negate: true)
           BinaryOp.LT => {
-            val (lval, rval) = match self._compileBinaryOperands(left, right, "<") { Ok(v) => v, Err(e) => return Err(e) }
+            val (lval, rval) = try self._compileBinaryOperands(left, right, "<")
             val res = match self._currentFn.block.buildCompareLt(lval, rval, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(self._currentFn.block.buildExt(res, false))
           }
           BinaryOp.LTE => {
-            val (lval, rval) = match self._compileBinaryOperands(left, right, "<=") { Ok(v) => v, Err(e) => return Err(e) }
+            val (lval, rval) = try self._compileBinaryOperands(left, right, "<=")
             val res = match self._currentFn.block.buildCompareLte(lval, rval, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(self._currentFn.block.buildExt(res, false))
           }
           BinaryOp.Shl => {
-            val leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
-            val rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+            val leftVal = try self._compileExpression(left)
+            val rightVal = try self._compileExpression(right)
 
             val res = match self._currentFn.block.buildShl(leftVal, rightVal, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(res)
           }
           BinaryOp.GT => {
-            val (lval, rval) = match self._compileBinaryOperands(left, right, ">") { Ok(v) => v, Err(e) => return Err(e) }
+            val (lval, rval) = try self._compileBinaryOperands(left, right, ">")
             val res = match self._currentFn.block.buildCompareGt(lval, rval, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(self._currentFn.block.buildExt(res, false))
           }
           BinaryOp.GTE => {
-            val (lval, rval) = match self._compileBinaryOperands(left, right, ">=") { Ok(v) => v, Err(e) => return Err(e) }
+            val (lval, rval) = try self._compileBinaryOperands(left, right, ">=")
             val res = match self._currentFn.block.buildCompareGte(lval, rval, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(self._currentFn.block.buildExt(res, false))
           }
           BinaryOp.Shr => {
-            val leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
-            val rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+            val leftVal = try self._compileExpression(left)
+            val rightVal = try self._compileExpression(right)
 
             val res = match self._currentFn.block.buildShr(leftVal, rightVal, resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(res)
@@ -993,11 +999,11 @@ export type Compiler {
         // If a variable is function parameter, it can just be referenced by name as a temporary/local, otherwise it can be obtained by
         // loading the value pointed to by the temporary/local with that name.
         // TODO: handle captured variables in closures, global variables, etc).
-        val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+        val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
         if variable.isParameter {
           if variable.isCaptured {
             if variable.mutable return unreachable("parameters cannot be mutable", node.token.position)
-            val value = match self._getCapturedVarPtr(variable) { Ok(v) => v, Err(e) => return Err(e) }
+            val value = try self._getCapturedVarPtr(variable)
             Ok(value)
           } else {
             val varName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'", node.token.position)
@@ -1018,11 +1024,11 @@ export type Compiler {
               }
 
               val capturesMem = if !fn.isClosure() None else {
-                val mem = match self._getCapturesArrForClosure(fn) { Ok(v) => v, Err(e) => return Err(e) }
+                val mem = try self._getCapturesArrForClosure(fn)
                 Some(mem)
               }
 
-              val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
+              val fnValBase = try self._getOrCompileFunction(fn)
               self._compileFunctionValue(node.token.position, fn, fnValBase, targetParamTypes, capturesMem, None)
             }
             _ => {
@@ -1032,7 +1038,7 @@ export type Compiler {
                 val res = self._currentFn.block.buildLoad(varTy, slot)
                 Ok(res)
               } else if variable.isCaptured {
-                val ptr = match self._getCapturedVarPtr(variable) { Ok(v) => v, Err(e) => return Err(e) }
+                val ptr = try self._getCapturedVarPtr(variable)
                 val res = if variable.mutable {
                   self._currentFn.block.addComment("deref ptr to captured mutable '${variable.label.name}'")
                   self._currentFn.block.buildLoad(varTy, ptr)
@@ -1083,7 +1089,7 @@ export type Compiler {
             }
 
             if fn.isClosure() {
-              val capturesArr = match self._getCapturesArrForClosure(fn) { Ok(v) => v, Err(e) => return Err(e) }
+              val capturesArr = try self._getCapturesArrForClosure(fn)
               closureEnvCtx = Some((capturesArr, false))
             }
 
@@ -1091,11 +1097,11 @@ export type Compiler {
 
             val fnVal = match fn.kind {
               FunctionKind.StaticMethod(parentTy) => {
-                val fnVal = match self._getOrCompileMethod(Type(kind: TypeKind.Type(parentTy)), fn) { Ok(v) => v, Err(e) => return Err(e) }
+                val fnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(parentTy)), fn)
                 fnVal
               }
               FunctionKind.Standalone => {
-                val fnVal = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
+                val fnVal = try self._getOrCompileFunction(fn)
                 fnVal
               }
               FunctionKind.InstanceMethod => return unreachable("instance methods handled elsewhere", node.token.position)
@@ -1107,7 +1113,7 @@ export type Compiler {
             (Callable.Function(fnVal), argMetadata)
           }
           TypedInvokee.Method(fn, selfExpr, isOptSafe) => {
-            var selfInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(selfExpr.ty, fn.label.name, node.token.position, resolvedGenerics) { Ok(v) => v, Err(e) => return Err(e) }
+            var selfInstanceType = try self._addResolvedGenericsLayerForInstanceMethod(selfExpr.ty, fn.label.name, node.token.position, resolvedGenerics)
 
             val intrinsicDec = fn.decorators.find(dec => dec.label.name == "Intrinsic")
             if intrinsicDec |dec| {
@@ -1118,7 +1124,7 @@ export type Compiler {
             }
 
             if fn.isClosure() {
-              val capturesArr = match self._getCapturesArrForClosure(fn) { Ok(v) => v, Err(e) => return Err(e) }
+              val capturesArr = try self._getCapturesArrForClosure(fn)
               closureEnvCtx = Some((capturesArr, false))
             }
 
@@ -1128,8 +1134,8 @@ export type Compiler {
               val innerTy = if self._typeIsOption(selfInstanceType) |innerTy| innerTy else return unreachable("an opt-safe invocation needs to have an Option type as its lhs")
               selfInstanceType = innerTy
 
-              val selfVal = match self._compileExpression(selfExpr) { Ok(v) => v, Err(e) => return Err(e) }
-              val variantIsOptionSome = match self._emitOptValueIsSomeVariant(selfVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val selfVal = try self._compileExpression(selfExpr)
+              val variantIsOptionSome = try self._emitOptValueIsSomeVariant(selfVal)
 
               val labelIsSome = self._currentFn.block.addLabel("optsafe_call_is_some")
               val labelIsNone = self._currentFn.block.addLabel("optsafe_call_is_none")
@@ -1142,7 +1148,7 @@ export type Compiler {
               val noneRes = if fn.returnType.kind != TypeKind.PrimitiveUnit {
                 val optNoneVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "None") |v| v else return unreachable("Option.None must exist")
                 match self._resolvedGenerics.addLayer("Option.None", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.None", message: e))) }
-                val noneVariantFn = match self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant) { Ok(v) => v, Err(e) => return Err(e) }
+                val noneVariantFn = try self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant)
                 self._resolvedGenerics.popLayer()
                 val noneRes = match self._currentFn.block.buildCall(Callable.Function(noneVariantFn), []) { Ok(v) => v, Err(e) => return qbeError(e) }
                 Some(noneRes)
@@ -1152,20 +1158,20 @@ export type Compiler {
               self._currentFn.block.registerLabel(labelIsSome)
               val optSomeVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "Some") |v| v else return unreachable("Option.Some must exist")
               match self._resolvedGenerics.addLayer("Option.Some", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.Some", message: e))) }
-              val someVariantFn = match self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optSomeVariant) { Ok(v) => v, Err(e) => return Err(e) }
+              val someVariantFn = try self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optSomeVariant)
               self._resolvedGenerics.popLayer()
 
               optSafeCtx = Some((labelIsNone, noneRes, someVariantFn, labelCont))
 
-              val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
-              val v = match self._emitOptValueGetValue(innerQbeType, selfVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+              val v = try self._emitOptValueGetValue(innerQbeType, selfVal)
               v
             } else {
-              val v = match self._compileExpression(selfExpr) { Ok(v) => v, Err(e) => return Err(e) }
+              val v = try self._compileExpression(selfExpr)
               v
             }
 
-            val fnVal = match self._getOrCompileMethod(selfInstanceType, fn) { Ok(v) => v, Err(e) => return Err(e) }
+            val fnVal = try self._getOrCompileMethod(selfInstanceType, fn)
             args.push(selfVal)
 
             self._resolvedGenerics.popLayer()
@@ -1176,7 +1182,7 @@ export type Compiler {
           TypedInvokee.Struct(struct) => {
             match self._resolvedGenerics.addLayer(struct.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: struct.label.name, message: e))) }
             fnHasOptionalParameters = struct.fields.any(f => !!f.initializer)
-            val fnVal = match self._getOrCompileStructInitializer(struct) { Ok(v) => v, Err(e) => return Err(e) }
+            val fnVal = try self._getOrCompileStructInitializer(struct)
 
             self._resolvedGenerics.popLayer()
 
@@ -1185,7 +1191,7 @@ export type Compiler {
           }
           TypedInvokee.EnumVariant(enum_, variant) => {
             match self._resolvedGenerics.addLayer(variant.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: variant.label.name, message: e))) }
-            val enumVariantFn = match self._getOrCompileEnumVariantFn(enum_, variant) { Ok(v) => v, Err(e) => return Err(e) }
+            val enumVariantFn = try self._getOrCompileEnumVariantFn(enum_, variant)
 
             self._resolvedGenerics.popLayer()
 
@@ -1196,7 +1202,7 @@ export type Compiler {
             (Callable.Function(enumVariantFn), argMetadata)
           }
           TypedInvokee.Expr(expr) => {
-            val fnObj = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
+            val fnObj = try self._compileExpression(expr)
             val envPtr = self._currentFn.block.buildLoadL(fnObj)
             closureEnvCtx = Some((envPtr, true))
 
@@ -1210,7 +1216,7 @@ export type Compiler {
             val retTypeQbe = if node.ty.kind == TypeKind.PrimitiveUnit {
               None
             } else {
-              val ty = match self._getQbeTypeForTypeExpect(node.ty, "unacceptable return type", None) { Ok(v) => v, Err(e) => return Err(e) }
+              val ty = try self._getQbeTypeForTypeExpect(node.ty, "unacceptable return type", None)
               Some(ty)
             }
             (Callable.Value(fnValPtr, retTypeQbe), [])
@@ -1231,12 +1237,12 @@ export type Compiler {
           }
 
           if arg |node| {
-            val arg = match self._compileExpression(node) { Ok(v) => v, Err(e) => return Err(e) }
+            val arg = try self._compileExpression(node)
             args.push(arg)
           } else if argTy |argTy| {
             defaultValueFlags ||= (1 << defaultValueParamIdx)
 
-            val argQbeType = match self._getQbeTypeForTypeExpect(argTy, "unacceptable type for argument", Some(node.token.position)) { Ok(v) => v, Err(e) => return Err(e) }
+            val argQbeType = try self._getQbeTypeForTypeExpect(argTy, "unacceptable type for argument", Some(node.token.position))
             args.push(argQbeType.zeroValue())
           } else {
             return unreachable("invocation target must be an arbitrary expression, which do not have default-valued arguments", node.token.position)
@@ -1435,17 +1441,17 @@ export type Compiler {
         }
 
         val arrayWithCapacityFn = if self._project.preludeArrayStruct.staticMethods.find(m => m.label.name == "withCapacity") |fn| fn else return unreachable("Array.withCapacity must exist")
-        val arrayWithCapacityFnVal = match self._getOrCompileMethod(node.ty, arrayWithCapacityFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val arrayWithCapacityFnVal = try self._getOrCompileMethod(node.ty, arrayWithCapacityFn)
 
         val sizeVal = Value.Int(items.length.nextPowerOf2())
         val arrayInstance = match self._currentFn.block.buildCall(Callable.Function(arrayWithCapacityFnVal), [sizeVal], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
         self._currentFn.block.addCommentBefore("${arrayInstance.repr()}: ${node.ty.repr()}")
 
         val arrayPushFn = if self._project.preludeArrayStruct.instanceMethods.find(m => m.label.name == "push") |fn| fn else return unreachable("Array#push must exist")
-        val arrayPushFnVal = match self._getOrCompileMethod(node.ty, arrayPushFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val arrayPushFnVal = try self._getOrCompileMethod(node.ty, arrayPushFn)
 
         for item in items {
-          val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
+          val itemVal = try self._compileExpression(item)
           self._currentFn.block.buildVoidCall(Callable.Function(arrayPushFnVal), [arrayInstance, itemVal])
         }
 
@@ -1463,16 +1469,16 @@ export type Compiler {
         }
 
         val setNewFn = if self._project.preludeSetStruct.staticMethods.find(m => m.label.name == "new") |fn| fn else return unreachable("Set.new must exist")
-        val setNewFnVal = match self._getOrCompileMethod(node.ty, setNewFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val setNewFnVal = try self._getOrCompileMethod(node.ty, setNewFn)
 
         val setInstance = match self._currentFn.block.buildCall(Callable.Function(setNewFnVal), [Value.Int(0), Value.Int32(1)], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
         self._currentFn.block.addCommentBefore("${setInstance.repr()}: ${node.ty.repr()}")
 
         val setInsertFn = if self._project.preludeSetStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else return unreachable("Set#insert must exist")
-        val setInsertFnVal = match self._getOrCompileMethod(node.ty, setInsertFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val setInsertFnVal = try self._getOrCompileMethod(node.ty, setInsertFn)
 
         for item in items {
-          val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
+          val itemVal = try self._compileExpression(item)
           self._currentFn.block.buildVoidCall(Callable.Function(setInsertFnVal), [setInstance, itemVal])
         }
 
@@ -1492,17 +1498,17 @@ export type Compiler {
 
 
         val mapNewFn = if self._project.preludeMapStruct.staticMethods.find(m => m.label.name == "new") |fn| fn else return unreachable("Map.new must exist")
-        val mapNewFnVal = match self._getOrCompileMethod(node.ty, mapNewFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val mapNewFnVal = try self._getOrCompileMethod(node.ty, mapNewFn)
 
         val mapInstance = match self._currentFn.block.buildCall(Callable.Function(mapNewFnVal), [Value.Int(0), Value.Int32(1)], resultLocalName) { Ok(v) => v, Err(e) => return qbeError(e) }
         self._currentFn.block.addCommentBefore("${mapInstance.repr()}: ${node.ty.repr()}")
 
         val mapInsertFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else return unreachable("Map#insert must exist")
-        val mapInsertFnVal = match self._getOrCompileMethod(node.ty, mapInsertFn) { Ok(v) => v, Err(e) => return Err(e) }
+        val mapInsertFnVal = try self._getOrCompileMethod(node.ty, mapInsertFn)
 
         for (keyExpr, valExpr) in items {
-          val keyVal = match self._compileExpression(keyExpr) { Ok(v) => v, Err(e) => return Err(e) }
-          val valueVal = match self._compileExpression(valExpr) { Ok(v) => v, Err(e) => return Err(e) }
+          val keyVal = try self._compileExpression(keyExpr)
+          val valueVal = try self._compileExpression(valExpr)
           match self._currentFn.block.buildCall(Callable.Function(mapInsertFnVal), [mapInstance, keyVal, valueVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
         }
 
@@ -1520,13 +1526,13 @@ export type Compiler {
           resolvedGenerics[name] = ty
         }
         match self._resolvedGenerics.addLayer(tupleStruct.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: tupleStruct.label.name, message: e))) }
-        val fnVal = match self._getOrCompileStructInitializer(tupleStruct) { Ok(v) => v, Err(e) => return Err(e) }
+        val fnVal = try self._getOrCompileStructInitializer(tupleStruct)
 
         self._resolvedGenerics.popLayer()
 
         val itemVals: Value[] = []
         for item in items {
-          val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
+          val itemVal = try self._compileExpression(item)
           itemVals.push(itemVal)
         }
 
@@ -1536,19 +1542,19 @@ export type Compiler {
       TypedAstNodeKind.Indexing(indexingNode) => {
         match indexingNode {
           TypedIndexingNode.ArrayLike(expr, indexingMode) => {
-            val exprVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
+            val exprVal = try self._compileExpression(expr)
 
             match indexingMode {
               IndexingMode.Single(idxExpr) => {
-                val idxExprVal = match self._compileExpression(idxExpr) { Ok(v) => v, Err(e) => return Err(e) }
+                val idxExprVal = try self._compileExpression(idxExpr)
 
-                val instType = match self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "get", expr.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-                val (structOrEnum, _) = match self._getInstanceTypeForType(expr.ty) { Ok(v) => v, Err(e) => return Err(e) }
+                val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "get", expr.token.position)
+                val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
                 val getFn = match structOrEnum {
                   StructOrEnum.Struct(struct) => if struct.instanceMethods.find(m => m.label.name == "get") |fn| fn else return unreachable("#get must exist for array-like indexing")
                   StructOrEnum.Enum => return unreachable("array-like indexing never applies to enum instances")
                 }
-                val getFnVal = match self._getOrCompileMethod(instType, getFn) { Ok(v) => v, Err(e) => return Err(e) }
+                val getFnVal = try self._getOrCompileMethod(instType, getFn)
                 self._resolvedGenerics.popLayer()
 
                 val res = match self._currentFn.block.buildCall(Callable.Function(getFnVal), [exprVal, idxExprVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -1557,27 +1563,25 @@ export type Compiler {
               IndexingMode.Range(startExpr, endExpr) => {
                 var maskParam = 0
                 val startExprVal = if startExpr |startExpr| {
-                  val res = match self._compileExpression(startExpr) { Ok(v) => v, Err(e) => return Err(e) }
-                  res
+                  try self._compileExpression(startExpr)
                 } else {
                   maskParam ||= 1
                   Value.Int(0)
                 }
                 val endExprVal = if endExpr |endExpr| {
-                  val res = match self._compileExpression(endExpr) { Ok(v) => v, Err(e) => return Err(e) }
-                  res
+                  try self._compileExpression(endExpr)
                 } else {
                   maskParam ||= (1 << 1)
                   Value.Int(0)
                 }
 
-                val instType = match self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "getRange", expr.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-                val (structOrEnum, _) = match self._getInstanceTypeForType(expr.ty) { Ok(v) => v, Err(e) => return Err(e) }
+                val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "getRange", expr.token.position)
+                val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
                 val getRangeFn = match structOrEnum {
                   StructOrEnum.Struct(struct) => if struct.instanceMethods.find(m => m.label.name == "getRange") |fn| fn else return unreachable("#getRange must exist for array-like indexing")
                   StructOrEnum.Enum => return unreachable("array-like indexing never applies to enum instances")
                 }
-                val getRangeFnVal = match self._getOrCompileMethod(instType, getRangeFn) { Ok(v) => v, Err(e) => return Err(e) }
+                val getRangeFnVal = try self._getOrCompileMethod(instType, getRangeFn)
                 self._resolvedGenerics.popLayer()
 
                 val res = match self._currentFn.block.buildCall(Callable.Function(getRangeFnVal), [exprVal, startExprVal, endExprVal, Value.Int32(maskParam)]) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -1586,11 +1590,11 @@ export type Compiler {
             }
           }
           TypedIndexingNode.Map(expr, idxExpr) => {
-            val exprVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
-            val idxExprVal = match self._compileExpression(idxExpr) { Ok(v) => v, Err(e) => return Err(e) }
+            val exprVal = try self._compileExpression(expr)
+            val idxExprVal = try self._compileExpression(idxExpr)
 
-            val instType = match self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "get", expr.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-            val (structOrEnum, _) = match self._getInstanceTypeForType(expr.ty) { Ok(v) => v, Err(e) => return Err(e) }
+            val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "get", expr.token.position)
+            val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
             val struct = match structOrEnum {
               StructOrEnum.Struct(struct) => struct
               StructOrEnum.Enum => return unreachable("map indexing never applies to enum instances")
@@ -1598,16 +1602,16 @@ export type Compiler {
             if struct != self._project.preludeMapStruct return unreachable("map indexing only implemented for map")
 
             val getFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "get") |fn| fn else return unreachable("Map#get must exist")
-            val getFnVal = match self._getOrCompileMethod(instType, getFn) { Ok(v) => v, Err(e) => return Err(e) }
+            val getFnVal = try self._getOrCompileMethod(instType, getFn)
             self._resolvedGenerics.popLayer()
 
             val res = match self._currentFn.block.buildCall(Callable.Function(getFnVal), [exprVal, idxExprVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
             Ok(res)
           }
           TypedIndexingNode.Tuple(tupleExpr, idx) => {
-            val exprVal = match self._compileExpression(tupleExpr) { Ok(v) => v, Err(e) => return Err(e) }
+            val exprVal = try self._compileExpression(tupleExpr)
 
-            val (structOrEnum, typeArgs) = match self._getInstanceTypeForType(tupleExpr.ty) { Ok(v) => v, Err(e) => return Err(e) }
+            val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(tupleExpr.ty)
             val struct = match structOrEnum {
               StructOrEnum.Struct(struct) => struct
               StructOrEnum.Enum => return unreachable("tuples are represented as structs")
@@ -1626,7 +1630,7 @@ export type Compiler {
             for f, fieldIdx in struct.fields {
               if fieldIdx == idx break
 
-              val fieldTy = match self._getQbeTypeForTypeExpect(f.ty, "unacceptable type for field", Some(f.name.position)) { Ok(v) => v, Err(e) => return Err(e) }
+              val fieldTy = try self._getQbeTypeForTypeExpect(f.ty, "unacceptable type for field", Some(f.name.position))
               offset += fieldTy.size()
             }
 
@@ -1652,11 +1656,11 @@ export type Compiler {
         }
 
         val capturesMem = if !fn.isClosure() None else {
-          val mem = match self._createClosureCaptures(fn) { Ok(v) => v, Err(e) => return Err(e) }
+          val mem = try self._createClosureCaptures(fn)
           Some(mem)
         }
 
-        val fnValBase = match self._getOrCompileFunction(fn) { Ok(v) => v, Err(e) => return Err(e) }
+        val fnValBase = try self._getOrCompileFunction(fn)
         self._compileFunctionValue(node.token.position, fn, fnValBase, targetParamTypes, capturesMem, None)
       }
       TypedAstNodeKind.If(isStatement, cond, conditionBinding, ifBlock, ifBlockTerminator, elseBlock, elseBlockTerminator) => {
@@ -1667,10 +1671,10 @@ export type Compiler {
         val labelElse = self._currentFn.block.addLabel("else")
         val labelCont = self._currentFn.block.addLabel("cont")
 
-        val condVal = match self._compileExpression(cond) { Ok(v) => v, Err(e) => return Err(e) }
+        val condVal = try self._compileExpression(cond)
         val condExprIsOpt = self._typeIsOption(cond.ty)
         if condExprIsOpt {
-          val variantIsOptionSome = match self._emitOptValueIsSomeVariant(condVal) { Ok(v) => v, Err(e) => return Err(e) }
+          val variantIsOptionSome = try self._emitOptValueIsSomeVariant(condVal)
           self._currentFn.block.buildJnz(variantIsOptionSome, labelThen, labelElse)
         } else {
           self._currentFn.block.buildJnz(condVal, labelThen, labelElse)
@@ -1683,16 +1687,16 @@ export type Compiler {
           val variables = vars.keyBy(v => v.label.name)
 
           val bindingVal = if condExprIsOpt |innerTy| {
-            val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
-            val optInnerValue = match self._emitOptValueGetValue(innerQbeType, condVal) { Ok(v) => v, Err(e) => return Err(e) }
+            val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+            val optInnerValue = try self._emitOptValueGetValue(innerQbeType, condVal)
             optInnerValue
           } else {
             Value.Int(1)
           }
-          match self._compileBindingPattern(bindingPattern, variables, Some(bindingVal)) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._compileBindingPattern(bindingPattern, variables, Some(bindingVal))
         }
         for node, idx in ifBlock {
-          val res = match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+          val res = try self._compileStatement(node)
           if idx == ifBlock.length - 1 {
             if res |res| {
               val label = self._currentFn.block.currentLabel
@@ -1709,7 +1713,7 @@ export type Compiler {
         if !elseBlock.isEmpty() {
           self._currentFn.block.registerLabel(labelElse)
           for node, idx in elseBlock {
-            val res = match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+            val res = try self._compileStatement(node)
             if idx == elseBlock.length - 1 {
               if res |res| {
                 val label = self._currentFn.block.currentLabel
@@ -1735,12 +1739,12 @@ export type Compiler {
         }
       }
       TypedAstNodeKind.Match(isStatement, expr, cases) => {
-        val res = match self._compileMatch(node, isStatement, expr, cases) { Ok(v) => v, Err(e) => return Err(e) }
+        val res = try self._compileMatch(node, isStatement, expr, cases)
         if res |res| Ok(res) else return unreachable("match expression needs a resulting value", node.token.position)
       }
       TypedAstNodeKind.Try(expr) => {
-        val exprVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
-        val isErr = match self._emitResultValueIsOkVariant(exprVal, negate: true) { Ok(v) => v, Err(e) => return Err(e) }
+        val exprVal = try self._compileExpression(expr)
+        val isErr = try self._emitResultValueIsOkVariant(exprVal, negate: true)
 
         val labelIsErr = self._currentFn.block.addLabel("isErr")
         val labelCont = self._currentFn.block.addLabel("cont")
@@ -1750,8 +1754,8 @@ export type Compiler {
         self._currentFn.block.buildReturn(Some(exprVal))
 
         self._currentFn.block.registerLabel(labelCont)
-        val okValTy = match self._getQbeTypeForTypeExpect(node.ty, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
-        val okValue = match self._emitResultValueGetValue(okValTy, exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+        val okValTy = try self._getQbeTypeForTypeExpect(node.ty, "unacceptable type", None)
+        val okValue = try self._emitResultValueGetValue(okValTy, exprVal)
 
         Ok(okValue)
       }
@@ -1770,14 +1774,14 @@ export type Compiler {
       LiteralAstNode.Bool(b) => (Value.Int(if b 1 else 0), Type(kind: TypeKind.PrimitiveBool))
       LiteralAstNode.String(s) => {
         val dataPtr = self._builder.buildGlobalString(s.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n").replaceAll("\r", "\\r"))
-        val instancePtr = match self._constructString(dataPtr, Value.Int(s.length)) { Ok(v) => v, Err(e) => return Err(e) }
+        val instancePtr = try self._constructString(dataPtr, Value.Int(s.length))
         (instancePtr, Type(kind: TypeKind.PrimitiveString))
       }
     })
   }
 
   func _compileMatch(self, node: TypedAstNode, isStatement: Bool, expr: TypedAstNode, cases: TypedMatchCase[]): Result<Value?, CompileError> {
-    val exprVal = match self._compileExpression(expr) { Ok(v) => v, Err(e) => return Err(e) }
+    val exprVal = try self._compileExpression(expr)
 
     val matchLabelPrefix = "match_${node.token.position.line}_${node.token.position.col}"
     val endLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_end")
@@ -1786,7 +1790,7 @@ export type Compiler {
 
     val resValSlotCtx = if !isStatement {
       val slotName = "${matchLabelPrefix}_result.slot"
-      val nodeTypeQbe = match self._getQbeTypeForTypeExpect(node.ty, "qbe type should exist", Some(node.token.position)) { Ok(v) => v, Err(e) => return Err(e) }
+      val nodeTypeQbe = try self._getQbeTypeForTypeExpect(node.ty, "qbe type should exist", Some(node.token.position))
       val slot = self._buildStackAllocForQbeType(nodeTypeQbe, Some(slotName))
       Some((slot, nodeTypeQbe))
     } else None
@@ -1797,27 +1801,27 @@ export type Compiler {
           val nextCaseLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_case_${idx}__next")
 
           val (exprVal, exprType) = if exprTypeIsOpt |innerTy| {
-            val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
+            val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
             if seenNoneCase {
-              val optInnerValue = match self._emitOptValueGetValue(innerQbeType, exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val optInnerValue = try self._emitOptValueGetValue(innerQbeType, exprVal)
               (optInnerValue, innerTy)
             } else {
-              val isSomeCond = match self._emitOptValueIsSomeVariant(exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val isSomeCond = try self._emitOptValueIsSomeVariant(exprVal)
               val isSomeLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_case_${idx}__issome")
               self._currentFn.block.buildJnz(isSomeCond, isSomeLabel, nextCaseLabel)
               self._currentFn.block.registerLabel(isSomeLabel)
-              val optInnerValue = match self._emitOptValueGetValue(innerQbeType, exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val optInnerValue = try self._emitOptValueGetValue(innerQbeType, exprVal)
               (optInnerValue, innerTy)
             }
           } else {
             (exprVal, expr.ty)
           }
 
-          val (litVal, litType) = match self._compileLiteral(lit) { Ok(v) => v, Err(e) => return Err(e) }
+          val (litVal, litType) = try self._compileLiteral(lit)
 
           if !self._project.typesAreEquivalent(exprType, litType) return unreachable("equality operators require matching types", node.token.position)
 
-          val cond = match self._compileEqLogic(exprVal, litVal, litType, expr.token.position) { Ok(v) => v, Err(e) => return Err(e) }
+          val cond = try self._compileEqLogic(exprVal, litVal, litType, expr.token.position)
           val isEqLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_iseq")
 
           self._currentFn.block.buildJnz(cond, isEqLabel, nextCaseLabel)
@@ -1828,7 +1832,7 @@ export type Compiler {
         TypedMatchCaseKind.None_ => {
           seenNoneCase = true
 
-          val isNoneCond = match self._emitOptValueIsSomeVariant(exprVal: exprVal, negate: true) { Ok(v) => v, Err(e) => return Err(e) }
+          val isNoneCond = try self._emitOptValueIsSomeVariant(exprVal: exprVal, negate: true)
           val isNoneLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_isnone")
           val nextCaseLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_next_$idx")
 
@@ -1840,16 +1844,16 @@ export type Compiler {
         TypedMatchCaseKind.EnumVariant(enum_, variant, variantIdx, destructuredVariables) => {
           val nextCaseLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_case_${idx}__next")
           val (exprVal, exprType) = if exprTypeIsOpt |innerTy| {
-            val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
+            val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
             if seenNoneCase {
-              val optInnerValue = match self._emitOptValueGetValue(innerQbeType, exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val optInnerValue = try self._emitOptValueGetValue(innerQbeType, exprVal)
               (optInnerValue, innerTy)
             } else {
-              val isSomeCond = match self._emitOptValueIsSomeVariant(exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val isSomeCond = try self._emitOptValueIsSomeVariant(exprVal)
               val isSomeLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_case_${idx}__issome")
               self._currentFn.block.buildJnz(isSomeCond, isSomeLabel, nextCaseLabel)
               self._currentFn.block.registerLabel(isSomeLabel)
-              val optInnerValue = match self._emitOptValueGetValue(innerQbeType, exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val optInnerValue = try self._emitOptValueGetValue(innerQbeType, exprVal)
               (optInnerValue, innerTy)
             }
           } else {
@@ -1864,16 +1868,16 @@ export type Compiler {
           self._currentFn.block.registerLabel(isVariantLabel)
 
           if !destructuredVariables.isEmpty() {
-            match self._addResolvedGenericsLayerForEnumVariant(exprType, variant.label.name, node.token.position) { Ok(v) => v, Err(e) => return Err(e) }
+            try self._addResolvedGenericsLayerForEnumVariant(exprType, variant.label.name, node.token.position)
             val variantFields = match variant.kind {
               EnumVariantKind.Container(fields) => fields
               _ => return unreachable("cannot destructure a non-container enum variant", node.token.position)
             }
 
-            var memCursor = match self._emitGetEnumVariantValueStart(exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+            var memCursor = try self._emitGetEnumVariantValueStart(exprVal)
             for v, idx in destructuredVariables {
               val field = if variantFields[idx] |f| f else return unreachable("this should be caught during typechecking", node.token.position)
-              val fieldTy = match self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position)) { Ok(v) => v, Err(e) => return Err(e) }
+              val fieldTy = try self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position))
 
               val fieldVal = self._currentFn.block.buildLoad(fieldTy, memCursor)
               val slotName = self._currentFn.block.addVar(variableToVar(v))
@@ -1894,8 +1898,8 @@ export type Compiler {
         TypedMatchCaseKind.Else => {
           val (exprVal, exprType) = if exprTypeIsOpt |innerTy| {
             if seenNoneCase {
-              val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
-              val optInnerValue = match self._emitOptValueGetValue(innerQbeType, exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+              val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+              val optInnerValue = try self._emitOptValueGetValue(innerQbeType, exprVal)
 
               (optInnerValue, innerTy)
             } else {
@@ -1911,13 +1915,13 @@ export type Compiler {
 
       if case.binding |v| {
         val slotName = self._currentFn.block.addVar(variableToVar(v))
-        val bindingTypeQbe = match self._getQbeTypeForTypeExpect(exprType, "qbe type should exist", Some(v.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+        val bindingTypeQbe = try self._getQbeTypeForTypeExpect(exprType, "qbe type should exist", Some(v.label.position))
         val slot = self._buildStackAllocForQbeType(bindingTypeQbe, Some(slotName))
         self._currentFn.block.buildStore(bindingTypeQbe, exprVal, slot)
       }
 
       for node, idx in case.body {
-        val res = match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+        val res = try self._compileStatement(node)
         if idx == case.body.length - 1 {
           if resValSlotCtx |(slot, slotTy)| {
             if res |res| {
@@ -1958,13 +1962,13 @@ export type Compiler {
           val tupleItemSlotTy = match pat {
             BindingPattern.Variable(label) => {
               val variable = if variables[label.name] |v| v else return unreachable("expected binding '${label.name}', but missing from variables")
-              val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+              val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
               varTy
             }
             _ => QbeType.Pointer
           }
           val tupleItemVal = self._currentFn.block.buildLoad(tupleItemSlotTy, tupleItemSlot)
-          match self._compileBindingPattern(pat, variables, Some(tupleItemVal)) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._compileBindingPattern(pat, variables, Some(tupleItemVal))
         }
 
         return Ok(0)
@@ -1972,7 +1976,7 @@ export type Compiler {
     }
 
     val variable = if variables[varName] |v| v else return unreachable("expected binding '$varName', but missing from variables")
-    val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+    val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
     val slotName = self._currentFn.block.addVar(variableToVar(variable))
 
     val v = if exprVal |v| v else return Ok(0)
@@ -2012,8 +2016,7 @@ export type Compiler {
               QbeType.Pointer
             } else {
               self._currentFn.block.addComment("get captured '${variable.label.name}'")
-              val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
-              varTy
+              try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
             }
             val ptrOrValue = self._currentFn.block.buildLoad(varTy, captureSlot)
             return Ok(ptrOrValue)
@@ -2026,7 +2029,7 @@ export type Compiler {
     // parameter (simply by name) since it's an immutable variable that has not been moved to the heap.
     if variable.isParameter {
       val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'")
-      val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+      val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
       return Ok(Value.Ident(slotName, varTy))
     }
 
@@ -2041,8 +2044,7 @@ export type Compiler {
       QbeType.Pointer
     } else {
       self._currentFn.block.addComment("get captured '${variable.label.name}'")
-      val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
-      varTy
+      try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
     }
     val ptrOrValue = self._currentFn.block.buildLoad(varTy, slot)
     Ok(ptrOrValue)
@@ -2054,14 +2056,13 @@ export type Compiler {
     var cursor = capturesMem
 
     for variable in fn.captures {
-      val ptr = match self._getCapturedVarPtr(variable) { Ok(v) => v, Err(e) => return Err(e) }
+      val ptr = try self._getCapturedVarPtr(variable)
       var varTy = if variable.mutable {
         self._currentFn.block.addComment("store ptr to captured mutable '${variable.label.name}' in captures")
         QbeType.Pointer
       } else {
         self._currentFn.block.addComment("store captured '${variable.label.name}' in captures")
-        val varTy = match self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
-        varTy
+        try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
       }
       self._currentFn.block.buildStore(varTy, ptr, cursor)
       if fn.captures.length > 1 || fn.capturedClosures.length > 0 {
@@ -2070,7 +2071,7 @@ export type Compiler {
     }
 
     for capturedFn in fn.capturedClosures {
-      val capturesArr = match self._getCapturesArrForClosure(capturedFn) { Ok(v) => v, Err(e) => return Err(e) }
+      val capturesArr = try self._getCapturesArrForClosure(capturedFn)
       self._currentFn.block.buildStore(QbeType.Pointer, capturesArr, cursor)
       if fn.capturedClosures.length > 1 {
         cursor = match self._currentFn.block.buildAdd(Value.Int(QbeType.Pointer.size()), cursor) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -2125,8 +2126,8 @@ export type Compiler {
   }
 
   func _compileBinaryOperands(self, left: TypedAstNode, right: TypedAstNode, op: String): Result<(Value, Value), CompileError> {
-    var leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
-    var rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+    var leftVal = try self._compileExpression(left)
+    var rightVal = try self._compileExpression(right)
 
     if !self._project.typesAreEquivalent(left.ty, right.ty) {
       val leftIsFloat = self._typeIsFloat(left.ty)
@@ -2144,8 +2145,8 @@ export type Compiler {
   }
 
   func _compileBinaryEq(self, left: TypedAstNode, right: TypedAstNode, localName: String? = None, negate = false): Result<Value, CompileError> {
-    var leftVal = match self._compileExpression(left) { Ok(v) => v, Err(e) => return Err(e) }
-    var rightVal = match self._compileExpression(right) { Ok(v) => v, Err(e) => return Err(e) }
+    var leftVal = try self._compileExpression(left)
+    var rightVal = try self._compileExpression(right)
 
     if !self._project.typesAreEquivalent(left.ty, right.ty) return unreachable("equality operators require matching types", right.token.position)
 
@@ -2164,8 +2165,8 @@ export type Compiler {
       return Ok(res)
     }
 
-    val instType = match self._addResolvedGenericsLayerForInstanceMethod(ty, "eq", position) { Ok(v) => v, Err(e) => return Err(e) }
-    val eqFnVal = match self._getOrCompileEqMethod(instType) { Ok(v) => v, Err(e) => return Err(e) }
+    val instType = try self._addResolvedGenericsLayerForInstanceMethod(ty, "eq", position)
+    val eqFnVal = try self._getOrCompileEqMethod(instType)
     self._resolvedGenerics.popLayer()
 
     val res = match self._currentFn.block.buildCall(Callable.Function(eqFnVal), [leftVal, rightVal], localName) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -2190,7 +2191,7 @@ export type Compiler {
     val closureEnvPtr = capturesPtr ?: Value.Int(0)
 
     val (selfVal, selfTy) = if capturedSelf |(selfVal, selfType)| {
-      val selfTy = match self._getQbeTypeForTypeExpect(selfType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+      val selfTy = try self._getQbeTypeForTypeExpect(selfType, "unacceptable type for param", Some(position))
       (selfVal, Some(selfTy))
     } else {
       (Value.Int(0), None)
@@ -2264,7 +2265,7 @@ export type Compiler {
       if self._builder.getFunction(wrapperFnName) |wrapperFnVal| {
         Ok(wrapperFnVal)
       } else {
-        val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+        val returnTypeQbe = try self._getQbeTypeForType(fn.returnType)
         val wrapperFnVal = self._builder.buildFunction(name: wrapperFnName, returnType: returnTypeQbe)
 
         val prevFn = self._currentFn
@@ -2272,7 +2273,7 @@ export type Compiler {
 
         val args = if selfTy |selfTy| [wrapperFnVal.addParameter("self", selfTy)] else []
         for paramType, idx in fnValParamTypes {
-          val paramTy = match self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+          val paramTy = try self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position))
           if fn.params[idx] |param| {
             args.push(wrapperFnVal.addParameter(param.label.name, paramTy))
           } else {
@@ -2282,7 +2283,7 @@ export type Compiler {
 
         var defaultMaskFlag = 0
         for paramToDefault, idx in fn.params[targetArity:] {
-          val paramTy = match self._getQbeTypeForTypeExpect(paramToDefault.ty, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+          val paramTy = try self._getQbeTypeForTypeExpect(paramToDefault.ty, "unacceptable type for param", Some(position))
           args.push(paramTy.zeroValue())
           defaultMaskFlag ||= (1 << (firstOptionalParamIdxBeingGivenDefaultValue + idx))
         }
@@ -2313,7 +2314,7 @@ export type Compiler {
     } else {
       return unreachable("All valid cases exhausted above", position)
     }
-    val fnVal = match fnValRes { Ok(v) => v, Err(e) => return Err(e) }
+    val fnVal = try fnValRes
 
     val hasReturn = fn.returnType.kind != TypeKind.PrimitiveUnit
     val struct = self._functionStruct(targetArity, hasReturn)
@@ -2326,7 +2327,7 @@ export type Compiler {
       resolvedGenerics[name] = ty
     }
     match self._resolvedGenerics.addLayer(struct.label.name, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: struct.label.name, message: e))) }
-    val initFnVal = match self._getOrCompileStructInitializer(struct) { Ok(v) => v, Err(e) => return Err(e) }
+    val initFnVal = try self._getOrCompileStructInitializer(struct)
 
     self._resolvedGenerics.popLayer()
 
@@ -2349,7 +2350,7 @@ export type Compiler {
     val discardedParamTypeReprs: String[] = []
     for paramTy, idx in fnValParamTypes[numParams:] {
       discardedParamTypeReprs.push(paramTy.repr())
-      val (instTy, typeArgs) = match self._getInstanceTypeForType(paramTy) { Ok(v) => v, Err(e) => return Err(e) }
+      val (instTy, typeArgs) = try self._getInstanceTypeForType(paramTy)
       val instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
 
       val resolvedGenerics: Map<String, Type> = {}
@@ -2363,11 +2364,10 @@ export type Compiler {
       }
       match self._resolvedGenerics.addLayer("discarded param $idx", resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: "discarded param $idx", message: e))) }
 
-      val _paramTypeName = match instTy {
-        StructOrEnum.Struct(s) => self._structTypeName(s)
-        StructOrEnum.Enum(e) => self._enumTypeName(e)
+      val paramTypeName = match instTy {
+        StructOrEnum.Struct(s) => try self._structTypeName(s)
+        StructOrEnum.Enum(e) => try self._enumTypeName(e)
       }
-      val paramTypeName = match _paramTypeName { Ok(v) => v, Err(e) => return Err(e) }
       self._resolvedGenerics.popLayer()
 
       wrapperSuffix += "D${idx + 1}$paramTypeName"
@@ -2377,7 +2377,7 @@ export type Compiler {
 
     if self._builder.getFunction(wrapperFnName) |wrapperFnVal| return Ok(wrapperFnVal)
 
-    val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+    val returnTypeQbe = try self._getQbeTypeForType(fn.returnType)
     val wrapperFnVal = self._builder.buildFunction(name: wrapperFnName, returnType: returnTypeQbe)
 
     val prevFn = self._currentFn
@@ -2385,7 +2385,7 @@ export type Compiler {
 
     val args = if selfInstTy |selfInstTy| [wrapperFnVal.addParameter("self", selfInstTy)] else []
     for paramType, idx in fnValParamTypes {
-      val paramTy = match self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position)) { Ok(v) => v, Err(e) => return Err(e) }
+      val paramTy = try self._getQbeTypeForTypeExpect(paramType, "unacceptable type for param", Some(position))
       if fn.params[idx] |param| {
         args.push(wrapperFnVal.addParameter(param.label.name, paramTy))
       } else {
@@ -2410,7 +2410,7 @@ export type Compiler {
   }
 
   func _constructString(self, ptrVal: Value, lenVal: Value, localName: String? = None): Result<Value, CompileError> {
-    val fnVal = match self._getOrCompileStructInitializer(self._project.preludeStringStruct) { Ok(v) => v, Err(e) => return Err(e) }
+    val fnVal = try self._getOrCompileStructInitializer(self._project.preludeStringStruct)
     val structTy = if fnVal.returnType |ty| ty else return unreachable("initializer functions must have return types specified")
 
     val res = match self._currentFn.block.buildCall(Callable.Function(fnVal), [lenVal, ptrVal, Value.Int32(0)], localName) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -2454,7 +2454,7 @@ export type Compiler {
   }
 
   func _getQbeTypeForTypeExpect(self, ty: Type, reason: String, position: Position? = None): Result<QbeType, CompileError> {
-    val _ty = match self._getQbeTypeForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+    val _ty = try self._getQbeTypeForType(ty)
     if _ty |ty| Ok(ty) else if position |pos| unreachable(reason, pos) else unreachable(reason)
   }
 
@@ -2466,22 +2466,22 @@ export type Compiler {
     match segs[0] {
       AccessorPathSegment.Field => {
         // TODO: assert that `head.ty` is a pointer type (attempting to do pointer arithmetic later on will fail otherwise)
-        val (_instTy, typeArgs) = match self._getInstanceTypeForType(head.ty) { Ok(v) => v, Err(e) => return Err(e) }
+        val (_instTy, typeArgs) = try self._getInstanceTypeForType(head.ty)
         instTy = _instTy
         instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
 
-        curVal = match self._compileExpression(head) { Ok(v) => v, Err(e) => return Err(e) }
+        curVal = try self._compileExpression(head)
         self._currentFn.block.addCommentBefore("${curVal.repr()}: ${head.ty.repr()}")
       }
       AccessorPathSegment.Method(_, fn, _, _) => {
         match fn.kind {
           FunctionKind.InstanceMethod => {
             // TODO: assert that `head.ty` is a pointer type (attempting to do pointer arithmetic later on will fail otherwise)
-            val (_instTy, typeArgs) = match self._getInstanceTypeForType(head.ty) { Ok(v) => v, Err(e) => return Err(e) }
+            val (_instTy, typeArgs) = try self._getInstanceTypeForType(head.ty)
             instTy = _instTy
             instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
 
-            curVal = match self._compileExpression(head) { Ok(v) => v, Err(e) => return Err(e) }
+            curVal = try self._compileExpression(head)
             self._currentFn.block.addCommentBefore("${curVal.repr()}: ${head.ty.repr()}")
           }
           _ => {}
@@ -2493,8 +2493,8 @@ export type Compiler {
     for seg, idx in segs {
       match seg {
         AccessorPathSegment.EnumVariant(label, ty, enum_, variant) => {
-          match self._addResolvedGenericsLayerForEnumVariant(ty, variant.label.name, label.position) { Ok(v) => v, Err(e) => return Err(e) }
-          val enumVariantFn = match self._getOrCompileEnumVariantFn(enum_, variant) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._addResolvedGenericsLayerForEnumVariant(ty, variant.label.name, label.position)
+          val enumVariantFn = try self._getOrCompileEnumVariantFn(enum_, variant)
           curVal = match self._currentFn.block.buildCall(Callable.Function(enumVariantFn), []) { Ok(v) => v, Err(e) => return qbeError(e) }
           self._resolvedGenerics.popLayer()
 
@@ -2505,15 +2505,15 @@ export type Compiler {
 
           val selfInstType = match fn.kind {
             FunctionKind.InstanceMethod => {
-              val selfInstType = match self._addResolvedGenericsLayerForInstanceMethod(instType, fn.label.name, label.position) { Ok(v) => v, Err(e) => return Err(e) }
+              val selfInstType = try self._addResolvedGenericsLayerForInstanceMethod(instType, fn.label.name, label.position)
               Some(selfInstType)
             }
             _ => None
           }
-          val fnBaseVal = match self._getOrCompileMethod(instType, fn) { Ok(v) => v, Err(e) => return Err(e) }
+          val fnBaseVal = try self._getOrCompileMethod(instType, fn)
 
           val capturesMem = if fn.isClosure() {
-            val capturesArr = match self._getCapturesArrForClosure(fn) { Ok(v) => v, Err(e) => return Err(e) }
+            val capturesArr = try self._getCapturesArrForClosure(fn)
             Some(capturesArr)
           } else {
             None
@@ -2533,7 +2533,7 @@ export type Compiler {
           self._resolvedGenerics.popLayer()
 
           val selfVal = if selfInstType |selfInstType| Some((curVal, selfInstType)) else None
-          curVal = match self._compileFunctionValue(label.position, fn, fnBaseVal, targetParamTypes, capturesMem, selfVal) { Ok(v) => v, Err(e) => return Err(e) }
+          curVal = try self._compileFunctionValue(label.position, fn, fnBaseVal, targetParamTypes, capturesMem, selfVal)
         }
         AccessorPathSegment.Field(label, ty, field, isOptSafe) => {
           var optSafeCtx: (Label, Value, QbeFunction, Label)? = None
@@ -2542,10 +2542,10 @@ export type Compiler {
             val innerTy = if self._typeIsOption(ty) |innerTy| innerTy else return unreachable("an opt-safe field accessor needs to have an Option type as its lhs")
             val unwrappedInstType = if self._typeIsOption(instType) |innerTy| innerTy else return unreachable("an opt-safe field accessor needs to have an Option type as its lhs")
             instType = unwrappedInstType
-            val (_instTy, _) = match self._getInstanceTypeForType(unwrappedInstType) { Ok(v) => v, Err(e) => return Err(e) }
+            val (_instTy, _) = try self._getInstanceTypeForType(unwrappedInstType)
             instTy = _instTy
 
-            val variantIsOptionSome = match self._emitOptValueIsSomeVariant(curVal) { Ok(v) => v, Err(e) => return Err(e) }
+            val variantIsOptionSome = try self._emitOptValueIsSomeVariant(curVal)
             val labelIsSome = self._currentFn.block.addLabel("optsafe_field_is_some")
             val labelIsNone = self._currentFn.block.addLabel("optsafe_field_is_none")
             val labelCont = self._currentFn.block.addLabel("optsafe_field_cont")
@@ -2556,7 +2556,7 @@ export type Compiler {
             self._currentFn.block.registerLabel(labelIsNone)
             val optNoneVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "None") |v| v else return unreachable("Option.None must exist")
             match self._resolvedGenerics.addLayer("Option.None", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: label.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.None", message: e))) }
-            val noneVariantFn = match self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant) { Ok(v) => v, Err(e) => return Err(e) }
+            val noneVariantFn = try self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant)
             self._resolvedGenerics.popLayer()
             val noneRes = match self._currentFn.block.buildCall(Callable.Function(noneVariantFn), []) { Ok(v) => v, Err(e) => return qbeError(e) }
             self._currentFn.block.buildJmp(labelCont)
@@ -2564,13 +2564,13 @@ export type Compiler {
             self._currentFn.block.registerLabel(labelIsSome)
             val optSomeVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "Some") |v| v else return unreachable("Option.Some must exist")
             match self._resolvedGenerics.addLayer("Option.Some", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: label.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.Some", message: e))) }
-            val someVariantFn = match self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optSomeVariant) { Ok(v) => v, Err(e) => return Err(e) }
+            val someVariantFn = try self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optSomeVariant)
             self._resolvedGenerics.popLayer()
 
             optSafeCtx = Some((labelIsNone, noneRes, someVariantFn, labelCont))
 
-            val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
-            curVal = match self._emitOptValueGetValue(innerQbeType, curVal) { Ok(v) => v, Err(e) => return Err(e) }
+            val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+            curVal = try self._emitOptValueGetValue(innerQbeType, curVal)
           }
 
           match instTy {
@@ -2578,7 +2578,7 @@ export type Compiler {
               var offset = 0
               var fieldTyQbe = QbeType.F32 // placeholder sentinel value
               for f in struct.fields {
-                val fieldTy = match self._getQbeTypeForTypeExpect(f.ty, "unacceptable type for field", Some(f.name.position)) { Ok(v) => v, Err(e) => return Err(e) }
+                val fieldTy = try self._getQbeTypeForTypeExpect(f.ty, "unacceptable type for field", Some(f.name.position))
                 if f.name.name == field.name.name {
                   fieldTyQbe = fieldTy
                   break
@@ -2618,7 +2618,7 @@ export type Compiler {
             curVal = match self._currentFn.block.buildPhi(phiCases, localName) { Ok(v) => v, Err(e) => return qbeError(e) }
           }
 
-          val (_instTy, typeArgs) = match self._getInstanceTypeForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+          val (_instTy, typeArgs) = try self._getInstanceTypeForType(ty)
           instTy = _instTy
           instType = Type(kind: TypeKind.Instance(instTy, typeArgs))
         }
@@ -2629,20 +2629,20 @@ export type Compiler {
   }
 
   func _getOrCompileStructInitializer(self, struct: Struct): Result<QbeFunction, CompileError> {
-    val fnName = match self._structInitializerFnName(struct) { Ok(v) => v, Err(e) => return Err(e) }
+    val fnName = try self._structInitializerFnName(struct)
     if self._builder.getFunction(fnName) |fn| return Ok(fn)
 
     val fnVal = self._builder.buildFunction(name: fnName, returnType: Some(QbeType.Pointer))
     val prevFn = self._currentFn
     self._currentFn = fnVal
-    fnVal.addCommentMultiline(match self._structSignature(struct) { Ok(v) => v, Err(e) => return Err(e) })
+    fnVal.addCommentMultiline(try self._structSignature(struct))
 
     var defaultValueParamIdx = 0
     var defaultValuesMaskParam: Value? = None
     var addMaskParam = false
     var size = 0
     for field in struct.fields {
-      val fieldTy = match self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position)) { Ok(v) => v, Err(e) => return Err(e) }
+      val fieldTy = try self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position))
       size += fieldTy.size()
 
       if field.initializer |initializerNode| {
@@ -2662,7 +2662,7 @@ export type Compiler {
         self._currentFn.block.buildJnz(paramNeedsDefault, labelUseDefaultValue, labelUsePassedValue)
 
         self._currentFn.block.registerLabel(labelUseDefaultValue)
-        val res = match self._compileExpression(initializerNode) { Ok(v) => v, Err(e) => return Err(e) }
+        val res = try self._compileExpression(initializerNode)
         val resLabel = self._currentFn.block.currentLabel
         self._currentFn.block.buildJmp(labelCont)
 
@@ -2685,7 +2685,7 @@ export type Compiler {
 
     var offset = 0
     for field in struct.fields {
-      val fieldTy = match self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position)) { Ok(v) => v, Err(e) => return Err(e) }
+      val fieldTy = try self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position))
       val param = Value.Ident(field.name.name, fieldTy)
 
       val localName = "mem_offset_${field.name.name}"
@@ -2705,21 +2705,21 @@ export type Compiler {
   }
 
   func _getOrCompileEnumVariantFn(self, enum_: Enum, variant: TypedEnumVariant): Result<QbeFunction, CompileError> {
-    val variantFnName = match self._enumVariantFnName(enum_, variant) { Ok(v) => v, Err(e) => return Err(e) }
+    val variantFnName = try self._enumVariantFnName(enum_, variant)
     if self._builder.getFunction(variantFnName) |fn| return Ok(fn)
 
     // TODO: constant variants shouldn't be a function - it should just be a `data` segment with the proper idx set
     val fn = self._builder.buildFunction(name: variantFnName, returnType: Some(QbeType.Pointer))
     val prevFn = self._currentFn
     self._currentFn = fn
-    fn.addComment(match self._enumVariantSignature(enum_, variant) { Ok(v) => v, Err(e) => return Err(e) })
+    fn.addComment(try self._enumVariantSignature(enum_, variant))
 
     var size = 0
     size += QbeType.U64.size() // account for space for variant idx slot
     match variant.kind {
       EnumVariantKind.Container(fields) => {
         for field in fields {
-          val fieldTy = match self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position)) { Ok(v) => v, Err(e) => return Err(e) }
+          val fieldTy = try self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position))
           size += fieldTy.size()
           fn.addParameter(field.name.name, fieldTy)
         }
@@ -2736,7 +2736,7 @@ export type Compiler {
     match variant.kind {
       EnumVariantKind.Container(fields) => {
         for field in fields {
-          val fieldTy = match self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position)) { Ok(v) => v, Err(e) => return Err(e) }
+          val fieldTy = try self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position))
           val param = Value.Ident(field.name.name, fieldTy)
 
           val localName = "mem_offset_${field.name.name}"
@@ -2770,16 +2770,16 @@ export type Compiler {
     } else []
 
     val stdoutWriteFn = if self._project.preludeScope.functions.find(fn => fn.label.name == "stdoutWrite") |fn| fn else return unreachable("`stdoutWrite` must exist in prelude")
-    val stdoutWriteFnVal = match self._getOrCompileFunction(stdoutWriteFn) { Ok(v) => v, Err(e) => return Err(e) }
+    val stdoutWriteFnVal = try self._getOrCompileFunction(stdoutWriteFn)
 
     val space = self._builder.buildGlobalString(" ")
-    val spaceStr = match self._constructString(space, Value.Int(1)) { Ok(v) => v, Err(e) => return Err(e) }
+    val spaceStr = try self._constructString(space, Value.Int(1))
 
     for item, idx in varargItems {
-      val itemVal = match self._compileExpression(item) { Ok(v) => v, Err(e) => return Err(e) }
+      val itemVal = try self._compileExpression(item)
 
-      val itemInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(item.ty, "toString", item.token.position) { Ok(v) => v, Err(e) => return Err(e) }
-      val itemToStringFnVal = match self._getOrCompileToStringMethod(itemInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
+      val itemInstanceType = try self._addResolvedGenericsLayerForInstanceMethod(item.ty, "toString", item.token.position)
+      val itemToStringFnVal = try self._getOrCompileToStringMethod(itemInstanceType)
       self._resolvedGenerics.popLayer()
 
       val toStringVal = match self._currentFn.block.buildCall(Callable.Function(itemToStringFnVal), [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -2793,7 +2793,7 @@ export type Compiler {
 
     if withNewline {
       val newline = self._builder.buildGlobalString("\\n")
-      val newlineStr = match self._constructString(newline, Value.Int(1)) { Ok(v) => v, Err(e) => return Err(e) }
+      val newlineStr = try self._constructString(newline, Value.Int(1))
       self._currentFn.block.buildVoidCall(Callable.Function(stdoutWriteFnVal), [newlineStr])
     }
 
@@ -2811,14 +2811,14 @@ export type Compiler {
     val args: Value[] = []
     for arg in arguments {
       if arg |node| {
-        val arg = match self._compileExpression(node) { Ok(v) => v, Err(e) => return Err(e) }
+        val arg = try self._compileExpression(node)
         args.push(arg)
       } else {
         return unreachable("functions with @CBinding decorator cannot have optional parameters")
       }
     }
 
-    val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+    val returnTypeQbe = try self._getQbeTypeForType(fn.returnType)
     val res = if returnTypeQbe |returnTy| {
       val res = match self._currentFn.block.buildCallRaw(cFnName, returnTy, args) { Ok(v) => v, Err(e) => return qbeError(e) }
       res
@@ -2868,7 +2868,7 @@ export type Compiler {
 
         val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_is_null' has 1 required argument")
         val ptr = if _ptr |arg| arg else return unreachable("'pointer_is_null' has 1 required argument")
-        val ptrVal = match self._compileExpression(ptr) { Ok(v) => v, Err(e) => return Err(e) }
+        val ptrVal = try self._compileExpression(ptr)
 
         val labelIsNull = self._currentFn.block.addLabel("ptr_is_null")
         val labelIsNotNull = self._currentFn.block.addLabel("ptr_is_not_null")
@@ -2896,10 +2896,10 @@ export type Compiler {
 
         val _count = if arguments[0] |arg| arg else return unreachable("'pointer_malloc' has 1 required argument")
         val count = if _count |arg| arg else return unreachable("'pointer_malloc' has 1 required argument")
-        val countVal = match self._compileExpression(count) { Ok(v) => v, Err(e) => return Err(e) }
+        val countVal = try self._compileExpression(count)
 
         val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_malloc) could not resolve T for Pointer<T>")
-        val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
+        val innerTySize = try self._pointerSize(innerTy)
         val sizeVal = match self._currentFn.block.buildMul(Value.Int(innerTySize), countVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
         val mem = match self._currentFn.block.buildCall(Callable.Function(self._malloc), [sizeVal], Some("ptr.mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -2913,14 +2913,14 @@ export type Compiler {
 
         val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_realloc' has 2 required arguments")
         val ptr = if _ptr |arg| arg else return unreachable("'pointer_realloc' has 2 required arguments")
-        val ptrVal = match self._compileExpression(ptr) { Ok(v) => v, Err(e) => return Err(e) }
+        val ptrVal = try self._compileExpression(ptr)
 
         val _count = if arguments[1] |arg| arg else return unreachable("'pointer_realloc' has 2 required arguments")
         val count = if _count |arg| arg else return unreachable("'pointer_realloc' has 2 required arguments")
-        val countVal = match self._compileExpression(count) { Ok(v) => v, Err(e) => return Err(e) }
+        val countVal = try self._compileExpression(count)
 
         val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_realloc) could not resolve T for Pointer<T>")
-        val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
+        val innerTySize = try self._pointerSize(innerTy)
         val sizeVal = match self._currentFn.block.buildMul(Value.Int(innerTySize), countVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
         val mem = match self._currentFn.block.buildCall(Callable.Function(self._realloc), [ptrVal, sizeVal], Some("mem")) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -2934,15 +2934,15 @@ export type Compiler {
 
         val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_store' has 2 required arguments")
         val ptr = if _ptr |arg| arg else return unreachable("'pointer_store' has 2 required arguments")
-        val ptrVal = match self._compileExpression(ptr) { Ok(v) => v, Err(e) => return Err(e) }
+        val ptrVal = try self._compileExpression(ptr)
 
         val _value = if arguments[1] |arg| arg else return unreachable("'pointer_store' has 2 required arguments")
         val value = if _value |arg| arg else return unreachable("'pointer_store' has 2 required arguments")
-        val valueVal = match self._compileExpression(value) { Ok(v) => v, Err(e) => return Err(e) }
+        val valueVal = try self._compileExpression(value)
 
         val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_store) could not resolve T for Pointer<T>")
-        val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
-        val innerQbeType = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
+        val innerTySize = try self._pointerSize(innerTy)
+        val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
         self._currentFn.block.buildStore(innerQbeType, valueVal, ptrVal)
 
         self._currentFn.block.addComment("...pointer_store end")
@@ -2954,14 +2954,14 @@ export type Compiler {
 
         val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_offset' has 2 required arguments")
         val ptr = if _ptr |arg| arg else return unreachable("'pointer_offset' has 2 required arguments")
-        val ptrVal = match self._compileExpression(ptr) { Ok(v) => v, Err(e) => return Err(e) }
+        val ptrVal = try self._compileExpression(ptr)
 
         val _offset = if arguments[1] |arg| arg else return unreachable("'pointer_offset' has 2 required arguments")
         val offset = if _offset |arg| arg else return unreachable("'pointer_offset' has 2 required arguments")
-        val offsetVal = match self._compileExpression(offset) { Ok(v) => v, Err(e) => return Err(e) }
+        val offsetVal = try self._compileExpression(offset)
 
         val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_offset) could not resolve T for Pointer<T>")
-        val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
+        val innerTySize = try self._pointerSize(innerTy)
         val sizeVal = match self._currentFn.block.buildMul(Value.Int(innerTySize), offsetVal) { Ok(v) => v, Err(e) => return qbeError(e) }
 
         val mem = match self._currentFn.block.buildAdd(sizeVal, ptrVal) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -2975,7 +2975,7 @@ export type Compiler {
 
         val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_load' has 1 required argument")
         val ptr = if _ptr |arg| arg else return unreachable("'pointer_load' has 1 required argument")
-        val ptrVal = match self._compileExpression(ptr) { Ok(v) => v, Err(e) => return Err(e) }
+        val ptrVal = try self._compileExpression(ptr)
 
         val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_load) could not resolve T for Pointer<T>")
 
@@ -2990,7 +2990,7 @@ export type Compiler {
           _ => false
         }
         val innerQbeType = if isByte QbeType.U8 else {
-          val res = match self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None) { Ok(v) => v, Err(e) => return Err(e) }
+          val res = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
           res
         }
 
@@ -3005,18 +3005,18 @@ export type Compiler {
 
         val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
         val ptr = if _ptr |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
-        val ptrVal = match self._compileExpression(ptr) { Ok(v) => v, Err(e) => return Err(e) }
+        val ptrVal = try self._compileExpression(ptr)
 
         val _other = if arguments[1] |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
         val other = if _other |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
-        val otherVal = match self._compileExpression(other) { Ok(v) => v, Err(e) => return Err(e) }
+        val otherVal = try self._compileExpression(other)
 
         val _size = if arguments[2] |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
         val size = if _size |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
-        val sizeArg = match self._compileExpression(size) { Ok(v) => v, Err(e) => return Err(e) }
+        val sizeArg = try self._compileExpression(size)
 
         val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_copy_from) could not resolve T for Pointer<T>")
-        val innerTySize = match self._pointerSize(innerTy) { Ok(v) => v, Err(e) => return Err(e) }
+        val innerTySize = try self._pointerSize(innerTy)
         val sizeVal = match self._currentFn.block.buildMul(Value.Int(innerTySize), sizeArg) { Ok(v) => v, Err(e) => return qbeError(e) }
 
         self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [ptrVal, otherVal, sizeVal])
@@ -3046,7 +3046,7 @@ export type Compiler {
 
         val _arg = if arguments[0] |arg| arg else return unreachable("'byte_from_int' has 1 required argument")
         val arg = if _arg |arg| arg else return unreachable("'byte_from_int' has 1 required argument")
-        val argVal = match self._compileExpression(arg) { Ok(v) => v, Err(e) => return Err(e) }
+        val argVal = try self._compileExpression(arg)
 
         self._currentFn.block.addComment("...byte_from_int end")
 
@@ -3057,7 +3057,7 @@ export type Compiler {
 
         val _arg = if arguments[0] |arg| arg else return unreachable("'byte_as_int' has 1 required argument")
         val arg = if _arg |arg| arg else return unreachable("'byte_as_int' has 1 required argument")
-        val argVal = match self._compileExpression(arg) { Ok(v) => v, Err(e) => return Err(e) }
+        val argVal = try self._compileExpression(arg)
 
         self._currentFn.block.addComment("...byte_as_int end")
 
@@ -3068,7 +3068,7 @@ export type Compiler {
 
         val _arg = if arguments[0] |arg| arg else return unreachable("'int_as_float' has 1 required argument")
         val arg = if _arg |arg| arg else return unreachable("'int_as_float' has 1 required argument")
-        val argVal = match self._compileExpression(arg) { Ok(v) => v, Err(e) => return Err(e) }
+        val argVal = try self._compileExpression(arg)
 
         val res = self._currentFn.block.buildLToF(argVal)
 
@@ -3081,7 +3081,7 @@ export type Compiler {
 
         val _arg = if arguments[0] |arg| arg else return unreachable("'float_as_int' has 1 required argument")
         val arg = if _arg |arg| arg else return unreachable("'float_as_int' has 1 required argument")
-        val argVal = match self._compileExpression(arg) { Ok(v) => v, Err(e) => return Err(e) }
+        val argVal = try self._compileExpression(arg)
 
         val res = self._currentFn.block.buildFToL(argVal)
 
@@ -3094,7 +3094,7 @@ export type Compiler {
 
         val _arg = if arguments[0] |arg| arg else return unreachable("'float_floor' has 1 required argument")
         val arg = if _arg |arg| arg else return unreachable("'float_floor' has 1 required argument")
-        val argVal = match self._compileExpression(arg) { Ok(v) => v, Err(e) => return Err(e) }
+        val argVal = try self._compileExpression(arg)
 
         val floorRes = match self._currentFn.block.buildCallRaw("floor", QbeType.F64, [argVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
         val res = self._currentFn.block.buildFToL(floorRes)
@@ -3108,7 +3108,7 @@ export type Compiler {
 
         val _arg = if arguments[0] |arg| arg else return unreachable("'float_ceil' has 1 required argument")
         val arg = if _arg |arg| arg else return unreachable("'float_ceil' has 1 required argument")
-        val argVal = match self._compileExpression(arg) { Ok(v) => v, Err(e) => return Err(e) }
+        val argVal = try self._compileExpression(arg)
 
         val ceilRes = match self._currentFn.block.buildCallRaw("ceil", QbeType.F64, [argVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
         val res = self._currentFn.block.buildFToL(ceilRes)
@@ -3122,7 +3122,7 @@ export type Compiler {
 
         val _arg = if arguments[0] |arg| arg else return unreachable("'float_round' has 1 required argument")
         val arg = if _arg |arg| arg else return unreachable("'float_round' has 1 required argument")
-        val argVal = match self._compileExpression(arg) { Ok(v) => v, Err(e) => return Err(e) }
+        val argVal = try self._compileExpression(arg)
 
         val roundRes = match self._currentFn.block.buildCallRaw("round", QbeType.F64, [argVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
         val res = self._currentFn.block.buildFToL(roundRes)
@@ -3153,12 +3153,12 @@ export type Compiler {
     val fnName = self._fnName(fn)
     if self._builder.getFunction(fnName) |fn| return Ok(fn)
 
-    val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+    val returnTypeQbe = try self._getQbeTypeForType(fn.returnType)
     val fnVal = self._builder.buildFunction(name: fnName, returnType: returnTypeQbe)
     if fn.isClosure() fnVal.addEnv()
 
-    match self._compileFunc(fnVal, fn) { Ok(v) => v, Err(e) => return Err(e) }
-    fnVal.addComment(match self._fnSignature(None, fn) { Ok(v) => v, Err(e) => return Err(e) })
+    try self._compileFunc(fnVal, fn)
+    fnVal.addComment(try self._fnSignature(None, fn))
 
     Ok(fnVal)
   }
@@ -3169,22 +3169,22 @@ export type Compiler {
     if isInstanceMethod && fn.label.name == "eq" && fn.isGenerated return self._getOrCompileEqMethod(selfType)
     if isInstanceMethod && fn.label.name == "hash" && fn.isGenerated return self._getOrCompileHashMethod(selfType)
 
-    val (selfTy, _) = match self._getInstanceTypeForType(selfType) { Ok(v) => v, Err(e) => return Err(e) }
-    val methodName = match self._methodFnName(selfTy, fn) { Ok(v) => v, Err(e) => return Err(e) }
+    val (selfTy, _) = try self._getInstanceTypeForType(selfType)
+    val methodName = try self._methodFnName(selfTy, fn)
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
 
-    val returnTypeQbe = match self._getQbeTypeForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+    val returnTypeQbe = try self._getQbeTypeForType(fn.returnType)
     val fnVal = self._builder.buildFunction(name: methodName, returnType: returnTypeQbe)
     if fn.isClosure() fnVal.addEnv()
 
     if isInstanceMethod {
-      val selfTyQbe = match self._getQbeTypeForTypeExpect(selfType, "unacceptable type for self") { Ok(v) => v, Err(e) => return Err(e) }
+      val selfTyQbe = try self._getQbeTypeForTypeExpect(selfType, "unacceptable type for self")
       fnVal.addParameter("self", selfTyQbe)
       val selfVariable = if fn.scope.variables.find(v => v.label.name == "self") |selfVariable| selfVariable else return unreachable("Function '${fn.label.name}' is an instance method but does not have a variable 'self' in its scope", fn.label.position)
       fnVal.block.addVar(variableToVar(selfVariable), Some("self"))
     }
-    match self._compileFunc(fnVal, fn) { Ok(v) => v, Err(e) => return Err(e) }
-    fnVal.addComment(match self._fnSignature(Some(selfTy), fn) { Ok(v) => v, Err(e) => return Err(e) })
+    try self._compileFunc(fnVal, fn)
+    fnVal.addComment(try self._fnSignature(Some(selfTy), fn))
 
     Ok(fnVal)
   }
@@ -3199,7 +3199,7 @@ export type Compiler {
     var defaultValuesMaskParam: Value? = None
     var addMaskParam = false
     for param in fn.params {
-      val paramTy = match self._getQbeTypeForTypeExpect(param.ty, "unacceptable type for param", Some(param.label.position)) { Ok(v) => v, Err(e) => return Err(e) }
+      val paramTy = try self._getQbeTypeForTypeExpect(param.ty, "unacceptable type for param", Some(param.label.position))
 
       if param.defaultValue |defaultValueNode| {
         val paramLocal = fnVal.addParameter("${param.label.name}_", paramTy)
@@ -3218,7 +3218,7 @@ export type Compiler {
         self._currentFn.block.buildJnz(paramNeedsDefault, labelUseDefaultValue, labelUsePassedValue)
 
         self._currentFn.block.registerLabel(labelUseDefaultValue)
-        val res = match self._compileExpression(defaultValueNode) { Ok(v) => v, Err(e) => return Err(e) }
+        val res = try self._compileExpression(defaultValueNode)
         val resLabel = self._currentFn.block.currentLabel
         self._currentFn.block.buildJmp(labelCont)
 
@@ -3241,7 +3241,7 @@ export type Compiler {
 
     var retVal: Value? = None
     for node, idx in fn.body {
-      val res = match self._compileStatement(node) { Ok(v) => v, Err(e) => return Err(e) }
+      val res = try self._compileStatement(node)
       if idx == fn.body.length - 1 && fn.returnType.kind != TypeKind.PrimitiveUnit {
         retVal = res
       }
@@ -3258,7 +3258,7 @@ export type Compiler {
   }
 
   func _getOrCompileToStringMethod(self, ty: Type): Result<QbeFunction, CompileError> {
-    val (selfTy, typeArgs) = match self._getInstanceTypeForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+    val (selfTy, typeArgs) = try self._getInstanceTypeForType(ty)
     val (methodName, fn) = match selfTy {
       StructOrEnum.Struct(struct) => {
         if struct == self._project.preludeIntStruct return self._getOrCompileIntToStringMethod()
@@ -3269,13 +3269,13 @@ export type Compiler {
         val _fn = struct.instanceMethods.find(m => m.label.name == "toString")
         val fn = if _fn |f| f else return unreachable("every struct has a toString method defined")
 
-        (match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }, fn)
+        (try self._structMethodFnName(struct, fn), fn)
       }
       StructOrEnum.Enum(enum_) => {
         val _fn = enum_.instanceMethods.find(m => m.label.name == "toString")
         val fn = if _fn |f| f else return unreachable("every enum has a toString method defined")
 
-        (match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }, fn)
+        (try self._enumMethodFnName(enum_, fn), fn)
       }
     }
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
@@ -3286,12 +3286,12 @@ export type Compiler {
   }
 
   func _compileGeneratedToStringMethod(self, selfType: Type, fn: Function): Result<QbeFunction, CompileError> {
-    val stringTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+    val stringTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist")
 
-    val (selfTy, typeArgs) = match self._getInstanceTypeForType(selfType) { Ok(v) => v, Err(e) => return Err(e) }
+    val (selfTy, typeArgs) = try self._getInstanceTypeForType(selfType)
     val selfInstanceTy = Type(kind: TypeKind.Instance(selfTy, typeArgs))
 
-    val methodName = match self._methodFnName(selfTy, fn) { Ok(v) => v, Err(e) => return Err(e) }
+    val methodName = try self._methodFnName(selfTy, fn)
 
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(stringTypeQbe))
     val prevFn = self._currentFn
@@ -3299,7 +3299,7 @@ export type Compiler {
     val prevFunction = self._currentFunction
     self._currentFunction = Some(fn)
 
-    val selfTyQbe = match self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self") { Ok(v) => v, Err(e) => return Err(e) }
+    val selfTyQbe = try self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self")
     val selfParamVal = fnVal.addParameter("self", selfTyQbe)
 
     match selfTy {
@@ -3308,7 +3308,7 @@ export type Compiler {
 
         if self._isFunctionStruct(struct) {
           val str = self._builder.buildGlobalString("<#function>")
-          val res = match self._constructString(str, Value.Int(11)) { Ok(v) => v, Err(e) => return Err(e) }
+          val res = try self._constructString(str, Value.Int(11))
 
           self._currentFn.block.buildReturn(Some(res))
         } else {
@@ -3319,7 +3319,7 @@ export type Compiler {
           }
 
           val prefix = if isTuple "" else struct.label.name
-          val res = match self._emitToStringLogicForStructuredData(prefix, selfParamVal, data) { Ok(v) => v, Err(e) => return Err(e) }
+          val res = try self._emitToStringLogicForStructuredData(prefix, selfParamVal, data)
           self._currentFn.block.buildReturn(Some(res))
         }
       }
@@ -3349,7 +3349,7 @@ export type Compiler {
           match variant.kind {
             EnumVariantKind.Constant => {
               val variantNameStr = self._builder.buildGlobalString(variantName)
-              val retVal = match self._constructString(variantNameStr, Value.Int(variantName.length)) { Ok(v) => v, Err(e) => return Err(e) }
+              val retVal = try self._constructString(variantNameStr, Value.Int(variantName.length))
               self._currentFn.block.buildReturn(Some(retVal))
             }
             EnumVariantKind.Container(fields) => {
@@ -3357,8 +3357,8 @@ export type Compiler {
               for field in fields {
                 data.push((field.name.name, field.name.position, field.ty))
               }
-              val ptr = match self._emitGetEnumVariantValueStart(selfParamVal) { Ok(v) => v, Err(e) => return Err(e) }
-              val retVal = match self._emitToStringLogicForStructuredData(variantName, ptr, data) { Ok(v) => v, Err(e) => return Err(e) }
+              val ptr = try self._emitGetEnumVariantValueStart(selfParamVal)
+              val retVal = try self._emitToStringLogicForStructuredData(variantName, ptr, data)
               self._currentFn.block.buildReturn(Some(retVal))
             }
           }
@@ -3369,7 +3369,7 @@ export type Compiler {
       }
     }
 
-    fnVal.addComment(match self._fnSignature(Some(selfTy), fn) { Ok(v) => v, Err(e) => return Err(e) })
+    fnVal.addComment(try self._fnSignature(Some(selfTy), fn))
 
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
@@ -3390,11 +3390,11 @@ export type Compiler {
       // If the item label is meant to be output, account for the label as well as ':' and ' ' between the label and the value
       if !itemName.isEmpty() { len += (itemName.length + 2) }
 
-      val itemInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(itemType, "toString", itemPosition) { Ok(v) => v, Err(e) => return Err(e) }
-      val itemToStringFnVal = match self._getOrCompileToStringMethod(itemInstanceType) { Ok(v) => v, Err(e) => return Err(e) }
+      val itemInstanceType = try self._addResolvedGenericsLayerForInstanceMethod(itemType, "toString", itemPosition)
+      val itemToStringFnVal = try self._getOrCompileToStringMethod(itemInstanceType)
       self._resolvedGenerics.popLayer()
 
-      val itemTy = match self._getQbeTypeForTypeExpect(itemType, "unacceptable type for item", Some(itemPosition)) { Ok(v) => v, Err(e) => return Err(e) }
+      val itemTy = try self._getQbeTypeForTypeExpect(itemType, "unacceptable type for item", Some(itemPosition))
       val itemIsString = self._typeIsString(itemInstanceType)
 
       val memCursorLocalName = if itemName.isEmpty() "$idx" else itemName
@@ -3416,7 +3416,7 @@ export type Compiler {
 
     val totalLengthVal = match self._currentFn.block.buildAdd(Value.Int(len), lenVal) { Ok(v) => v, Err(e) => return qbeError(e) }
     val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
-    val stringWithLengthFnVal = match self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn) { Ok(v) => v, Err(e) => return Err(e) }
+    val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
     val newStr = match self._currentFn.block.buildCall(Callable.Function(stringWithLengthFnVal), [totalLengthVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
     var newStrBuf = self._currentFn.block.buildLoadL(match self._currentFn.block.buildAdd(Value.Int(8), newStr) { Ok(v) => v, Err(e) => return qbeError(e) })
@@ -3473,10 +3473,10 @@ export type Compiler {
   }
 
   func _getOrCompileIntToStringMethod(self): Result<QbeFunction, CompileError> {
-    val stringTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
-    val intTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+    val stringTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist")
+    val intTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist")
 
-    val typeName = match self._structTypeName(self._project.preludeIntStruct) { Ok(v) => v, Err(e) => return Err(e) }
+    val typeName = try self._structTypeName(self._project.preludeIntStruct)
     val methodName = "$typeName..toString"
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
 
@@ -3494,7 +3494,7 @@ export type Compiler {
     val mem = match fnVal.block.buildCall(Callable.Function(self._malloc), [mallocSizeVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
     match fnVal.block.buildCall(Callable.Function(self._snprintf), [mem, mallocSizeVal, intFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-    val str = match self._constructString(mem, sizeVal) { Ok(v) => v, Err(e) => return Err(e) }
+    val str = try self._constructString(mem, sizeVal)
     fnVal.block.buildReturn(Some(str))
 
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -3505,10 +3505,10 @@ export type Compiler {
   }
 
   func _getOrCompileFloatToStringMethod(self): Result<QbeFunction, CompileError> {
-    val stringTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
-    val floatTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveFloat), "float qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+    val stringTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist")
+    val floatTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveFloat), "float qbe type should exist")
 
-    val typeName = match self._structTypeName(self._project.preludeFloatStruct) { Ok(v) => v, Err(e) => return Err(e) }
+    val typeName = try self._structTypeName(self._project.preludeFloatStruct)
     val methodName = "$typeName..toString"
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
 
@@ -3526,7 +3526,7 @@ export type Compiler {
     val mem = match fnVal.block.buildCall(Callable.Function(self._malloc), [mallocSizeVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
     match fnVal.block.buildCall(Callable.Function(self._snprintf), [mem, mallocSizeVal, floatFmtPtr, selfParam]) { Ok(v) => v, Err(e) => return qbeError(e) }
 
-    val str = match self._constructString(mem, sizeVal) { Ok(v) => v, Err(e) => return Err(e) }
+    val str = try self._constructString(mem, sizeVal)
     fnVal.block.buildReturn(Some(str))
 
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -3537,10 +3537,10 @@ export type Compiler {
   }
 
   func _getOrCompileBoolToStringMethod(self): Result<QbeFunction, CompileError> {
-    val stringTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
-    val boolTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+    val stringTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist")
+    val boolTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist")
 
-    val typeName = match self._structTypeName(self._project.preludeBoolStruct) { Ok(v) => v, Err(e) => return Err(e) }
+    val typeName = try self._structTypeName(self._project.preludeBoolStruct)
     val methodName = "$typeName..toString"
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
 
@@ -3557,12 +3557,12 @@ export type Compiler {
 
     fnVal.block.registerLabel(labelIfTrue)
     val trueStrData = self._builder.buildGlobalString("true")
-    val trueStr = match self._constructString(trueStrData, Value.Int(4)) { Ok(v) => v, Err(e) => return Err(e) }
+    val trueStr = try self._constructString(trueStrData, Value.Int(4))
     fnVal.block.buildReturn(Some(trueStr))
 
     fnVal.block.registerLabel(labelIfFalse)
     val falseStrData = self._builder.buildGlobalString("false")
-    val falseStr = match self._constructString(falseStrData, Value.Int(5)) { Ok(v) => v, Err(e) => return Err(e) }
+    val falseStr = try self._constructString(falseStrData, Value.Int(5))
     fnVal.block.buildReturn(Some(falseStr))
 
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -3573,9 +3573,9 @@ export type Compiler {
   }
 
   func _getOrCompileStringToStringMethod(self): Result<QbeFunction, CompileError> {
-    val stringTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+    val stringTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveString), "string qbe type should exist")
 
-    val typeName = match self._structTypeName(self._project.preludeStringStruct) { Ok(v) => v, Err(e) => return Err(e) }
+    val typeName = try self._structTypeName(self._project.preludeStringStruct)
     val methodName = "$typeName..toString"
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
 
@@ -3595,14 +3595,14 @@ export type Compiler {
   }
 
   func _getOrCompileEqMethod(self, ty: Type): Result<QbeFunction, CompileError> {
-    val (selfTy, _) = match self._getInstanceTypeForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+    val (selfTy, _) = try self._getInstanceTypeForType(ty)
     val (methodName, fn) = match selfTy {
       StructOrEnum.Struct(struct) => {
-        val boolTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+        val boolTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist")
 
         // TODO: surely there's a cleaner way to represent these built-in eq methods
         if struct == self._project.preludeIntStruct {
-          val intTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+          val intTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist")
 
           val methodName = "Int..eq"
           if self._builder.getFunction(methodName) |fn| return Ok(fn)
@@ -3624,7 +3624,7 @@ export type Compiler {
           return Ok(fnVal)
         }
         if struct == self._project.preludeFloatStruct {
-          val floatTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveFloat), "float qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+          val floatTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveFloat), "float qbe type should exist")
 
           val methodName = "Float..eq"
           if self._builder.getFunction(methodName) |fn| return Ok(fn)
@@ -3669,13 +3669,13 @@ export type Compiler {
         val _fn = struct.instanceMethods.find(m => m.label.name == "eq")
         val fn = if _fn |f| f else return unreachable("every struct has an eq method defined")
 
-        (match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }, fn)
+        (try self._structMethodFnName(struct, fn), fn)
       }
       StructOrEnum.Enum(enum_) => {
         val _fn = enum_.instanceMethods.find(m => m.label.name == "eq")
         val fn = if _fn |f| f else return unreachable("every enum has an eq method defined")
 
-        (match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }, fn)
+        (try self._enumMethodFnName(enum_, fn), fn)
       }
     }
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
@@ -3686,12 +3686,12 @@ export type Compiler {
   }
 
   func _compileGeneratedEqMethod(self, selfType: Type, fn: Function): Result<QbeFunction, CompileError> {
-    val boolTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+    val boolTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist")
 
-    val (selfTy, typeArgs) = match self._getInstanceTypeForType(selfType) { Ok(v) => v, Err(e) => return Err(e) }
+    val (selfTy, typeArgs) = try self._getInstanceTypeForType(selfType)
     val selfInstanceTy = Type(kind: TypeKind.Instance(selfTy, typeArgs))
 
-    val methodName = match self._methodFnName(selfTy, fn) { Ok(v) => v, Err(e) => return Err(e) }
+    val methodName = try self._methodFnName(selfTy, fn)
 
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(boolTypeQbe))
     val prevFn = self._currentFn
@@ -3699,7 +3699,7 @@ export type Compiler {
     val prevFunction = self._currentFunction
     self._currentFunction = Some(fn)
 
-    val selfTyQbe = match self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self") { Ok(v) => v, Err(e) => return Err(e) }
+    val selfTyQbe = try self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self")
     val selfParamVal = fnVal.addParameter("self", selfTyQbe)
     val otherParamVal = fnVal.addParameter("other", selfTyQbe)
 
@@ -3713,7 +3713,7 @@ export type Compiler {
           data.push((fieldName, field.name.position, field.ty))
         }
 
-        match self._emitEqLogicForStructuredData(selfParamVal, otherParamVal, data) { Ok(v) => v, Err(e) => return Err(e) }
+        try self._emitEqLogicForStructuredData(selfParamVal, otherParamVal, data)
       }
       StructOrEnum.Enum(enum_) => {
         val selfVariantIdxVal = self._emitGetEnumVariantIdx(selfParamVal)
@@ -3760,9 +3760,9 @@ export type Compiler {
               for field in fields {
                 data.push((field.name.name, field.name.position, field.ty))
               }
-              val selfPtr = match self._emitGetEnumVariantValueStart(selfParamVal) { Ok(v) => v, Err(e) => return Err(e) }
-              val otherPtr = match self._emitGetEnumVariantValueStart(otherParamVal) { Ok(v) => v, Err(e) => return Err(e) }
-              match self._emitEqLogicForStructuredData(selfPtr, otherPtr, data) { Ok(v) => v, Err(e) => return Err(e) }
+              val selfPtr = try self._emitGetEnumVariantValueStart(selfParamVal)
+              val otherPtr = try self._emitGetEnumVariantValueStart(otherParamVal)
+              try self._emitEqLogicForStructuredData(selfPtr, otherPtr, data)
             }
           }
         }
@@ -3772,7 +3772,7 @@ export type Compiler {
       }
     }
 
-    fnVal.addComment(match self._fnSignature(Some(selfTy), fn) { Ok(v) => v, Err(e) => return Err(e) })
+    fnVal.addComment(try self._fnSignature(Some(selfTy), fn))
 
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
@@ -3785,7 +3785,7 @@ export type Compiler {
   func _emitEqLogicForStructuredData(self, selfPtr: Value, otherPtr: Value, data: (String, Position, Type)[]): Result<Int, CompileError> {
     var offset = 0
     for (itemName, itemPosition, itemType) in data {
-      val itemTy = match self._getQbeTypeForTypeExpect(itemType, "unacceptable type for item", Some(itemPosition)) { Ok(v) => v, Err(e) => return Err(e) }
+      val itemTy = try self._getQbeTypeForTypeExpect(itemType, "unacceptable type for item", Some(itemPosition))
 
       val selfMemCursor = match self._currentFn.block.buildAdd(Value.Int(offset), selfPtr, Some("self_mem_offset_$itemName")) { Ok(v) => v, Err(e) => return qbeError(e) }
       val selfItemVal = self._currentFn.block.buildLoad(itemTy, selfMemCursor)
@@ -3795,7 +3795,7 @@ export type Compiler {
       val labelNeq = self._currentFn.block.addLabel("${itemName}_vals_not_equal")
       val labelEq = self._currentFn.block.addLabel("${itemName}_vals_equal")
 
-      val fieldsEqVal = match self._compileEqLogic(selfItemVal, otherItemVal, itemType, itemPosition) { Ok(v) => v, Err(e) => return Err(e) }
+      val fieldsEqVal = try self._compileEqLogic(selfItemVal, otherItemVal, itemType, itemPosition)
       self._currentFn.block.buildJnz(fieldsEqVal, labelEq, labelNeq)
 
       self._currentFn.block.registerLabel(labelNeq)
@@ -3814,10 +3814,10 @@ export type Compiler {
   }
 
   func _getOrCompileHashMethod(self, ty: Type): Result<QbeFunction, CompileError> {
-    val (selfTy, _) = match self._getInstanceTypeForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+    val (selfTy, _) = try self._getInstanceTypeForType(ty)
     val (methodName, fn) = match selfTy {
       StructOrEnum.Struct(struct) => {
-        val intTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+        val intTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist")
 
         // TODO: surely there's a cleaner way to represent these built-in hash methods
         if struct == self._project.preludeIntStruct {
@@ -3839,7 +3839,7 @@ export type Compiler {
           return Ok(fnVal)
         }
         if struct == self._project.preludeFloatStruct {
-          val floatTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveFloat), "float qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+          val floatTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveFloat), "float qbe type should exist")
 
           val methodName = "Float..hash"
           if self._builder.getFunction(methodName) |fn| return Ok(fn)
@@ -3860,7 +3860,7 @@ export type Compiler {
           return Ok(fnVal)
         }
         if struct == self._project.preludeBoolStruct {
-          val boolTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+          val boolTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist")
 
           val methodName = "Bool..hash"
           if self._builder.getFunction(methodName) |fn| return Ok(fn)
@@ -3884,13 +3884,13 @@ export type Compiler {
         val _fn = struct.instanceMethods.find(m => m.label.name == "hash")
         val fn = if _fn |f| f else return unreachable("every struct has a hash method defined")
 
-        (match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }, fn)
+        (try self._structMethodFnName(struct, fn), fn)
       }
       StructOrEnum.Enum(enum_) => {
         val _fn = enum_.instanceMethods.find(m => m.label.name == "hash")
         val fn = if _fn |f| f else return unreachable("every enum has a hash method defined")
 
-        (match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }, fn)
+        (try self._enumMethodFnName(enum_, fn), fn)
       }
     }
     if self._builder.getFunction(methodName) |fn| return Ok(fn)
@@ -3901,12 +3901,12 @@ export type Compiler {
   }
 
   func _compileGeneratedHashMethod(self, selfType: Type, fn: Function): Result<QbeFunction, CompileError> {
-    val intTypeQbe = match self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist") { Ok(v) => v, Err(e) => return Err(e) }
+    val intTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist")
 
-    val (selfTy, typeArgs) = match self._getInstanceTypeForType(selfType) { Ok(v) => v, Err(e) => return Err(e) }
+    val (selfTy, typeArgs) = try self._getInstanceTypeForType(selfType)
     val selfInstanceTy = Type(kind: TypeKind.Instance(selfTy, typeArgs))
 
-    val methodName = match self._methodFnName(selfTy, fn) { Ok(v) => v, Err(e) => return Err(e) }
+    val methodName = try self._methodFnName(selfTy, fn)
 
     val fnVal = self._builder.buildFunction(name: methodName, returnType: Some(intTypeQbe))
     val prevFn = self._currentFn
@@ -3914,7 +3914,7 @@ export type Compiler {
     val prevFunction = self._currentFunction
     self._currentFunction = Some(fn)
 
-    val selfTyQbe = match self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self") { Ok(v) => v, Err(e) => return Err(e) }
+    val selfTyQbe = try self._getQbeTypeForTypeExpect(selfInstanceTy, "unacceptable type for self")
     val selfParamVal = fnVal.addParameter("self", selfTyQbe)
 
     match selfTy {
@@ -3926,7 +3926,7 @@ export type Compiler {
           data.push((fieldName, field.name.position, field.ty))
         }
 
-        match self._emitHashLogicForStructuredData(selfParamVal, data) { Ok(v) => v, Err(e) => return Err(e) }
+        try self._emitHashLogicForStructuredData(selfParamVal, data)
       }
       StructOrEnum.Enum(enum_) => {
         val variantIdxVal = self._emitGetEnumVariantIdx(selfParamVal)
@@ -3959,8 +3959,8 @@ export type Compiler {
               for field in fields {
                 data.push((field.name.name, field.name.position, field.ty))
               }
-              val selfPtr = match self._emitGetEnumVariantValueStart(selfParamVal) { Ok(v) => v, Err(e) => return Err(e) }
-              match self._emitHashLogicForStructuredData(selfPtr, data) { Ok(v) => v, Err(e) => return Err(e) }
+              val selfPtr = try self._emitGetEnumVariantValueStart(selfParamVal)
+              try self._emitHashLogicForStructuredData(selfPtr, data)
             }
           }
         }
@@ -3970,7 +3970,7 @@ export type Compiler {
       }
     }
 
-    fnVal.addComment(match self._fnSignature(Some(selfTy), fn) { Ok(v) => v, Err(e) => return Err(e) })
+    fnVal.addComment(try self._fnSignature(Some(selfTy), fn))
 
     match fnVal.block.verify() { Ok(v) => v, Err(e) => return qbeError(e) }
 
@@ -3984,13 +3984,13 @@ export type Compiler {
     var retVal = Value.Int(1)
     var offset = 0
     for (itemName, itemPosition, itemType) in data {
-      val itemTy = match self._getQbeTypeForTypeExpect(itemType, "unacceptable type for item", Some(itemPosition)) { Ok(v) => v, Err(e) => return Err(e) }
+      val itemTy = try self._getQbeTypeForTypeExpect(itemType, "unacceptable type for item", Some(itemPosition))
 
       val memCursor = match self._currentFn.block.buildAdd(Value.Int(offset), selfPtr, Some("self_mem_offset_$itemName")) { Ok(v) => v, Err(e) => return qbeError(e) }
       val itemVal = self._currentFn.block.buildLoad(itemTy, memCursor)
 
-      val itemInstanceType = match self._addResolvedGenericsLayerForInstanceMethod(itemType, "hash", itemPosition) { Ok(v) => v, Err(e) => return Err(e) }
-      val itemHashFnVal = match self._getOrCompileHashMethod(itemType) { Ok(v) => v, Err(e) => return Err(e) }
+      val itemInstanceType = try self._addResolvedGenericsLayerForInstanceMethod(itemType, "hash", itemPosition)
+      val itemHashFnVal = try self._getOrCompileHashMethod(itemType)
       self._resolvedGenerics.popLayer()
 
       val itemHashVal = match self._currentFn.block.buildCall(Callable.Function(itemHashFnVal), [itemVal]) { Ok(v) => v, Err(e) => return qbeError(e) }
@@ -4036,7 +4036,7 @@ export type Compiler {
   }
 
   func _emitOptValueGetValue(self, ty: QbeType, exprVal: Value): Result<Value, CompileError> {
-    val valueSlot = match self._emitGetEnumVariantValueStart(exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+    val valueSlot = try self._emitGetEnumVariantValueStart(exprVal)
     val value = self._currentFn.block.buildLoad(ty, valueSlot)
 
     Ok(value)
@@ -4055,14 +4055,14 @@ export type Compiler {
   }
 
   func _emitResultValueGetValue(self, ty: QbeType, exprVal: Value): Result<Value, CompileError> {
-    val valueSlot = match self._emitGetEnumVariantValueStart(exprVal) { Ok(v) => v, Err(e) => return Err(e) }
+    val valueSlot = try self._emitGetEnumVariantValueStart(exprVal)
     val value = self._currentFn.block.buildLoad(ty, valueSlot)
 
     Ok(value)
   }
 
   func _addResolvedGenericsLayerForInstanceMethod(self, ty: Type, methodName: String, position: Position, resolvedGenerics: Map<String, Type> = {}): Result<Type, CompileError> {
-    val (structOrEnum, typeArgs) = match self._getInstanceTypeForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+    val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(ty)
     val (template, selfInstanceType) = match structOrEnum {
       StructOrEnum.Struct(struct) => {
         val template = Type(kind: TypeKind.Instance(structOrEnum, struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
@@ -4090,7 +4090,7 @@ export type Compiler {
   }
 
   func _addResolvedGenericsLayerForEnumVariant(self, ty: Type, variantName: String, position: Position, resolvedGenerics: Map<String, Type> = {}): Result<Type, CompileError> {
-    val (structOrEnum, typeArgs) = match self._getInstanceTypeForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+    val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(ty)
     match structOrEnum {
       StructOrEnum.Struct => unreachable("type should always be an enum here")
       StructOrEnum.Enum(enum_) => {
@@ -4187,7 +4187,7 @@ export type Compiler {
         if !typeParams.isEmpty() {
           val params: String[] = []
           for p in typeParams {
-            params.push(match self._getReprForType(p) { Ok(v) => v, Err(e) => return Err(e) })
+            params.push(try self._getReprForType(p))
           }
 
           Ok("$n<${params.join(", ")}>")
@@ -4223,7 +4223,7 @@ export type Compiler {
         if !typeParams.isEmpty() {
           val params: String[] = []
           for p in typeParams {
-            params.push(match self._getNameForType(p) { Ok(v) => v, Err(e) => return Err(e) })
+            params.push(try self._getNameForType(p))
           }
 
           Ok("$n.${params.join(".")}")
@@ -4259,7 +4259,7 @@ export type Compiler {
       val parts: String[] = []
       for name in struct.typeParams {
         val repr = if self._resolvedGenerics.resolveGeneric(name) |ty| {
-          match self._getNameForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._getNameForType(ty)
         } else {
           return unreachable("could not resolve '$name'")
         }
@@ -4286,7 +4286,7 @@ export type Compiler {
     }
   }
   func _structInitializerFnName(self, struct: Struct): Result<String, CompileError> {
-    val structTypeName = match self._structTypeName(struct) { Ok(v) => v, Err(e) => return Err(e) }
+    val structTypeName = try self._structTypeName(struct)
     Ok("$structTypeName.init")
   }
 
@@ -4296,7 +4296,7 @@ export type Compiler {
       val parts: String[] = []
       for name in enum_.typeParams {
         val repr = if self._resolvedGenerics.resolveGeneric(name) |ty| {
-          match self._getNameForType(ty) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._getNameForType(ty)
         } else {
           return unreachable("could not resolve '$name'")
         }
@@ -4323,13 +4323,13 @@ export type Compiler {
     }
   }
   func _enumVariantFnName(self, enum_: Enum, variant: TypedEnumVariant): Result<String, CompileError> {
-    val enumTypeName = match self._enumTypeName(enum_) { Ok(v) => v, Err(e) => return Err(e) }
+    val enumTypeName = try self._enumTypeName(enum_)
     Ok("$enumTypeName.${variant.label.name}")
   }
 
   func _fnName(self, fn: Function): String = ".${fn.label.name}"
   func _structMethodFnName(self, struct: Struct, fn: Function): Result<String, CompileError> {
-    val typeName = match self._structTypeName(struct) { Ok(v) => v, Err(e) => return Err(e) }
+    val typeName = try self._structTypeName(struct)
     val sep = match fn.kind {
       FunctionKind.InstanceMethod => ".."
       _ => "."
@@ -4337,7 +4337,7 @@ export type Compiler {
     Ok("${typeName}${sep}${fn.label.name}")
   }
   func _enumMethodFnName(self, enum_: Enum, fn: Function): Result<String, CompileError> {
-    val typeName = match self._enumTypeName(enum_) { Ok(v) => v, Err(e) => return Err(e) }
+    val typeName = try self._enumTypeName(enum_)
     val sep = match fn.kind {
       FunctionKind.InstanceMethod => ".."
       _ => "."
@@ -4346,11 +4346,10 @@ export type Compiler {
   }
 
   func _methodFnName(self, structOrEnum: StructOrEnum, fn: Function): Result<String, CompileError> {
-    val methodName = match structOrEnum {
-      StructOrEnum.Struct(struct) => match self._structMethodFnName(struct, fn) { Ok(v) => v, Err(e) => return Err(e) }
-      StructOrEnum.Enum(enum_) => match self._enumMethodFnName(enum_, fn) { Ok(v) => v, Err(e) => return Err(e) }
+    match structOrEnum {
+      StructOrEnum.Struct(struct) => self._structMethodFnName(struct, fn)
+      StructOrEnum.Enum(enum_) => self._enumMethodFnName(enum_, fn)
     }
-    Ok(methodName)
   }
 
   func _fnSignature(self, structOrEnum: StructOrEnum?, fn: Function): Result<String, CompileError> {
@@ -4406,7 +4405,7 @@ export type Compiler {
       _ => {}
     }
     for param in fn.params {
-      val paramTyRepr = match self._getReprForType(param.ty) { Ok(v) => v, Err(e) => return Err(e) }
+      val paramTyRepr = try self._getReprForType(param.ty)
       val defaultExpr = if param.defaultValue " = ..." else ""
       args.push("${param.label.name}: $paramTyRepr$defaultExpr")
     }
@@ -4414,7 +4413,7 @@ export type Compiler {
     parts.push(")")
 
     if fn.returnType.kind != TypeKind.PrimitiveUnit {
-      val returnTyRepr = match self._getReprForType(fn.returnType) { Ok(v) => v, Err(e) => return Err(e) }
+      val returnTyRepr = try self._getReprForType(fn.returnType)
       parts.push(": $returnTyRepr")
     }
 
@@ -4448,7 +4447,7 @@ export type Compiler {
       EnumVariantKind.Container(fields) => {
         parts.push("(")
         for field, idx in fields {
-          val fieldTyRepr = match self._getReprForType(field.ty) { Ok(v) => v, Err(e) => return Err(e) }
+          val fieldTyRepr = try self._getReprForType(field.ty)
           parts.push("${field.name.name}: $fieldTyRepr")
           if idx != fields.length - 1 {
             parts.push(", ")

--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -227,11 +227,11 @@ export type Lexer {
     val tokens: Token[] = []
 
     val lexer = Lexer(_input: contents)
-    var nextToken = match lexer.nextToken() { Ok(v) => v, Err(e) => return Err(e) }
+    var nextToken = try lexer.nextToken()
     while nextToken |tok| {
       tokens.push(tok)
 
-      nextToken = match lexer.nextToken() { Ok(v) => v, Err(e) => return Err(e) }
+      nextToken = try lexer.nextToken()
     }
 
     Ok(tokens)
@@ -247,22 +247,16 @@ export type Lexer {
     val position = self._curPos()
 
     val token = if ch.isDigit() {
-      val tok = match self._tokenizeInteger(startPos: position) { Ok(v) => v Err(e) => return Err(e) }
-      tok
+      try self._tokenizeInteger(startPos: position)
     } else if ch == "\"" {
-      val tok = match self._tokenizeString() { Ok(v) => v Err(e) => return Err(e) }
-      tok
+      try self._tokenizeString()
     } else if ch.isAlpha() || ch == "_" {
       self._tokenizeIdentifier(startPos: position)
     } else if ch == "/" && (peek == "/" || peek == "*") {
       if self._skipComment() |error| return Err(error)
       return self.nextToken()
     } else {
-      val tok = match self._tokenizeSymbol(startPos: position, sawPreceedingNewline: sawNewline) {
-        Ok(v) => v
-        Err(e) => return Err(e)
-      }
-      tok
+      try self._tokenizeSymbol(startPos: position, sawPreceedingNewline: sawNewline)
     }
 
     Ok(Some(token))
@@ -468,7 +462,7 @@ export type Lexer {
           "\'" => "\'",
           "\"" => "\"",
           "$" => "$",
-          "u" => match self._parseUnicodeEscape(pos) { Ok(v) => v, Err(e) => return Err(e) }
+          "u" => try self._parseUnicodeEscape(pos)
           _ => return Err(LexerError(position: pos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: "\\$ch", isUnicode: false)))
         }
 
@@ -485,12 +479,12 @@ export type Lexer {
         self._advance() // consume '$'
         if self._input[self._cursor] == "{" {
           val initialChunk = StringInterpolationChunk.String(position: startPos, value: str)
-          match self.nextToken() { Ok(v) => v, Err(e) => return Err(e) }
+          try self.nextToken()
 
           val interpolatedTokens: Token[] = []
           var curlyCount = 1
           while curlyCount != 0 {
-            val nextToken = match self.nextToken() { Ok(v) => v, Err(e) => return Err(e) }
+            val nextToken = try self.nextToken()
             if nextToken |tok| {
               if tok.kind == TokenKind.LBrace {
                 curlyCount += 1

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -369,7 +369,7 @@ export type Parser {
           return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
         }
 
-        val importNode = match parser._parseImport() { Ok(v) => v, Err(e) => return Err(e) }
+        val importNode = try parser._parseImport()
         imports.push(importNode)
         continue
       }
@@ -413,7 +413,7 @@ export type Parser {
   }
 
   func _expectNextLabel(self): Result<Label, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
     match token.kind {
       TokenKind.Ident(name) => Ok(Label(name: name, position: token.position))
       _ => Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
@@ -421,7 +421,7 @@ export type Parser {
   }
 
   func _expectNextTokenKind(self, kind: TokenKind): Result<Token, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
 
     val nextTokenMatches = match kind {
       TokenKind.Int => match token.kind { TokenKind.Int => true, _ => false }
@@ -447,27 +447,27 @@ export type Parser {
   }
 
   func _parseImport(self): Result<ImportNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
 
-    val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val nextToken = try self._expectPeek()
     val importNode = match nextToken.kind {
       TokenKind.String(string) => {
         val moduleName = Label(name: string, position: nextToken.position)
         self._advance() // consume string token
 
-        val nextToken = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+        val nextToken = try self._expectNext()
         if nextToken.kind != TokenKind.As {
           return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.As], nextToken.kind)))
         }
 
-        val aliasName = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+        val aliasName = try self._expectNextLabel()
         val kind = ImportKind.Alias(aliasName)
 
         ImportNode(token: token, kind: kind, moduleName: moduleName)
       }
       TokenKind.Ident => {
-        val importsRes = self._commaSeparated(end: TokenKind.From, consumeFinal: true, fn: () => {
-          val label = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+        val imports = try self._commaSeparated(end: TokenKind.From, consumeFinal: true, fn: () => {
+          val label = try self._expectNextLabel()
           if label.name == "_" {
             val tok = Token(position: label.position, kind: TokenKind.Ident(label.name))
             Err(ParseError(position: label.position, kind: ParseErrorKind.UnexpectedToken(tok)))
@@ -475,10 +475,9 @@ export type Parser {
             Ok(label)
           }
         })
-        val imports = match importsRes { Ok(v) => v, Err(e) => return Err(e) }
         val kind = ImportKind.List(imports)
 
-        val nextToken = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+        val nextToken = try self._expectNext()
         val moduleName = match nextToken.kind {
           TokenKind.String(name) => Label(name: name, position: nextToken.position)
           _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String("")], nextToken.kind)))
@@ -493,12 +492,12 @@ export type Parser {
   }
 
   func _parseStatement(self): Result<AstNode, ParseError> {
-    val token = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectPeek()
     match token.kind {
       TokenKind.At => {
-        match self._parseDecorator() { Ok(v) => v, Err(e) => return Err(e) }
+        try self._parseDecorator()
 
-        val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+        val nextToken = try self._expectPeek()
         val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum, TokenKind.At, TokenKind.Export]
         if !expected.contains(nextToken.kind) {
           return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
@@ -510,7 +509,7 @@ export type Parser {
         self._exportToken = Some(token)
         self._advance() // consume 'export' token
 
-        val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+        val nextToken = try self._expectPeek()
         val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum]
         if !expected.contains(nextToken.kind) {
           return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
@@ -533,16 +532,15 @@ export type Parser {
   }
 
   func _parseDecorator(self): Result<Int, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
 
-    val decoratorName = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+    val decoratorName = try self._expectNextLabel()
 
-    val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val nextToken = try self._expectPeek()
     val arguments = match nextToken.kind {
       TokenKind.LParen => {
         self._advance() // consume '(' token
-        val arguments = match self._parseInvocationArguments() { Ok(v) => v, Err(e) => return Err(e) }
-        arguments
+        try self._parseInvocationArguments()
       }
       _ => []
     }
@@ -564,17 +562,16 @@ export type Parser {
   }
 
   func _parseBindingPattern(self): Result<BindingPattern, ParseError> {
-    val token = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectPeek()
     val pat = match token.kind {
       TokenKind.Ident => {
-        val label = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+        val label = try self._expectNextLabel()
         BindingPattern.Variable(label)
       }
       TokenKind.LParen => {
-        val lParenTok = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-        val itemsRes = self._commaSeparated(end: TokenKind.RParen, consumeFinal: false, fn: () => self._parseBindingPattern())
-        val items = match itemsRes { Ok(v) => v, Err(e) => return Err(e) }
-        val rParenTok = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+        val lParenTok = try self._expectNext()
+        val items = try self._commaSeparated(end: TokenKind.RParen, consumeFinal: false, fn: () => self._parseBindingPattern())
+        val rParenTok = try self._expectNext()
         if items.isEmpty() {
           return Err(ParseError(position: rParenTok.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident(""), TokenKind.LParen(true)], token.kind)))
         }
@@ -594,8 +591,8 @@ export type Parser {
     val exportToken = self._exportToken
     self._exportToken = None
 
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val pat = match self._parseBindingPattern() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val pat = try self._parseBindingPattern()
 
     if self._cursor >= self._tokens.length {
       val node = BindingDeclarationNode(
@@ -608,11 +605,10 @@ export type Parser {
       return Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
     }
 
-    var colonToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    var colonToken = try self._expectPeek()
     val typeAnnotation = if colonToken.kind == TokenKind.Colon {
       self._advance() // consume ':' token
-      val a = match self._parseTypeIdentifier() { Ok(v) => v, Err(e) => return Err(e) }
-      Some(a)
+      Some(try self._parseTypeIdentifier())
     } else {
       None
     }
@@ -628,11 +624,10 @@ export type Parser {
       return Ok(AstNode(token: token, kind: AstNodeKind.BindingDeclaration(node)))
     }
 
-    val eqToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val eqToken = try self._expectPeek()
     val expr = if eqToken.kind == TokenKind.Eq {
       self._advance() // consume '=' token
-      val e = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
-      Some(e)
+      Some(try self._parseExpression())
     } else {
       None
     }
@@ -654,30 +649,28 @@ export type Parser {
     val exportToken = self._exportToken
     self._exportToken = None
 
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val label = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
-    var nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val label = try self._expectNextLabel()
+    var nextToken = try self._expectPeek()
     val typeParams = match nextToken.kind {
       TokenKind.LT => {
         self._advance() // consume '<' token
-        val labels = match self._parseTypeParameters() { Ok(v) => v, Err(e) => return Err(e) }
-        labels
+        try self._parseTypeParameters()
       }
       TokenKind.LParen => []
       _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
     }
 
     // The `true` in LParen is disregarded within _expectNextTokenKind
-    match self._expectNextTokenKind(TokenKind.LParen(true)) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._expectNextTokenKind(TokenKind.LParen(true))
 
-    val params = match self._parseFunctionParameters(allowSelf: true) { Ok(v) => v, Err(e) => return Err(e) }
+    val params = try self._parseFunctionParameters(allowSelf: true)
 
-    nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    nextToken = try self._expectPeek()
     val returnTypeAnnotation = if nextToken.kind == TokenKind.Colon {
       self._advance() // consume ':' token
 
-      val ann = match self._parseTypeIdentifier() { Ok(v) => v, Err(e) => return Err(e) }
-      Some(ann)
+      Some(try self._parseTypeIdentifier())
     } else {
       None
     }
@@ -690,13 +683,13 @@ export type Parser {
     val body: AstNode[] = if isStub {
       []
     } else {
-      val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      val nextToken = try self._expectPeek()
       if nextToken.kind == TokenKind.Eq {
         self._advance() // consume '=' token
-        val expr = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+        val expr = try self._parseExpression()
         [expr]
       } else {
-        match self._parseBlockOrSingleExpression() { Ok(v) => v, Err(e) => return Err(e) }
+        try self._parseBlockOrSingleExpression()
       }
     }
 
@@ -719,29 +712,28 @@ export type Parser {
     val exportToken = self._exportToken
     self._exportToken = None
 
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val typeName = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val typeName = try self._expectNextLabel()
 
-    var nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    var nextToken = try self._expectPeek()
     val typeParams = match nextToken.kind {
       TokenKind.LT => {
         self._advance() // consume '<' token
-        val labels = match self._parseTypeParameters() { Ok(v) => v, Err(e) => return Err(e) }
-        labels
+        try self._parseTypeParameters()
       }
       TokenKind.LBrace => []
       _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
     }
 
-    match self._expectNextTokenKind(TokenKind.LBrace) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._expectNextTokenKind(TokenKind.LBrace)
 
     val fields: TypeField[] = []
     while self._peek() |nextToken| {
       match nextToken.kind {
         TokenKind.Ident => {
-          val field = match self._parseField() { Ok(v) => v, Err(e) => return Err(e) }
+          val field = try self._parseField()
 
-          val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+          val nextToken = try self._expectPeek()
           if nextToken.kind == TokenKind.Comma {
             self._advance() // consume ',' token
           }
@@ -752,9 +744,9 @@ export type Parser {
       }
     }
 
-    val (methods, types, enums) = match self._parseBodyForTypeOrEnum() { Ok(v) => v, Err(e) => return Err(e) }
+    val (methods, types, enums) = try self._parseBodyForTypeOrEnum()
 
-    match self._expectNextTokenKind(TokenKind.RBrace) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._expectNextTokenKind(TokenKind.RBrace)
 
     val node = TypeDeclarationNode(
       decorators: decorators,
@@ -776,28 +768,26 @@ export type Parser {
     val exportToken = self._exportToken
     self._exportToken = None
 
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val enumName = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val enumName = try self._expectNextLabel()
 
-    var nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    var nextToken = try self._expectPeek()
     val typeParams = match nextToken.kind {
       TokenKind.LT => {
         self._advance() // consume '<' token
-        val labels = match self._parseTypeParameters() { Ok(v) => v, Err(e) => return Err(e) }
-        labels
+        try self._parseTypeParameters()
       }
       TokenKind.LBrace => []
       _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(true)], nextToken.kind)))
     }
 
-    match self._expectNextTokenKind(TokenKind.LBrace) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._expectNextTokenKind(TokenKind.LBrace)
 
     val variants: EnumVariant[] = []
     while self._peek() |identTok| {
       val name = match identTok.kind {
         TokenKind.Ident => {
-          val name = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
-          name
+          try self._expectNextLabel()
         }
         TokenKind.None_ => {
           self._advance() // consume 'None' token
@@ -806,14 +796,14 @@ export type Parser {
         _ => break
       }
 
-      var nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      var nextToken = try self._expectPeek()
       val variant = match nextToken.kind {
         TokenKind.LParen => {
           self._advance() // consume '(' token
 
           val paramsRes = self._commaSeparated(end: TokenKind.RParen, consumeFinal: false, fn: () => self._parseField())
-          val params = match paramsRes { Ok(v) => v, Err(e) => return Err(e) }
-          val rParen = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+          val params = try paramsRes
+          val rParen = try self._expectNext()
           if params.isEmpty() {
             return Err(ParseError(position: rParen.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], rParen.kind)))
           }
@@ -822,16 +812,16 @@ export type Parser {
         _ => EnumVariant.Constant(name)
       }
 
-      nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      nextToken = try self._expectPeek()
       if nextToken.kind == TokenKind.Comma {
         self._advance() // consume ',' token
       }
       variants.push(variant)
     }
 
-    val (methods, types, enums) = match self._parseBodyForTypeOrEnum() { Ok(v) => v, Err(e) => return Err(e) }
+    val (methods, types, enums) = try self._parseBodyForTypeOrEnum()
 
-    match self._expectNextTokenKind(TokenKind.RBrace) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._expectNextTokenKind(TokenKind.RBrace)
 
     val node = EnumDeclarationNode(
       decorators: decorators,
@@ -847,15 +837,14 @@ export type Parser {
   }
 
   func _parseField(self): Result<TypeField, ParseError> {
-    val name = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
-    match self._expectNextTokenKind(TokenKind.Colon) { Ok(v) => v, Err(e) => return Err(e) }
-    val typeAnnotation = match self._parseTypeIdentifier() { Ok(v) => v, Err(e) => return Err(e) }
+    val name = try self._expectNextLabel()
+    try self._expectNextTokenKind(TokenKind.Colon)
+    val typeAnnotation = try self._parseTypeIdentifier()
 
-    var nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    var nextToken = try self._expectPeek()
     val initializer = if nextToken.kind == TokenKind.Eq {
       self._advance() // consume '=' token
-      val expr = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
-      Some(expr)
+      Some(try self._parseExpression())
     } else {
       None
     }
@@ -869,16 +858,15 @@ export type Parser {
     val enums: EnumDeclarationNode[] = []
     while self._peek() |nextToken| {
       if nextToken.kind == TokenKind.RBrace break
-      val nodeRes = match nextToken.kind {
+      val node = match nextToken.kind {
         TokenKind.RBrace => break
-        TokenKind.At => self._parseStatement()
-        TokenKind.Func => self._parseStatement()
-        TokenKind.Type => self._parseStatement()
-        TokenKind.Enum => self._parseStatement()
+        TokenKind.At => try self._parseStatement()
+        TokenKind.Func => try self._parseStatement()
+        TokenKind.Type => try self._parseStatement()
+        TokenKind.Enum => try self._parseStatement()
         _ => return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.UnexpectedToken(nextToken)))
       }
 
-      val node = match nodeRes { Ok(v) => v, Err(e) => return Err(e) }
       match node.kind {
         AstNodeKind.FunctionDeclaration(node) => methods.push(node)
         AstNodeKind.TypeDeclaration(node) => types.push(node)
@@ -891,7 +879,7 @@ export type Parser {
   }
 
   func _parseTypeIdentifier(self): Result<TypeIdentifier, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
     var typeIdent =  match token.kind {
       TokenKind.Ident(name) => {
         var label = Label(name: name, position: token.position)
@@ -903,16 +891,16 @@ export type Parser {
             TokenKind.LT => {
               self._advance() // consume '<' token
 
-              val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+              val nextToken = try self._expectPeek()
               if nextToken.kind == TokenKind.GT {
                 return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], nextToken.kind)))
               }
-              typeArguments = match self._commaSeparated(end: TokenKind.GT, consumeFinal: true, fn: () => self._parseTypeIdentifier()) { Ok(v) => v, Err(e) => return Err(e) }
+              typeArguments = try self._commaSeparated(end: TokenKind.GT, consumeFinal: true, fn: () => self._parseTypeIdentifier())
               break
             }
             TokenKind.Dot => {
               self._advance() // consume '.' token
-              val nextToken = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+              val nextToken = try self._expectNext()
               match nextToken.kind {
                 TokenKind.Ident(name) => {
                   path.push(label)
@@ -928,13 +916,12 @@ export type Parser {
         TypeIdentifier.Normal(name: label, typeArguments: typeArguments, path: path)
       }
       TokenKind.LParen => {
-        val a = self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => self._parseTypeIdentifier())
-        val args = match a { Ok(v) => v, Err(e) => return Err(e) }
+        val args = try self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => self._parseTypeIdentifier())
 
         val nextTokenIsArrow = if self._peek()?.kind |kind| kind == TokenKind.Arrow else false
         if nextTokenIsArrow {
           self._advance() // consume '=>' token
-          val retType = match self._parseTypeIdentifier() { Ok(v) => v, Err(e) => return Err(e) }
+          val retType = try self._parseTypeIdentifier()
           TypeIdentifier.Function(args, retType)
         } else if args[0] |first| {
           // TODO: There should be a more ergonomic way of writing this... maybe like
@@ -945,7 +932,7 @@ export type Parser {
             TypeIdentifier.Tuple(args)
           }
         } else {
-          val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+          val nextToken = try self._expectPeek()
           return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Arrow], nextToken.kind)))
         }
       }
@@ -958,7 +945,7 @@ export type Parser {
           break
         } else {
           self._advance() // consume '[' token
-          match self._expectNextTokenKind(TokenKind.RBrack) { Ok(v) => v, Err(e) => return Err(e) }
+          try self._expectNextTokenKind(TokenKind.RBrack)
 
           typeIdent = TypeIdentifier.Array(inner: typeIdent)
         }
@@ -975,11 +962,11 @@ export type Parser {
 
   func _parseFunctionParameters(self, allowSelf: Bool): Result<FunctionParam[], ParseError> {
     self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: paramIdx => {
-      var token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+      var token = try self._expectNext()
       var starToken: Token? = None
       val isVariadic = if token.kind == TokenKind.Star {
         starToken = Some(token)
-        token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+        token = try self._expectNext()
         true
       } else {
         false
@@ -1001,20 +988,18 @@ export type Parser {
         return Ok(FunctionParam(label: label, isVariadic: false, typeAnnotation: None, defaultValue: None))
       }
 
-      var nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      var nextToken = try self._expectPeek()
       val typeAnnotation = if nextToken.kind == TokenKind.Colon {
         self._advance() // consume ':' token
-        val ann = match self._parseTypeIdentifier() { Ok(v) => v, Err(e) => return Err(e) }
-        Some(ann)
+        Some(try self._parseTypeIdentifier())
       } else {
         None
       }
 
-      nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      nextToken = try self._expectPeek()
       val defaultValue = if nextToken.kind == TokenKind.Eq {
         self._advance() // consume '=' token
-        val e = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
-        Some(e)
+        Some(try self._parseExpression())
       } else {
         None
       }
@@ -1025,9 +1010,9 @@ export type Parser {
   }
 
   func _parseTypeParameters(self): Result<Label[], ParseError> {
-    val labels = match self._commaSeparated(end: TokenKind.GT, consumeFinal: false, fn: () => self._expectNextLabel()) { Ok(v) => v, Err(e) => return Err(e) }
+    val labels = try self._commaSeparated(end: TokenKind.GT, consumeFinal: false, fn: () => self._expectNextLabel())
     if labels.isEmpty() {
-      val token = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      val token = try self._expectPeek()
       Err(ParseError(position: token.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], token.kind)))
     } else {
       self._advance() // consume '>' token
@@ -1036,43 +1021,43 @@ export type Parser {
   }
 
   func _parseBlockOrSingleExpression(self, allowTerminators = false): Result<AstNode[], ParseError> {
-    val token = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectPeek()
     val nodes = match token.kind {
       TokenKind.LBrace => {
         self._advance() // consume '{' token
         val nodes: AstNode[] = []
         while true {
-          val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+          val nextToken = try self._expectPeek()
           if nextToken.kind == TokenKind.RBrace {
             self._advance() // consume '}' token
             break
           }
 
-          val node = match self._parseStatement() { Ok(v) => v, Err(e) => return Err(e) }
+          val node = try self._parseStatement()
           nodes.push(node)
         }
         nodes
       }
       TokenKind.Break => if allowTerminators {
-        val node = match self._parseStatement() { Ok(v) => v, Err(e) => return Err(e) }
+        val node = try self._parseStatement()
         [node]
       } else {
         return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
       TokenKind.Continue => if allowTerminators {
-        val node = match self._parseStatement() { Ok(v) => v, Err(e) => return Err(e) }
+        val node = try self._parseStatement()
         [node]
       } else {
         return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
       TokenKind.Return => if allowTerminators {
-        val node = match self._parseStatement() { Ok(v) => v, Err(e) => return Err(e) }
+        val node = try self._parseStatement()
         [node]
       } else {
         return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
       }
       _ => {
-        val node = match self._parsePrecedence(prec: 0) { Ok(v) => v, Err(e) => return Err(e) }
+        val node = try self._parsePrecedence(prec: 0)
         [node]
       }
     }
@@ -1083,7 +1068,7 @@ export type Parser {
   func _parseExpressionStatement(self): Result<AstNode, ParseError> = self._parsePrecedence(prec: 0)
 
   func _parseExpression(self): Result<AstNode, ParseError> {
-    val node = match self._parsePrecedence(prec: 0) { Ok(v) => v, Err(e) => return Err(e) }
+    val node = try self._parsePrecedence(prec: 0)
     if node.kind.isAssignmentExpression() {
       return Err(ParseError(position: node.token.position, kind: ParseErrorKind.UnexpectedToken(node.token)))
     }
@@ -1091,13 +1076,13 @@ export type Parser {
   }
 
   func _parsePrecedence(self, prec: Int): Result<AstNode, ParseError> {
-    val prefixToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
-    var leftNode = match self._prefixRule(prefixToken) { Ok(v) => v, Err(e) => return Err(e) }
+    val prefixToken = try self._expectPeek()
+    var leftNode = try self._prefixRule(prefixToken)
 
     while self._peek() |nextToken| {
       val nextPrec = Precedence.forToken(nextToken)
       if prec < nextPrec {
-        leftNode = match self._infixRule(leftNode) { Ok(v) => v, Err(e) => return Err(e) }
+        leftNode = try self._infixRule(leftNode)
       } else {
         break
       }
@@ -1130,7 +1115,7 @@ export type Parser {
   }
 
   func _infixRule(self, left: AstNode): Result<AstNode, ParseError> {
-    val infixToken = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val infixToken = try self._expectNext()
     match infixToken.kind {
       TokenKind.Dot => self._parseAccessor(infixToken, left)
       TokenKind.QuestionDot => self._parseAccessor(infixToken, left)
@@ -1143,7 +1128,7 @@ export type Parser {
   }
 
   func _parseLiteral(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
     val literal = match token.kind {
       TokenKind.Int(value) => LiteralAstNode.Int(value)
       TokenKind.Float(value) => LiteralAstNode.Float(value)
@@ -1159,7 +1144,7 @@ export type Parser {
   }
 
   func _parseStringInterpolation(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
     val chunks = match token.kind {
       TokenKind.StringInterpolation(chunks) => chunks
       _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
@@ -1174,6 +1159,7 @@ export type Parser {
         }
         StringInterpolationChunk.Interpolation(tokens) => {
           val subParser = Parser(_tokens: tokens)
+          // TODO: try/else
           val node = match subParser._parseExpression() {
             Ok(v) => v
             Err(e) => {
@@ -1198,27 +1184,27 @@ export type Parser {
   }
 
   func _parseUnary(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
     val op = match token.kind {
       TokenKind.Minus => UnaryOp.Minus
       TokenKind.Bang => UnaryOp.Negate
       _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.NotYetImplemented))
     }
 
-    val expr = match self._parsePrecedence(prec: Precedence.unary()) { Ok(v) => v, Err(e) => return Err(e) }
+    val expr = try self._parsePrecedence(prec: Precedence.unary())
     Ok(AstNode(token: token, kind: AstNodeKind.Unary(UnaryAstNode(op: op, expr: expr))))
   }
 
   func _parseGroupedOrTupleOrLambda(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
 
-    val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val nextToken = try self._expectPeek()
     // If the next token is ')' then we must be parsing a no-args lambda
     match nextToken.kind {
       TokenKind.RParen => {
         self._advance() // consume ')' token
-        val arrowToken = match self._expectNextTokenKind(TokenKind.Arrow) { Ok(v) => v, Err(e) => return Err(e) }
-        val body = match self._parseBlockOrSingleExpression() { Ok(v) => v, Err(e) => return Err(e) }
+        val arrowToken = try self._expectNextTokenKind(TokenKind.Arrow)
+        val body = try self._parseBlockOrSingleExpression()
 
         return Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: [], body: body))))
       }
@@ -1234,7 +1220,7 @@ export type Parser {
           Ok(params) => {
             match self._expectNextTokenKind(TokenKind.Arrow) {
               Ok(arrowToken) => {
-                val body = match self._parseBlockOrSingleExpression() { Ok(v) => v, Err(e) => return Err(e) }
+                val body = try self._parseBlockOrSingleExpression()
 
                 return Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
               }
@@ -1245,16 +1231,16 @@ export type Parser {
         }
       }
       TokenKind.Star => { // a variadic parameter could be first
-        val params = match self._parseFunctionParameters(allowSelf: false) { Ok(v) => v, Err(e) => return Err(e) }
-        val arrowToken = match self._expectNextTokenKind(TokenKind.Arrow) { Ok(v) => v, Err(e) => return Err(e) }
-        val body = match self._parseBlockOrSingleExpression() { Ok(v) => v, Err(e) => return Err(e) }
+        val params = try self._parseFunctionParameters(allowSelf: false)
+        val arrowToken = try self._expectNextTokenKind(TokenKind.Arrow)
+        val body = try self._parseBlockOrSingleExpression()
 
         return Ok(AstNode(token: arrowToken, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
       }
       _ => {}
     }
 
-    val exprs = match self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => self._parseExpression()) { Ok(v) => v, Err(e) => return Err(e) }
+    val exprs = try self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => self._parseExpression())
     val nodeKind = if exprs.length == 1 {
       // TODO: Again, there needs to be a more ergonomic way of doing this. `if exprs.length == 1 && exprs[0] |inner| { ... }` maybe? or even just `exprs[0].!` to force-unwrap
       if exprs[0] |inner| {
@@ -1279,12 +1265,12 @@ export type Parser {
             if typeArgs.isEmpty() {
               self._cursor = savedCursor
             } else {
-              val nextToken = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+              val nextToken = try self._expectNext()
               if nextToken.kind != TokenKind.LParen(false) {
                 return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.LParen(false)], nextToken.kind)))
               }
 
-              val arguments = match self._parseInvocationArguments() { Ok(v) => v, Err(e) => return Err(e) }
+              val arguments = try self._parseInvocationArguments()
               val invocationNode = InvocationAstNode(invokee: invokee, typeArguments: typeArgs, arguments: arguments)
               return Ok(Some(AstNode(token: nextToken, kind: AstNodeKind.Invocation(invocationNode))))
             }
@@ -1303,80 +1289,74 @@ export type Parser {
   }
 
   func _parseIdentifier(self, kind: IdentifierKind): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
     val identNode = AstNode(token: token, kind: AstNodeKind.Identifier(kind))
 
-    val res = match self._tryParseInvocationWithTypeArgs(invokee: identNode) { Ok(v) => v, Err(e) => return Err(e) }
+    val res = try self._tryParseInvocationWithTypeArgs(invokee: identNode)
     if res |invocationNode| return Ok(invocationNode)
 
     Ok(identNode)
   }
 
   func _parseArray(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val itemsRes = self._commaSeparated(end: TokenKind.RBrack, consumeFinal: true, fn: () => self._parseExpression())
-    val items = match itemsRes { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val items = try self._commaSeparated(end: TokenKind.RBrack, consumeFinal: true, fn: () => self._parseExpression())
 
     Ok(AstNode(token: token, kind: AstNodeKind.Array(items)))
   }
 
   func _parseSet(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val itemsRes = self._commaSeparated(end: TokenKind.RBrace, consumeFinal: true, fn: () => self._parseExpression())
-    val items = match itemsRes { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val items = try self._commaSeparated(end: TokenKind.RBrace, consumeFinal: true, fn: () => self._parseExpression())
 
     Ok(AstNode(token: token, kind: AstNodeKind.Set(items)))
   }
 
   func _parseMap(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val itemsRes = self._commaSeparated(end: TokenKind.RBrace, consumeFinal: true, fn: () => {
-      val keyToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
-      val keyRes = match keyToken.kind {
-        TokenKind.String => self._parseExpression()
-        TokenKind.Ident => self._parseExpression()
+    val token = try self._expectNext()
+    val items = try self._commaSeparated(end: TokenKind.RBrace, consumeFinal: true, fn: () => {
+      val keyToken = try self._expectPeek()
+      val key = match keyToken.kind {
+        TokenKind.String => try self._parseExpression()
+        TokenKind.Ident => try self._parseExpression()
         TokenKind.LParen => {
           self._advance() // consume '(' token
-          val key = self._parseExpression()
-          match self._expectNextTokenKind(TokenKind.RParen) { Ok(v) => v, Err(e) => return Err(e) }
+          val key = try self._parseExpression()
+          try self._expectNextTokenKind(TokenKind.RParen)
           key
         }
-        _ => {
-          return Err(ParseError(position: keyToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String(""), TokenKind.Ident(""), TokenKind.LParen(false)], keyToken.kind)))
-        }
+        _ => return Err(ParseError(position: keyToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.String(""), TokenKind.Ident(""), TokenKind.LParen(false)], keyToken.kind)))
       }
-      val key = match keyRes { Ok(v) => v, Err(e) => return Err(e) }
 
-      match self._expectNextTokenKind(TokenKind.Colon) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._expectNextTokenKind(TokenKind.Colon)
 
-      val value = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+      val value = try self._parseExpression()
 
       Ok((key, value))
     })
-    val items = match itemsRes { Ok(v) => v, Err(e) => return Err(e) }
 
     Ok(AstNode(token: token, kind: AstNodeKind.Map(items)))
   }
 
   func _parseIf(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val condition = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val condition = try self._parseExpression()
 
-    val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val nextToken = try self._expectPeek()
     val conditionBinding = if nextToken.kind == TokenKind.Pipe {
       self._advance() // consume opening '|' token
-      val pat = match self._parseBindingPattern() { Ok(v) => v, Err(e) => return Err(e) }
-      match self._expectNextTokenKind(TokenKind.Pipe) { Ok(v) => v, Err(e) => return Err(e) }
+      val pat = try self._parseBindingPattern()
+      try self._expectNextTokenKind(TokenKind.Pipe)
       Some(pat)
     } else {
       None
     }
 
-    val ifBlock = match self._parseBlockOrSingleExpression(allowTerminators: true) { Ok(v) => v, Err(e) => return Err(e) }
+    val ifBlock = try self._parseBlockOrSingleExpression(allowTerminators: true)
     val elseBlock = if self._peek() |nextToken| {
       if nextToken.kind == TokenKind.Else {
         self._advance() // consume 'else' token
-        val elseBlock = match self._parseBlockOrSingleExpression(allowTerminators: true) { Ok(v) => v, Err(e) => return Err(e) }
+        val elseBlock = try self._parseBlockOrSingleExpression(allowTerminators: true)
         Some(elseBlock)
       } else {
         None
@@ -1389,10 +1369,10 @@ export type Parser {
   }
 
   func _parseMatch(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val expr = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val expr = try self._parseExpression()
 
-    match self._expectNextTokenKind(TokenKind.LBrace) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._expectNextTokenKind(TokenKind.LBrace)
 
     val cases: MatchCase[] = []
     while self._peek() |next| {
@@ -1424,33 +1404,28 @@ export type Parser {
             self._advance() // consume '_' token
             MatchCaseKind.Else
           } else {
-            val label = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+            val label = try self._expectNextLabel()
             var last = label
             val path: Label[] = []
             while self._peek() |nextToken| {
               if nextToken.kind != TokenKind.Dot break
               self._advance() // consume '.' token
-              val label = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+              val label = try self._expectNextLabel()
               path.push(last)
               last = label
             }
 
-            val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+            val nextToken = try self._expectPeek()
             val args = match nextToken.kind {
               TokenKind.LParen => {
                 self._advance() // consume '(' token
 
-                val next = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+                val next = try self._expectPeek()
                 if next.kind == TokenKind.RParen {
                   return Err(ParseError(position: next.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], next.kind)))
                 }
 
-                val argsRes = self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => {
-                  val label = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
-                  Ok(label)
-                })
-                val args = match argsRes { Ok(v) => v, Err(e) => return Err(e) }
-                args
+                try self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => self._expectNextLabel())
               }
               _ => []
             }
@@ -1472,23 +1447,20 @@ export type Parser {
         }
       }
 
-      var nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      var nextToken = try self._expectPeek()
       val binding = match nextToken.kind {
-        TokenKind.Ident => {
-          val label = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
-          Some(label)
-        }
+        TokenKind.Ident => Some(try self._expectNextLabel())
         _ => None
       }
 
-      nextToken = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+      nextToken = try self._expectNext()
       if nextToken.kind != TokenKind.Arrow {
         val expected = if binding { [TokenKind.Arrow] } else [TokenKind.Ident(""), TokenKind.Arrow]
         return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
       }
 
-      val body = match self._parseBlockOrSingleExpression(allowTerminators: true) { Ok(v) => v, Err(e) => return Err(e) }
-      nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      val body = try self._parseBlockOrSingleExpression(allowTerminators: true)
+      nextToken = try self._expectPeek()
       if nextToken.kind == TokenKind.Comma {
         self._advance() // consume ',' token
       }
@@ -1501,73 +1473,67 @@ export type Parser {
   }
 
   func _parseTry(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val expr = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val expr = try self._parseExpression()
 
     Ok(AstNode(token: token, kind: AstNodeKind.Try(expr)))
   }
 
   func _parseWhileLoop(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val condition = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val condition = try self._parseExpression()
 
-    val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val nextToken = try self._expectPeek()
     val conditionBinding = if nextToken.kind == TokenKind.Pipe {
       self._advance() // consume opening '|' token
-      val pat = match self._parseBindingPattern() { Ok(v) => v, Err(e) => return Err(e) }
-      match self._expectNextTokenKind(TokenKind.Pipe) { Ok(v) => v, Err(e) => return Err(e) }
+      val pat = try self._parseBindingPattern()
+      try self._expectNextTokenKind(TokenKind.Pipe)
       Some(pat)
     } else {
       None
     }
 
-    val block = match self._parseBlockOrSingleExpression(allowTerminators: true) { Ok(v) => v, Err(e) => return Err(e) }
+    val block = try self._parseBlockOrSingleExpression(allowTerminators: true)
 
     Ok(AstNode(token: token, kind: AstNodeKind.While(condition, conditionBinding, block)))
   }
 
   func _parseForLoop(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val itemPattern = match self._parseBindingPattern() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
+    val itemPattern = try self._parseBindingPattern()
 
-    var nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    var nextToken = try self._expectPeek()
     val indexPattern = if nextToken.kind == TokenKind.Comma {
       self._advance() // consume ',' token
-      val pat = match self._parseBindingPattern() { Ok(v) => v, Err(e) => return Err(e) }
-      Some(pat)
+      Some(try self._parseBindingPattern())
     } else {
       None
     }
 
-    match self._expectNextTokenKind(TokenKind.In) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._expectNextTokenKind(TokenKind.In)
 
-    val iterator = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+    val iterator = try self._parseExpression()
 
-    val block = match self._parseBlockOrSingleExpression(allowTerminators: true) { Ok(v) => v, Err(e) => return Err(e) }
+    val block = try self._parseBlockOrSingleExpression(allowTerminators: true)
 
     Ok(AstNode(token: token, kind: AstNodeKind.For(itemPattern, indexPattern, iterator, block)))
   }
 
   func _parseBreak(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
 
     Ok(AstNode(token: token, kind: AstNodeKind.Break))
   }
 
   func _parseContinue(self): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val token = try self._expectNext()
 
     Ok(AstNode(token: token, kind: AstNodeKind.Continue))
   }
 
   func _parseReturn(self, hasNewline: Bool): Result<AstNode, ParseError> {
-    val token = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
-    val expr = if hasNewline {
-      None
-    } else {
-      val expr = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
-      Some(expr)
-    }
+    val token = try self._expectNext()
+    val expr = if hasNewline None else Some(try self._parseExpression())
     Ok(AstNode(token: token, kind: AstNodeKind.Return(expr)))
   }
 
@@ -1595,7 +1561,7 @@ export type Parser {
       TokenKind.EqEq => BinaryOp.Eq
       TokenKind.Neq => BinaryOp.Neq
       TokenKind.LT => {
-        val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+        val nextToken = try self._expectPeek()
         if nextToken.kind == TokenKind.LT {
           self._advance() // consume '<' token
           BinaryOp.Shl
@@ -1605,7 +1571,7 @@ export type Parser {
       }
       TokenKind.LTE => BinaryOp.LTE
       TokenKind.GT => {
-        val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+        val nextToken = try self._expectPeek()
         if nextToken.kind == TokenKind.GT {
           self._advance() // consume '>' token
           BinaryOp.Shr
@@ -1617,12 +1583,12 @@ export type Parser {
       _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
     }
 
-    val right = match self._parsePrecedence(prec: prec) { Ok(v) => v, Err(e) => return Err(e) }
+    val right = try self._parsePrecedence(prec: prec)
     Ok(AstNode(token: token, kind: AstNodeKind.Binary(BinaryAstNode(left: left, op: op, right: right))))
   }
 
   func _parseAccessor(self, token: Token, left: AstNode): Result<AstNode, ParseError> {
-    val label = match self._expectNextLabel() { Ok(v) => v, Err(e) => return Err(e) }
+    val label = try self._expectNextLabel()
 
     val accessorNode = match left.kind {
       AstNodeKind.Accessor(accessorNode) => accessorNode
@@ -1632,7 +1598,7 @@ export type Parser {
 
     val node = AstNode(token: token, kind: AstNodeKind.Accessor(accessorNode))
 
-    val res = match self._tryParseInvocationWithTypeArgs(invokee: node) { Ok(v) => v, Err(e) => return Err(e) }
+    val res = try self._tryParseInvocationWithTypeArgs(invokee: node)
     if res |invocationNode| return Ok(invocationNode)
 
     Ok(node)
@@ -1644,7 +1610,7 @@ export type Parser {
     var endExpected = false
     var idx = 0
     while true {
-      val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      val nextToken = try self._expectPeek()
       if nextToken.kind == end {
         if consumeFinal self._advance() // consume end token before exiting
         break
@@ -1653,10 +1619,10 @@ export type Parser {
         return Err(ParseError(position: nextToken.position, kind: kind))
       }
 
-      val item = match fn(idx) { Ok(v) => v, Err(e) => return Err(e) }
+      val item = try fn(idx)
       items.push(item)
 
-      val peekToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      val peekToken = try self._expectPeek()
       if peekToken.kind == TokenKind.Comma {
         self._advance() // consume ',' token
       } else {
@@ -1670,11 +1636,11 @@ export type Parser {
   }
 
   func _parseInvocationArguments(self): Result<InvocationArgument[], ParseError> {
-    val argsRes = self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => {
-      val expr = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+    self._commaSeparated(end: TokenKind.RParen, consumeFinal: true, fn: () => {
+      val expr = try self._parseExpression()
       val arg = match expr.kind {
         AstNodeKind.Identifier(identifierKind) => {
-          val peekToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+          val peekToken = try self._expectPeek()
           val arg = if peekToken.kind == TokenKind.Colon {
             self._advance() // consume ':' token
 
@@ -1685,7 +1651,7 @@ export type Parser {
                 return Err(ParseError(position: expr.token.position, kind: kind))
               }
             }
-            val value = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+            val value = try self._parseExpression()
 
             InvocationArgument(label: Some(label), value: value)
           } else {
@@ -1698,13 +1664,10 @@ export type Parser {
 
       Ok(arg)
     })
-    val arguments = match argsRes { Ok(v) => v, Err(e) => return Err(e) }
-
-    Ok(arguments)
   }
 
   func _parseInvocation(self, token: Token, left: AstNode): Result<AstNode, ParseError> {
-    val arguments = match self._parseInvocationArguments() { Ok(v) => v, Err(e) => return Err(e) }
+    val arguments = try self._parseInvocationArguments()
 
     val isSome = match left.kind {
       AstNodeKind.Identifier(identKind) => match identKind {
@@ -1730,23 +1693,23 @@ export type Parser {
   }
 
   func _parseIndexing(self, token: Token, left: AstNode): Result<AstNode, ParseError> {
-    val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+    val nextToken = try self._expectPeek()
     val index = if nextToken.kind == TokenKind.Colon {
       self._advance() // consume ':' token
-      val rangeEnd = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+      val rangeEnd = try self._parseExpression()
       IndexingMode.Range(start: None, end: Some(rangeEnd))
     } else {
-      val expr = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
-      val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+      val expr = try self._parseExpression()
+      val nextToken = try self._expectPeek()
       if nextToken.kind == TokenKind.RBrack {
         IndexingMode.Single(expr)
       } else if nextToken.kind == TokenKind.Colon {
         self._advance() // consume ':' token
-        val nextToken = match self._expectPeek() { Ok(v) => v, Err(e) => return Err(e) }
+        val nextToken = try self._expectPeek()
         if nextToken.kind == TokenKind.RBrack {
           IndexingMode.Range(start: Some(expr), end: None)
         } else {
-          val rangeEnd = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+          val rangeEnd = try self._parseExpression()
           IndexingMode.Range(start: Some(expr), end: Some(rangeEnd))
         }
       } else {
@@ -1754,7 +1717,7 @@ export type Parser {
       }
     }
 
-    val lastToken = match self._expectNext() { Ok(v) => v, Err(e) => return Err(e) }
+    val lastToken = try self._expectNext()
     if lastToken.kind != TokenKind.RBrack {
       return Err(ParseError(position: lastToken.position, kind: ParseErrorKind.UnexpectedToken(lastToken)))
     }
@@ -1796,7 +1759,7 @@ export type Parser {
       _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
     }
 
-    val body = match self._parseBlockOrSingleExpression() { Ok(v) => v, Err(e) => return Err(e) }
+    val body = try self._parseBlockOrSingleExpression()
 
     Ok(AstNode(token: token, kind: AstNodeKind.Lambda(LambdaNode(params: params, body: body))))
   }
@@ -1815,7 +1778,7 @@ export type Parser {
       _ => return Err(ParseError(position: token.position, kind: ParseErrorKind.UnexpectedToken(token)))
     }
 
-    val rhs = match self._parseExpression() { Ok(v) => v, Err(e) => return Err(e) }
+    val rhs = try self._parseExpression()
 
     val expr = match assignOp {
       AssignOp.Assign => rhs

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -1472,7 +1472,7 @@ export type Typechecker {
   func typecheckEntrypoint(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
     val preludeModulePathSegs = getAbsolutePath(self.moduleLoader.stdRoot + "/prelude.abra")
     val preludeModulePathAbs = "/" + preludeModulePathSegs.join("/")
-    match self._typecheckModule(preludeModulePathAbs) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._typecheckModule(preludeModulePathAbs)
 
     val preludeStructs = [
       self.project.preludeIntStruct,
@@ -1502,9 +1502,7 @@ export type Typechecker {
       }
     }
 
-    val mod = match self._typecheckModule(modulePathAbs) { Ok(v) => v, Err(e) => return Err(e) }
-
-    Ok(mod)
+    self._typecheckModule(modulePathAbs)
   }
 
   func _tokenizeAndParse(self, modulePathAbs: String): Result<ParsedModule, TypecheckerError> {
@@ -1575,10 +1573,10 @@ export type Typechecker {
 
   func _addStructToScope(self, struct: Struct, isExported: Bool, scope = self.currentScope): Result<Int, TypeError> {
     val structTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Struct(struct)))
-    match self._addTypeToScope(structTy) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._addTypeToScope(structTy)
 
     val variable = Variable(label: struct.label, scope: scope, mutable: false, ty: structTy, alias: Some(VariableAlias.Struct(struct)))
-    match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._addVariableToScope(variable)
 
     scope.structs.push(struct)
 
@@ -1592,10 +1590,10 @@ export type Typechecker {
 
   func _addEnumToScope(self, enum_: Enum, isExported: Bool, scope = self.currentScope): Result<Int, TypeError> {
     val enumTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Enum(enum_)))
-    match self._addTypeToScope(enumTy) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._addTypeToScope(enumTy)
 
     val variable = Variable(label: enum_.label, scope: scope, mutable: false, ty: enumTy, alias: Some(VariableAlias.Enum(enum_)))
-    match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._addVariableToScope(variable)
 
     scope.enums.push(enum_)
 
@@ -1632,7 +1630,7 @@ export type Typechecker {
     val types: Type[] = []
     for i in range(0, num) {
       val typeIdent = if typeArguments.get(i) |typeIdent| typeIdent else return unreachable(position, "verified above that typeArguments.length == num")
-      val ty = match self._resolveTypeIdentifier(typeIdent) { Ok(v) => v, Err(e) => return Err(e) }
+      val ty = try self._resolveTypeIdentifier(typeIdent)
       types.push(ty)
     }
 
@@ -1643,13 +1641,13 @@ export type Typechecker {
     match structOrEnum {
       StructOrEnum.Struct(struct) => {
         if label.name == struct.label.name {
-          val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length) { Ok(v) => v, Err(e) => return Err(e) }
+          val instanceTypeArgs = try self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length)
           return Ok(Some(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), instanceTypeArgs))))
         }
       }
       StructOrEnum.Enum(enum_) => {
         if label.name == enum_.label.name {
-          val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length) { Ok(v) => v, Err(e) => return Err(e) }
+          val instanceTypeArgs = try self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length)
           return Ok(Some(Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), instanceTypeArgs))))
         }
       }
@@ -1725,7 +1723,7 @@ export type Typechecker {
     val ty = match typeIdent {
       TypeIdentifier.Normal(label, typeArguments, path) => {
         if path[0] |firstSeg| {
-          val _mod = match self._findModuleByAlias(firstSeg.name) { Ok(v) => v, Err(e) => return Err(e) }
+          val _mod = try self._findModuleByAlias(firstSeg.name)
           val (mod, aliasLabel) = if _mod |mod| mod else return Err(TypeError(position: firstSeg.position, kind: TypeErrorKind.UnknownName(firstSeg.name, "module")))
 
           if path[1] |seg| return todo(seg.position, "qualified type paths longer than 2")
@@ -1733,8 +1731,7 @@ export type Typechecker {
           val foundTy = match mod.exports[label.name] {
             None => return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownImportForAlias(label.name, aliasLabel)))
             Export.Type(structOrEnum, _) => {
-              val t = match self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments) { Ok(v) => v, Err(e) => return Err(e) }
-              t
+              try self._resolveInstanceTypeIdentifier(structOrEnum, label, typeArguments)
             }
             _ => None
           }
@@ -1747,40 +1744,38 @@ export type Typechecker {
           return res
         }
 
-        val ty = match self._findTypeByNameInScope(label) { Ok(v) => v, Err(e) => return Err(e) }
-        val t = match ty.kind {
+        val ty = try self._findTypeByNameInScope(label)
+        match ty.kind {
           TypeKind.Type(structOrEnum) => {
-            val t = match structOrEnum {
+            match structOrEnum {
               StructOrEnum.Struct(struct) => {
-                val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length) { Ok(v) => v, Err(e) => return Err(e) }
+                val instanceTypeArgs = try self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length)
                 Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), instanceTypeArgs))
               }
               StructOrEnum.Enum(enum_) => {
-                val instanceTypeArgs = match self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length) { Ok(v) => v, Err(e) => return Err(e) }
+                val instanceTypeArgs = try self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length)
                 Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), instanceTypeArgs))
               }
             }
-            t
           }
           _ => {
-            match self._verifyNumTypeArgs(label.position, typeArguments, 0) { Ok(v) => v, Err(e) => return Err(e) }
+            try self._verifyNumTypeArgs(label.position, typeArguments, 0)
             ty
           }
         }
-        t
       }
       TypeIdentifier.Array(inner) => {
-        val innerTy = match self._resolveTypeIdentifier(inner) { Ok(v) => v, Err(e) => return Err(e) }
+        val innerTy = try self._resolveTypeIdentifier(inner)
         Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [innerTy]))
       }
       TypeIdentifier.Option(inner) => {
-        val innerTy = match self._resolveTypeIdentifier(inner) { Ok(v) => v, Err(e) => return Err(e) }
+        val innerTy = try self._resolveTypeIdentifier(inner)
         Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [innerTy]))
       }
       TypeIdentifier.Tuple(typeIdents) => {
         val types: Type[] = []
         for typeIdent in typeIdents {
-          val ty = match self._resolveTypeIdentifier(typeIdent) { Ok(v) => v, Err(e) => return Err(e) }
+          val ty = try self._resolveTypeIdentifier(typeIdent)
           types.push(ty)
         }
 
@@ -1789,11 +1784,11 @@ export type Typechecker {
       TypeIdentifier.Function(params, ret) => {
         val paramTypes: (Type, Bool)[] = []
         for p in params {
-          val t = match self._resolveTypeIdentifier(p) { Ok(v) => v, Err(e) => return Err(e) }
-          paramTypes.push((t, true))
+          val typeIdent = try self._resolveTypeIdentifier(p)
+          paramTypes.push((typeIdent, true))
         }
 
-        val returnType = match self._resolveTypeIdentifier(ret) { Ok(v) => v, Err(e) => return Err(e) }
+        val returnType = try self._resolveTypeIdentifier(ret)
         Type(kind: TypeKind.Func(paramTypes, returnType))
       }
     }
@@ -1807,7 +1802,7 @@ export type Typechecker {
   func _resolveTypeOrEnumVariant(self, path: Label[], last: Label): Result<Either<Type, (Enum, TypedEnumVariant, Int)>, TypeError> {
     match path[0] {
       None => {
-        val ty = match self._findTypeByNameInScope(last) { Ok(v) => v, Err(e) => return Err(e) }
+        val ty = try self._findTypeByNameInScope(last)
         val t = match ty.kind {
           TypeKind.Type(structOrEnum) => Type(kind: TypeKind.Instance(structOrEnum, []))
           _ => ty
@@ -1815,10 +1810,10 @@ export type Typechecker {
         return Ok(Either.Left(t))
       }
       _ first => {
-        val mod = match self._findModuleByAlias(first.name) { Ok(v) => v, Err(e) => return Err(e) }
+        val mod = try self._findModuleByAlias(first.name)
         match mod {
           None => {
-            val ty = match self._findTypeByNameInScope(first) { Ok(v) => v, Err(e) => return Err(e) }
+            val ty = try self._findTypeByNameInScope(first)
             val label = if path[1] |seg| {
               return Err(TypeError(position: seg.position, kind: TypeErrorKind.UnknownName(seg.name, "type")))
             } else {
@@ -2080,7 +2075,7 @@ export type Typechecker {
     val mod = TypedModule(id: -1, name: modulePathAbs, code: [], rootScope: Scope.bogus())
     self.project.modules[modulePathAbs] = mod
 
-    val parsedModule = match self._tokenizeAndParse(modulePathAbs) { Ok(v) => v, Err(e) => return Err(e) }
+    val parsedModule = try self._tokenizeAndParse(modulePathAbs)
     val imports: (TypedModule, ImportNode)[] = []
     for importNode in parsedModule.imports {
       var importNodePath = importNode.moduleName.name
@@ -2174,7 +2169,7 @@ export type Typechecker {
   func _typecheckDecoratorNode(self, dec: DecoratorNode): Result<Decorator, TypeError> {
     val args: LiteralAstNode[] = []
     for arg in dec.arguments {
-      val typedArg = match self._typecheckExpression(arg.value, None) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedArg = try self._typecheckExpression(arg.value, None)
       match typedArg.kind {
         TypedAstNodeKind.Literal(litNode) => args.push(litNode)
         _ => return unreachable(typedArg.token.position, "should have been caught during parsing")
@@ -2187,7 +2182,7 @@ export type Typechecker {
   func _typecheckFunctionPass1(self, node: FunctionDeclarationNode): Result<Function, TypeError> {
     val decorators: Decorator[] = []
     for d in node.decorators {
-      val dec = match self._typecheckDecoratorNode(d) { Ok(v) => v, Err(e) => return Err(e) }
+      val dec = try self._typecheckDecoratorNode(d)
       decorators.push(dec)
     }
 
@@ -2204,13 +2199,12 @@ export type Typechecker {
       seenTypeParams[label.name] = label
 
       val generic = Type(kind: TypeKind.Generic(label.name))
-      match self._addTypeToScope(generic) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._addTypeToScope(generic)
       typeParams.push((generic, label))
     }
 
     val returnType = if node.returnTypeAnnotation |typeAnn| {
-      val ty = match self._resolveTypeIdentifier(typeAnn) { Ok(v) => v, Err(e) => return Err(e) }
-      ty
+      try self._resolveTypeIdentifier(typeAnn)
     } else {
       Type(kind: TypeKind.PrimitiveUnit)
     }
@@ -2232,7 +2226,7 @@ export type Typechecker {
     }
 
     val fn = Function(label: node.name, scope: fnScope, kind: fnKind, typeParams: typeParams, params: [], returnType: returnType, body: [], decorators: decorators)
-    match self._addFunctionToScope(fn) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._addFunctionToScope(fn)
 
     Ok(fn)
   }
@@ -2254,7 +2248,7 @@ export type Typechecker {
         }
 
         val variable = Variable(label: param.label, scope: self.currentScope, mutable: false, ty: ty, isParameter: true)
-        match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
+        try self._addVariableToScope(variable)
 
         val typedParam = TypedFunctionParam(label: param.label, ty: ty, defaultValue: None, isVariadic: false, variable: variable)
         return Ok((typedParam, false))
@@ -2264,7 +2258,7 @@ export type Typechecker {
     }
 
     val paramType = if param.typeAnnotation |typeAnn| {
-      val ty = match self._resolveTypeIdentifier(typeAnn) { Ok(v) => v, Err(e) => return Err(e) }
+      val ty = try self._resolveTypeIdentifier(typeAnn)
       if typeHint |hintTy| {
         if !self._typeSatisfiesRequired(ty: ty, required: hintTy) {
           return Err(TypeError(position: param.label.position, kind: TypeErrorKind.TypeMismatch([hintTy], ty)))
@@ -2280,7 +2274,7 @@ export type Typechecker {
     var defaultValue: TypedAstNode? = None
     if param.defaultValue |node| {
       if isRevisit {
-        val expr = match self._typecheckExpression(node, paramType) { Ok(v) => v, Err(e) => return Err(e) }
+        val expr = try self._typecheckExpression(node, paramType)
         defaultValue = Some(expr)
       } else {
         // TODO: There has to be a cleaner way of representing this
@@ -2324,7 +2318,7 @@ export type Typechecker {
     }
 
     val variable = Variable(label: param.label, scope: self.currentScope, mutable: false, ty: ty, isParameter: true)
-    match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._addVariableToScope(variable)
 
     if param.isVariadic {
       if self._typeAsInstance1(ty, self.project.preludeArrayStruct) |innerType| {
@@ -2366,7 +2360,7 @@ export type Typechecker {
       }
 
       val hint = paramHints[idx]
-      val (typedParam, needsRevisit) = match self._typecheckFunctionParam(param, hint, allowSelf) { Ok(v) => v, Err(e) => return Err(e) }
+      val (typedParam, needsRevisit) = try self._typecheckFunctionParam(param, hint, allowSelf)
       val paramName = typedParam.label.name
       // This is a bit messy - if param is `self` then don't add here; it's already denoted as an instance method via its FunctionKind
       if paramName != "self" { fn.params.push(typedParam) }
@@ -2403,7 +2397,7 @@ export type Typechecker {
       val defaultValueNode = if paramNode.defaultValue |n| n else return unreachable(param.label.position, "the only way a parameter needs revisiting is if it has a default value")
 
       val hint = paramHints[idx]
-      val (typedParam, needsRevisit) = match self._typecheckFunctionParam(param: paramNode, typeHint: hint, allowSelf: allowSelf, isRevisit: true) { Ok(v) => v, Err(e) => return Err(e) }
+      val (typedParam, needsRevisit) = try self._typecheckFunctionParam(param: paramNode, typeHint: hint, allowSelf: allowSelf, isRevisit: true)
       if needsRevisit return unreachable(param.label.position, "parameters should not need to be revisited more than once")
       fn.params[idx] = typedParam
     }
@@ -2433,7 +2427,7 @@ export type Typechecker {
         //     Ok(123)
         //   }
         val hint = if fn.returnType.hasUnfilledHoles() None else Some(fn.returnType)
-        val expr = match self._typecheckExpressionOrTerminator(node, hint) { Ok(v) => v, Err(e) => return Err(e) }
+        val expr = try self._typecheckExpressionOrTerminator(node, hint)
         if fn.returnType.hasUnfilledHoles() {
           fn.returnType.tryFillHoles(expr.ty)
         }
@@ -2447,8 +2441,7 @@ export type Typechecker {
 
         expr
       } else {
-        val stmt = match self._typecheckStatement(node, None) { Ok(v) => v, Err(e) => return Err(e) }
-        stmt
+        try self._typecheckStatement(node, None)
       }
       fn.body.push(typedNode)
     }
@@ -2461,7 +2454,7 @@ export type Typechecker {
 
   func _typecheckStructPass1(self, node: TypeDeclarationNode): Result<Struct, TypeError> {
     val isExported = if node.exportToken |exportToken| {
-      match self._ensureValidExportScope(exportToken) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._ensureValidExportScope(exportToken)
       true
     } else {
       false
@@ -2480,14 +2473,14 @@ export type Typechecker {
       seenTypeParams[label.name] = label
 
       val generic = Type(kind: TypeKind.Generic(label.name))
-      match self._addTypeToScope(generic) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._addTypeToScope(generic)
       typeParams.push(label.name)
     }
 
     self.currentScope = prevScope
 
     val struct = Struct(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
-    match self._addStructToScope(struct, isExported) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._addStructToScope(struct, isExported)
 
     Ok(struct)
   }
@@ -2505,12 +2498,12 @@ export type Typechecker {
       }
       seenFields[field.name.name] = field.name
 
-      val ty = match self._resolveTypeIdentifier(field.typeAnnotation) { Ok(v) => v, Err(e) => return Err(e) }
+      val ty = try self._resolveTypeIdentifier(field.typeAnnotation)
       struct.fields.push(Field(name: field.name, ty: ty, initializer: None))
     }
 
     for funcDeclNode in node.methods {
-      val fn = match self._typecheckFunctionPass1(funcDeclNode) { Ok(v) => v, Err(e) => return Err(e) }
+      val fn = try self._typecheckFunctionPass1(funcDeclNode)
       match fn.kind {
         FunctionKind.InstanceMethod => struct.instanceMethods.push(fn)
         FunctionKind.StaticMethod => struct.staticMethods.push(fn)
@@ -2559,7 +2552,7 @@ export type Typechecker {
       } else {
         return unreachable(funcDeclNode.name.position, "could not find function among instance/static methods")
       }
-      val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: true, params: funcDeclNode.params) { Ok(v) => v, Err(e) => return Err(e) }
+      val paramsNeedingRevisit = try self._typecheckFunctionPass2(fn: fn, allowSelf: true, params: funcDeclNode.params)
       allParamsNeedingRevisit[fn.label] = paramsNeedingRevisit
 
       if isToString {
@@ -2610,7 +2603,7 @@ export type Typechecker {
     val prevTypeDecl = self.currentTypeDecl
     self.currentTypeDecl = Some(StructOrEnum.Struct(struct))
 
-    val allParamsNeedingRevisit = match self._typecheckMethodsPass2(StructOrEnum.Struct(struct), node.methods) { Ok(v) => v, Err(e) => return Err(e) }
+    val allParamsNeedingRevisit = try self._typecheckMethodsPass2(StructOrEnum.Struct(struct), node.methods)
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
@@ -2628,7 +2621,7 @@ export type Typechecker {
       val initializer = if field.initializer |v| v else continue
       val structField = if struct.fields[idx] |f| f else return unreachable(struct.label.position, "")
 
-      val typedInitializer = match self._typecheckExpression(initializer, Some(structField.ty)) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedInitializer = try self._typecheckExpression(initializer, Some(structField.ty))
       if !self._typeSatisfiesRequired(ty: typedInitializer.ty, required: structField.ty) {
         return Err(TypeError(position: initializer.token.position, kind: TypeErrorKind.TypeMismatch([structField.ty], typedInitializer.ty)))
       }
@@ -2648,7 +2641,7 @@ export type Typechecker {
       }
 
       val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
-      match self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit)
     }
 
     self.currentTypeDecl = prevTypeDecl
@@ -2659,7 +2652,7 @@ export type Typechecker {
 
   func _typecheckEnumPass1(self, node: EnumDeclarationNode): Result<Enum, TypeError> {
     val isExported = if node.exportToken |exportToken| {
-      match self._ensureValidExportScope(exportToken) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._ensureValidExportScope(exportToken)
       true
     } else {
       false
@@ -2678,14 +2671,14 @@ export type Typechecker {
       seenTypeParams[label.name] = label
 
       val generic = Type(kind: TypeKind.Generic(label.name))
-      match self._addTypeToScope(generic) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._addTypeToScope(generic)
       typeParams.push(label.name)
     }
 
     self.currentScope = prevScope
 
     val enum_ = Enum(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
-    match self._addEnumToScope(enum_, isExported) { Ok(v) => v, Err(e) => return Err(e) }
+    try self._addEnumToScope(enum_, isExported)
 
     Ok(enum_)
   }
@@ -2720,7 +2713,7 @@ export type Typechecker {
             }
             seenFields[field.name.name] = field.name
 
-            val ty = match self._resolveTypeIdentifier(field.typeAnnotation) { Ok(v) => v, Err(e) => return Err(e) }
+            val ty = try self._resolveTypeIdentifier(field.typeAnnotation)
             // The initializer (if present) will be filled in during the next pass
             typedFields.push(Field(name: field.name, ty: ty, initializer: None))
           }
@@ -2731,7 +2724,7 @@ export type Typechecker {
     }
 
     for funcDeclNode in node.methods {
-      val fn = match self._typecheckFunctionPass1(funcDeclNode) { Ok(v) => v, Err(e) => return Err(e) }
+      val fn = try self._typecheckFunctionPass1(funcDeclNode)
       match fn.kind {
         FunctionKind.InstanceMethod => enum_.instanceMethods.push(fn)
         FunctionKind.StaticMethod => enum_.staticMethods.push(fn)
@@ -2763,7 +2756,7 @@ export type Typechecker {
           for typedField, idx in typedFields {
             val field = if fields[idx] |f| f else return unreachable(typedField.name.position, "the untyped field must exist at index")
             if field.initializer |initializer| {
-              val typedInitializer = match self._typecheckExpression(initializer, Some(typedField.ty)) { Ok(v) => v, Err(e) => return Err(e) }
+              val typedInitializer = try self._typecheckExpression(initializer, Some(typedField.ty))
               if !self._typeSatisfiesRequired(ty: typedInitializer.ty, required: typedField.ty) {
                 return Err(TypeError(position: typedInitializer.token.position, kind: TypeErrorKind.TypeMismatch([typedField.ty], typedInitializer.ty)))
               }
@@ -2777,7 +2770,7 @@ export type Typechecker {
       }
     }
 
-    val allParamsNeedingRevisit = match self._typecheckMethodsPass2(StructOrEnum.Enum(enum_), node.methods) { Ok(v) => v, Err(e) => return Err(e) }
+    val allParamsNeedingRevisit = try self._typecheckMethodsPass2(StructOrEnum.Enum(enum_), node.methods)
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
@@ -2804,7 +2797,7 @@ export type Typechecker {
       }
 
       val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
-      match self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit)
     }
 
     self.currentTypeDecl = prevTypeDecl
@@ -2870,7 +2863,7 @@ export type Typechecker {
     val typecheckingPrelude = self.typecheckingBuiltin == Some(BuiltinModule.Prelude)
     val structsPass1: (Struct, TypeDeclarationNode)[] = []
     for node in typeDecls {
-      val struct = match self._typecheckStructPass1(node) { Ok(v) => v, Err(e) => return Err(e) }
+      val struct = try self._typecheckStructPass1(node)
       if typecheckingPrelude {
         match struct.label.name {
           "Int" => self.project.preludeIntStruct = struct
@@ -2888,7 +2881,7 @@ export type Typechecker {
 
     val enumsPass1: (Enum, EnumDeclarationNode)[] = []
     for node in enumDecls {
-      val enum_ = match self._typecheckEnumPass1(node) { Ok(v) => v, Err(e) => return Err(e) }
+      val enum_ = try self._typecheckEnumPass1(node)
       if typecheckingPrelude {
         match enum_.label.name {
           "Option" => self.project.preludeOptionEnum = enum_
@@ -2902,13 +2895,13 @@ export type Typechecker {
     val functionsPass1: (Function, Variable, FunctionDeclarationNode)[] = []
     for node in funcDecls {
       val isExported = if node.exportToken |exportToken| {
-        match self._ensureValidExportScope(exportToken) { Ok(v) => v, Err(e) => return Err(e) }
+        try self._ensureValidExportScope(exportToken)
         true
       } else {
         false
       }
 
-      val fn = match self._typecheckFunctionPass1(node) { Ok(v) => v, Err(e) => return Err(e) }
+      val fn = try self._typecheckFunctionPass1(node)
       val aliasVar = Variable(label: fn.label, scope: self.currentScope, mutable: false, ty: fn.getType(), alias: Some(VariableAlias.Function(fn)))
       self.currentScope.variables.push(aliasVar)
       functionsPass1.push((fn, aliasVar, node))
@@ -2922,35 +2915,35 @@ export type Typechecker {
 
     val structsPass2_1: (Struct, TypeDeclarationNode)[] = []
     for (struct, node) in structsPass1 {
-      match self._typecheckStructPass2_1(struct, node) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._typecheckStructPass2_1(struct, node)
 
       structsPass2_1.push((struct, node))
     }
 
     val enumsPass2_1: (Enum, EnumDeclarationNode)[] = []
     for (enum_, node) in enumsPass1 {
-      match self._typecheckEnumPass2_1(enum_, node) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._typecheckEnumPass2_1(enum_, node)
 
       enumsPass2_1.push((enum_, node))
     }
 
     val structsPass2_2: (Struct, TypeDeclarationNode, Map<Label, Int[]>)[] = []
     for (struct, node) in structsPass1 {
-      val toRevisit = match self._typecheckStructPass2_2(struct, node) { Ok(v) => v, Err(e) => return Err(e) }
+      val toRevisit = try self._typecheckStructPass2_2(struct, node)
 
       structsPass2_2.push((struct, node, toRevisit))
     }
 
     val enumsPass2_2: (Enum, EnumDeclarationNode, Map<Label, Int[]>)[] = []
     for (enum_, node) in enumsPass2_1 {
-      val toRevisit = match self._typecheckEnumPass2_2(enum_, node) { Ok(v) => v, Err(e) => return Err(e) }
+      val toRevisit = try self._typecheckEnumPass2_2(enum_, node)
 
       enumsPass2_2.push((enum_, node, toRevisit))
     }
 
     val functionsPass2: (Function, FunctionDeclarationNode, Int[])[] = []
     for (fn, aliasVar, node) in functionsPass1 {
-      val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params) { Ok(v) => v, Err(e) => return Err(e) }
+      val paramsNeedingRevisit = try self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params)
 
       aliasVar.ty = fn.getType()
       functionsPass2.push((fn, node, paramsNeedingRevisit))
@@ -2962,10 +2955,10 @@ export type Typechecker {
 
     val typedNodes: TypedAstNode[] = []
     for node in nodes {
-      val res = match node.kind {
+      val typedNode = match node.kind {
         AstNodeKind.FunctionDeclaration => {
           val typedNode = if functionsIter.next() |(fn, fnDeclNode, paramsNeedingRevisit)| {
-            match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: fnDeclNode.params, body: fnDeclNode.body, paramsNeedingRevisit: paramsNeedingRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+            try self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: fnDeclNode.params, body: fnDeclNode.body, paramsNeedingRevisit: paramsNeedingRevisit)
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.FunctionDeclaration(fn))
           } else {
             return unreachable(node.token.position, "there should be as many functions as there are functiondecl nodes")
@@ -2976,7 +2969,7 @@ export type Typechecker {
         }
         AstNodeKind.TypeDeclaration => {
           val typedNode = if structsIter.next() |(struct, typeDeclNode, toRevisit)| {
-            match self._typecheckStructPass3(struct, typeDeclNode, toRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+            try self._typecheckStructPass3(struct, typeDeclNode, toRevisit)
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.TypeDeclaration(struct))
           } else {
             return unreachable(node.token.position, "there should be as many types as there are typedecl nodes")
@@ -2987,7 +2980,7 @@ export type Typechecker {
         }
         AstNodeKind.EnumDeclaration => {
           val typedNode = if enumsIter.next() |(enum_, enumDeclNode, toRevisit)| {
-            match self._typecheckEnumPass3(enum_, enumDeclNode, toRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+            try self._typecheckEnumPass3(enum_, enumDeclNode, toRevisit)
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.EnumDeclaration(enum_))
           } else {
             return unreachable(node.token.position, "there should be as many enums as there are enumdecl nodes")
@@ -2996,10 +2989,9 @@ export type Typechecker {
           typedNodes.push(typedNode)
           continue
         }
-        _ => self._typecheckStatement(node: node, typeHint: None)
+        _ => try self._typecheckStatement(node: node, typeHint: None)
       }
 
-      val typedNode = match res { Ok(v) => v, Err(e) => return Err(e) }
       typedNodes.push(typedNode)
     }
 
@@ -3025,7 +3017,7 @@ export type Typechecker {
     match pattern {
       BindingPattern.Variable(label) => {
         val variable = Variable(label: label, scope: self.currentScope, mutable: mutable, ty: ty)
-        match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
+        try self._addVariableToScope(variable)
 
         Ok([variable])
       }
@@ -3047,7 +3039,7 @@ export type Typechecker {
             return Err(TypeError(position: lParenTok.position, kind: kind))
           }
 
-          val foundVars = match self._typecheckBindingPattern(mutable, pat, innerType) { Ok(v) => v, Err(e) => return Err(e) }
+          val foundVars = try self._typecheckBindingPattern(mutable, pat, innerType)
           for v in foundVars variables.push(v)
         }
 
@@ -3059,21 +3051,21 @@ export type Typechecker {
   func _typecheckBindingDeclaration(self, token: Token, node: BindingDeclarationNode): Result<TypedAstNode, TypeError> {
     val isMutable = token.kind == TokenKind.Var
     val isExported = if node.exportToken |exportToken| {
-      match self._ensureValidExportScope(exportToken) { Ok(v) => v, Err(e) => return Err(e) }
+      try self._ensureValidExportScope(exportToken)
       true
     } else {
       false
     }
 
     val annType = if node.typeAnnotation |typeAnn| {
-      val ty = match self._resolveTypeIdentifier(typeAnn) { Ok(v) => v, Err(e) => return Err(e) }
+      val ty = try self._resolveTypeIdentifier(typeAnn)
       Some(ty)
     } else {
       None
     }
 
     val (expr, ty) = if node.expr |expr| {
-      val typedExpr = match self._typecheckExpression(expr, annType) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedExpr = try self._typecheckExpression(expr, annType)
       val ty = if annType |annotatedType| {
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: annotatedType) {
           return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([annotatedType], typedExpr.ty)))
@@ -3105,7 +3097,7 @@ export type Typechecker {
       return Err(err)
     }
 
-    val variables = match self._typecheckBindingPattern(isMutable, node.bindingPattern, ty) { Ok(v) => v, Err(e) => return Err(e) }
+    val variables = try self._typecheckBindingPattern(isMutable, node.bindingPattern, ty)
     for v in variables {
       if isExported {
         v.isExported = true
@@ -3137,7 +3129,7 @@ export type Typechecker {
           }
         }
 
-        val typedExpr = match self._typecheckExpression(expr, Some(variable.ty)) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedExpr = try self._typecheckExpression(expr, Some(variable.ty))
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: variable.ty) {
           return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([variable.ty], typedExpr.ty)))
         }
@@ -3146,14 +3138,14 @@ export type Typechecker {
         return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
       }
       AssignmentMode.Indexing(targetExpr, indexExpr) => {
-        val typedLhs = match self._typecheckIndexing(token, targetExpr, IndexingMode.Single(indexExpr), None) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedLhs = try self._typecheckIndexing(token, targetExpr, IndexingMode.Single(indexExpr), None)
         val typedIndexingNode = match typedLhs.kind {
           TypedAstNodeKind.Indexing(node) => node
           _ => return unreachable(typedLhs.token.position, "_typecheckIndexing returned unexpected TypedAstNodeKind")
         }
         val assignmentTy = if self._typeIsOption(typedLhs.ty) |inner| inner else typedLhs.ty
 
-        val typedExpr = match self._typecheckExpression(expr, Some(assignmentTy)) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedExpr = try self._typecheckExpression(expr, Some(assignmentTy))
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: assignmentTy) {
           return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([assignmentTy], typedExpr.ty)))
         }
@@ -3162,7 +3154,7 @@ export type Typechecker {
         return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
       }
       AssignmentMode.Accessor(accessorNode) => {
-        val typedLhs = match self._typecheckAccessor(token, accessorNode, None) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedLhs = try self._typecheckAccessor(token, accessorNode, None)
         val (mode, fieldLabel, field) = match typedLhs.kind {
           TypedAstNodeKind.Accessor(head, mid, tail) => {
             val t = match tail {
@@ -3192,7 +3184,7 @@ export type Typechecker {
           _ => return unreachable(typedLhs.token.position, "_typecheckAccessor returned unexpected TypedAstNodeKind")
         }
 
-        val typedExpr = match self._typecheckExpression(expr, Some(field.ty)) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedExpr = try self._typecheckExpression(expr, Some(field.ty))
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: field.ty) {
           return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([field.ty], typedExpr.ty)))
         }
@@ -3203,7 +3195,7 @@ export type Typechecker {
   }
 
   func _typecheckWhile(self, token: Token, condition: AstNode, conditionBinding: BindingPattern?, block: AstNode[]): Result<TypedAstNode, TypeError> {
-    val typedCondition = match self._typecheckExpression(condition, None) { Ok(v) => v, Err(e) => return Err(e) }
+    val typedCondition = try self._typecheckExpression(condition, None)
     val condOptInnerTy = self._typeIsOption(typedCondition.ty)
     if !condOptInnerTy && !self._typeSatisfiesRequired(ty: typedCondition.ty, required: Type(kind: TypeKind.PrimitiveBool)) {
       return Err(TypeError(position: typedCondition.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedCondition.ty, purpose: "while")))
@@ -3215,7 +3207,7 @@ export type Typechecker {
     val conditionBindingPattern = if conditionBinding |pattern| {
       val ty = condOptInnerTy ?: typedCondition.ty
 
-      val vars = match self._typecheckBindingPattern(false, pattern, ty) { Ok(v) => v, Err(e) => return Err(e) }
+      val vars = try self._typecheckBindingPattern(false, pattern, ty)
       Some((pattern, vars))
     } else {
       None
@@ -3225,7 +3217,7 @@ export type Typechecker {
     for node in block {
       if self.currentScope.terminator return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
-      val typedNode = match self._typecheckStatement(node, None) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedNode = try self._typecheckStatement(node, None)
       typedNodes.push(typedNode)
     }
     val terminator = self.currentScope.terminator
@@ -3313,7 +3305,7 @@ export type Typechecker {
   }
 
   func _typecheckFor(self, token: Token, itemPattern: BindingPattern, indexPattern: BindingPattern?, iterator: AstNode, block: AstNode[]): Result<TypedAstNode, TypeError> {
-    val typedIterator = match self._typecheckExpression(iterator, None) { Ok(v) => v, Err(e) => return Err(e) }
+    val typedIterator = try self._typecheckExpression(iterator, None)
     val itemType = if self._typeIsIterable(typedIterator.ty) |innerTy| innerTy else {
       return Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
     }
@@ -3324,9 +3316,9 @@ export type Typechecker {
     val prevScope = self.currentScope
     self.currentScope = self.currentScope.makeChild("for", ScopeKind.For)
 
-    val variables = match self._typecheckBindingPattern(false, itemPattern, itemType) { Ok(v) => v, Err(e) => return Err(e) }
+    val variables = try self._typecheckBindingPattern(false, itemPattern, itemType)
     val indexBinding = if indexPattern |pat| {
-      val variables = match self._typecheckBindingPattern(false, pat, Type(kind: TypeKind.PrimitiveInt)) { Ok(v) => v, Err(e) => return Err(e) }
+      val variables = try self._typecheckBindingPattern(false, pat, Type(kind: TypeKind.PrimitiveInt))
       variables[0]
     } else {
       None
@@ -3336,7 +3328,7 @@ export type Typechecker {
     for node in block {
       if self.currentScope.terminator return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
-      val typedNode = match self._typecheckStatement(node, None) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedNode = try self._typecheckStatement(node, None)
       typedNodes.push(typedNode)
     }
     val terminator = self.currentScope.terminator
@@ -3386,7 +3378,7 @@ export type Typechecker {
     }
 
     val typedExpr = if expr |expr| {
-      val typedExpr = match self._typecheckExpression(expr, Some(fn.returnType)) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedExpr = try self._typecheckExpression(expr, Some(fn.returnType))
       if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: fn.returnType) {
         val fnName = if fn.isLambda None else Some(fn.label.name)
         return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.ReturnTypeMismatch(fnName, fn.returnType, Some(typedExpr.ty))))
@@ -3422,7 +3414,7 @@ export type Typechecker {
   ): Result<TypedAstNode, TypeError> {
     val isStatement = if typeHint |hint| hint.kind == TypeKind.PrimitiveUnit else false
 
-    val typedCondition = match self._typecheckExpression(condition, None) { Ok(v) => v, Err(e) => return Err(e) }
+    val typedCondition = try self._typecheckExpression(condition, None)
     val condOptInnerTy = self._typeIsOption(typedCondition.ty)
     if !condOptInnerTy && !self._typeSatisfiesRequired(ty: typedCondition.ty, required: Type(kind: TypeKind.PrimitiveBool)) {
       return Err(TypeError(position: typedCondition.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedCondition.ty, purpose: "if")))
@@ -3435,7 +3427,7 @@ export type Typechecker {
     val conditionBindingPattern = if conditionBinding |pattern| {
       val ty = condOptInnerTy ?: typedCondition.ty
 
-      val vars = match self._typecheckBindingPattern(false, pattern, ty) { Ok(v) => v, Err(e) => return Err(e) }
+      val vars = try self._typecheckBindingPattern(false, pattern, ty)
       Some((pattern, vars))
     } else {
       None
@@ -3445,10 +3437,10 @@ export type Typechecker {
       if self.currentScope.terminator == Some(Terminator.Returning) return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
       if idx == ifBlock.length - 1 && !isStatement {
-        val typedNode = match self._typecheckExpressionOrTerminator(node, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedNode = try self._typecheckExpressionOrTerminator(node, typeHint)
         typedIfBlock.push(typedNode)
       } else {
-        val typedNode = match self._typecheckStatement(node, None) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedNode = try self._typecheckStatement(node, None)
         typedIfBlock.push(typedNode)
       }
     }
@@ -3467,10 +3459,10 @@ export type Typechecker {
 
         if idx == elseBlock.length - 1 && !isStatement {
           val hint = if ifType |t| (if t.hasUnfilledHoles() None else ifType) else None
-          val typedNode = match self._typecheckExpressionOrTerminator(node, hint) { Ok(v) => v, Err(e) => return Err(e) }
+          val typedNode = try self._typecheckExpressionOrTerminator(node, hint)
           typedElseBlock.push(typedNode)
         } else {
-          val typedNode = match self._typecheckStatement(node, None) { Ok(v) => v, Err(e) => return Err(e) }
+          val typedNode = try self._typecheckStatement(node, None)
           typedElseBlock.push(typedNode)
         }
       }
@@ -3515,7 +3507,7 @@ export type Typechecker {
 
   func _typecheckMatch(self, token: Token, expr: AstNode, cases: MatchCase[], typeHint: Type?): Result<TypedAstNode, TypeError> {
     val isStatement = if typeHint |hint| hint.kind == TypeKind.PrimitiveUnit else false
-    val typedExpr = match self._typecheckExpression(expr, None) { Ok(v) => v, Err(e) => return Err(e) }
+    val typedExpr = try self._typecheckExpression(expr, None)
 
     var subjectTy = typedExpr.ty
     val typedCases: TypedMatchCase[] = []
@@ -3562,7 +3554,7 @@ export type Typechecker {
       var caseVar: Variable? = None
       val typedMatchCaseKind = match case.kind {
         MatchCaseKind.Type(path, last, args) => {
-          val typeOrEnumVariant = match self._resolveTypeOrEnumVariant(path, last) { Ok(v) => v, Err(e) => return Err(e) }
+          val typeOrEnumVariant = try self._resolveTypeOrEnumVariant(path, last)
           val typedCaseKind = match typeOrEnumVariant {
             Either.Left(caseTy) => {
               if seenTypes.contains(caseTy) return Err(TypeError(position: case.position, kind: TypeErrorKind.DuplicateMatchCase))
@@ -3631,7 +3623,7 @@ export type Typechecker {
                         field.ty
                       }
                       val variable = Variable(label: arg, scope: self.currentScope, mutable: false, ty: variableTy)
-                      match self._addVariableToScope(variable) { Ok(v) => v, Err(e) => return Err(e) }
+                      try self._addVariableToScope(variable)
                       variables.push(variable)
                     }
                   }
@@ -3703,17 +3695,17 @@ export type Typechecker {
       }
 
       if caseVar |v| {
-        match self._addVariableToScope(v) { Ok(v) => v, Err(e) => return Err(e) }
+        try self._addVariableToScope(v)
       }
 
       for node, idx in case.body {
         if self.currentScope.terminator return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
         if idx == case.body.length - 1 && !isStatement {
-          val typedNode = match self._typecheckExpressionOrTerminator(node, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
+          val typedNode = try self._typecheckExpressionOrTerminator(node, typeHint)
           typedBody.push(typedNode)
         } else {
-          val typedNode = match self._typecheckStatement(node, None) { Ok(v) => v, Err(e) => return Err(e) }
+          val typedNode = try self._typecheckStatement(node, None)
           typedBody.push(typedNode)
         }
       }
@@ -3768,7 +3760,7 @@ export type Typechecker {
 
   func _typecheckExpression(self, node: AstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
     val token = node.token
-    val typedExprRes: Result<TypedAstNode, TypeError> = match node.kind {
+    val typedExpr = try match node.kind {
       AstNodeKind.Literal(literal) => {
         val kind = match literal {
           LiteralAstNode.Int => TypeKind.PrimitiveInt
@@ -3783,7 +3775,7 @@ export type Typechecker {
       AstNodeKind.Unary(node) => self._typecheckUnary(token, node)
       AstNodeKind.Binary(node) => self._typecheckBinary(token, node)
       AstNodeKind.Grouped(inner) => {
-        val expr = match self._typecheckExpression(inner, None) { Ok(v) => v, Err(e) => return Err(e) }
+        val expr = try self._typecheckExpression(inner, None)
         Ok(TypedAstNode(token: token, ty: expr.ty, kind: TypedAstNodeKind.Grouped(expr)))
       }
       AstNodeKind.Identifier(kind) => self._typecheckIdentifier(token, kind, typeHint)
@@ -3800,8 +3792,6 @@ export type Typechecker {
       AstNodeKind.Try(expr) => self._typecheckTry(token, expr, typeHint)
       _ => unreachable(node.token.position, "all other node types should have already been handled")
     }
-
-    val typedExpr = match typedExprRes { Ok(v) => v, Err(e) => return Err(e) }
 
     match typedExpr.ty.kind {
       TypeKind.Type => {
@@ -3827,7 +3817,7 @@ export type Typechecker {
   func _typecheckStringInterpolation(self, token: Token, exprs: AstNode[]): Result<TypedAstNode, TypeError> {
     val typedExprs: TypedAstNode[] = []
     for expr in exprs {
-      val typedExpr = match self._typecheckExpression(expr, None) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedExpr = try self._typecheckExpression(expr, None)
       typedExprs.push(typedExpr)
     }
 
@@ -3835,7 +3825,7 @@ export type Typechecker {
   }
 
   func _typecheckUnary(self, token: Token, node: UnaryAstNode): Result<TypedAstNode, TypeError> {
-    val expr = match self._typecheckExpression(node: node.expr, typeHint: None) { Ok(v) => v, Err(e) => return Err(e) }
+    val expr = try self._typecheckExpression(node: node.expr, typeHint: None)
     val ty = match node.op {
       UnaryOp.Minus => {
         if !self._typeSatisfiesRequired(ty: expr.ty, required: Type(kind: TypeKind.PrimitiveInt)) &&
@@ -3858,8 +3848,8 @@ export type Typechecker {
 
   func _typecheckBinary(self, token: Token, node: BinaryAstNode): Result<TypedAstNode, TypeError> {
     val handleCases: ((TypeKind, TypeKind, TypeKind)[]) => Result<TypedAstNode, TypeError> = (cases) => {
-      val left = match self._typecheckExpression(node.left, None) { Ok(v) => v, Err(e) => return Err(e) }
-      val right = match self._typecheckExpression(node.right, None) { Ok(v) => v, Err(e) => return Err(e) }
+      val left = try self._typecheckExpression(node.left, None)
+      val right = try self._typecheckExpression(node.right, None)
       for (lTy, rTy, outTy) in cases {
         if (lTy == TypeKind.Hole || self._typeSatisfiesRequired(ty: left.ty, required: Type(kind: lTy))) &&
           ((rTy == TypeKind.Hole || self._typeSatisfiesRequired(ty: right.ty, required: Type(kind: rTy)))) {
@@ -3871,8 +3861,8 @@ export type Typechecker {
     }
 
     val handleEquality: () => Result<TypedAstNode, TypeError> = () => {
-      val left = match self._typecheckExpression(node.left, None) { Ok(v) => v, Err(e) => return Err(e) }
-      val right = match self._typecheckExpression(node.right, Some(left.ty)) { Ok(v) => v, Err(e) => return Err(e) }
+      val left = try self._typecheckExpression(node.left, None)
+      val right = try self._typecheckExpression(node.right, Some(left.ty))
 
       if !self._typeSatisfiesRequired(ty: right.ty, required: left.ty) {
         return Err(TypeError(position: right.token.position, kind: TypeErrorKind.TypeMismatch([left.ty], right.ty)))
@@ -3926,9 +3916,9 @@ export type Typechecker {
       BinaryOp.Xor => handleCases(boolOpCases)
       BinaryOp.Coalesce => {
         // If the lhs isn't a nullable type then we can short-circuit and don't even typecheck the rhs
-        val left = match self._typecheckExpression(node.left, None) { Ok(v) => v, Err(e) => return Err(e) }
+        val left = try self._typecheckExpression(node.left, None)
         val right = if self._typeIsOption(left.ty) |innerTy| {
-          val right = match self._typecheckExpression(node.right, Some(innerTy)) { Ok(v) => v, Err(e) => return Err(e) }
+          val right = try self._typecheckExpression(node.right, Some(innerTy))
           if !self._typeSatisfiesRequired(ty: right.ty, required: innerTy) {
             return Err(TypeError(position: right.token.position, kind: TypeErrorKind.TypeMismatch([innerTy], right.ty)))
           }
@@ -3989,8 +3979,7 @@ export type Typechecker {
           ))
         )
 
-        val e = match self._typecheckExpression(replacement, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
-        return Ok(e)
+        return self._typecheckExpression(replacement, typeHint)
       }
       IdentifierKind.Self => {
         val resolvedIdentifier = if self._resolveIdentifier("self") |_v| _v else {
@@ -4131,14 +4120,10 @@ export type Typechecker {
   func _resolveModuleAliasAccessor(self, root: AstNode, field: (Token, Label)): Result<TypedAstNode?, TypeError> {
     val _mod = match root.kind {
       AstNodeKind.Identifier(identKind) => {
-        val m = match identKind {
-          IdentifierKind.Named(name) => {
-            val m = match self._findModuleByAlias(name) { Ok(v) => v, Err(e) => return Err(e) }
-            m
-          }
+        match identKind {
+          IdentifierKind.Named(name) => try self._findModuleByAlias(name)
           _ => None
         }
-        m
       }
       _ => None
     }
@@ -4167,7 +4152,7 @@ export type Typechecker {
     var accessorPath = node.path
 
     val firstSeg = if accessorPath[0] |p| p else return unreachable(token.position, "path should have at least 1 segment")
-    val maybeModuleAccessor = match self._resolveModuleAliasAccessor(node.root, firstSeg) { Ok(v) => v, Err(e) => return Err(e) }
+    val maybeModuleAccessor = try self._resolveModuleAliasAccessor(node.root, firstSeg)
     val typedRoot = if maybeModuleAccessor |n| {
       if accessorPath.length == 1 return Ok(n)
 
@@ -4175,7 +4160,7 @@ export type Typechecker {
       n
     } else {
       self.isStructOrEnumValueAllowed = true
-      val typedNode = match self._typecheckExpression(node.root, None) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedNode = try self._typecheckExpression(node.root, None)
       self.isStructOrEnumValueAllowed = false
       typedNode
     }
@@ -4198,7 +4183,7 @@ export type Typechecker {
         ty
       }
 
-      val seg = match self._resolveAccessorPathSegment(subjTy, label, typeHint, isOptSafe) { Ok(v) => v, Err(e) => return Err(e) }
+      val seg = try self._resolveAccessorPathSegment(subjTy, label, typeHint, isOptSafe)
       if seg |seg| {
         val nextTy = seg.getType()
 
@@ -4226,7 +4211,7 @@ export type Typechecker {
         }
       } else {
         val specialCase = if optInnerTy |innerTy| {
-          val seg = match self._resolveAccessorPathSegment(innerTy, label, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
+          val seg = try self._resolveAccessorPathSegment(innerTy, label, typeHint)
           if seg {
             Some(UnknownFieldSpecialCase.ExistsButTypeIsNullable(seenOptSafeDot))
           } else {
@@ -4235,14 +4220,7 @@ export type Typechecker {
         } else {
           match ty.kind {
             TypeKind.Instance(structOrEnum, _) => {
-              val seg = match structOrEnum {
-                StructOrEnum.Struct(struct) => {
-                  match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Struct(struct))), label, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
-                }
-                StructOrEnum.Enum(enum_) => {
-                  match self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))), label, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
-                }
-              }
+              val seg = try self._resolveAccessorPathSegment(Type(kind: TypeKind.Type(structOrEnum)), label, typeHint)
 
               if seg {
                 Some(UnknownFieldSpecialCase.StaticFieldReferencedAsInstance)
@@ -4266,7 +4244,7 @@ export type Typechecker {
   func _typecheckInvocation(self, token: Token, node: InvocationAstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
     self.isStructOrEnumValueAllowed = true
     self.isEnumContainerValueAllowed = true
-    val invokee = match self._typecheckExpression(node.invokee, None) { Ok(v) => v, Err(e) => return Err(e) }
+    val invokee = try self._typecheckExpression(node.invokee, None)
     self.isEnumContainerValueAllowed = false
     self.isStructOrEnumValueAllowed = false
 
@@ -4304,7 +4282,7 @@ export type Typechecker {
                 }
 
                 if optSafe {
-                  val typedNode = match self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint, Some((selfVal, true))) { Ok(v) => v, Err(e) => return Err(e) }
+                  val typedNode = try self._typecheckInvocationOfFunction(token, invokee, fn, node, typeHint, Some((selfVal, true)))
                   typedNode.ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [typedNode.ty]))
                   Ok(typedNode)
                 } else {
@@ -4342,7 +4320,7 @@ export type Typechecker {
         return Err(TypeError(position: arg.position(), kind: TypeErrorKind.WrongInvocationArity(expected: paramTypes.length, given: invocationNode.arguments.length)))
       }
 
-      val typedArg = match self._typecheckExpression(arg.value, Some(paramType)) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedArg = try self._typecheckExpression(arg.value, Some(paramType))
       if !self._typeSatisfiesRequired(ty: typedArg.ty, required: paramType) {
         return Err(TypeError(position: typedArg.token.position, kind: TypeErrorKind.ParameterTypeMismatch(None, paramType, typedArg.ty)))
       }
@@ -4375,12 +4353,12 @@ export type Typechecker {
     val resolvedGenerics: Map<String, Type> = {}
 
     if !invocationNode.typeArguments.isEmpty() {
-      for generic, idx in fn.typeParams {
+      for (_, typeParamLabel), idx in fn.typeParams {
         val typeArg = if invocationNode.typeArguments[idx] |typeArg| typeArg else {
           return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.WrongTypeArgumentArity(expected: fn.typeParams.length, given: invocationNode.typeArguments.length)))
         }
-        val typeArgTy = match self._resolveTypeIdentifier(typeArg) { Ok(v) => v, Err(e) => return Err(e) }
-        resolvedGenerics[generic[1].name] = typeArgTy
+        val typeArgTy = try self._resolveTypeIdentifier(typeArg)
+        resolvedGenerics[typeParamLabel.name] = typeArgTy
       }
       if invocationNode.typeArguments.length > fn.typeParams.length {
         return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.WrongTypeArgumentArity(expected: fn.typeParams.length, given: invocationNode.typeArguments.length)))
@@ -4461,7 +4439,7 @@ export type Typechecker {
       val (typedArg, paramType) = if param.ty.containsGenerics() {
         var paramType = paramTy.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: genericsInScope)
 
-        val typedArg = match self._typecheckExpression(arg.value, Some(paramType)) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedArg = try self._typecheckExpression(arg.value, Some(paramType))
         if numAttempts < 1 && typedArg.ty.hasUnfilledHoles() {
           argumentsQueue.push((arg, argIdx, numAttempts + 1))
           continue
@@ -4493,7 +4471,7 @@ export type Typechecker {
         paramType = paramTy.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: genericsInScope)
         (typedArg, paramType)
       } else {
-        val typedArg = match self._typecheckExpression(arg.value, Some(paramTy)) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedArg = try self._typecheckExpression(arg.value, Some(paramTy))
         (typedArg, paramTy)
       }
       if !self._typeSatisfiesRequired(ty: typedArg.ty, required: paramType) {
@@ -4589,7 +4567,7 @@ export type Typechecker {
     var makeItemsNullable = false
     val typedItems: TypedAstNode[] = []
     for node in items {
-      val typedItem = match self._typecheckExpression(node: node, typeHint: innerType) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedItem = try self._typecheckExpression(node: node, typeHint: innerType)
       if innerType |ty| {
         if !self._typeSatisfiesRequired(ty: typedItem.ty, required: ty) {
           return Err(TypeError(position: typedItem.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedItem.ty)))
@@ -4629,7 +4607,7 @@ export type Typechecker {
     var makeItemsNullable = false
     val typedItems: TypedAstNode[] = []
     for node in items {
-      val typedItem = match self._typecheckExpression(node: node, typeHint: innerType) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedItem = try self._typecheckExpression(node: node, typeHint: innerType)
       if innerType |ty| {
         if !self._typeSatisfiesRequired(ty: typedItem.ty, required: ty) {
           return Err(TypeError(position: typedItem.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedItem.ty)))
@@ -4676,19 +4654,10 @@ export type Typechecker {
         AstNodeKind.Identifier(identKind) => match identKind {
           IdentifierKind.Named(name) => TypedAstNode(token: keyNode.token, ty: Type(kind: TypeKind.PrimitiveString), kind: TypedAstNodeKind.Literal(LiteralAstNode.String(name)))
           IdentifierKind.Discard => TypedAstNode(token: keyNode.token, ty: Type(kind: TypeKind.PrimitiveString), kind: TypedAstNodeKind.Literal(LiteralAstNode.String("_")))
-          IdentifierKind.Self => {
-            val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Ok(v) => v, Err(e) => return Err(e) }
-            e
-          }
-          IdentifierKind.None_ => {
-            val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Ok(v) => v, Err(e) => return Err(e) }
-            e
-          }
+          IdentifierKind.Self => try self._typecheckExpression(node: keyNode, typeHint: keyTy)
+          IdentifierKind.None_ => try self._typecheckExpression(node: keyNode, typeHint: keyTy)
         }
-        _ => {
-          val e = match self._typecheckExpression(node: keyNode, typeHint: keyTy) { Ok(v) => v, Err(e) => return Err(e) }
-          e
-        }
+        _ => try self._typecheckExpression(node: keyNode, typeHint: keyTy)
       }
 
       if keyTy |ty| {
@@ -4699,7 +4668,7 @@ export type Typechecker {
         keyTy = Some(typedKey.ty)
       }
 
-      val typedVal = match self._typecheckExpression(node: valNode, typeHint: valTy) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedVal = try self._typecheckExpression(node: valNode, typeHint: valTy)
       if valTy |ty| {
         if !self._typeSatisfiesRequired(ty: typedVal.ty, required: ty) {
           return Err(TypeError(position: typedVal.token.position, kind: TypeErrorKind.TypeMismatch([ty], typedVal.ty)))
@@ -4737,7 +4706,7 @@ export type Typechecker {
     val typedItems: TypedAstNode[] = []
     for node, idx in items {
       val typeHint = if typeHints |typeHints| typeHints[idx] else None
-      val typedExpr = match self._typecheckExpression(node, typeHint) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedExpr = try self._typecheckExpression(node, typeHint)
       if typeHint |hint| {
         if !self._typeSatisfiesRequired(ty: typedExpr.ty, required: hint) {
           return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.TypeMismatch([hint], typedExpr.ty)))
@@ -4757,12 +4726,12 @@ export type Typechecker {
   }
 
   func _typecheckIndexing(self, token: Token, expr: AstNode, indexMode: IndexingMode<AstNode>, typeHint: Type?): Result<TypedAstNode, TypeError> {
-    val typedExpr = match self._typecheckExpression(expr, None) { Ok(v) => v, Err(e) => return Err(e) }
+    val typedExpr = try self._typecheckExpression(expr, None)
     if self._typeIsOption(typedExpr.ty) {
       return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
     }
 
-    val res = match typedExpr.ty.kind {
+    match typedExpr.ty.kind {
       TypeKind.PrimitiveString => {
         val resTy = Type(kind: TypeKind.PrimitiveString)
         self._typecheckIndexingArraylike(token: token, typedExpr: typedExpr, indexMode: indexMode, singleModeType: resTy, rangeModeType: resTy)
@@ -4775,7 +4744,7 @@ export type Typechecker {
         } else if self._typeAsInstance2(typedExpr.ty, self.project.preludeMapStruct) |(keyTy, valTy)| {
           match indexMode {
             IndexingMode.Single(idxExpr) => {
-              val typedIdxExpr = match self._typecheckExpression(idxExpr, Some(keyTy)) { Ok(v) => v, Err(e) => return Err(e) }
+              val typedIdxExpr = try self._typecheckExpression(idxExpr, Some(keyTy))
               if !self._typeSatisfiesRequired(ty: typedIdxExpr.ty, required: keyTy) {
                 return Err(TypeError(position: typedIdxExpr.token.position, kind: TypeErrorKind.TypeMismatch([keyTy], typedIdxExpr.ty)))
               }
@@ -4791,14 +4760,12 @@ export type Typechecker {
       }
       _ => return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
     }
-
-    res
   }
 
   func _typecheckIndexingArraylike(self, token: Token, typedExpr: TypedAstNode, indexMode: IndexingMode<AstNode>, singleModeType: Type, rangeModeType: Type): Result<TypedAstNode, TypeError> {
     match indexMode {
       IndexingMode.Single(idxExpr) => {
-        val typedIdxExpr = match self._typecheckExpression(idxExpr, None) { Ok(v) => v, Err(e) => return Err(e) }
+        val typedIdxExpr = try self._typecheckExpression(idxExpr, None)
         val idxTy = typedIdxExpr.ty
         if idxTy.kind != TypeKind.PrimitiveInt || !!self._typeIsOption(idxTy) {
           return Err(TypeError(position: typedIdxExpr.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], idxTy)))
@@ -4809,14 +4776,14 @@ export type Typechecker {
       }
       IndexingMode.Range(startExpr, endExpr) => {
         val typedStartExpr = if startExpr |expr| {
-          val e = match self._typecheckExpression(expr, None) { Ok(v) => v, Err(e) => return Err(e) }
+          val e = try self._typecheckExpression(expr, None)
           if e.ty.kind != TypeKind.PrimitiveInt || !!self._typeIsOption(e.ty) {
             return Err(TypeError(position: e.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], e.ty)))
           }
           Some(e)
         } else None
         val typedEndExpr = if endExpr |expr| {
-          val e = match self._typecheckExpression(expr, None) { Ok(v) => v, Err(e) => return Err(e) }
+          val e = try self._typecheckExpression(expr, None)
           if e.ty.kind != TypeKind.PrimitiveInt || !!self._typeIsOption(e.ty) {
             return Err(TypeError(position: e.token.position, kind: TypeErrorKind.TypeMismatch([Type(kind: TypeKind.PrimitiveInt)], e.ty)))
           }
@@ -4889,8 +4856,8 @@ export type Typechecker {
       isLambda: true,
     )
 
-    val paramsNeedingRevisit = match self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params, paramHints: paramHints) { Ok(v) => v, Err(e) => return Err(e) }
-    match self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: node.params, body: node.body, paramsNeedingRevisit: paramsNeedingRevisit) { Ok(v) => v, Err(e) => return Err(e) }
+    val paramsNeedingRevisit = try self._typecheckFunctionPass2(fn: fn, allowSelf: false, params: node.params, paramHints: paramHints)
+    try self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: node.params, body: node.body, paramsNeedingRevisit: paramsNeedingRevisit)
 
     if fn.isClosure() {
       if self.currentFunction |currentFn| {
@@ -4920,7 +4887,7 @@ export type Typechecker {
 
     val (_, retErrType) = if self._typeIsResult(currentFn.returnType) |t| t else {
       // A bit wasteful perhaps, but attempt to get the type of the try expression's subject without the hint, for a nicer error message
-      val typedExpr = match self._typecheckExpression(expr, None) { Ok(v) => v, Err(e) => return Err(e) }
+      val typedExpr = try self._typecheckExpression(expr, None)
       return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel: currentFn.label, tryType: typedExpr.ty, returnType: currentFn.returnType))))
     }
 
@@ -4929,7 +4896,7 @@ export type Typechecker {
     } else {
       None
     }
-    val typedExpr = match self._typecheckExpression(expr, hint) { Ok(v) => v, Err(e) => return Err(e) }
+    val typedExpr = try self._typecheckExpression(expr, hint)
 
     // TODO: other Try-able types
     val (tryValType, tryErrType) = if self._typeIsResult(typedExpr.ty) |t| t else return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.InvalidTryTarget(typedExpr.ty)))


### PR DESCRIPTION
Now that the compiler supports try expressions and that version has been published, I can use try expressions within the compiler itself. This helps reduce a ton of noise in error handling, and also likely improves performance (however negligible) since the emitted code for try expressions is much smaller than the previous `match`-based approach that I had been using throughout the rest of the compiler code.