### PR TITLE
LSP: Using a virtual filesystem

### DIFF
--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -12,9 +12,10 @@ enum TokenizeAndParseError {
 export type ModuleLoader {
   stdRoot: String
   parsedModules: Map<String, ParsedModule> = {}
-  documentStore: Map<String, String> = {}
-  useDocumentStore: Bool = false
-  _invalidated: Map<String, Bool> = {}
+  _virtualFileSystem: Map<String, String>? = None
+
+  func usingVirtualFileSystem(stdRoot: String, fileMap: Map<String, String>): ModuleLoader =
+    ModuleLoader(stdRoot: stdRoot, _virtualFileSystem: Some(fileMap))
 
   func resolvePath(self, modulePath: String, relativeTo: String?): String {
     if relativeTo |relativeTo| {
@@ -28,12 +29,12 @@ export type ModuleLoader {
   func hasSeenModule(self, modulePathAbs: String): Bool = self.parsedModules.containsKey(modulePathAbs)
 
   func invalidateModule(self, modulePathAbs: String) {
-    self._invalidated[modulePathAbs] = true
+    self.parsedModules.remove(modulePathAbs)
   }
 
   func _loadFileContents(self, modulePathAbs: String): String? {
-    if self.useDocumentStore {
-      val inMemContents = self.documentStore[modulePathAbs]
+    if self._virtualFileSystem |vfs| {
+      val inMemContents = vfs[modulePathAbs]
       if inMemContents return inMemContents
     }
 
@@ -44,22 +45,15 @@ export type ModuleLoader {
   }
 
   func tokenizeAndParse(self, modulePath: String): Result<ParsedModule, TokenizeAndParseError> {
-    if self.parsedModules[modulePath] |m| {
-      val invalidated = self._invalidated[modulePath] ?: false
-      if !invalidated return Ok(m)
-    }
+    if self.parsedModules[modulePath] |m| return Ok(m)
 
     val parsedModule = if self._loadFileContents(modulePath) |contents| {
       match Lexer.tokenize(contents) {
         Ok(tokens) => {
-          val module = match Parser.parse(tokens) {
+          match Parser.parse(tokens) {
             Ok(parsedModule) => parsedModule
             Err(error) => return Err(TokenizeAndParseError.ParseError(error))
           }
-
-          self._invalidated[modulePath] = false
-
-          module
         }
         Err(error) => return Err(TokenizeAndParseError.LexerError(error))
       }
@@ -1495,28 +1489,31 @@ export type Typechecker {
   func typecheckEntrypoint(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
     val preludeModulePathSegs = getAbsolutePath(self.moduleLoader.stdRoot + "/prelude.abra")
     val preludeModulePathAbs = "/" + preludeModulePathSegs.join("/")
-    try self._typecheckModule(preludeModulePathAbs)
 
-    val preludeStructs = [
-      self.project.preludeIntStruct,
-      self.project.preludeFloatStruct,
-      self.project.preludeBoolStruct,
-      self.project.preludeCharStruct,
-      self.project.preludeStringStruct,
-      self.project.preludeArrayStruct,
-      self.project.preludeMapStruct,
-      self.project.preludeSetStruct,
-    ]
-    for struct in preludeStructs {
-      if struct.label.position == Position(line: 0, col: 0) unreachable("Improperly initialized prelude struct ${struct.label.name}")
-    }
+    if !self.project.modules[preludeModulePathAbs] {
+      try self._typecheckModule(preludeModulePathAbs)
 
-    val preludeEnums = [
-      self.project.preludeOptionEnum,
-      self.project.preludeResultEnum,
-    ]
-    for enum_ in preludeEnums {
-      if enum_.label.position == Position(line: 0, col: 0) unreachable("Improperly initialized prelude enum ${enum_.label.name}")
+      val preludeStructs = [
+        self.project.preludeIntStruct,
+        self.project.preludeFloatStruct,
+        self.project.preludeBoolStruct,
+        self.project.preludeCharStruct,
+        self.project.preludeStringStruct,
+        self.project.preludeArrayStruct,
+        self.project.preludeMapStruct,
+        self.project.preludeSetStruct,
+      ]
+      for struct in preludeStructs {
+        if struct.label.position == Position(line: 0, col: 0) unreachable("Improperly initialized prelude struct ${struct.label.name}")
+      }
+
+      val preludeEnums = [
+        self.project.preludeOptionEnum,
+        self.project.preludeResultEnum,
+      ]
+      for enum_ in preludeEnums {
+        if enum_.label.position == Position(line: 0, col: 0) unreachable("Improperly initialized prelude enum ${enum_.label.name}")
+      }
     }
 
     self._typecheckModule(modulePathAbs)
@@ -2070,6 +2067,8 @@ export type Typechecker {
   }
 
   func _typecheckModule(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
+    if self.project.modules[modulePathAbs] |mod| return Ok(mod)
+
     self.typecheckingBuiltin = if modulePathAbs == self.moduleLoader.stdRoot + "/prelude.abra" {
       self.project.preludeScope = self.currentScope.makeChild("module_prelude", ScopeKind.Module(id: -1))
       Some(BuiltinModule.Prelude)

--- a/projects/lsp/src/language_service.abra
+++ b/projects/lsp/src/language_service.abra
@@ -2,25 +2,26 @@ import "fs" as fs
 import JsonValue from "json"
 import log from "./log"
 import ModuleLoader, Project, Typechecker, TypecheckerErrorKind from "../../compiler/src/typechecker"
-import RequestMessage, NotificationMessage, ResponseMessage, ResponseResult, ResponseError, ResponseErrorCode, ServerCapabilities, TextDocumentSyncKind, ServerInfo, TextDocumentItem, TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity from "./lsp_spec"
+import RequestMessage, NotificationMessage, ResponseMessage, ResponseResult, ResponseError, ResponseErrorCode, ServerCapabilities, TextDocumentSyncOptions, TextDocumentSyncKind, SaveOptions, ServerInfo, TextDocumentItem, TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity from "./lsp_spec"
 
 export val contentLengthHeader = "Content-Length: "
 export val bogusMessageId = -999
 
 export type AbraLanguageService {
-  _virtualFileSystem: Map<String, String>
+  // _virtualFileSystem: Map<String, String>
   _moduleLoader: ModuleLoader
   _project: Project
   _initialized: Bool = false
   _root: String = ""
 
   func new(abraStdRoot: String): AbraLanguageService {
-    val virtualFileSystem: Map<String, String> = {}
-    val moduleLoader = ModuleLoader.usingVirtualFileSystem(stdRoot: abraStdRoot, fileMap: virtualFileSystem)
+    // val virtualFileSystem: Map<String, String> = {}
+    // val moduleLoader = ModuleLoader.usingVirtualFileSystem(stdRoot: abraStdRoot, fileMap: virtualFileSystem)
+    val moduleLoader = ModuleLoader(stdRoot: abraStdRoot)
     val project = Project()
 
     AbraLanguageService(
-      _virtualFileSystem: virtualFileSystem,
+      // _virtualFileSystem: virtualFileSystem,
       _moduleLoader: moduleLoader,
       _project: project,
     )
@@ -32,8 +33,22 @@ export type AbraLanguageService {
     self._root = if rootPath |p| p else return internalError(id, "rootPath required")
     self._initialized = true
 
+    // Instruct the client to not send textDocument/didOpen or textDocument/didClose events,
+    // and to send textDocument/didSave events, but do not include file contents when saved.
+    //
+    // Additionally, for now, instruct the client to NOT send textDocument/didChange events;
+    // sending the full contents each time (replacing the file in the ModuleLoader's vfs) is
+    // pretty wasteful and causes problems with larger files. Eventually, I'll implement a
+    // more performant model using the Incremental updates, but for now the client will only
+    // receive diagnostics from the server when the file is saved (which is file, frankly).
     val result = ResponseResult.Initialize(
-      capabilities: ServerCapabilities(textDocumentSync: Some(TextDocumentSyncKind.Full)),
+      capabilities: ServerCapabilities(
+        textDocumentSync: Some(TextDocumentSyncOptions(
+          openClose: Some(false),
+          change: Some(TextDocumentSyncKind.None_),
+          save: Some(SaveOptions(includeText: Some(false)))
+        ))
+      ),
       serverInfo: ServerInfo(name: "abra-lsp", version: Some("0.0.1"))
     )
     ResponseMessage.Success(id: id, result: Some(result))
@@ -42,14 +57,14 @@ export type AbraLanguageService {
   // Notification handlers
 
   func _textDocumentDidOpen(self, textDocument: TextDocumentItem) {
+    // textDocument/didOpen events are currently not sent by the client (see self._initialize)
     val diagnostics = self._runTypecheckerStartingAtUri(textDocument.uri)
-    if !diagnostics.isEmpty() {
-      val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
-      self.sendNotification(notif)
-    }
+    val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
+    self.sendNotification(notif)
   }
 
   func _textDocumentDidChange(self, textDocument: VersionedTextDocumentIdentifier, contentChanges: TextDocumentContentChangeEvent[]) {
+    // textDocument/didChange events are currently not sent by the client (see self._initialize)
     if contentChanges.isEmpty() return
 
     val filePath = textDocument.uri.replaceAll("file://", "")
@@ -57,7 +72,7 @@ export type AbraLanguageService {
       match changeEvent {
         TextDocumentContentChangeEvent.Incremental => todo("TextDocumentContentChangeEvent.Incremental")
         TextDocumentContentChangeEvent.Full(text) => {
-          self._virtualFileSystem[filePath] = text
+          // self._virtualFileSystem[filePath] = text
         }
       }
     }
@@ -71,7 +86,9 @@ export type AbraLanguageService {
 
   func _textDocumentDidSave(self, textDocument: TextDocumentIdentifier) {
     val filePath = textDocument.uri.replaceAll("file://", "")
-    self._virtualFileSystem.remove(filePath)
+    self._moduleLoader.invalidateModule(filePath)
+    self._project.modules.remove(filePath)
+    // self._virtualFileSystem.remove(filePath)
 
     val diagnostics = self._runTypecheckerStartingAtUri(textDocument.uri)
     val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
@@ -141,6 +158,7 @@ export type AbraLanguageService {
       NotificationMessage.Initialized => { /* no-op */ }
       NotificationMessage.TextDocumentDidOpen(textDocument) => self._textDocumentDidOpen(textDocument)
       NotificationMessage.TextDocumentDidChange(textDocument, contentChanges) => self._textDocumentDidChange(textDocument, contentChanges)
+      NotificationMessage.TextDocumentDidSave(textDocument) => self._textDocumentDidSave(textDocument)
     }
   }
 

--- a/projects/lsp/src/language_service.abra
+++ b/projects/lsp/src/language_service.abra
@@ -1,32 +1,36 @@
 import "fs" as fs
-import "process" as process
 import JsonValue from "json"
 import log from "./log"
 import ModuleLoader, Project, Typechecker, TypecheckerErrorKind from "../../compiler/src/typechecker"
-import RequestMessage, NotificationMessage, ResponseMessage, ResponseResult, ResponseError, ResponseErrorCode, ServerCapabilities, TextDocumentSyncKind, ServerInfo, TextDocumentItem, VersionedTextDocumentIdentifier, TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity from "./lsp_spec"
+import RequestMessage, NotificationMessage, ResponseMessage, ResponseResult, ResponseError, ResponseErrorCode, ServerCapabilities, TextDocumentSyncKind, ServerInfo, TextDocumentItem, TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity from "./lsp_spec"
 
 export val contentLengthHeader = "Content-Length: "
 export val bogusMessageId = -999
 
-val abraStdRoot = if process.getEnvVar("ABRA_HOME") |v| v else {
-  println("Could not find ABRA_HOME (make sure \$ABRA_HOME environment variable is set)")
-  process.exit(1)
-}
-
-val moduleLoader = ModuleLoader(stdRoot: abraStdRoot, useDocumentStore: true)
-val documentStore = moduleLoader.documentStore
-val project = Project()
-val typechecker = Typechecker(moduleLoader: moduleLoader, project: project)
-
 export type AbraLanguageService {
-  initialized: Bool = false
-  root: String = ""
+  _virtualFileSystem: Map<String, String>
+  _moduleLoader: ModuleLoader
+  _project: Project
+  _initialized: Bool = false
+  _root: String = ""
+
+  func new(abraStdRoot: String): AbraLanguageService {
+    val virtualFileSystem: Map<String, String> = {}
+    val moduleLoader = ModuleLoader.usingVirtualFileSystem(stdRoot: abraStdRoot, fileMap: virtualFileSystem)
+    val project = Project()
+
+    AbraLanguageService(
+      _virtualFileSystem: virtualFileSystem,
+      _moduleLoader: moduleLoader,
+      _project: project,
+    )
+  }
 
   // Request Message handlers
 
   func _initialize(self, id: Int, processId: Int?, rootPath: String?): ResponseMessage {
-    self.root = if rootPath |p| p else return internalError(id, "rootPath required")
-    self.initialized = true
+    self._root = if rootPath |p| p else return internalError(id, "rootPath required")
+    self._initialized = true
 
     val result = ResponseResult.Initialize(
       capabilities: ServerCapabilities(textDocumentSync: Some(TextDocumentSyncKind.Full)),
@@ -53,17 +57,25 @@ export type AbraLanguageService {
       match changeEvent {
         TextDocumentContentChangeEvent.Incremental => todo("TextDocumentContentChangeEvent.Incremental")
         TextDocumentContentChangeEvent.Full(text) => {
-          documentStore[filePath] = text
+          self._virtualFileSystem[filePath] = text
         }
       }
     }
-    moduleLoader.invalidateModule(filePath)
+    self._moduleLoader.invalidateModule(filePath)
+    self._project.modules.remove(filePath)
 
     val diagnostics = self._runTypecheckerStartingAtUri(textDocument.uri)
-    if !diagnostics.isEmpty() {
-      val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
-      self.sendNotification(notif)
-    }
+    val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
+    self.sendNotification(notif)
+  }
+
+  func _textDocumentDidSave(self, textDocument: TextDocumentIdentifier) {
+    val filePath = textDocument.uri.replaceAll("file://", "")
+    self._virtualFileSystem.remove(filePath)
+
+    val diagnostics = self._runTypecheckerStartingAtUri(textDocument.uri)
+    val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
+    self.sendNotification(notif)
   }
 
   // Compiler bridge
@@ -71,6 +83,8 @@ export type AbraLanguageService {
   func _runTypecheckerStartingAtUri(self, uri: String): Diagnostic[] {
     // todo: what happens if it's not a `file://` uri?
     val filePath = uri.replaceAll("file://", "")
+
+    val typechecker = Typechecker(moduleLoader: self._moduleLoader, project: self._project)
 
     match typechecker.typecheckEntrypoint(filePath) {
       Ok => []

--- a/projects/lsp/src/lsp_spec.abra
+++ b/projects/lsp/src/lsp_spec.abra
@@ -38,10 +38,8 @@ export enum NotificationMessage {
   // Incoming notifications
   Initialized
   TextDocumentDidOpen(textDocument: TextDocumentItem)
-  // Omitted field `contentChanges`: the first iteration of the LSP will just re-read the changed files
-  // from disk upon change and will not reconstruct the file using deltas; the `textDocumentSyncKind`
-  // is set to Incremental in the server capabilities to reduce jsonrpc message size.
   TextDocumentDidChange(textDocument: VersionedTextDocumentIdentifier, contentChanges: TextDocumentContentChangeEvent[])
+  TextDocumentDidSave(textDocument: TextDocumentIdentifier)
 
   // Outgoing notifications
   TextDocumentPublishDiagnostics(uri: String, diagnostics: Diagnostic[])
@@ -72,6 +70,13 @@ export enum NotificationMessage {
 
         Ok(Some(NotificationMessage.TextDocumentDidChange(textDocument: textDocument, contentChanges: contentChanges)))
       }
+      "textDocument/didSave" => {
+        val params = try obj.getObjectRequired("params")
+        val textDocumentObj = try params.getValueRequired("textDocument")
+        val textDocument = try TextDocumentIdentifier.fromJson(textDocumentObj)
+
+        Ok(Some(NotificationMessage.TextDocumentDidSave(textDocument: textDocument)))
+      }
       else => {
         log.writeln("Unimplemented NotificationMessage method '$method'")
 
@@ -85,6 +90,7 @@ export enum NotificationMessage {
       NotificationMessage.Initialized => unreachable("should not be serializing 'initialized' notification")
       NotificationMessage.TextDocumentDidOpen => unreachable("should not be serializing 'textDocument/didOpen' notification")
       NotificationMessage.TextDocumentDidChange => unreachable("should not be serializing 'textDocument/didChange' notification")
+      NotificationMessage.TextDocumentDidSave => unreachable("should not be serializing 'textDocument/didSave' notification")
       NotificationMessage.TextDocumentPublishDiagnostics(uri, diagnostics) => {
         JsonValue.Object(JsonObject(_map: {
           method: JsonValue.String("textDocument/publishDiagnostics"),
@@ -253,6 +259,17 @@ export type TextDocumentItem {
     val text = try obj.getStringRequired("text")
 
     Ok(TextDocumentItem(uri: uri, languageId: languageId, version: version, text: text))
+  }
+}
+
+export type TextDocumentIdentifier {
+  uri: String
+
+  func fromJson(json: JsonValue): Result<TextDocumentIdentifier, JsonError> {
+    val obj = try json.asObject()
+    val uri = try obj.getStringRequired("uri")
+
+    Ok(TextDocumentIdentifier(uri: uri))
   }
 }
 

--- a/projects/lsp/src/lsp_spec.abra
+++ b/projects/lsp/src/lsp_spec.abra
@@ -57,19 +57,19 @@ export enum NotificationMessage {
 
         Ok(Some(NotificationMessage.TextDocumentDidOpen(textDocument: textDocument)))
       }
-      "textDocument/didChange" => {
-        val params = try obj.getObjectRequired("params")
-        val textDocumentObj = try params.getValueRequired("textDocument")
-        val textDocument = try VersionedTextDocumentIdentifier.fromJson(textDocumentObj)
+      // "textDocument/didChange" => {
+      //   val params = try obj.getObjectRequired("params")
+      //   val textDocumentObj = try params.getValueRequired("textDocument")
+      //   val textDocument = try VersionedTextDocumentIdentifier.fromJson(textDocumentObj)
 
-        val contentChanges: TextDocumentContentChangeEvent[] = []
-        val contentChangesArr = try params.getArrayRequired("contentChanges")
-        for item in contentChangesArr {
-          contentChanges.push(try TextDocumentContentChangeEvent.fromJson(item))
-        }
+      //   val contentChanges: TextDocumentContentChangeEvent[] = []
+      //   val contentChangesArr = try params.getArrayRequired("contentChanges")
+      //   for item in contentChangesArr {
+      //     contentChanges.push(try TextDocumentContentChangeEvent.fromJson(item))
+      //   }
 
-        Ok(Some(NotificationMessage.TextDocumentDidChange(textDocument: textDocument, contentChanges: contentChanges)))
-      }
+      //   Ok(Some(NotificationMessage.TextDocumentDidChange(textDocument: textDocument, contentChanges: contentChanges)))
+      // }
       "textDocument/didSave" => {
         val params = try obj.getObjectRequired("params")
         val textDocumentObj = try params.getValueRequired("textDocument")
@@ -186,18 +186,42 @@ export enum ResponseErrorCode {
 }
 
 export type ServerCapabilities {
-  textDocumentSync: TextDocumentSyncKind? = None
+  textDocumentSync: TextDocumentSyncOptions? = None
   diagnosticProvider: DiagnosticOptions? = None
 
   func toJson(self): JsonValue {
     val obj = JsonObject()
 
     if self.textDocumentSync |tds| {
-      obj.set("textDocumentSync", JsonValue.Number(Either.Left(tds.intVal())))
+      obj.set("textDocumentSync", tds.toJson())
     }
 
     if self.diagnosticProvider |dp| {
       obj.set("diagnosticProvider", dp.toJson())
+    }
+
+    JsonValue.Object(obj)
+  }
+}
+
+export type TextDocumentSyncOptions {
+  openClose: Bool? = None
+  change: TextDocumentSyncKind? = None
+  save: SaveOptions? = None
+
+  func toJson(self): JsonValue {
+    val obj = JsonObject()
+
+    if self.openClose |openClose| {
+      obj.set("openClose", JsonValue.Boolean(openClose))
+    }
+
+    if self.change |change| {
+      obj.set("change", JsonValue.Number(Either.Left(change.intVal())))
+    }
+
+    if self.save |save| {
+      obj.set("save", save.toJson())
     }
 
     JsonValue.Object(obj)
@@ -213,6 +237,20 @@ export enum TextDocumentSyncKind {
     TextDocumentSyncKind.None_ => 0
     TextDocumentSyncKind.Full => 1
     TextDocumentSyncKind.Incremental => 2
+  }
+}
+
+export type SaveOptions {
+  includeText: Bool? = None
+
+  func toJson(self): JsonValue {
+    val obj = JsonObject()
+
+    if self.includeText |includeText| {
+      obj.set("includeText", JsonValue.Boolean(includeText))
+    }
+
+    JsonValue.Object(obj)
   }
 }
 

--- a/projects/lsp/src/main.abra
+++ b/projects/lsp/src/main.abra
@@ -33,7 +33,12 @@ func processMessage(lsp: AbraLanguageService, message: String): Result<ResponseM
 }
 
 func main() {
-  val lsp = AbraLanguageService()
+  val abraStdRoot = if process.getEnvVar("ABRA_HOME") |v| v else {
+    println("Could not find ABRA_HOME (make sure \$ABRA_HOME environment variable is set)")
+    process.exit(1)
+  }
+
+  val lsp = AbraLanguageService.new(abraStdRoot)
 
   val stdin = process.stdin()
 


### PR DESCRIPTION
Add a primitive notion of a "virtual filesystem" (which is just a `Map<String, String>` for now) to represent abra files that require typechecking but which have not yet been saved to disk. For now, the contents of this map are wholesale replaced upon receipt of a `textDocument/didChange` notification from the LSP client, and removed upon `textDocument/didSave` (since at that point, the file can once again be read from disk to obtain the latest version).

In the future, there ought to be a more sophisticated way of representing the file contents in the virtual filesystem, which leverages the Incremental `contentChange` option for `textDocument/didChange` notifications, rather than having to wastefully parse and replace the entire contents of the document each time. In fact, the LSP currently falls over when trying to operate on large files, most likely for this reason.