### PR TITLE
Add `todo` and `unreachable` builtins

### DIFF
--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -38,7 +38,8 @@ jobs:
         wget https://github.com/kengorab/abra-lang/releases/latest/download/abra-linux.tar.gz
         tar -xzf abra-linux.tar.gz -C abra-linux
         echo "PATH=$(pwd)/abra-linux:$PATH" >> $GITHUB_ENV
-        echo "ABRA_HOME=`realpath $(pwd)/abra-linux/std`" >> $GITHUB_ENV
+        # echo "ABRA_HOME=`realpath $(pwd)/abra-linux/std`" >> $GITHUB_ENV
+        echo "ABRA_HOME=`realpath $(pwd)/projects/std/src`" >> $GITHUB_ENV
     - name: Run tests
       run: |
         cd projects/compiler

--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -55,7 +55,7 @@ type CompileError {
       }
       "  |  $line\n     ${cursor.join()}"
     } else {
-      "unreachable"
+      unreachable()
     }
   }
 }
@@ -2501,7 +2501,7 @@ export type Compiler {
 
   func _getQbeTypeForTypeExpect(self, ty: Type, reason: String, position: Position? = None): Result<QbeType, CompileError> {
     val _ty = try self._getQbeTypeForType(ty)
-    if _ty |ty| Ok(ty) else if position |pos| unreachable(reason) else unreachable(reason)
+    if _ty |ty| Ok(ty) else if position |pos| unreachable("($pos) reason") else unreachable(reason)
   }
 
   func _followAccessorPath(self, head: TypedAstNode, middle: AccessorPathSegment[], tail: AccessorPathSegment, loadFinal: Bool, localName: String? = None): Result<Value, CompileError> {

--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -30,11 +30,6 @@ type CompileError {
         lines.push(self._getCursorLine(self.position, contents))
         lines.push("Reason: $reason")
       }
-      CompileErrorKind.Unreachable(message) => {
-        lines.push("Unreachable code reached")
-        lines.push(self._getCursorLine(self.position, contents))
-        lines.push("Internal error: $message")
-      }
       CompileErrorKind.QbeError(message) => {
         // todo: somehow thread the `node` which generated the error through to the error message
         lines.push("Encountered error while generating qbe code:")
@@ -67,7 +62,6 @@ type CompileError {
 
 enum CompileErrorKind {
   NotYetImplemented(reason: String)
-  Unreachable(message: String)
   QbeError(message: String)
   ResolvedGenericsError(context: String, message: String)
 }
@@ -371,12 +365,12 @@ export type Compiler {
         val (iterVal, iterTy, nextFn, popAdditionalResolvedGenericsLayer) = match instTy {
           StructOrEnum.Struct(s) => {
             if s == self._project.preludeArrayStruct {
-              val innerTy = if typeArgs[0] |t| t else return unreachable("Array has 1 required type argument")
+              val innerTy = if typeArgs[0] |t| t else unreachable("Array has 1 required type argument")
               match self._resolvedGenerics.addLayer("array literal", { "T": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "array literal", message: e))) }
 
               val arrayVal = try self._compileExpression(typedIterator)
               val instType = try self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position)
-              val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else return unreachable("Array#iterator must exist")
+              val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else unreachable("Array#iterator must exist")
               val iteratorFnVal = try self._getOrCompileMethod(instType, iteratorFn)
               self._resolvedGenerics.popLayer()
 
@@ -387,17 +381,17 @@ export type Compiler {
                 StructOrEnum.Struct(s) => s.instanceMethods
                 StructOrEnum.Enum(e) => e.instanceMethods
               }
-              val nextFn = if instanceMethods.find(m => m.label.name == "next") |fn| fn else return unreachable("a type must have a 'next' method if it's to be iterable")
+              val nextFn = if instanceMethods.find(m => m.label.name == "next") |fn| fn else unreachable("a type must have a 'next' method if it's to be iterable")
 
               val iterTy = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
               (iter, iterTy, nextFn, true)
             } else if s == self._project.preludeSetStruct {
-              val innerTy = if typeArgs[0] |t| t else return unreachable("Set has 1 required type argument")
+              val innerTy = if typeArgs[0] |t| t else unreachable("Set has 1 required type argument")
               match self._resolvedGenerics.addLayer("set literal", { "T": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "set literal", message: e))) }
 
               val mapVal = try self._compileExpression(typedIterator)
               val instType = try self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position)
-              val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else return unreachable("Set#iterator must exist")
+              val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else unreachable("Set#iterator must exist")
               val iteratorFnVal = try self._getOrCompileMethod(instType, iteratorFn)
               self._resolvedGenerics.popLayer()
 
@@ -408,18 +402,18 @@ export type Compiler {
                 StructOrEnum.Struct(s) => s.instanceMethods
                 StructOrEnum.Enum(e) => e.instanceMethods
               }
-              val nextFn = if instanceMethods.find(m => m.label.name == "next") |fn| fn else return unreachable("a type must have a 'next' method if it's to be iterable")
+              val nextFn = if instanceMethods.find(m => m.label.name == "next") |fn| fn else unreachable("a type must have a 'next' method if it's to be iterable")
 
               val iterTy = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
               (iter, iterTy, nextFn, true)
             } else if s == self._project.preludeMapStruct {
-              val keyTy = if typeArgs[0] |t| t else return unreachable("Map has 2 required type arguments")
-              val valTy = if typeArgs[1] |t| t else return unreachable("Map has 2 required type arguments")
+              val keyTy = if typeArgs[0] |t| t else unreachable("Map has 2 required type arguments")
+              val valTy = if typeArgs[1] |t| t else unreachable("Map has 2 required type arguments")
               match self._resolvedGenerics.addLayer("map literal", { "K": keyTy, "V": valTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "map literal", message: e))) }
 
               val mapVal = try self._compileExpression(typedIterator)
               val instType = try self._addResolvedGenericsLayerForInstanceMethod(typedIterator.ty, "iterator", typedIterator.token.position)
-              val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else return unreachable("Map#iterator must exist")
+              val iteratorFn = if s.instanceMethods.find(m => m.label.name == "iterator") |fn| fn else unreachable("Map#iterator must exist")
               val iteratorFnVal = try self._getOrCompileMethod(instType, iteratorFn)
               self._resolvedGenerics.popLayer()
 
@@ -430,21 +424,21 @@ export type Compiler {
                 StructOrEnum.Struct(s) => s.instanceMethods
                 StructOrEnum.Enum(e) => e.instanceMethods
               }
-              val nextFn = if instanceMethods.find(m => m.label.name == "next") |fn| fn else return unreachable("a type must have a 'next' method if it's to be iterable")
+              val nextFn = if instanceMethods.find(m => m.label.name == "next") |fn| fn else unreachable("a type must have a 'next' method if it's to be iterable")
 
               val iterTy = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
               (iter, iterTy, nextFn, true)
             } else {
               val iter = try self._compileExpression(typedIterator)
-              val nextFn = if s.instanceMethods.find(m => m.label.name == "next") |fn| fn else return unreachable("a type must have a 'next' method if it's to be iterable")
+              val nextFn = if s.instanceMethods.find(m => m.label.name == "next") |fn| fn else unreachable("a type must have a 'next' method if it's to be iterable")
 
               (iter, typedIterator.ty, nextFn, false)
             }
           }
-          StructOrEnum.Enum(_enum) => return todo_("enum as for-loop target")
+          StructOrEnum.Enum(_enum) => todo("enum as for-loop target")
         }
 
-        val nextItemTy = if self._typeIsOption(nextFn.returnType) |innerTy| innerTy else return unreachable("a 'next' method must return an Option type")
+        val nextItemTy = if self._typeIsOption(nextFn.returnType) |innerTy| innerTy else unreachable("a 'next' method must return an Option type")
         val iterInstTy = try self._addResolvedGenericsLayerForInstanceMethod(iterTy, "next", node.token.position)
         val nextItemQbeTy = try self._getQbeTypeForTypeExpect(nextItemTy, "unacceptable type for 'next' method return type")
 
