### PR TITLE
Better globals

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,2 +1,18 @@
-val x = if true 123 else Process.exit()
-println("x =", x)
+import foo from "process"
+
+println(foo())
+
+var capturedInt = 11
+type FooWithCaptures {
+  i: Int
+
+  func foo_(self): Int = self.i + capturedInt
+  func foo2(self, a = capturedInt): Int = self.i + a
+  func fooStatic(): Int = capturedInt
+}
+
+val fooWithCaptures = FooWithCaptures(i: 12)
+/// Expect: 23
+println(fooWithCaptures.foo_())
+capturedInt = 17
+println(capturedInt)

--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -568,10 +568,17 @@ export type Compiler {
             if variable.isParameter unreachable("parameters cannot be reassigned to")
 
             val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
+            // A top-level variable in a module is only hoisted to global if it's captured; otherwise it's effectively a local within the module wrapper function
             if variable.isCaptured {
-              val ptr = try self._getCapturedVarPtr(variable)
-              self._currentFn.block.addComment("overwrite ptr to captured '${variable.label.name}'")
-              self._currentFn.block.buildStore(varTy, res, ptr)
+              if variable.isGlobal() |modId| {
+                val name = self._globalVarName(modId, variable.label.name)
+                val slot = Value.Global(name, QbeType.Pointer)
+                self._currentFn.block.buildStore(varTy, res, slot)
+              } else {
+                val ptr = try self._getCapturedVarPtr(variable)
+                self._currentFn.block.addComment("overwrite ptr to captured '${variable.label.name}'")
+                self._currentFn.block.buildStore(varTy, res, ptr)
+              }
             } else {
               val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else unreachable("Could not resolve name for variable '${variable.label.name}'")
               val slot = Value.Ident(slotName, QbeType.Pointer)
@@ -1027,18 +1034,26 @@ export type Compiler {
             }
             _ => {
               if varImportModule |mod| {
-                val name = self._exportedVarName(mod.id, name)
+                val name = self._globalVarName(mod.id, name)
                 val slot = Value.Global(name, QbeType.Pointer)
                 val res = self._currentFn.block.buildLoad(varTy, slot)
                 Ok(res)
               } else if variable.isCaptured {
-                val ptr = try self._getCapturedVarPtr(variable)
-                val res = if variable.mutable {
-                  self._currentFn.block.addComment("deref ptr to captured mutable '${variable.label.name}'")
-                  self._currentFn.block.buildLoad(varTy, ptr)
+                // A top-level variable in a module is only hoisted to global if it's captured; otherwise it's effectively a local within the module wrapper function
+                val res = if variable.isGlobal() |modId| {
+                  val name = self._globalVarName(modId, name)
+                  val slot = Value.Global(name, QbeType.Pointer)
+                  self._currentFn.block.buildLoad(varTy, slot)
                 } else {
-                  ptr
+                  val ptr = try self._getCapturedVarPtr(variable)
+                  if variable.mutable {
+                    self._currentFn.block.addComment("deref ptr to captured mutable '${variable.label.name}'")
+                    self._currentFn.block.buildLoad(varTy, ptr)
+                  } else {
+                    ptr
+                  }
                 }
+
                 Ok(res)
               } else {
                 val slotName = if self._currentFn.block.lookupVarName(variableToVar(variable)) |varName| varName else unreachable("Could not resolve name for variable '${variable.label.name}'")
@@ -2023,14 +2038,21 @@ export type Compiler {
 
     val variable = if variables[varName] |v| v else unreachable("expected binding '$varName', but missing from variables")
     val varTy = try self._getQbeTypeForTypeExpect(variable.ty, "unacceptable type for variable", Some(variable.label.position))
-    val slotName = self._currentFn.block.addVar(variableToVar(variable))
 
     val v = if exprVal |v| v else return Ok(0)
-    if variable.isExported {
-      val name = self._exportedVarName(self._currentModule.id, variable.label.name)
+
+    // A top-level variable in a module is only hoisted to global if it's captured; otherwise it's effectively a local within the module wrapper function
+    val isGlobal = !!variable.isGlobal()
+    if variable.isExported || (variable.isCaptured && isGlobal) {
+      val name = self._globalVarName(self._currentModule.id, variable.label.name)
+      self._currentFn.block.addVar(variableToVar(variable))
       val slot = self._builder.addData(QbeData(name: name, kind: QbeDataKind.Constants([(varTy, varTy.zeroValue())])))
       self._currentFn.block.buildStore(varTy, v, slot)
-    } else if variable.isCaptured && variable.mutable {
+      return Ok(0)
+    }
+
+    val slotName = self._currentFn.block.addVar(variableToVar(variable))
+    if variable.isCaptured && variable.mutable && !isGlobal {
       // Only move captured variables to the heap if they're mutable - captured immutable variables can just have their value present in
       // a closure's captures array, but a mutable variable needs an additional layer of indirection to handle possible reassignment.
       self._currentFn.block.addComment("move captured mutable '${variable.label.name}' to heap")
@@ -2049,6 +2071,8 @@ export type Compiler {
   }
 
   func _getCapturedVarPtr(self, variable: Variable): Result<Value, CompileError> {
+    if variable.isGlobal() unreachable("Global variables are never included in a function's captures")
+
     if self._currentFunction |fn| {
       if self._currentFn._env |env| {
         for v, idx in fn.captures {
@@ -4297,7 +4321,7 @@ export type Compiler {
   // thus introduce no conflicts (qbe doesn't care about function name rules).
   func _moduleWrapperFnName(self, module: TypedModule): String = "..module_${module.id}"
 
-  func _exportedVarName(self, modId: Int, name: String): String = "mod${modId}exp_${name}.slot"
+  func _globalVarName(self, modId: Int, name: String): String = "mod${modId}_${name}.slot"
 
   func _structTypeName(self, struct: Struct): Result<String, CompileError> {
     val base = ".${struct.moduleId}.${struct.label.name}"

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -106,6 +106,8 @@ export type Variable {
     val label = Label(name: "_bogus", position: Position(line: 0, col: 0))
     Variable(label: label, scope: Scope.bogus(), mutable: false, ty: Type(kind: TypeKind.Never))
   }
+
+  func isGlobal(self): Int? = match self.scope.kind { ScopeKind.Module(id) => Some(id), _ => None }
 }
 
 export enum Terminator {
@@ -128,7 +130,7 @@ export enum Terminator {
 
 export enum ScopeKind {
   Root
-  Module
+  Module(id: Int)
   Func
   If
   MatchCase
@@ -1839,7 +1841,8 @@ export type Typechecker {
           if !v.alias && fnBarrierBreached {
             v.isCaptured = true
             if self.currentFunction |fn| {
-              if !fn.captures.contains(v) {
+              // Captured top-level variables in a module are marked as captured but are not included in a function's captures
+              if !v.isGlobal() && !fn.captures.contains(v) {
                 fn.captures.push(v)
               }
             }
@@ -2026,10 +2029,9 @@ export type Typechecker {
   }
 
   func _ensureValidExportScope(self, exportToken: Token): Result<Int, TypeError> {
-    if self.currentScope.kind != ScopeKind.Module {
-      Err(TypeError(position: exportToken.position, kind: TypeErrorKind.IllegalExportScope))
-    } else {
-      Ok(0) // <-- unnecessary int
+    match self.currentScope.kind {
+      ScopeKind.Module => Ok(0) // <-- unnecessary int
+      _ => Err(TypeError(position: exportToken.position, kind: TypeErrorKind.IllegalExportScope))
     }
   }
 
@@ -2039,10 +2041,9 @@ export type Typechecker {
     name
   }
 
-
   func _typecheckModule(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
     self.typecheckingBuiltin = if modulePathAbs == self.moduleLoader.stdRoot + "/prelude.abra" {
-      self.project.preludeScope = self.currentScope.makeChild("module_prelude", ScopeKind.Module)
+      self.project.preludeScope = self.currentScope.makeChild("module_prelude", ScopeKind.Module(id: -1))
       Some(BuiltinModule.Prelude)
     } else if modulePathAbs == self.moduleLoader.stdRoot + "/_intrinsics.abra" {
       Some(BuiltinModule.Intrinsics)
@@ -2109,9 +2110,10 @@ export type Typechecker {
     self.currentModuleId = moduleId
 
     val moduleScope = if self.typecheckingBuiltin == Some(BuiltinModule.Prelude) {
+      self.project.preludeScope.kind = ScopeKind.Module(id: moduleId)
       self.project.preludeScope
     } else {
-      self.currentScope.makeChild("module_$moduleId", ScopeKind.Module)
+      self.currentScope.makeChild("module_$moduleId", ScopeKind.Module(id: moduleId))
     }
     val prevScope = self.currentScope
     self.currentScope = moduleScope

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -1864,11 +1864,7 @@ export type Typechecker {
       if v.label.name == ident {
         if !v.alias && fnBarrierBreached {
           v.isCaptured = true
-          if self.currentFunction |fn| {
-            if !fn.captures.contains(v) {
-              fn.captures.push(v)
-            }
-          }
+          if !v.isGlobal() unreachable("Exported variable 'prelude:${v.label.name}' is not marked as a global")
         }
 
         return Some((v, None))
@@ -1882,11 +1878,7 @@ export type Typechecker {
             TypedImportKind.Variable(v) => {
               if !v.alias && fnBarrierBreached {
                 v.isCaptured = true
-                if self.currentFunction |fn| {
-                  if !fn.captures.contains(v) {
-                    fn.captures.push(v)
-                  }
-                }
+                if !v.isGlobal() unreachable("Exported variable '$name:${v.label.name}' is not marked as a global")
               }
 
               v


### PR DESCRIPTION
Top-level variables in a module are only hoisted to globals if they're referenced in a function (ie. captured). Since these variables can be referenced as globals from within those functions, there's no need to store them as captures for that function, and the function can effectively be invoked as if it were an ordinary function. Top-level variables that are _not_ referenced in functions are treated effectively as locals within the module's wrapper function. Exported variables (which can only be top-level) are always hoisted to globals.