@@ -543,7 +537,7 @@ export type Compiler {
 
           Ok(None)
         } else {
-          unreachable("cannot have a break statement outside of a loop", node.token.position)
+          unreachable("cannot have a break statement outside of a loop")
         }
       }
       TypedAstNodeKind.Continue => {
@@ -552,7 +546,7 @@ export type Compiler {
 
           Ok(None)
         } else {
-          unreachable("cannot have a continue statement outside of a loop", node.token.position)
+          unreachable("cannot have a continue statement outside of a loop")
         }
       }
       TypedAstNodeKind.Return(expr) => {
@@ -565,13 +559,13 @@ export type Compiler {
 
         Ok(None)
       }
-      TypedAstNodeKind.Placeholder => unreachable("placeholder ast node emitted from typechecker", node.token.position)
+      TypedAstNodeKind.Placeholder => unreachable("placeholder ast node emitted from typechecker")
       TypedAstNodeKind.Assignment(mode, op, expr) => {
         val res = try self._compileExpression(expr)
 
         match mode {
           TypedAssignmentMode.Variable(variable) => {
-            if variable.isParameter return unreachable("parameters cannot be reassigned to", node.token.position)
+            if variable.isParameter unreachable("parameters cannot be reassigned to")
 
             val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
             if variable.isCaptured {
@@ -579,7 +573,7 @@ export type Compiler {
               self._currentFn.block.addComment("overwrite ptr to captured '${variable.label.name}'")
               self._currentFn.block.buildStore(varTy, res, ptr)
             } else {
-              val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'", node.token.position)
+              val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else unreachable("Could not resolve name for variable '${variable.label.name}'")
               val slot = Value.Ident(slotName, QbeType.Pointer)
               self._currentFn.block.buildStore(varTy, res, slot)
             }
@@ -596,17 +590,17 @@ export type Compiler {
                     val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
                     val struct = match structOrEnum {
                       StructOrEnum.Struct(struct) => struct
-                      StructOrEnum.Enum => return unreachable("index-assignment only implemented for arrays")
+                      StructOrEnum.Enum => unreachable("index-assignment only implemented for arrays")
                     }
-                    if struct != self._project.preludeArrayStruct return unreachable("index-assignment only implemented for arrays")
+                    if struct != self._project.preludeArrayStruct unreachable("index-assignment only implemented for arrays")
 
-                    val setFn = if self._project.preludeArrayStruct.instanceMethods.find(m => m.label.name == "set") |fn| fn else return unreachable("Array#set must exist")
+                    val setFn = if self._project.preludeArrayStruct.instanceMethods.find(m => m.label.name == "set") |fn| fn else unreachable("Array#set must exist")
                     val setFnVal = try self._getOrCompileMethod(instType, setFn)
                     self._resolvedGenerics.popLayer()
 
                     try self._currentFn.block.buildCall(Callable.Function(setFnVal), [exprVal, idxExprVal, res]) else |e| return qbeError(e)
                   }
-                  _ => return unreachable("cannot use range index in index-assignment")
+                  _ => unreachable("cannot use range index in index-assignment")
                 }
               }
               TypedIndexingNode.Map(expr, idxExpr) => {
@@ -617,17 +611,17 @@ export type Compiler {
                 val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
                 val struct = match structOrEnum {
                   StructOrEnum.Struct(struct) => struct
-                  StructOrEnum.Enum => return unreachable("index-assignment only implemented for maps")
+                  StructOrEnum.Enum => unreachable("index-assignment only implemented for maps")
                 }
-                if struct != self._project.preludeMapStruct return unreachable("index-assignment only implemented for map")
+                if struct != self._project.preludeMapStruct unreachable("index-assignment only implemented for map")
 
-                val insertFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else return unreachable("Map#insert must exist")
+                val insertFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else unreachable("Map#insert must exist")
                 val insertFnVal = try self._getOrCompileMethod(instType, insertFn)
                 self._resolvedGenerics.popLayer()
 
                 try self._currentFn.block.buildCall(Callable.Function(insertFnVal), [exprVal, idxExprVal, res]) else |e| return qbeError(e)
               }
-              TypedIndexingNode.Tuple(_, _) => return unreachable("tuples are not assignable via index-assignment")
+              TypedIndexingNode.Tuple(_, _) => unreachable("tuples are not assignable via index-assignment")
             }
           }
           TypedAssignmentMode.Accessor(head, middle, tail) => {
@@ -681,7 +675,7 @@ export type Compiler {
           lenVal = try self._currentFn.block.buildAdd(lenVal, stringLength) else |e| return qbeError(e)
         }
 
-        val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
+        val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else unreachable("String.withLength must exist")
         val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
         val newString = try self._currentFn.block.buildCall(Callable.Function(stringWithLengthFnVal), [lenVal]) else |e| return qbeError(e)
         var newBuffer = self._currentFn.block.buildLoadL(try self._currentFn.block.buildAdd(Value.Int(8), newString) else |e| return qbeError(e))
@@ -749,7 +743,7 @@ export type Compiler {
                 rightVal = try self._currentFn.block.buildCall(Callable.Function(rightToStringFnVal), [rightVal]) else |e| return qbeError(e)
               }
 
-              val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
+              val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else unreachable("String.withLength must exist")
               val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
               val leftLength = self._currentFn.block.buildLoadL(leftVal)
               val rightLength = self._currentFn.block.buildLoadL(rightVal)
@@ -938,7 +932,7 @@ export type Compiler {
             self._currentFn.block.buildJnz(isSome, labelThen, labelElse)
 
             self._currentFn.block.registerLabel(labelThen)
-            val innerTy = if self._typeIsOption(left.ty) |innerTy| innerTy else return unreachable("", node.token.position)
+            val innerTy = if self._typeIsOption(left.ty) |innerTy| innerTy else unreachable()
             val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
             val innerVal = try self._emitOptValueGetValue(innerQbeType, leftVal)
             val leftLabel = self._currentFn.block.currentLabel
@@ -1002,11 +996,11 @@ export type Compiler {
         val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
         if variable.isParameter {
           if variable.isCaptured {
-            if variable.mutable return unreachable("parameters cannot be mutable", node.token.position)
+            if variable.mutable unreachable("parameters cannot be mutable")
             val value = try self._getCapturedVarPtr(variable)
             Ok(value)
           } else {
-            val varName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'", node.token.position)
+            val varName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else unreachable("Could not resolve name for variable '${variable.label.name}'")
             Ok(Value.Ident(varName, varTy))
           }
         } else {
@@ -1016,7 +1010,7 @@ export type Compiler {
                 val paramTypes = match hint.kind {
                   TypeKind.Func(paramTypes, _) => Some(paramTypes)
                   TypeKind.Any => None // if the function value is being treated as an Any, then no param type info needs to be known later anyway
-                  _ => return unreachable("fnAliasTypeKind must be TypeKind.Func", node.token.position)
+                  _ => unreachable("fnAliasTypeKind must be TypeKind.Func")
                 }
                 paramTypes
               } else {
@@ -1047,7 +1041,7 @@ export type Compiler {
                 }
                 Ok(res)
               } else {
-                val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'")
+                val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else unreachable("Could not resolve name for variable '${variable.label.name}'")
                 val slot = Value.Ident(slotName, QbeType.Pointer)
                 val res = self._currentFn.block.buildLoad(varTy, slot)
                 Ok(res)
@@ -1104,7 +1098,7 @@ export type Compiler {
                 val fnVal = try self._getOrCompileFunction(fn)
                 fnVal
               }
-              FunctionKind.InstanceMethod => return unreachable("instance methods handled elsewhere", node.token.position)
+              FunctionKind.InstanceMethod => unreachable("instance methods handled elsewhere")
             }
 
             self._resolvedGenerics.popLayer()
@@ -1117,7 +1111,7 @@ export type Compiler {
 
             val intrinsicDec = fn.decorators.find(dec => dec.label.name == "Intrinsic")
             if intrinsicDec |dec| {
-              if isOptSafe return unreachable("cannot have opt-safe intrinsic method calls")
+              if isOptSafe unreachable("cannot have opt-safe intrinsic method calls")
               val res = self._invokeIntrinsicFn(dec, fn, [Some(selfExpr)].concat(arguments))
               self._resolvedGenerics.popLayer()
               return res
@@ -1131,7 +1125,7 @@ export type Compiler {
             fnHasOptionalParameters = fn.params.any(p => !!p.defaultValue)
 
             val selfVal = if isOptSafe {
-              val innerTy = if self._typeIsOption(selfInstanceType) |innerTy| innerTy else return unreachable("an opt-safe invocation needs to have an Option type as its lhs")
+              val innerTy = if self._typeIsOption(selfInstanceType) |innerTy| innerTy else unreachable("an opt-safe invocation needs to have an Option type as its lhs")
               selfInstanceType = innerTy
 
               val selfVal = try self._compileExpression(selfExpr)
@@ -1146,7 +1140,7 @@ export type Compiler {
 
               self._currentFn.block.registerLabel(labelIsNone)
               val noneRes = if fn.returnType.kind != TypeKind.PrimitiveUnit {
-                val optNoneVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "None") |v| v else return unreachable("Option.None must exist")
+                val optNoneVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "None") |v| v else unreachable("Option.None must exist")
                 match self._resolvedGenerics.addLayer("Option.None", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.None", message: e))) }
                 val noneVariantFn = try self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant)
                 self._resolvedGenerics.popLayer()
@@ -1156,7 +1150,7 @@ export type Compiler {
               self._currentFn.block.buildJmp(labelCont)
 
               self._currentFn.block.registerLabel(labelIsSome)
-              val optSomeVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "Some") |v| v else return unreachable("Option.Some must exist")
+              val optSomeVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "Some") |v| v else unreachable("Option.Some must exist")
               match self._resolvedGenerics.addLayer("Option.Some", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.Some", message: e))) }
               val someVariantFn = try self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optSomeVariant)
               self._resolvedGenerics.popLayer()
@@ -1245,7 +1239,7 @@ export type Compiler {
             val argQbeType = try self._getQbeTypeForTypeExpect(argTy, "unacceptable type for argument", Some(node.token.position))
             args.push(argQbeType.zeroValue())
           } else {
-            return unreachable("invocation target must be an arbitrary expression, which do not have default-valued arguments", node.token.position)
+            unreachable("invocation target must be an arbitrary expression, which do not have default-valued arguments")
           }
         }
 
@@ -1438,20 +1432,20 @@ export type Compiler {
       TypedAstNodeKind.Array(items) => {
         match node.ty.kind {
           TypeKind.Instance(_, generics) => {
-            val inner = if generics[0] |t| t else return unreachable("Array has 1 required type argument")
+            val inner = if generics[0] |t| t else unreachable("Array has 1 required type argument")
             match self._resolvedGenerics.addLayer("array literal", { "T": inner }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "array literal", message: e))) }
           }
-          _ => return unreachable("we know it's an array instance here")
+          _ => unreachable("we know it's an array instance here")
         }
 
-        val arrayWithCapacityFn = if self._project.preludeArrayStruct.staticMethods.find(m => m.label.name == "withCapacity") |fn| fn else return unreachable("Array.withCapacity must exist")
+        val arrayWithCapacityFn = if self._project.preludeArrayStruct.staticMethods.find(m => m.label.name == "withCapacity") |fn| fn else unreachable("Array.withCapacity must exist")
         val arrayWithCapacityFnVal = try self._getOrCompileMethod(node.ty, arrayWithCapacityFn)
 
         val sizeVal = Value.Int(items.length.nextPowerOf2())
         val arrayInstance = try self._currentFn.block.buildCall(Callable.Function(arrayWithCapacityFnVal), [sizeVal], resultLocalName) else |e| return qbeError(e)
         self._currentFn.block.addCommentBefore("${arrayInstance.repr()}: ${node.ty.repr()}")
 
-        val arrayPushFn = if self._project.preludeArrayStruct.instanceMethods.find(m => m.label.name == "push") |fn| fn else return unreachable("Array#push must exist")
+        val arrayPushFn = if self._project.preludeArrayStruct.instanceMethods.find(m => m.label.name == "push") |fn| fn else unreachable("Array#push must exist")
         val arrayPushFnVal = try self._getOrCompileMethod(node.ty, arrayPushFn)
 
         for item in items {
@@ -1466,19 +1460,19 @@ export type Compiler {
       TypedAstNodeKind.Set(items) => {
         match node.ty.kind {
           TypeKind.Instance(_, generics) => {
-            val inner = if generics[0] |t| t else return unreachable("Set has 1 required type argument")
+            val inner = if generics[0] |t| t else unreachable("Set has 1 required type argument")
             match self._resolvedGenerics.addLayer("set literal", { "T": inner }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "set literal", message: e))) }
           }
-          _ => return unreachable("we know it's a set instance here")
+          _ => unreachable("we know it's a set instance here")
         }
 
-        val setNewFn = if self._project.preludeSetStruct.staticMethods.find(m => m.label.name == "new") |fn| fn else return unreachable("Set.new must exist")
+        val setNewFn = if self._project.preludeSetStruct.staticMethods.find(m => m.label.name == "new") |fn| fn else unreachable("Set.new must exist")
         val setNewFnVal = try self._getOrCompileMethod(node.ty, setNewFn)
 
         val setInstance = try self._currentFn.block.buildCall(Callable.Function(setNewFnVal), [Value.Int(0), Value.Int32(1)], resultLocalName) else |e| return qbeError(e)
         self._currentFn.block.addCommentBefore("${setInstance.repr()}: ${node.ty.repr()}")
 
-        val setInsertFn = if self._project.preludeSetStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else return unreachable("Set#insert must exist")
+        val setInsertFn = if self._project.preludeSetStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else unreachable("Set#insert must exist")
         val setInsertFnVal = try self._getOrCompileMethod(node.ty, setInsertFn)
 
         for item in items {
@@ -1493,21 +1487,21 @@ export type Compiler {
       TypedAstNodeKind.Map(items) => {
         match node.ty.kind {
           TypeKind.Instance(_, generics) => {
-            val key = if generics[0] |t| t else return unreachable("Map has 2 required type arguments")
-            val value = if generics[1] |t| t else return unreachable("Map has 2 required type arguments")
+            val key = if generics[0] |t| t else unreachable("Map has 2 required type arguments")
+            val value = if generics[1] |t| t else unreachable("Map has 2 required type arguments")
             match self._resolvedGenerics.addLayer("map literal", { "K": key, "V": value }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "map literal", message: e))) }
           }
-          _ => return unreachable("we know it's a map instance here")
+          _ => unreachable("we know it's a map instance here")
         }
 
 
-        val mapNewFn = if self._project.preludeMapStruct.staticMethods.find(m => m.label.name == "new") |fn| fn else return unreachable("Map.new must exist")
+        val mapNewFn = if self._project.preludeMapStruct.staticMethods.find(m => m.label.name == "new") |fn| fn else unreachable("Map.new must exist")
         val mapNewFnVal = try self._getOrCompileMethod(node.ty, mapNewFn)
 
         val mapInstance = try self._currentFn.block.buildCall(Callable.Function(mapNewFnVal), [Value.Int(0), Value.Int32(1)], resultLocalName) else |e| return qbeError(e)
         self._currentFn.block.addCommentBefore("${mapInstance.repr()}: ${node.ty.repr()}")
 
-        val mapInsertFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else return unreachable("Map#insert must exist")
+        val mapInsertFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "insert") |fn| fn else unreachable("Map#insert must exist")
         val mapInsertFnVal = try self._getOrCompileMethod(node.ty, mapInsertFn)
 
         for (keyExpr, valExpr) in items {
@@ -1555,8 +1549,8 @@ export type Compiler {
                 val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "get", expr.token.position)
                 val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
                 val getFn = match structOrEnum {
-                  StructOrEnum.Struct(struct) => if struct.instanceMethods.find(m => m.label.name == "get") |fn| fn else return unreachable("#get must exist for array-like indexing")
-                  StructOrEnum.Enum => return unreachable("array-like indexing never applies to enum instances")
+                  StructOrEnum.Struct(struct) => if struct.instanceMethods.find(m => m.label.name == "get") |fn| fn else unreachable("#get must exist for array-like indexing")
+                  StructOrEnum.Enum => unreachable("array-like indexing never applies to enum instances")
                 }
                 val getFnVal = try self._getOrCompileMethod(instType, getFn)
                 self._resolvedGenerics.popLayer()
@@ -1582,8 +1576,8 @@ export type Compiler {
                 val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "getRange", expr.token.position)
                 val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
                 val getRangeFn = match structOrEnum {
-                  StructOrEnum.Struct(struct) => if struct.instanceMethods.find(m => m.label.name == "getRange") |fn| fn else return unreachable("#getRange must exist for array-like indexing")
-                  StructOrEnum.Enum => return unreachable("array-like indexing never applies to enum instances")
+                  StructOrEnum.Struct(struct) => if struct.instanceMethods.find(m => m.label.name == "getRange") |fn| fn else unreachable("#getRange must exist for array-like indexing")
+                  StructOrEnum.Enum => unreachable("array-like indexing never applies to enum instances")
                 }
                 val getRangeFnVal = try self._getOrCompileMethod(instType, getRangeFn)
                 self._resolvedGenerics.popLayer()
@@ -1601,11 +1595,11 @@ export type Compiler {
             val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
             val struct = match structOrEnum {
               StructOrEnum.Struct(struct) => struct
-              StructOrEnum.Enum => return unreachable("map indexing never applies to enum instances")
+              StructOrEnum.Enum => unreachable("map indexing never applies to enum instances")
             }
-            if struct != self._project.preludeMapStruct return unreachable("map indexing only implemented for map")
+            if struct != self._project.preludeMapStruct unreachable("map indexing only implemented for map")
 
-            val getFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "get") |fn| fn else return unreachable("Map#get must exist")
+            val getFn = if self._project.preludeMapStruct.instanceMethods.find(m => m.label.name == "get") |fn| fn else unreachable("Map#get must exist")
             val getFnVal = try self._getOrCompileMethod(instType, getFn)
             self._resolvedGenerics.popLayer()
 
@@ -1618,7 +1612,7 @@ export type Compiler {
             val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(tupleExpr.ty)
             val struct = match structOrEnum {
               StructOrEnum.Struct(struct) => struct
-              StructOrEnum.Enum => return unreachable("tuples are represented as structs")
+              StructOrEnum.Enum => unreachable("tuples are represented as structs")
             }
 
             val selfType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
@@ -1652,7 +1646,7 @@ export type Compiler {
           val paramTypes = match hint.kind {
             TypeKind.Func(paramTypes, _) => Some(paramTypes)
             TypeKind.Any => None // if the function value is being treated as an Any, then no param type info needs to be known later anyway
-            _ => return unreachable("typeKind must be TypeKind.Func", node.token.position)
+            _ => unreachable("typeKind must be TypeKind.Func")
           }
           paramTypes
         } else {
@@ -1668,8 +1662,8 @@ export type Compiler {
         self._compileFunctionValue(node.token.position, fn, fnValBase, targetParamTypes, capturesMem, None)
       }
       TypedAstNodeKind.If(isStatement, cond, conditionBinding, ifBlock, ifBlockTerminator, elseBlock, elseBlockTerminator) => {
-        if isStatement return unreachable("if-statements are handled elsewhere", node.token.position)
-        if elseBlock.isEmpty() return unreachable("if-expressions must not have empty else-blocks", node.token.position)
+        if isStatement unreachable("if-statements are handled elsewhere")
+        if elseBlock.isEmpty() unreachable("if-expressions must not have empty else-blocks")
 
         val labelThen = self._currentFn.block.addLabel("then")
         val labelElse = self._currentFn.block.addLabel("else")
@@ -1707,7 +1701,7 @@ export type Compiler {
                 val label = self._currentFn.block.currentLabel
                 phiCases.push((label, res))
               } else {
-                return unreachable("last statement in if-expr block has no value and is not a terminator", node.token.position)
+                unreachable("last statement in if-expr block has no value and is not a terminator")
               }
             }
           }
@@ -1726,7 +1720,7 @@ export type Compiler {
                   val label = self._currentFn.block.currentLabel
                   phiCases.push((label, res))
                 } else {
-                  return unreachable("last statement in if-expr else block has no value and is not a terminator", node.token.position)
+                  unreachable("last statement in if-expr else block has no value and is not a terminator")
                 }
               }
             }
@@ -1748,7 +1742,7 @@ export type Compiler {
       }
       TypedAstNodeKind.Match(isStatement, expr, cases) => {
         val res = try self._compileMatch(node, isStatement, expr, cases)
-        if res |res| Ok(res) else return unreachable("match expression needs a resulting value", node.token.position)
+        if res |res| Ok(res) else unreachable("match expression needs a resulting value")
       }
       TypedAstNodeKind.Try(expr, elseClause) => {
         val exprVal = try self._compileExpression(expr)
@@ -1778,7 +1772,7 @@ export type Compiler {
                 val label = self._currentFn.block.currentLabel
                 phiCases.push((label, res))
               } else if !clause.terminator {
-                return unreachable("last statement in try-else block has no value and is not a terminator", node.token.position)
+                unreachable("last statement in try-else block has no value and is not a terminator")
               }
             }
           }
@@ -1809,7 +1803,7 @@ export type Compiler {
           Ok(okValue)
         }
       }
-      _ => unreachable("node must be a statement", node.token.position)
+      _ => unreachable("node must be a statement")
     }
 
     self._currentNode = prevNode
@@ -1869,7 +1863,7 @@ export type Compiler {
 
           val (litVal, litType) = try self._compileLiteral(lit)
 
-          if !self._project.typesAreEquivalent(exprType, litType) return unreachable("equality operators require matching types", node.token.position)
+          if !self._project.typesAreEquivalent(exprType, litType) unreachable("equality operators require matching types")
 
           val cond = try self._compileEqLogic(exprVal, litVal, litType, expr.token.position)
           val isEqLabel = self._currentFn.block.addLabel("${matchLabelPrefix}_iseq")
@@ -1921,12 +1915,12 @@ export type Compiler {
             try self._addResolvedGenericsLayerForEnumVariant(exprType, variant.label.name, node.token.position)
             val variantFields = match variant.kind {
               EnumVariantKind.Container(fields) => fields
-              _ => return unreachable("cannot destructure a non-container enum variant", node.token.position)
+              _ => unreachable("cannot destructure a non-container enum variant")
             }
 
             var memCursor = try self._emitGetEnumVariantValueStart(exprVal)
             for v, idx in destructuredVariables {
-              val field = if variantFields[idx] |f| f else return unreachable("this should be caught during typechecking", node.token.position)
+              val field = if variantFields[idx] |f| f else unreachable("this should be caught during typechecking")
               val fieldTy = try self._getQbeTypeForTypeExpect(field.ty, "unacceptable type for field", Some(field.name.position))
 
               val fieldVal = self._currentFn.block.buildLoad(fieldTy, memCursor)
@@ -1960,7 +1954,7 @@ export type Compiler {
           // No nextCaseLabel, since the `else` case will always be the last case if present
           (None, exprVal, exprType)
         }
-        _ => return todo_("other match case types", node.token.position)
+        _ => todo("other match case types")
       }
 
       if case.binding |v| {
@@ -2013,7 +2007,7 @@ export type Compiler {
           val tupleItemSlot = try self._currentFn.block.buildAdd(Value.Int(idx * QbeType.Pointer.size()), tuplePtr) else |e| return qbeError(e)
           val tupleItemSlotTy = match pat {
             BindingPattern.Variable(label) => {
-              val variable = if variables[label.name] |v| v else return unreachable("expected binding '${label.name}', but missing from variables")
+              val variable = if variables[label.name] |v| v else unreachable("expected binding '${label.name}', but missing from variables")
               val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
               varTy
             }
@@ -2027,7 +2021,7 @@ export type Compiler {
       }
     }
 
-    val variable = if variables[varName] |v| v else return unreachable("expected binding '$varName', but missing from variables")
+    val variable = if variables[varName] |v| v else unreachable("expected binding '$varName', but missing from variables")
     val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
     val slotName = self._currentFn.block.addVar(variableToVar(variable))
 
@@ -2080,7 +2074,7 @@ export type Compiler {
     // If the captured variable is a parameter but we're not currently referencing it from a closure, then it can be resolved as any ordinary
     // parameter (simply by name) since it's an immutable variable that has not been moved to the heap.
     if variable.isParameter {
-      val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'")
+      val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else unreachable("Could not resolve name for variable '${variable.label.name}'")
       val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
       return Ok(Value.Ident(slotName, varTy))
     }
@@ -2089,7 +2083,7 @@ export type Compiler {
     // we may need to undo the extra layer of pointer indirection which comes as a result of being captured by some other function,
     // if the captured variable is mutable. If it's not mutable then it will not have been moved to the heap, so no additional pointer
     // needs to be dereferenced.
-    val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else return unreachable("Could not resolve name for variable '${variable.label.name}'")
+    val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else unreachable("Could not resolve name for variable '${variable.label.name}'")
     val slot = Value.Ident(slotName, QbeType.Pointer)
     var varTy = if variable.mutable {
       self._currentFn.block.addComment("get ptr to captured mutable '${variable.label.name}'")
@@ -2141,10 +2135,10 @@ export type Compiler {
     }
 
     val res = if !fnInvocationIsAtDeclaredScope {
-      val currentFunc = if self._currentFunction |currentFn| currentFn else return unreachable("we must be within a function to enter this case", fn.label.position)
+      val currentFunc = if self._currentFunction |currentFn| currentFn else unreachable("we must be within a function to enter this case")
 
-      val idx = if currentFunc.capturedClosures.findIndex(f => f.label.name == fn.label.name) |(_, idx)| idx else return unreachable("closure '${fn.label.name}' called within function '${currentFunc.label.name}', but not tracked in its capturedClosures", fn.label.position)
-      val env = if self._currentFn._env |env| env else return unreachable("expected currentFn ('${self._currentFn.name}') to have an `_env`, but it didn't")
+      val idx = if currentFunc.capturedClosures.findIndex(f => f.label.name == fn.label.name) |(_, idx)| idx else unreachable("closure '${fn.label.name}' called within function '${currentFunc.label.name}', but not tracked in its capturedClosures")
+      val env = if self._currentFn._env |env| env else unreachable("expected currentFn ('${self._currentFn.name}') to have an `_env`, but it didn't")
       val offset = QbeType.Pointer.size() * (currentFunc.captures.length + idx)
 
       val ptr = try self._currentFn.block.buildAdd(Value.Int(offset), env) else |e| return qbeError(e)
@@ -2159,7 +2153,7 @@ export type Compiler {
               StructOrEnum.Enum(enum_) => enum_.label.name
             }
             "$typeName.."
-          } else return unreachable("an instance method should have a structOrEnum", fn.label.position)
+          } else unreachable("an instance method should have a structOrEnum")
         }
         FunctionKind.StaticMethod(structOrEnum) => {
           val typeName = match structOrEnum {
@@ -2189,7 +2183,7 @@ export type Compiler {
       } else if rightIsFloat && !leftIsFloat {
         leftVal = self._currentFn.block.buildLToF(leftVal)
       } else {
-        return unreachable("unknown operator '$op' between types '${left.ty.repr()}' and '${right.ty.repr()}'")
+        unreachable("unknown operator '$op' between types '${left.ty.repr()}' and '${right.ty.repr()}'")
       }
     }
 
@@ -2200,7 +2194,7 @@ export type Compiler {
     var leftVal = try self._compileExpression(left)
     var rightVal = try self._compileExpression(right)
 
-    if !self._project.typesAreEquivalent(left.ty, right.ty) return unreachable("equality operators require matching types", right.token.position)
+    if !self._project.typesAreEquivalent(left.ty, right.ty) unreachable("equality operators require matching types")
 
     self._compileEqLogic(leftVal, rightVal, left.ty, left.token.position, localName, negate)
   }
@@ -2279,7 +2273,7 @@ export type Compiler {
         //   func foo(a: Int, b: Int): Int = ...
         //   callFn(foo)
         // In this case, typechecking fails since `callFn` won't provide a value for the parameter `b`.
-        return unreachable("This should have been caught during typechecking", position)
+        unreachable("This should have been caught during typechecking")
       } else {
         // In this case, consider the following example:
         //   func foo(): Int = ...
@@ -2294,7 +2288,7 @@ export type Compiler {
       //   callFn(foo)
       // In this case, typechecking fails since `callFn` won't provide a value for the parameter `b`.
       // This is similar to the case above, except here we have an optional parameter.
-      return unreachable("This should be caught during typechecking", position)
+      unreachable("This should be caught during typechecking")
     } else if fnNumReqParams <= targetArity && targetArity <= numParams {
       // In this case, we need to "artificially (monotonically) shrink" the arity of the underlying function.
       // It's "monotonically" because the arity itself might not actually shrink; consider this example:
@@ -2364,7 +2358,7 @@ export type Compiler {
       // because in order to reach this case, it must be the case that all of the optional parameters are passed a value.
       self._compileParamDiscardingFunctionWrapper(fnValParamTypes, fn, fnValBase, position, true, selfTy)
     } else {
-      return unreachable("All valid cases exhausted above", position)
+      unreachable("All valid cases exhausted above")
     }
     val fnVal = try fnValRes
 
@@ -2463,7 +2457,7 @@ export type Compiler {
 
   func _constructString(self, ptrVal: Value, lenVal: Value, localName: String? = None): Result<Value, CompileError> {
     val fnVal = try self._getOrCompileStructInitializer(self._project.preludeStringStruct)
-    val structTy = if fnVal.returnType |ty| ty else return unreachable("initializer functions must have return types specified")
+    val structTy = if fnVal.returnType |ty| ty else unreachable("initializer functions must have return types specified")
 
     val res = try self._currentFn.block.buildCall(Callable.Function(fnVal), [lenVal, ptrVal, Value.Int32(0)], localName) else |e| return qbeError(e)
     self._currentFn.block.addCommentBefore("${res.repr()}: String")
@@ -2478,7 +2472,7 @@ export type Compiler {
       TypeKind.PrimitiveBool => Ok(Some(QbeType.U64))
       TypeKind.PrimitiveString => Ok(Some(QbeType.Pointer))
       TypeKind.Never => Ok(None)
-      TypeKind.Any => todo_("TypeKind.Any")
+      TypeKind.Any => todo("TypeKind.Any")
       TypeKind.Generic(name) => {
         if self._resolvedGenerics.resolveGeneric(name) |ty| self._getQbeTypeForType(ty) else unreachable("unexpected generic '$name' at this point")
       }
@@ -2499,7 +2493,7 @@ export type Compiler {
         Ok(Some(QbeType.Pointer))
       }
       TypeKind.Func(paramTypes, returnType) => Ok(Some(QbeType.Pointer))
-      TypeKind.Type(type_) => todo_("TypeKind.Type")
+      TypeKind.Type(type_) => todo("TypeKind.Type")
       TypeKind.Tuple(_) => Ok(Some(QbeType.Pointer))
       TypeKind.Hole => unreachable("unexpected hole in emitted typed ast")
     }
@@ -2507,7 +2501,7 @@ export type Compiler {
 
   func _getQbeTypeForTypeExpect(self, ty: Type, reason: String, position: Position? = None): Result<QbeType, CompileError> {
     val _ty = try self._getQbeTypeForType(ty)
-    if _ty |ty| Ok(ty) else if position |pos| unreachable(reason, pos) else unreachable(reason)
+    if _ty |ty| Ok(ty) else if position |pos| unreachable(reason) else unreachable(reason)
   }
 
   func _followAccessorPath(self, head: TypedAstNode, middle: AccessorPathSegment[], tail: AccessorPathSegment, loadFinal: Bool, localName: String? = None): Result<Value, CompileError> {
@@ -2553,7 +2547,7 @@ export type Compiler {
           instTy = StructOrEnum.Enum(enum_)
         }
         AccessorPathSegment.Method(label, fn, isOptSafe, fnAliasTypeHint) => {
-          if isOptSafe return todo_("opt-safe method accessor", label.position)
+          if isOptSafe todo("opt-safe method accessor")
 
           val selfInstType = match fn.kind {
             FunctionKind.InstanceMethod => {
@@ -2575,7 +2569,7 @@ export type Compiler {
             val paramTypes = match hint.kind {
               TypeKind.Func(paramTypes, _) => Some(paramTypes)
               TypeKind.Any => None // if the function value is being treated as an Any, then no param type info needs to be known later anyway
-              _ => return unreachable("fnAliasTypeKind must be TypeKind.Func", label.position)
+              _ => unreachable("fnAliasTypeKind must be TypeKind.Func")
             }
             paramTypes
           } else {
@@ -2591,8 +2585,8 @@ export type Compiler {
           var optSafeCtx: (Label, Value, QbeFunction, Label)? = None
 
           if isOptSafe {
-            val innerTy = if self._typeIsOption(ty) |innerTy| innerTy else return unreachable("an opt-safe field accessor needs to have an Option type as its lhs")
-            val unwrappedInstType = if self._typeIsOption(instType) |innerTy| innerTy else return unreachable("an opt-safe field accessor needs to have an Option type as its lhs")
+            val innerTy = if self._typeIsOption(ty) |innerTy| innerTy else unreachable("an opt-safe field accessor needs to have an Option type as its lhs")
+            val unwrappedInstType = if self._typeIsOption(instType) |innerTy| innerTy else unreachable("an opt-safe field accessor needs to have an Option type as its lhs")
             instType = unwrappedInstType
             val (_instTy, _) = try self._getInstanceTypeForType(unwrappedInstType)
             instTy = _instTy
@@ -2606,7 +2600,7 @@ export type Compiler {
             self._currentFn.block.buildJnz(variantIsOptionSome, labelIsSome, labelIsNone)
 
             self._currentFn.block.registerLabel(labelIsNone)
-            val optNoneVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "None") |v| v else return unreachable("Option.None must exist")
+            val optNoneVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "None") |v| v else unreachable("Option.None must exist")
             match self._resolvedGenerics.addLayer("Option.None", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: label.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.None", message: e))) }
             val noneVariantFn = try self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optNoneVariant)
             self._resolvedGenerics.popLayer()
@@ -2614,7 +2608,7 @@ export type Compiler {
             self._currentFn.block.buildJmp(labelCont)
 
             self._currentFn.block.registerLabel(labelIsSome)
-            val optSomeVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "Some") |v| v else return unreachable("Option.Some must exist")
+            val optSomeVariant = if self._project.preludeOptionEnum.variants.find(v => v.label.name == "Some") |v| v else unreachable("Option.Some must exist")
             match self._resolvedGenerics.addLayer("Option.Some", { "V": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: label.position, kind: CompileErrorKind.ResolvedGenericsError(context: "Option.Some", message: e))) }
             val someVariantFn = try self._getOrCompileEnumVariantFn(self._project.preludeOptionEnum, optSomeVariant)
             self._resolvedGenerics.popLayer()
@@ -2638,7 +2632,7 @@ export type Compiler {
 
                 offset += fieldTy.size()
               }
-              if fieldTyQbe == QbeType.F32 return unreachable("fieldTyQbe == QbeType.F32")
+              if fieldTyQbe == QbeType.F32 unreachable("fieldTyQbe == QbeType.F32")
 
               val ptr = try self._currentFn.block.buildAdd(Value.Int(offset), curVal) else |e| return qbeError(e)
               if idx == segs.length - 1 {
@@ -2655,7 +2649,7 @@ export type Compiler {
                 curVal = nextVal
               }
             }
-            StructOrEnum.Enum(_enum) => return todo_("enum field accessor")
+            StructOrEnum.Enum(_enum) => todo("enum field accessor")
           }
 
           if optSafeCtx |(labelIsNone, noneRes, someVariantFn, labelCont)| {
@@ -2781,7 +2775,7 @@ export type Compiler {
 
     val memLocal = try fn.block.buildCall(Callable.Function(self._malloc), [Value.Int(size)], Some("enum_variant.mem")) else |e| return qbeError(e)
 
-    val variantIdx = if enum_.variants.findIndex(v => v.label.name == variant.label.name) |(_, idx)| idx else return unreachable("variant '${variant.label.name}' must exist")
+    val variantIdx = if enum_.variants.findIndex(v => v.label.name == variant.label.name) |(_, idx)| idx else unreachable("variant '${variant.label.name}' must exist")
     fn.block.buildStoreW(Value.Int(variantIdx), memLocal) // Store variant idx at designated slot
     var offset = QbeType.U64.size() // begin inserting any fields after that variant idx slot
 
@@ -2815,13 +2809,13 @@ export type Compiler {
       if node |node| {
         val items = match node.kind {
           TypedAstNodeKind.Array(items) => items
-          _ => return unreachable("`$fnName` receives an array of its variadic arguments")
+          _ => unreachable("`$fnName` receives an array of its variadic arguments")
         }
         items
-      } else return unreachable("`$fnName` receives an array of its variadic arguments")
+      } else unreachable("`$fnName` receives an array of its variadic arguments")
     } else []
 
-    val stdoutWriteFn = if self._project.preludeScope.functions.find(fn => fn.label.name == "stdoutWrite") |fn| fn else return unreachable("`stdoutWrite` must exist in prelude")
+    val stdoutWriteFn = if self._project.preludeScope.functions.find(fn => fn.label.name == "stdoutWrite") |fn| fn else unreachable("`stdoutWrite` must exist in prelude")
     val stdoutWriteFnVal = try self._getOrCompileFunction(stdoutWriteFn)
 
     val space = self._builder.buildGlobalString(" ")
@@ -2857,7 +2851,7 @@ export type Compiler {
   func _invokeCBindingFn(self, dec: Decorator, fn: Function, arguments: TypedAstNode?[]): Result<Value, CompileError> {
     val cFnName = match dec.arguments[0] {
       LiteralAstNode.String(value) => value
-      _ => return unreachable("@CBinding decorator requires 1 string argument for the name")
+      _ => unreachable("@CBinding decorator requires 1 string argument for the name")
     }
 
     val args: Value[] = []
@@ -2866,7 +2860,7 @@ export type Compiler {
         val arg = try self._compileExpression(node)
         args.push(arg)
       } else {
-        return unreachable("functions with @CBinding decorator cannot have optional parameters")
+        unreachable("functions with @CBinding decorator cannot have optional parameters")
       }
     }
 
@@ -2884,7 +2878,7 @@ export type Compiler {
   func _pointerSize(self, ty: Type): Result<Int, CompileError> {
     val size = match ty.kind {
       TypeKind.PrimitiveBool => 4
-      TypeKind.Generic(name) => return unreachable("unresolved generic '$name'")
+      TypeKind.Generic(name) => unreachable("unresolved generic '$name'")
       TypeKind.Instance(structOrEnum, generics) => {
         match structOrEnum {
           StructOrEnum.Struct(struct) => {
@@ -2902,7 +2896,7 @@ export type Compiler {
   func _invokeIntrinsicFn(self, dec: Decorator, fn: Function, arguments: TypedAstNode?[]): Result<Value, CompileError> {
     val intrinsicFnName = match dec.arguments[0] {
       LiteralAstNode.String(value) => value
-      _ => return unreachable("@Intrinsic decorator requires 1 string argument for the name")
+      _ => unreachable("@Intrinsic decorator requires 1 string argument for the name")
     }
 
     match intrinsicFnName {
@@ -2918,8 +2912,8 @@ export type Compiler {
       "pointer_is_null" => {
         self._currentFn.block.addComment("begin pointer_is_null...")
 
-        val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_is_null' has 1 required argument")
-        val ptr = if _ptr |arg| arg else return unreachable("'pointer_is_null' has 1 required argument")
+        val _ptr = if arguments[0] |arg| arg else unreachable("'pointer_is_null' has 1 required argument")
+        val ptr = if _ptr |arg| arg else unreachable("'pointer_is_null' has 1 required argument")
         val ptrVal = try self._compileExpression(ptr)
 
         val labelIsNull = self._currentFn.block.addLabel("ptr_is_null")
@@ -2946,11 +2940,11 @@ export type Compiler {
       "pointer_malloc" => {
         self._currentFn.block.addComment("begin pointer_malloc...")
 
-        val _count = if arguments[0] |arg| arg else return unreachable("'pointer_malloc' has 1 required argument")
-        val count = if _count |arg| arg else return unreachable("'pointer_malloc' has 1 required argument")
+        val _count = if arguments[0] |arg| arg else unreachable("'pointer_malloc' has 1 required argument")
+        val count = if _count |arg| arg else unreachable("'pointer_malloc' has 1 required argument")
         val countVal = try self._compileExpression(count)
 
-        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_malloc) could not resolve T for Pointer<T>")
+        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else unreachable("(pointer_malloc) could not resolve T for Pointer<T>")
         val innerTySize = try self._pointerSize(innerTy)
         val sizeVal = try self._currentFn.block.buildMul(Value.Int(innerTySize), countVal) else |e| return qbeError(e)
 
@@ -2963,15 +2957,15 @@ export type Compiler {
       "pointer_realloc" => {
         self._currentFn.block.addComment("begin pointer_realloc...")
 
-        val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_realloc' has 2 required arguments")
-        val ptr = if _ptr |arg| arg else return unreachable("'pointer_realloc' has 2 required arguments")
+        val _ptr = if arguments[0] |arg| arg else unreachable("'pointer_realloc' has 2 required arguments")
+        val ptr = if _ptr |arg| arg else unreachable("'pointer_realloc' has 2 required arguments")
         val ptrVal = try self._compileExpression(ptr)
 
-        val _count = if arguments[1] |arg| arg else return unreachable("'pointer_realloc' has 2 required arguments")
-        val count = if _count |arg| arg else return unreachable("'pointer_realloc' has 2 required arguments")
+        val _count = if arguments[1] |arg| arg else unreachable("'pointer_realloc' has 2 required arguments")
+        val count = if _count |arg| arg else unreachable("'pointer_realloc' has 2 required arguments")
         val countVal = try self._compileExpression(count)
 
-        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_realloc) could not resolve T for Pointer<T>")
+        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else unreachable("(pointer_realloc) could not resolve T for Pointer<T>")
         val innerTySize = try self._pointerSize(innerTy)
         val sizeVal = try self._currentFn.block.buildMul(Value.Int(innerTySize), countVal) else |e| return qbeError(e)
 
@@ -2984,15 +2978,15 @@ export type Compiler {
       "pointer_store" => {
         self._currentFn.block.addComment("begin pointer_store...")
 
-        val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_store' has 2 required arguments")
-        val ptr = if _ptr |arg| arg else return unreachable("'pointer_store' has 2 required arguments")
+        val _ptr = if arguments[0] |arg| arg else unreachable("'pointer_store' has 2 required arguments")
+        val ptr = if _ptr |arg| arg else unreachable("'pointer_store' has 2 required arguments")
         val ptrVal = try self._compileExpression(ptr)
 
-        val _value = if arguments[1] |arg| arg else return unreachable("'pointer_store' has 2 required arguments")
-        val value = if _value |arg| arg else return unreachable("'pointer_store' has 2 required arguments")
+        val _value = if arguments[1] |arg| arg else unreachable("'pointer_store' has 2 required arguments")
+        val value = if _value |arg| arg else unreachable("'pointer_store' has 2 required arguments")
         val valueVal = try self._compileExpression(value)
 
-        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_store) could not resolve T for Pointer<T>")
+        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else unreachable("(pointer_store) could not resolve T for Pointer<T>")
         val innerTySize = try self._pointerSize(innerTy)
         val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
         self._currentFn.block.buildStore(innerQbeType, valueVal, ptrVal)
@@ -3004,15 +2998,15 @@ export type Compiler {
       "pointer_offset" => {
         self._currentFn.block.addComment("begin pointer_offset...")
 
-        val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_offset' has 2 required arguments")
-        val ptr = if _ptr |arg| arg else return unreachable("'pointer_offset' has 2 required arguments")
+        val _ptr = if arguments[0] |arg| arg else unreachable("'pointer_offset' has 2 required arguments")
+        val ptr = if _ptr |arg| arg else unreachable("'pointer_offset' has 2 required arguments")
         val ptrVal = try self._compileExpression(ptr)
 
-        val _offset = if arguments[1] |arg| arg else return unreachable("'pointer_offset' has 2 required arguments")
-        val offset = if _offset |arg| arg else return unreachable("'pointer_offset' has 2 required arguments")
+        val _offset = if arguments[1] |arg| arg else unreachable("'pointer_offset' has 2 required arguments")
+        val offset = if _offset |arg| arg else unreachable("'pointer_offset' has 2 required arguments")
         val offsetVal = try self._compileExpression(offset)
 
-        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_offset) could not resolve T for Pointer<T>")
+        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else unreachable("(pointer_offset) could not resolve T for Pointer<T>")
         val innerTySize = try self._pointerSize(innerTy)
         val sizeVal = try self._currentFn.block.buildMul(Value.Int(innerTySize), offsetVal) else |e| return qbeError(e)
 
@@ -3025,11 +3019,11 @@ export type Compiler {
       "pointer_load" => {
         self._currentFn.block.addComment("begin pointer_load...")
 
-        val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_load' has 1 required argument")
-        val ptr = if _ptr |arg| arg else return unreachable("'pointer_load' has 1 required argument")
+        val _ptr = if arguments[0] |arg| arg else unreachable("'pointer_load' has 1 required argument")
+        val ptr = if _ptr |arg| arg else unreachable("'pointer_load' has 1 required argument")
         val ptrVal = try self._compileExpression(ptr)
 
-        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_load) could not resolve T for Pointer<T>")
+        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else unreachable("(pointer_load) could not resolve T for Pointer<T>")
 
         val isByte = match innerTy.kind {
           TypeKind.Instance(structOrEnum, _) => {
@@ -3055,19 +3049,19 @@ export type Compiler {
       "pointer_copy_from" => {
         self._currentFn.block.addComment("begin pointer_copy_from...")
 
-        val _ptr = if arguments[0] |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
-        val ptr = if _ptr |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
+        val _ptr = if arguments[0] |arg| arg else unreachable("'pointer_copy_from' has 3 required arguments")
+        val ptr = if _ptr |arg| arg else unreachable("'pointer_copy_from' has 3 required arguments")
         val ptrVal = try self._compileExpression(ptr)
 
-        val _other = if arguments[1] |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
-        val other = if _other |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
+        val _other = if arguments[1] |arg| arg else unreachable("'pointer_copy_from' has 3 required arguments")
+        val other = if _other |arg| arg else unreachable("'pointer_copy_from' has 3 required arguments")
         val otherVal = try self._compileExpression(other)
 
-        val _size = if arguments[2] |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
-        val size = if _size |arg| arg else return unreachable("'pointer_copy_from' has 3 required arguments")
+        val _size = if arguments[2] |arg| arg else unreachable("'pointer_copy_from' has 3 required arguments")
+        val size = if _size |arg| arg else unreachable("'pointer_copy_from' has 3 required arguments")
         val sizeArg = try self._compileExpression(size)
 
-        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else return unreachable("(pointer_copy_from) could not resolve T for Pointer<T>")
+        val innerTy = if self._resolvedGenerics.resolveGeneric("T") |ty| ty else unreachable("(pointer_copy_from) could not resolve T for Pointer<T>")
         val innerTySize = try self._pointerSize(innerTy)
         val sizeVal = try self._currentFn.block.buildMul(Value.Int(innerTySize), sizeArg) else |e| return qbeError(e)
 
@@ -3083,7 +3077,7 @@ export type Compiler {
         val errnoFnName = match Process.uname().sysname {
           "Linux" => "__errno_location"
           "Darwin" => "__error"
-          _ sysname => return todo_("[errno] unsupported system " + sysname)
+          _ sysname => todo("[errno] unsupported system " + sysname)
         }
         val errnoPtr = try self._currentFn.block.buildCallRaw(errnoFnName, QbeType.Pointer, []) else |e| return qbeError(e)
         val errnoVal = self._currentFn.block.buildLoadW(errnoPtr)
@@ -3096,8 +3090,8 @@ export type Compiler {
       "byte_from_int" => {
         self._currentFn.block.addComment("begin byte_from_int...")
 
-        val _arg = if arguments[0] |arg| arg else return unreachable("'byte_from_int' has 1 required argument")
-        val arg = if _arg |arg| arg else return unreachable("'byte_from_int' has 1 required argument")
+        val _arg = if arguments[0] |arg| arg else unreachable("'byte_from_int' has 1 required argument")
+        val arg = if _arg |arg| arg else unreachable("'byte_from_int' has 1 required argument")
         val argVal = try self._compileExpression(arg)
 
         self._currentFn.block.addComment("...byte_from_int end")
@@ -3107,8 +3101,8 @@ export type Compiler {
       "byte_as_int" => {
         self._currentFn.block.addComment("begin byte_as_int...")
 
-        val _arg = if arguments[0] |arg| arg else return unreachable("'byte_as_int' has 1 required argument")
-        val arg = if _arg |arg| arg else return unreachable("'byte_as_int' has 1 required argument")
+        val _arg = if arguments[0] |arg| arg else unreachable("'byte_as_int' has 1 required argument")
+        val arg = if _arg |arg| arg else unreachable("'byte_as_int' has 1 required argument")
         val argVal = try self._compileExpression(arg)
 
         self._currentFn.block.addComment("...byte_as_int end")
@@ -3118,8 +3112,8 @@ export type Compiler {
       "int_as_float" => {
         self._currentFn.block.addComment("begin int_as_float...")
 
-        val _arg = if arguments[0] |arg| arg else return unreachable("'int_as_float' has 1 required argument")
-        val arg = if _arg |arg| arg else return unreachable("'int_as_float' has 1 required argument")
+        val _arg = if arguments[0] |arg| arg else unreachable("'int_as_float' has 1 required argument")
+        val arg = if _arg |arg| arg else unreachable("'int_as_float' has 1 required argument")
         val argVal = try self._compileExpression(arg)
 
         val res = self._currentFn.block.buildLToF(argVal)
@@ -3131,8 +3125,8 @@ export type Compiler {
       "float_as_int" => {
         self._currentFn.block.addComment("begin float_as_int...")
 
-        val _arg = if arguments[0] |arg| arg else return unreachable("'float_as_int' has 1 required argument")
-        val arg = if _arg |arg| arg else return unreachable("'float_as_int' has 1 required argument")
+        val _arg = if arguments[0] |arg| arg else unreachable("'float_as_int' has 1 required argument")
+        val arg = if _arg |arg| arg else unreachable("'float_as_int' has 1 required argument")
         val argVal = try self._compileExpression(arg)
 
         val res = self._currentFn.block.buildFToL(argVal)
@@ -3144,8 +3138,8 @@ export type Compiler {
       "float_floor" => {
         self._currentFn.block.addComment("begin float_floor...")
 
-        val _arg = if arguments[0] |arg| arg else return unreachable("'float_floor' has 1 required argument")
-        val arg = if _arg |arg| arg else return unreachable("'float_floor' has 1 required argument")
+        val _arg = if arguments[0] |arg| arg else unreachable("'float_floor' has 1 required argument")
+        val arg = if _arg |arg| arg else unreachable("'float_floor' has 1 required argument")
         val argVal = try self._compileExpression(arg)
 
         val floorRes = try self._currentFn.block.buildCallRaw("floor", QbeType.F64, [argVal]) else |e| return qbeError(e)
@@ -3158,8 +3152,8 @@ export type Compiler {
       "float_ceil" => {
         self._currentFn.block.addComment("begin float_ceil...")
 
-        val _arg = if arguments[0] |arg| arg else return unreachable("'float_ceil' has 1 required argument")
-        val arg = if _arg |arg| arg else return unreachable("'float_ceil' has 1 required argument")
+        val _arg = if arguments[0] |arg| arg else unreachable("'float_ceil' has 1 required argument")
+        val arg = if _arg |arg| arg else unreachable("'float_ceil' has 1 required argument")
         val argVal = try self._compileExpression(arg)
 
         val ceilRes = try self._currentFn.block.buildCallRaw("ceil", QbeType.F64, [argVal]) else |e| return qbeError(e)
@@ -3172,8 +3166,8 @@ export type Compiler {
       "float_round" => {
         self._currentFn.block.addComment("begin float_round...")
 
-        val _arg = if arguments[0] |arg| arg else return unreachable("'float_round' has 1 required argument")
-        val arg = if _arg |arg| arg else return unreachable("'float_round' has 1 required argument")
+        val _arg = if arguments[0] |arg| arg else unreachable("'float_round' has 1 required argument")
+        val arg = if _arg |arg| arg else unreachable("'float_round' has 1 required argument")
         val argVal = try self._compileExpression(arg)
 
         val roundRes = try self._currentFn.block.buildCallRaw("round", QbeType.F64, [argVal]) else |e| return qbeError(e)
@@ -3197,7 +3191,7 @@ export type Compiler {
 
         Ok(res)
       }
-      _ => unreachable("unsupported intrinsic '$intrinsicFnName'", fn.label.position)
+      _ => unreachable("unsupported intrinsic '$intrinsicFnName'")
     }
   }
 
@@ -3232,7 +3226,7 @@ export type Compiler {
     if isInstanceMethod {
       val selfTyQbe = try self._getQbeTypeForTypeExpect(selfType, "unacceptable type for self")
       fnVal.addParameter("self", selfTyQbe)
-      val selfVariable = if fn.scope.variables.find(v => v.label.name == "self") |selfVariable| selfVariable else return unreachable("Function '${fn.label.name}' is an instance method but does not have a variable 'self' in its scope", fn.label.position)
+      val selfVariable = if fn.scope.variables.find(v => v.label.name == "self") |selfVariable| selfVariable else unreachable("Function '${fn.label.name}' is an instance method but does not have a variable 'self' in its scope")
       fnVal.block.addVar(variableToVar(selfVariable), Some("self"))
     }
     try self._compileFunc(fnVal, fn)
@@ -3319,13 +3313,13 @@ export type Compiler {
         if struct == self._project.preludeBoolStruct return self._getOrCompileBoolToStringMethod()
 
         val _fn = struct.instanceMethods.find(m => m.label.name == "toString")
-        val fn = if _fn |f| f else return unreachable("every struct has a toString method defined")
+        val fn = if _fn |f| f else unreachable("every struct has a toString method defined")
 
         (try self._structMethodFnName(struct, fn), fn)
       }
       StructOrEnum.Enum(enum_) => {
         val _fn = enum_.instanceMethods.find(m => m.label.name == "toString")
-        val fn = if _fn |f| f else return unreachable("every enum has a toString method defined")
+        val fn = if _fn |f| f else unreachable("every enum has a toString method defined")
 
         (try self._enumMethodFnName(enum_, fn), fn)
       }
@@ -3467,7 +3461,7 @@ export type Compiler {
     }
 
     val totalLengthVal = try self._currentFn.block.buildAdd(Value.Int(len), lenVal) else |e| return qbeError(e)
-    val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else return unreachable("String.withLength must exist")
+    val stringWithLengthFn = if self._project.preludeStringStruct.staticMethods.find(m => m.label.name == "withLength") |fn| fn else unreachable("String.withLength must exist")
     val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
     val newStr = try self._currentFn.block.buildCall(Callable.Function(stringWithLengthFnVal), [totalLengthVal]) else |e| return qbeError(e)
 
@@ -3719,13 +3713,13 @@ export type Compiler {
         }
 
         val _fn = struct.instanceMethods.find(m => m.label.name == "eq")
-        val fn = if _fn |f| f else return unreachable("every struct has an eq method defined")
+        val fn = if _fn |f| f else unreachable("every struct has an eq method defined")
 
         (try self._structMethodFnName(struct, fn), fn)
       }
       StructOrEnum.Enum(enum_) => {
         val _fn = enum_.instanceMethods.find(m => m.label.name == "eq")
-        val fn = if _fn |f| f else return unreachable("every enum has an eq method defined")
+        val fn = if _fn |f| f else unreachable("every enum has an eq method defined")
 
         (try self._enumMethodFnName(enum_, fn), fn)
       }
@@ -3934,13 +3928,13 @@ export type Compiler {
         }
 
         val _fn = struct.instanceMethods.find(m => m.label.name == "hash")
-        val fn = if _fn |f| f else return unreachable("every struct has a hash method defined")
+        val fn = if _fn |f| f else unreachable("every struct has a hash method defined")
 
         (try self._structMethodFnName(struct, fn), fn)
       }
       StructOrEnum.Enum(enum_) => {
         val _fn = enum_.instanceMethods.find(m => m.label.name == "hash")
-        val fn = if _fn |f| f else return unreachable("every enum has a hash method defined")
+        val fn = if _fn |f| f else unreachable("every enum has a hash method defined")
 
         (try self._enumMethodFnName(enum_, fn), fn)
       }
@@ -4077,7 +4071,7 @@ export type Compiler {
 
   func _emitOptValueIsSomeVariant(self, exprVal: Value, negate = false): Result<Value, CompileError> {
     val variantIdx = self._emitGetEnumVariantIdx(exprVal)
-    val optionSomeVariantIdx = if self._project.preludeOptionEnum.variants.findIndex(v => v.label.name == "Some") |(_, idx)| idx else return unreachable("Option.Some must exist")
+    val optionSomeVariantIdx = if self._project.preludeOptionEnum.variants.findIndex(v => v.label.name == "Some") |(_, idx)| idx else unreachable("Option.Some must exist")
     if negate {
       val res = try self._currentFn.block.buildCompareNeq(variantIdx, Value.Int(optionSomeVariantIdx)) else |e| return qbeError(e)
       Ok(res)
@@ -4096,7 +4090,7 @@ export type Compiler {
 
   func _emitResultValueIsOkVariant(self, exprVal: Value, negate = false): Result<Value, CompileError> {
     val variantIdx = self._emitGetEnumVariantIdx(exprVal)
-    val resultOkVariantIdx = if self._project.preludeResultEnum.variants.findIndex(v => v.label.name == "Ok") |(_, idx)| idx else return unreachable("Result.Ok must exist")
+    val resultOkVariantIdx = if self._project.preludeResultEnum.variants.findIndex(v => v.label.name == "Ok") |(_, idx)| idx else unreachable("Result.Ok must exist")
     if negate {
       val res = try self._currentFn.block.buildCompareNeq(variantIdx, Value.Int(resultOkVariantIdx)) else |e| return qbeError(e)
       Ok(res)
@@ -4313,7 +4307,7 @@ export type Compiler {
         val repr = if self._resolvedGenerics.resolveGeneric(name) |ty| {
           try self._getNameForType(ty)
         } else {
-          return unreachable("could not resolve '$name'")
+          unreachable("could not resolve '$name'")
         }
         parts.push(repr)
       }
@@ -4350,7 +4344,7 @@ export type Compiler {
         val repr = if self._resolvedGenerics.resolveGeneric(name) |ty| {
           try self._getNameForType(ty)
         } else {
-          return unreachable("could not resolve '$name'")
+          unreachable("could not resolve '$name'")
         }
         parts.push(repr)
       }
@@ -4412,7 +4406,7 @@ export type Compiler {
         if !struct.typeParams.isEmpty() {
           parts.push("<")
           for name, idx in struct.typeParams {
-            val resolvedGeneric = if self._resolvedGenerics.resolveGeneric(name) |ty| ty else return unreachable("_fnSignature:struct (${struct.label.name}, ${fn.label.name}), could not resolve generic '$name'")
+            val resolvedGeneric = if self._resolvedGenerics.resolveGeneric(name) |ty| ty else unreachable("_fnSignature:struct (${struct.label.name}, ${fn.label.name}), could not resolve generic '$name'")
             parts.push(resolvedGeneric.repr())
 
             if idx != struct.typeParams.length - 1 { parts.push(", ") }
@@ -4426,7 +4420,7 @@ export type Compiler {
         if !enum_.typeParams.isEmpty() {
           parts.push("<")
           for name, idx in enum_.typeParams {
-            val resolvedGeneric = if self._resolvedGenerics.resolveGeneric(name) |ty| ty else return unreachable("_fnSignature:enum (${enum_.label.name}, ${fn.label.name}), could not resolve generic '$name'")
+            val resolvedGeneric = if self._resolvedGenerics.resolveGeneric(name) |ty| ty else unreachable("_fnSignature:enum (${enum_.label.name}, ${fn.label.name}), could not resolve generic '$name'")
             parts.push(resolvedGeneric.repr())
 
             if idx != enum_.typeParams.length - 1 { parts.push(", ") }
@@ -4442,7 +4436,7 @@ export type Compiler {
       parts.push("<")
       for (_, typeParamLabel), idx in fn.typeParams {
         val name = typeParamLabel.name
-        val resolvedGeneric = if self._resolvedGenerics.resolveGeneric(name) |ty| ty else return unreachable("_fnSignature:fn, could not resolve generic '$name'")
+        val resolvedGeneric = if self._resolvedGenerics.resolveGeneric(name) |ty| ty else unreachable("_fnSignature:fn, could not resolve generic '$name'")
         parts.push(resolvedGeneric.repr())
 
         if idx != fn.typeParams.length - 1 { parts.push(", ") }
@@ -4477,7 +4471,7 @@ export type Compiler {
     if !struct.typeParams.isEmpty() {
       firstLine.push("<")
       for name, idx in struct.typeParams {
-        val resolvedGeneric = if self._resolvedGenerics.resolveGeneric(name) |ty| ty else return unreachable("could not resolve generic '$name'")
+        val resolvedGeneric = if self._resolvedGenerics.resolveGeneric(name) |ty| ty else unreachable("could not resolve generic '$name'")
         firstLine.push("$name = ${resolvedGeneric.repr()}")
 
         if idx != struct.typeParams.length - 1 { firstLine.push(", ") }
@@ -4538,6 +4532,3 @@ export type Compiler {
     }
   }
 }
-
-func todo_<V>(message: String, position = Position(line: 0, col: 0)): Result<V, CompileError> = Err(CompileError(position: position, kind: CompileErrorKind.NotYetImplemented(message)))
-func unreachable<V>(message: String, position = Position(line: 0, col: 0)): Result<V, CompileError> = Err(CompileError(position: position, kind: CompileErrorKind.Unreachable(message)))

--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -212,7 +212,8 @@ export type LexerError {
       }
       "  |  $line\n     ${cursor.join()}"
     } else {
-      "unreachable"
+      // "unreachable"
+      unreachable()
     }
   }
 }
@@ -525,6 +526,7 @@ export type Lexer {
           continue
         } else {
           // should be unreachable
+          unreachable()
         }
       } else if ch == "\"" {
         closed = true

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -293,7 +293,6 @@ enum ParseErrorKind {
   ExpectedToken(expected: TokenKind[], received: TokenKind)
   UnexpectedEof
   NotYetImplemented
-  Unreachable
 }
 
 export type ParseError {
@@ -327,9 +326,6 @@ export type ParseError {
         lines.push("Not yet implemented:")
         lines.push(self._getCursorLine(self.position, contents))
       }
-      ParseErrorKind.Unreachable => {
-        lines.push("Critical error: reached unreachable location in code!")
-      }
     }
 
     lines.join("\n")
@@ -345,7 +341,7 @@ export type ParseError {
       }
       "  |  $line\n     ${cursor.join()}"
     } else {
-      "unreachable"
+      unreachable()
     }
   }
 }
@@ -432,7 +428,7 @@ export type Parser {
         TokenKind.StringInterpolation => true
         _ => false
       }
-      TokenKind.StringInterpolation => return unreachable() // no reason to ever explicitly expect a StringInterpolation token
+      TokenKind.StringInterpolation => unreachable("no reason to ever explicitly expect a StringInterpolation token")
       TokenKind.Ident => match token.kind { TokenKind.Ident => true, _ => false }
       TokenKind.LParen => match token.kind { TokenKind.LParen => true, _ => false }
       TokenKind.LBrack=> match token.kind { TokenKind.LBrack => true, _ => false }
@@ -871,7 +867,7 @@ export type Parser {
         AstNodeKind.FunctionDeclaration(node) => methods.push(node)
         AstNodeKind.TypeDeclaration(node) => types.push(node)
         AstNodeKind.EnumDeclaration(node) => enums.push(node)
-        _ => return unreachable()
+        _ => unreachable()
       }
     }
 
@@ -1246,7 +1242,7 @@ export type Parser {
       if exprs[0] |inner| {
         AstNodeKind.Grouped(inner: inner)
       } else {
-        return unreachable()
+        unreachable()
       }
     } else {
       AstNodeKind.Tuple(items: exprs)
@@ -1813,10 +1809,6 @@ export type Parser {
 
     Ok(AstNode(token: token, kind: AstNodeKind.Assignment(expr: expr, op: assignOp, mode: mode)))
   }
-}
-
-func unreachable<V>(): Result<V, ParseError> {
-  Err(ParseError(position: Position(line: 0, col: 0), kind: ParseErrorKind.Unreachable))
 }
 
 type Precedence {

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -513,15 +513,9 @@ export type Type {
       TypeKind.Instance(_, templateTypeArgs) => {
         match self.kind {
           TypeKind.Instance(_, sourceTypeArgs) => {
-            if templateTypeArgs.length != sourceTypeArgs.length {
-              __assertUnreachable("templateTypeArgs.length != sourceTypeArgs.length")
-              return
-            }
+            if templateTypeArgs.length != sourceTypeArgs.length unreachable("templateTypeArgs.length != sourceTypeArgs.length")
             for tplTypeArg, idx in templateTypeArgs {
-              val srcTypeArg = if sourceTypeArgs[idx] |t| t else {
-                __assertUnreachable("templateTypeArgs.length != sourceTypeArgs.length")
-                return
-              }
+              val srcTypeArg = if sourceTypeArgs[idx] |t| t else unreachable("templateTypeArgs.length != sourceTypeArgs.length")
               srcTypeArg._extractGenerics(template: tplTypeArg, extracted: extracted)
             }
           }
@@ -863,11 +857,6 @@ type TypeError {
         lines.push(self._getCursorLine(self.position, contents))
         lines.push("Reason: $reason")
       }
-      TypeErrorKind.Unreachable(message) => {
-        lines.push("Unreachable code reached")
-        lines.push(self._getCursorLine(self.position, contents))
-        lines.push("Internal error: $message")
-      }
       TypeErrorKind.TypeMismatch(expected, received) => {
         lines.push("Type mismatch")
         lines.push(self._getCursorLine(self.position, contents))
@@ -903,10 +892,7 @@ type TypeError {
           _ => {
             match specialCase {
               UnknownFieldSpecialCase.ExistsButTypeIsNullable(isViaOptChaining) => {
-                val nonOptVersion = if self._typeIsOption(ty) |ty| ty else {
-                  __assertUnreachable("ty should be Option<?> here")
-                  Type(kind: TypeKind.Hole)
-                }
+                val nonOptVersion = if self._typeIsOption(ty) |ty| ty else unreachable("ty should be Option<?> here")
 
                 if isViaOptChaining {
                   lines.push("Type '${nonOptVersion.repr()}' has field '$name', but lhs here is of type '${ty.repr()}' due to prior '?.'")
@@ -1135,7 +1121,7 @@ type TypeError {
           TypeKind.Instance(structOrEnum, _) => {
             match structOrEnum {
               StructOrEnum.Enum => lines.push("This is a constant enum variant, and it accepts no arguments")
-              _ => __assertUnreachable("This should be unreachable")
+              _ => unreachable()
             }
           }
           _ => lines.push("Type '${ty.repr()}' is not callable")
@@ -1172,14 +1158,14 @@ type TypeError {
             lines.push("No value at index for tuple of type '${ty.repr()}'")
             match ty.kind {
               TypeKind.Tuple(types) => lines.push("(Valid index values are from 0-${types.length - 1}, inclusive)")
-              _ => __assertUnreachable("The type here should always be a tuple")
+              _ => unreachable("The type here should always be a tuple")
             }
           }
           IllegalTupleIndexingReason.IndexNegative => {
             lines.push("Tuple index values must always be a non-negative integer")
             match ty.kind {
               TypeKind.Tuple(types) => lines.push("(Valid index values are from 0-${types.length - 1}, inclusive)")
-              _ => __assertUnreachable("The type here should always be a tuple")
+              _ => unreachable("The type here should always be a tuple")
             }
           }
           IllegalTupleIndexingReason.NotIntLiteral => lines.push("Cannot use non-Int literal as index value. Tuple index values must always be Int literals")
@@ -1357,7 +1343,7 @@ type TypeError {
       }
       "  |  $line\n     ${cursor.join()}"
     } else {
-      "unreachable"
+      unreachable()
     }
   }
 }
@@ -1407,7 +1393,6 @@ enum InvalidTryLocationReason {
 
 enum TypeErrorKind {
   NotYetImplemented(reason: String)
-  Unreachable(message: String)
   TypeMismatch(expected: Type[], received: Type)
   DuplicateName(original: Label)
   UnknownName(name: String, kind: String)
@@ -1492,22 +1477,15 @@ export type Typechecker {
       self.project.preludeSetStruct,
     ]
     for struct in preludeStructs {
-      if struct.label.position == Position(line: 0, col: 0) {
-        val message = "Improperly initialized prelude struct ${struct.label.name}"
-        val err = TypeError(position: struct.label.position, kind: TypeErrorKind.Unreachable(message))
-        return Err(TypecheckerError(modulePath: preludeModulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
-      }
+      if struct.label.position == Position(line: 0, col: 0) unreachable("Improperly initialized prelude struct ${struct.label.name}")
     }
 
     val preludeEnums = [
       self.project.preludeOptionEnum,
+      self.project.preludeResultEnum,
     ]
     for enum_ in preludeEnums {
-      if enum_.label.position == Position(line: 0, col: 0) {
-        val message = "Improperly initialized prelude enum ${enum_.label.name}"
-        val err = TypeError(position: enum_.label.position, kind: TypeErrorKind.Unreachable(message))
-        return Err(TypecheckerError(modulePath: preludeModulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
-      }
+      if enum_.label.position == Position(line: 0, col: 0) unreachable("Improperly initialized prelude enum ${enum_.label.name}")
     }
 
     self._typecheckModule(modulePathAbs)
@@ -1622,7 +1600,7 @@ export type Typechecker {
   func _findModuleByAlias(self, name: String): Result<(TypedModule, Label)?, TypeError> {
     for (importModulePath, importedModule) in self.currentModuleImports {
       if importedModule.aliases.find(a => a.name == name) |alias| {
-        val mod = if self.project.modules[importModulePath] |m| m else return unreachable(alias.position, "unknown module")
+        val mod = if self.project.modules[importModulePath] |m| m else unreachable("unknown module '$importModulePath'")
         return Ok(Some((mod, alias)))
       }
     }
@@ -1637,7 +1615,7 @@ export type Typechecker {
 
     val types: Type[] = []
     for i in range(0, num) {
-      val typeIdent = if typeArguments.get(i) |typeIdent| typeIdent else return unreachable(position, "verified above that typeArguments.length == num")
+      val typeIdent = if typeArguments.get(i) |typeIdent| typeIdent else unreachable("verified above that typeArguments.length == num")
       val ty = try self._resolveTypeIdentifier(typeIdent)
       types.push(ty)
     }
@@ -1734,7 +1712,7 @@ export type Typechecker {
           val _mod = try self._findModuleByAlias(firstSeg.name)
           val (mod, aliasLabel) = if _mod |mod| mod else return Err(TypeError(position: firstSeg.position, kind: TypeErrorKind.UnknownName(firstSeg.name, "module")))
 
-          if path[1] |seg| return todo(seg.position, "qualified type paths longer than 2")
+          if path[1] |seg| return Err(TypeError(position: seg.position, kind: TypeErrorKind.NotYetImplemented("qualified type paths longer than 2")))
 
           val foundTy = match mod.exports[label.name] {
             None => return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownImportForAlias(label.name, aliasLabel)))
@@ -1844,9 +1822,7 @@ export type Typechecker {
 
             Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownName(label.name, "type")))
           }
-          _ => {
-            return todo(first.position, "module aliases")
-          }
+          _ => todo("module aliases")
         }
       }
     }
@@ -1991,7 +1967,7 @@ export type Typechecker {
         TypeKind.Tuple(types) => {
           if reqTypes.length != types.length return false
           for reqTy, i in reqTypes {
-            val ty = if types[i] |t| t else { /* unreachable, length verified above to be equal */ return false }
+            val ty = if types[i] |t| t else unreachable("length verified above to be equal")
             if !self._typeSatisfiesRequired(ty: ty, required: reqTy) return false
           }
 
@@ -2011,10 +1987,7 @@ export type Typechecker {
       for (ty, _) in fn.typeParams {
         match ty.kind {
           TypeKind.Generic(name) => genericsInScope.insert(name)
-          _ => {
-            __assertUnreachable("typeParam.kind != TypeKind.Generic")
-            return #{}
-          }
+          _ => unreachable("typeParam.kind != TypeKind.Generic")
         }
       }
 
@@ -2180,7 +2153,7 @@ export type Typechecker {
       val typedArg = try self._typecheckExpression(arg.value, None)
       match typedArg.kind {
         TypedAstNodeKind.Literal(litNode) => args.push(litNode)
-        _ => return unreachable(typedArg.token.position, "should have been caught during parsing")
+        _ => unreachable("should have been caught during parsing")
       }
     }
 
@@ -2224,7 +2197,7 @@ export type Typechecker {
       if self.currentTypeDecl |selfType| {
         FunctionKind.InstanceMethod(Some(selfType))
       } else {
-        val param = if node.params[0] |p| p else return unreachable(node.name.position, "expected a first parameter to be present")
+        val param = if node.params[0] |p| p else unreachable("expected a first parameter to be present")
         return Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
       }
     } else if self.currentTypeDecl |parentType| {
@@ -2401,12 +2374,12 @@ export type Typechecker {
 
       // Since `self` is not included in the fn.params array, but it is in the untyped AST, when referring to the untyped AST, we need to adjust
       val origNodeParamIdx = match fn.kind { FunctionKind.InstanceMethod => idx + 1, _ => idx }
-      val paramNode = if params[origNodeParamIdx] |p| p else return unreachable(param.label.position, "there should be as many parameter nodes as typed parameters")
-      val defaultValueNode = if paramNode.defaultValue |n| n else return unreachable(param.label.position, "the only way a parameter needs revisiting is if it has a default value")
+      val paramNode = if params[origNodeParamIdx] |p| p else unreachable("there should be as many parameter nodes as typed parameters")
+      val defaultValueNode = if paramNode.defaultValue |n| n else unreachable("the only way a parameter needs revisiting is if it has a default value")
 
       val hint = paramHints[idx]
       val (typedParam, needsRevisit) = try self._typecheckFunctionParam(param: paramNode, typeHint: hint, allowSelf: allowSelf, isRevisit: true)
-      if needsRevisit return unreachable(param.label.position, "parameters should not need to be revisited more than once")
+      if needsRevisit unreachable("parameters should not need to be revisited more than once")
       fn.params[idx] = typedParam
     }
 
@@ -2515,7 +2488,7 @@ export type Typechecker {
       match fn.kind {
         FunctionKind.InstanceMethod => struct.instanceMethods.push(fn)
         FunctionKind.StaticMethod => struct.staticMethods.push(fn)
-        FunctionKind.Standalone => return unreachable(fn.label.position, "method has invalid function kind at this point")
+        FunctionKind.Standalone => unreachable("method has invalid function kind at this point")
       }
     }
 
@@ -2558,7 +2531,7 @@ export type Typechecker {
       } else if staticMethodsByName[funcDeclNode.name] |fn| {
         fn
       } else {
-        return unreachable(funcDeclNode.name.position, "could not find function among instance/static methods")
+        unreachable("could not find function among instance/static methods")
       }
       val paramsNeedingRevisit = try self._typecheckFunctionPass2(fn: fn, allowSelf: true, params: funcDeclNode.params)
       allParamsNeedingRevisit[fn.label] = paramsNeedingRevisit
@@ -2627,7 +2600,7 @@ export type Typechecker {
 
     for field, idx in node.fields {
       val initializer = if field.initializer |v| v else continue
-      val structField = if struct.fields[idx] |f| f else return unreachable(struct.label.position, "")
+      val structField = if struct.fields[idx] |f| f else unreachable()
 
       val typedInitializer = try self._typecheckExpression(initializer, Some(structField.ty))
       if !self._typeSatisfiesRequired(ty: typedInitializer.ty, required: structField.ty) {
@@ -2645,10 +2618,10 @@ export type Typechecker {
       } else if staticMethods[fnLabel] |f| {
         f
       } else {
-        return unreachable(funcDeclNode.name.position, "method not visited in prior pass")
+        unreachable("method not visited in prior pass")
       }
 
-      val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
+      val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else unreachable("params improperly visited in prior pass")
       try self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit)
     }
 
@@ -2736,7 +2709,7 @@ export type Typechecker {
       match fn.kind {
         FunctionKind.InstanceMethod => enum_.instanceMethods.push(fn)
         FunctionKind.StaticMethod => enum_.staticMethods.push(fn)
-        FunctionKind.Standalone => return unreachable(fn.label.position, "method has invalid function kind at this point")
+        FunctionKind.Standalone => unreachable("method has invalid function kind at this point")
       }
     }
 
@@ -2758,11 +2731,11 @@ export type Typechecker {
         EnumVariantKind.Container(typedFields) => {
           val fields = match node.variants[idx] {
             EnumVariant.Container(_, fields) => fields
-            _ => return unreachable(typedVariant.label.position, "the untyped enum variant must exist at index, and must also be a Container")
+            _ => unreachable("the untyped enum variant must exist at index, and must also be a Container")
           }
 
           for typedField, idx in typedFields {
-            val field = if fields[idx] |f| f else return unreachable(typedField.name.position, "the untyped field must exist at index")
+            val field = if fields[idx] |f| f else unreachable("the untyped field must exist at index")
             if field.initializer |initializer| {
               val typedInitializer = try self._typecheckExpression(initializer, Some(typedField.ty))
               if !self._typeSatisfiesRequired(ty: typedInitializer.ty, required: typedField.ty) {
@@ -2801,10 +2774,10 @@ export type Typechecker {
       } else if staticMethods[fnLabel] |f| {
         f
       } else {
-        return unreachable(funcDeclNode.name.position, "method not visited in prior pass")
+        unreachable("method not visited in prior pass")
       }
 
-      val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else return unreachable(funcDeclNode.name.position, "params improperly visited in prior pass")
+      val toRevisit = if paramsNeedingRevisit[fnLabel] |paramIds| paramIds else unreachable("params improperly visited in prior pass")
       try self._typecheckFunctionPass3(fn: fn, allowSelf: true, params: funcDeclNode.params, body: funcDeclNode.body, paramsNeedingRevisit: toRevisit)
     }
 
@@ -2969,7 +2942,7 @@ export type Typechecker {
             try self._typecheckFunctionPass3(fn: fn, allowSelf: false, params: fnDeclNode.params, body: fnDeclNode.body, paramsNeedingRevisit: paramsNeedingRevisit)
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.FunctionDeclaration(fn))
           } else {
-            return unreachable(node.token.position, "there should be as many functions as there are functiondecl nodes")
+            unreachable("there should be as many functions as there are functiondecl nodes")
           }
 
           typedNodes.push(typedNode)
@@ -2980,7 +2953,7 @@ export type Typechecker {
             try self._typecheckStructPass3(struct, typeDeclNode, toRevisit)
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.TypeDeclaration(struct))
           } else {
-            return unreachable(node.token.position, "there should be as many types as there are typedecl nodes")
+            unreachable("there should be as many types as there are typedecl nodes")
           }
 
           typedNodes.push(typedNode)
@@ -2991,7 +2964,7 @@ export type Typechecker {
             try self._typecheckEnumPass3(enum_, enumDeclNode, toRevisit)
             TypedAstNode(token: node.token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.EnumDeclaration(enum_))
           } else {
-            return unreachable(node.token.position, "there should be as many enums as there are enumdecl nodes")
+            unreachable("there should be as many enums as there are enumdecl nodes")
           }
 
           typedNodes.push(typedNode)
@@ -3152,7 +3125,7 @@ export type Typechecker {
         val typedLhs = try self._typecheckIndexing(token, targetExpr, IndexingMode.Single(indexExpr), None)
         val typedIndexingNode = match typedLhs.kind {
           TypedAstNodeKind.Indexing(node) => node
-          _ => return unreachable(typedLhs.token.position, "_typecheckIndexing returned unexpected TypedAstNodeKind")
+          _ => unreachable("_typecheckIndexing returned unexpected TypedAstNodeKind")
         }
         val assignmentTy = if self._typeIsOption(typedLhs.ty) |inner| inner else typedLhs.ty
 
@@ -3190,9 +3163,9 @@ export type Typechecker {
           TypedAstNodeKind.Identifier(name, _, _, varImportMod) => {
             val pos = typedLhs.token.position
             if varImportMod return Err(TypeError(position: pos, kind: TypeErrorKind.IllegalAssignment(kind: "member", name: name, reason: IllegalAssignmentReason.Import)))
-            return unreachable(pos, "_typecheckAccessor returned unexpected TypedAstNodeKind")
+            unreachable("_typecheckAccessor returned unexpected TypedAstNodeKind")
           }
-          _ => return unreachable(typedLhs.token.position, "_typecheckAccessor returned unexpected TypedAstNodeKind")
+          _ => unreachable("_typecheckAccessor returned unexpected TypedAstNodeKind")
         }
 
         val typedExpr = try self._typecheckExpression(expr, Some(field.ty))
@@ -3250,8 +3223,7 @@ export type Typechecker {
             if generics[0] |innerTy| {
               Some(innerTy)
             } else {
-              __assertUnreachable("Option instance lacks inner type")
-              None
+              unreachable("Option instance lacks inner type")
             }
           }
           _ => None
@@ -3271,12 +3243,10 @@ export type Typechecker {
               if generics[1] |errTy| {
                 Some((valTy, errTy))
               } else {
-                __assertUnreachable("Result instance lacks error type")
-                None
+                unreachable("Result instance lacks error type")
               }
             } else {
-              __assertUnreachable("Result instance lacks value type")
-              None
+              unreachable("Result instance lacks value type")
             }
           }
           _ => None
@@ -3763,9 +3733,7 @@ export type Typechecker {
     }
 
     val ty = if resultTy |ty| ty else {
-      if !isStatement {
-        return unreachable(token.position, "match expression without result type")
-      }
+      if !isStatement unreachable("match expression without result type")
       Type(kind: TypeKind.PrimitiveUnit)
     }
 
@@ -3807,7 +3775,7 @@ export type Typechecker {
       AstNodeKind.If(condition, conditionBinding, ifBlock, elseBlock) => self._typecheckIf(token, condition, conditionBinding, ifBlock, elseBlock, typeHint)
       AstNodeKind.Match(subject, cases) => self._typecheckMatch(token, subject, cases, typeHint)
       AstNodeKind.Try(expr, elseClause) => self._typecheckTry(token, expr, elseClause, typeHint)
-      _ => unreachable(node.token.position, "all other node types should have already been handled")
+      _ => unreachable("all other node types should have already been handled")
     }
 
     match typedExpr.ty.kind {
@@ -4048,7 +4016,7 @@ export type Typechecker {
               if field.name.name == label.name {
                 val resolvedGenerics: Map<String, Type> = {}
                 for name, idx in struct.typeParams {
-                  resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
+                  resolvedGenerics[name] = if generics[idx] |g| g else unreachable("typeParams.length != generics.length")
                 }
                 var ty = field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
                 if optSafe {
@@ -4067,7 +4035,7 @@ export type Typechecker {
           if fn.label.name == label.name {
             val resolvedGenerics: Map<String, Type> = {}
             for name, idx in typeParams {
-              resolvedGenerics[name] = if generics[idx] |g| g else return unreachable(label.position, "typeParams.length != generics.length")
+              resolvedGenerics[name] = if generics[idx] |g| g else unreachable("typeParams.length != generics.length")
             }
             val method = if resolvedGenerics.isEmpty() fn else fn.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: true, genericsInScope: #{})
             return Ok(Some(AccessorPathSegment.Method(label, method, optSafe, typeHint)))
@@ -4168,7 +4136,7 @@ export type Typechecker {
   func _typecheckAccessor(self, token: Token, node: AccessorAstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
     var accessorPath = node.path
 
-    val firstSeg = if accessorPath[0] |p| p else return unreachable(token.position, "path should have at least 1 segment")
+    val firstSeg = if accessorPath[0] |p| p else unreachable("path should have at least 1 segment")
     val maybeModuleAccessor = try self._resolveModuleAliasAccessor(node.root, firstSeg)
     val typedRoot = if maybeModuleAccessor |n| {
       if accessorPath.length == 1 return Ok(n)
@@ -4253,7 +4221,7 @@ export type Typechecker {
       }
     }
 
-    val finalField = if path.pop() |f| f else return unreachable(node.root.token.position, "the accessor path should not be empty")
+    val finalField = if path.pop() |f| f else unreachable("the accessor path should not be empty")
 
     Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Accessor(typedRoot, path, finalField)))
   }
@@ -4849,7 +4817,7 @@ export type Typechecker {
       match hint.kind {
         TypeKind.Func(paramTypes, retType) => {
           for (ty, isRequired) in paramTypes {
-            if !isRequired return unreachable(token.position, "unexpected non-required param in lambda param type hint")
+            if !isRequired unreachable("unexpected non-required param in lambda param type hint")
 
             paramHints.push(ty)
           }
@@ -4975,19 +4943,4 @@ export type Typechecker {
 
     Ok(TypedAstNode(token: token, ty: tryValType, kind: TypedAstNodeKind.Try(typedExpr, typedElseClause)))
   }
-}
-
-func todo<V>(position: Position, reason = ""): Result<V, TypeError> {
-  Err(TypeError(position: position, kind: TypeErrorKind.NotYetImplemented(reason)))
-}
-
-func unreachable<V>(position: Position, message: String): Result<V, TypeError> {
-  Err(TypeError(position: position, kind: TypeErrorKind.Unreachable(message)))
-}
-
-// There's currently no notion of asserts in the language but the message here will show up in output files
-// which will result in test failures, so in theory it won't go unnoticed. This should only be used in places
-// where the above `unreachable` function can't be used (ie. in a non-Result context).
-func __assertUnreachable(message: String) {
-  println("[ASSERT FAILED]:", message)
 }

--- a/projects/compiler/src/typechecker.test.abra
+++ b/projects/compiler/src/typechecker.test.abra
@@ -12,7 +12,7 @@ import Jsonifier from "./typechecker_test_utils"
 
 func verifyStdModule(modulesSortedById: TypedModule[], expectedId: Int, name: String): Bool {
   if modulesSortedById[expectedId] |m| {
-    if !m.name.endsWith("std/$name.abra") {
+    if !m.name.endsWith("/$name.abra") {
       println("Error: $name module misconfigured")
       return false
     }

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -938,6 +938,18 @@ type Process {
   func exit(status = 1) = libc.exit(status)
 }
 
+@noreturn
+export func unreachable(message = "") {
+  println("Encountered unreachable code:", message)
+  libc.exit(1)
+}
+
+@noreturn
+export func todo(message = "") {
+  println("Encountered unimplemented code:", message)
+  libc.exit(1)
+}
+
 type SetIterator<T> {
   set: Set<T>
   _mapIterator: MapIterator<T, Bool>? = None


### PR DESCRIPTION
Prelude: adding `todo(message: String)` and
`unreachable(message: String)` builtin functions. These functions have the `noreturn` decorator since they call `Process.exit()` after printing a specific message (along with the optional `message` parameter).

Compiler: Replace usages of ad-hoc todo/unreachable functions with the new builtin implementations. This requires that the `ABRA_HOME` environment variable be set to the _current_ `std/` dir during tests, as opposed to the `std/` dir packaged with the latest published version.