### PR TITLE
Introduce `pub` keyword

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,4 +1,3 @@
-func f12(): Int? = Ok(1)
+import foo from "./example2"
 
-/// Expect: Option.Some(value: 12)
-println(f12())
+println(foo())

--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,3 +1,8 @@
-import foo from "./example2"
+// type Foo {
+//   a: Int
+// }
 
-println(foo())
+// val f = Foo(a: 123)
+val a = [1, 2, 3]
+
+println(a.length)

--- a/projects/compiler/example2.abra
+++ b/projects/compiler/example2.abra
@@ -1,0 +1,1 @@
+pub func foo(): Int = 123

--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -262,7 +262,7 @@ export type Compiler {
           val dataPtr = self._builder.buildGlobalString("%s\\n")
           val tostringMethod = try self._getOrCompileToStringMethod(node.ty)
 
-          val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(node.ty))[0])))
+          val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(node.ty))[0]), true))
           val frameCtx = CallframeContext(position: node.token.position, callee: Some(fnName))
           val tostringRepr = try self._buildCall(Some(frameCtx), Callable.Function(tostringMethod), [v])
           val reprCharsPtr = try self._currentFn.block.buildAdd(Value.Int(8), tostringRepr, Some("_repr_chars_ptr")) else |e| return qbeError(e)
@@ -701,7 +701,7 @@ export type Compiler {
           val itemToStringFnVal = try self._getOrCompileToStringMethod(itemInstanceType)
           self._resolvedGenerics.popLayer()
 
-          val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(item.ty))[0])))
+          val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(item.ty))[0]), true))
           val frameCtx = CallframeContext(position: item.token.position, callee: Some(fnName))
           val toStringVal = try self._buildCall(Some(frameCtx), Callable.Function(itemToStringFnVal), [itemVal])
           strVals.push(toStringVal)
@@ -767,7 +767,7 @@ export type Compiler {
                 val leftToStringFnVal = try self._getOrCompileToStringMethod(leftInstanceType)
                 self._resolvedGenerics.popLayer()
 
-                val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(left.ty))[0])))
+                val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(left.ty))[0]), true))
                 val frameCtx = CallframeContext(position: left.token.position, callee: Some(fnName))
                 leftVal = try self._buildCall(Some(frameCtx), Callable.Function(leftToStringFnVal), [leftVal])
               }
@@ -778,7 +778,7 @@ export type Compiler {
                 val rightToStringFnVal = try self._getOrCompileToStringMethod(rightInstanceType)
                 self._resolvedGenerics.popLayer()
 
-                val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(right.ty))[0])))
+                val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(right.ty))[0]), true))
                 val frameCtx = CallframeContext(position: right.token.position, callee: Some(fnName))
                 rightVal = try self._buildCall(Some(frameCtx), Callable.Function(rightToStringFnVal), [rightVal])
               }
@@ -1133,7 +1133,7 @@ export type Compiler {
               if fn.params[idx] |param| { !!param.defaultValue && !arg } else { false }
             })
             val fnVal = match fn.kind {
-              FunctionKind.StaticMethod(parentTy) => {
+              FunctionKind.StaticMethod(parentTy, _) => {
                 try self._getOrCompileMethod(Type(kind: TypeKind.Type(parentTy)), fn, paramsNeedingDefaultValue)
               }
               FunctionKind.Standalone => {
@@ -2057,7 +2057,7 @@ export type Compiler {
     } else {
       // If the closure is being called in the same scope in which it was declared, then the `*.captures` value is visible as a stack local.
       val prefix = match fn.kind {
-        FunctionKind.InstanceMethod(structOrEnum) => {
+        FunctionKind.InstanceMethod(structOrEnum, _) => {
           if structOrEnum |structOrEnum| {
             val typeName = match structOrEnum {
               StructOrEnum.Struct(struct) => struct.label.name
@@ -2066,7 +2066,7 @@ export type Compiler {
             "$typeName.."
           } else unreachable("an instance method should have a structOrEnum")
         }
-        FunctionKind.StaticMethod(structOrEnum) => {
+        FunctionKind.StaticMethod(structOrEnum, _) => {
           val typeName = match structOrEnum {
             StructOrEnum.Struct(struct) => struct.label.name
             StructOrEnum.Enum(enum_) => enum_.label.name
@@ -2126,7 +2126,7 @@ export type Compiler {
     val eqFnVal = try self._getOrCompileEqMethod(instType)
     self._resolvedGenerics.popLayer()
 
-    val fnName = self._functionName("eq", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(ty))[0])))
+    val fnName = self._functionName("eq", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(ty))[0]), true))
     val frameCtx = CallframeContext(position: position, callee: Some(fnName))
     val res = try self._buildCall(Some(frameCtx), Callable.Function(eqFnVal), [leftVal, rightVal], localName)
     if negate {
@@ -2638,7 +2638,7 @@ export type Compiler {
       val itemToStringFnVal = try self._getOrCompileToStringMethod(itemInstanceType)
       self._resolvedGenerics.popLayer()
 
-      val fnName = self._functionName("eq", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(item.ty))[0])))
+      val fnName = self._functionName("eq", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(item.ty))[0]), true))
       val frameCtx = CallframeContext(position: item.token.position, callee: Some(fnName))
       val toStringVal = try self._buildCall(Some(frameCtx), Callable.Function(itemToStringFnVal), [itemVal])
 
@@ -3438,7 +3438,7 @@ export type Compiler {
 
       offset += itemTy.size()
 
-      val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(itemType))[0])))
+      val fnName = self._functionName("toString", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(itemType))[0]), true))
       val frameCtx = CallframeContext(position: itemPosition, callee: Some(fnName))
       val itemToStringVal = try self._buildCall(Some(frameCtx), Callable.Function(itemToStringFnVal), [itemVal])
       val itemToStringLengthVal = self._currentFn.block.buildLoadL(itemToStringVal)
@@ -4069,7 +4069,7 @@ export type Compiler {
       val itemHashFnVal = try self._getOrCompileHashMethod(itemType)
       self._resolvedGenerics.popLayer()
 
-      val fnName = self._functionName("hash", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(itemType))[0])))
+      val fnName = self._functionName("hash", FunctionKind.InstanceMethod(Some((try self._getInstanceTypeForType(itemType))[0]), true))
       val frameCtx = CallframeContext(position: itemPosition, callee: Some(fnName))
       val itemHashVal = try self._buildCall(Some(frameCtx), Callable.Function(itemHashFnVal), [itemVal])
       val newPart = try self._currentFn.block.buildMul(Value.Int(31), itemHashVal) else |e| return qbeError(e)
@@ -4224,7 +4224,7 @@ export type Compiler {
         name: "call",
         params: params,
         returnType: returnType,
-        kind: FunctionKind.InstanceMethod(Some(StructOrEnum.Struct(struct))),
+        kind: FunctionKind.InstanceMethod(Some(StructOrEnum.Struct(struct)), false),
       )
 
       (struct, callMethod)
@@ -4363,12 +4363,12 @@ export type Compiler {
   func _functionName(self, name: String, kind: FunctionKind): String {
     match kind {
       FunctionKind.Standalone => name
-      FunctionKind.InstanceMethod(structOrEnumOpt) => match structOrEnumOpt {
+      FunctionKind.InstanceMethod(structOrEnumOpt, _) => match structOrEnumOpt {
         StructOrEnum.Struct(s) => "${s.label.name}.$name"
         StructOrEnum.Enum(e) => "${e.label.name}.$name"
         _ => name
       }
-      FunctionKind.StaticMethod(structOrEnum) => match structOrEnum {
+      FunctionKind.StaticMethod(structOrEnum, _) => match structOrEnum {
         StructOrEnum.Struct(s) => "${s.label.name}#$name"
         StructOrEnum.Enum(e) => "${e.label.name}#$name"
       }

--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -45,6 +45,7 @@ export enum TokenKind {
   As
   Try
   None_
+  Pub
 
   // Symbols
   Plus
@@ -119,6 +120,7 @@ export enum TokenKind {
     TokenKind.As => "as"
     TokenKind.Try => "try"
     TokenKind.None_ => "None"
+    TokenKind.Pub => "pub"
     TokenKind.Plus => "+"
     TokenKind.PlusEq => "+="
     TokenKind.Minus => "-"
@@ -675,6 +677,7 @@ export type Lexer {
       "as" => TokenKind.As
       "try" => TokenKind.Try
       "None" => TokenKind.None_
+      "pub" => TokenKind.Pub
       _ => TokenKind.Ident(ident)
     }
     Token(position: startPos, kind: tokenKind)

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -185,7 +185,7 @@ export enum BindingPattern {
 
 export type BindingDeclarationNode {
   decorators: DecoratorNode[]
-  exportToken: Token?
+  pubToken: Token?
   bindingPattern: BindingPattern
   typeAnnotation: TypeIdentifier?
   expr: AstNode?
@@ -205,7 +205,7 @@ export type LambdaNode {
 
 export type FunctionDeclarationNode {
   decorators: DecoratorNode[]
-  exportToken: Token?
+  pubToken: Token?
   name: Label
   typeParams: Label[]
   params: FunctionParam[]
@@ -221,7 +221,7 @@ type TypeField {
 
 export type TypeDeclarationNode {
   decorators: DecoratorNode[]
-  exportToken: Token?
+  pubToken: Token?
   name: Label
   typeParams: Label[]
   fields: TypeField[]
@@ -237,7 +237,7 @@ export enum EnumVariant {
 
 export type EnumDeclarationNode {
   decorators: DecoratorNode[]
-  exportToken: Token?
+  pubToken: Token?
   name: Label
   typeParams: Label[]
   variants: EnumVariant[]
@@ -351,7 +351,7 @@ export type Parser {
   _tokens: Token[]
   _cursor: Int = 0
   _seenDecorators: DecoratorNode[] = []
-  _exportToken: Token? = None
+  _pubToken: Token? = None
 
   func parse(tokens: Token[]): Result<ParsedModule, ParseError> {
     val parser = Parser(_tokens: tokens)
@@ -495,7 +495,7 @@ export type Parser {
         try self._parseDecorator()
 
         val nextToken = try self._expectPeek()
-        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum, TokenKind.At, TokenKind.Export]
+        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum, TokenKind.At, TokenKind.Export, TokenKind.Pub]
         if !expected.contains(nextToken.kind) {
           return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
         }
@@ -503,8 +503,20 @@ export type Parser {
         self._parseStatement()
       }
       TokenKind.Export => {
-        self._exportToken = Some(token)
+        self._pubToken = Some(token)
         self._advance() // consume 'export' token
+
+        val nextToken = try self._expectPeek()
+        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum]
+        if !expected.contains(nextToken.kind) {
+          return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
+        }
+
+        self._parseStatement()
+      }
+      TokenKind.Pub => {
+        self._pubToken = Some(token)
+        self._advance() // consume 'pub' token
 
         val nextToken = try self._expectPeek()
         val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum]
@@ -585,8 +597,8 @@ export type Parser {
     val decorators = self._seenDecorators
     self._seenDecorators = []
 
-    val exportToken = self._exportToken
-    self._exportToken = None
+    val pubToken = self._pubToken
+    self._pubToken = None
 
     val token = try self._expectNext()
     val pat = try self._parseBindingPattern()
@@ -594,7 +606,7 @@ export type Parser {
     if self._cursor >= self._tokens.length {
       val node = BindingDeclarationNode(
         decorators: decorators,
-        exportToken: exportToken,
+        pubToken: pubToken,
         bindingPattern: pat,
         typeAnnotation: None,
         expr: None,
@@ -613,7 +625,7 @@ export type Parser {
     if self._cursor >= self._tokens.length {
       val node = BindingDeclarationNode(
         decorators: decorators,
-        exportToken: exportToken,
+        pubToken: pubToken,
         bindingPattern: pat,
         typeAnnotation: typeAnnotation,
         expr: None,
@@ -631,7 +643,7 @@ export type Parser {
 
     val node = BindingDeclarationNode(
       decorators: decorators,
-      exportToken: exportToken,
+      pubToken: pubToken,
       bindingPattern: pat,
       typeAnnotation: typeAnnotation,
       expr: expr,
@@ -643,8 +655,8 @@ export type Parser {
     val decorators = self._seenDecorators
     self._seenDecorators = []
 
-    val exportToken = self._exportToken
-    self._exportToken = None
+    val pubToken = self._pubToken
+    self._pubToken = None
 
     val token = try self._expectNext()
     val label = try self._expectNextLabel()
@@ -692,7 +704,7 @@ export type Parser {
 
     val node = FunctionDeclarationNode(
       decorators: decorators,
-      exportToken: exportToken,
+      pubToken: pubToken,
       name: label,
       typeParams: typeParams,
       params: params,
@@ -706,8 +718,8 @@ export type Parser {
     val decorators = self._seenDecorators
     self._seenDecorators = []
 
-    val exportToken = self._exportToken
-    self._exportToken = None
+    val pubToken = self._pubToken
+    self._pubToken = None
 
     val token = try self._expectNext()
     val typeName = try self._expectNextLabel()
@@ -747,7 +759,7 @@ export type Parser {
 
     val node = TypeDeclarationNode(
       decorators: decorators,
-      exportToken: exportToken,
+      pubToken: pubToken,
       name: typeName,
       typeParams: typeParams,
       fields: fields,
@@ -762,8 +774,8 @@ export type Parser {
     val decorators = self._seenDecorators
     self._seenDecorators = []
 
-    val exportToken = self._exportToken
-    self._exportToken = None
+    val pubToken = self._pubToken
+    self._pubToken = None
 
     val token = try self._expectNext()
     val enumName = try self._expectNextLabel()
@@ -822,7 +834,7 @@ export type Parser {
 
     val node = EnumDeclarationNode(
       decorators: decorators,
-      exportToken: exportToken,
+      pubToken: pubToken,
       name: enumName,
       typeParams: typeParams,
       variants: variants,

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -217,6 +217,7 @@ type TypeField {
   name: Label
   typeAnnotation: TypeIdentifier
   initializer: AstNode?
+  pubToken: Token?
 }
 
 export type TypeDeclarationNode {
@@ -737,10 +738,11 @@ export type Parser {
     try self._expectNextTokenKind(TokenKind.LBrace)
 
     val fields: TypeField[] = []
+    var fieldPubToken: Token? = None
     while self._peek() |nextToken| {
       match nextToken.kind {
         TokenKind.Ident => {
-          val field = try self._parseField()
+          val field = try self._parseField(fieldPubToken)
 
           val nextToken = try self._expectPeek()
           if nextToken.kind == TokenKind.Comma {
@@ -748,6 +750,14 @@ export type Parser {
           }
 
           fields.push(field)
+          fieldPubToken = None
+        }
+        TokenKind.Pub => {
+          if fieldPubToken |token| {
+            return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], nextToken.kind)))
+          }
+          self._advance() // consume 'pub' token
+          fieldPubToken = Some(nextToken)
         }
         _ => break
       }
@@ -845,7 +855,7 @@ export type Parser {
     Ok(AstNode(token: token, kind: AstNodeKind.EnumDeclaration(node)))
   }
 
-  func _parseField(self): Result<TypeField, ParseError> {
+  func _parseField(self, pubToken: Token? = None): Result<TypeField, ParseError> {
     val name = try self._expectNextLabel()
     try self._expectNextTokenKind(TokenKind.Colon)
     val typeAnnotation = try self._parseTypeIdentifier()
@@ -858,7 +868,7 @@ export type Parser {
       None
     }
 
-    Ok(TypeField(name: name, typeAnnotation: typeAnnotation, initializer: initializer))
+    Ok(TypeField(name: name, typeAnnotation: typeAnnotation, initializer: initializer, pubToken: pubToken))
   }
 
   func _parseBodyForTypeOrEnum(self): Result<(FunctionDeclarationNode[], TypeDeclarationNode[], EnumDeclarationNode[]), ParseError> {
@@ -870,6 +880,7 @@ export type Parser {
       val node = match nextToken.kind {
         TokenKind.RBrace => break
         TokenKind.At => try self._parseStatement()
+        TokenKind.Pub => try self._parseStatement()
         TokenKind.Func => try self._parseStatement()
         TokenKind.Type => try self._parseStatement()
         TokenKind.Enum => try self._parseStatement()

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -689,7 +689,7 @@ export type Parser {
       decName == "Stub" || decName == "Intrinsic" || decName == "CBinding"
     })
 
-    val body: AstNode[] = if isStub {
+    val body = if isStub {
       []
     } else {
       val nextToken = try self._expectPeek()

--- a/projects/compiler/src/test_utils.abra
+++ b/projects/compiler/src/test_utils.abra
@@ -89,6 +89,7 @@ func printTokenKindAsJson(kind: TokenKind, indentLevelStart: Int, currentIndentL
     TokenKind.As => println("$fieldsIndent\"name\": \"As\"")
     TokenKind.Try => println("$fieldsIndent\"name\": \"Try\"")
     TokenKind.None_ => println("$fieldsIndent\"name\": \"None\"")
+    TokenKind.Pub => println("$fieldsIndent\"name\": \"Pub\"")
     TokenKind.Plus => println("$fieldsIndent\"name\": \"Plus\"")
     TokenKind.PlusEq => println("$fieldsIndent\"name\": \"PlusEq\"")
     TokenKind.Minus => println("$fieldsIndent\"name\": \"Minus\"")
@@ -814,12 +815,12 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
         }
         println("$fieldsIndent],")
       }
-      if value.exportToken |token| {
-        print("$fieldsIndent\"exportToken\": ")
+      if value.pubToken |token| {
+        print("$fieldsIndent\"pubToken\": ")
         printTokenAsJson(token, 0, currentIndentLevel + 1)
         println(",")
       } else {
-        println("$fieldsIndent\"exportToken\": null,")
+        println("$fieldsIndent\"pubToken\": null,")
       }
       print("$fieldsIndent\"bindingPattern\": ")
       printBindingPatternAsJson(value.bindingPattern, 0, currentIndentLevel + 1)
@@ -851,12 +852,12 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
         }
         println("$fieldsIndent],")
       }
-      if node.exportToken |token| {
-        print("$fieldsIndent\"exportToken\": ")
+      if node.pubToken |token| {
+        print("$fieldsIndent\"pubToken\": ")
         printTokenAsJson(token, 0, currentIndentLevel + 1)
         println(",")
       } else {
-        println("$fieldsIndent\"exportToken\": null,")
+        println("$fieldsIndent\"pubToken\": null,")
       }
       print("$fieldsIndent\"ident\": ")
       printLabelAsJson(node.name)
@@ -923,12 +924,12 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
         }
         println("$fieldsIndent],")
       }
-      if node.exportToken |token| {
-        print("$fieldsIndent\"exportToken\": ")
+      if node.pubToken |token| {
+        print("$fieldsIndent\"pubToken\": ")
         printTokenAsJson(token, 0, currentIndentLevel + 1)
         println(",")
       } else {
-        println("$fieldsIndent\"exportToken\": null,")
+        println("$fieldsIndent\"pubToken\": null,")
       }
       print("$fieldsIndent\"typeName\": ")
       printLabelAsJson(node.name)
@@ -1017,12 +1018,12 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
         }
         println("$fieldsIndent],")
       }
-      if node.exportToken |token| {
-        print("$fieldsIndent\"exportToken\": ")
+      if node.pubToken |token| {
+        print("$fieldsIndent\"pubToken\": ")
         printTokenAsJson(token, 0, currentIndentLevel + 1)
         println(",")
       } else {
-        println("$fieldsIndent\"exportToken\": null,")
+        println("$fieldsIndent\"pubToken\": null,")
       }
       print("$fieldsIndent\"typeName\": ")
       printLabelAsJson(node.name)

--- a/projects/compiler/src/test_utils.abra
+++ b/projects/compiler/src/test_utils.abra
@@ -955,6 +955,10 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
           println("$fieldsIndent  {")
           print("$fieldsIndent    \"label\": ")
           printLabelAsJson(f.name)
+          if f.pubToken |token| {
+            print(",\n$fieldsIndent    \"pubToken\": ")
+            printTokenAsJson(token, 0, currentIndentLevel + 3)
+          }
           print(",\n$fieldsIndent    \"typeAnnotation\": ")
           printTypeIdentifierAsJson(f.typeAnnotation, 0, currentIndentLevel + 3)
           print(",\n$fieldsIndent    \"initializer\": ")

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -117,6 +117,8 @@ export type TypedModule {
   imports: Map<String, ImportedModule> = {}
   exports: Map<String, Export> = {}
   identsByLine: Map<Int, (Int, Int, IdentifierMeta)[]> = {}
+
+  func bogus(): TypedModule = TypedModule(id: -1, name: "bogus", code: [], rootScope: Scope.bogus())
 }
 
 export enum VariableAlias {
@@ -1271,7 +1273,7 @@ type TypeError {
         lines.push("The current module is imported by the imported module (or one of its imports), resulting in a cycle")
       }
       TypeErrorKind.IllegalExportScope => {
-        lines.push("Invalid export modifier")
+        lines.push("Invalid visibility modifier")
         lines.push(self._getCursorLine(self.position, contents))
         lines.push("Exported values may only appear at the top level scope in a module")
       }
@@ -1281,7 +1283,7 @@ type TypeError {
         lines.push("There's no exported value named '$importName' in module '$moduleName'")
       }
       TypeErrorKind.UnknownImportForAlias(importName, alias) => {
-        lines.push("Unknown exported name for aliased module")
+        lines.push("Unknown member '$importName'")
         lines.push(self._getCursorLine(self.position, contents))
         lines.push("There's no exported value named '$importName' in module aliased as '${alias.name}' at:")
         lines.push(self._getCursorLine(alias.position, contents))
@@ -1516,10 +1518,7 @@ type ParamDefaultValueContext {
 export type Typechecker {
   moduleLoader: ModuleLoader
   project: Project
-  currentModuleId: Int = -1
-  currentModuleName: String = ""
-  currentModuleExports: Map<String, Export> = {} // TODO: this is a little gross, could we instead track the currentModule?
-  currentModuleImports: Map<String, ImportedModule> = {} // TODO: see above todo
+  currentModule: TypedModule = TypedModule.bogus()
   currentScope: Scope = Scope(name: "\$root")
   currentTypeDecl: StructOrEnum? = None
   currentFunction: Function? = None
@@ -1583,7 +1582,7 @@ export type Typechecker {
   }
 
   func _verifyNameUniqueInScope(self, label: Label, scope: Scope): TypeError? {
-    for importedModule in self.currentModuleImports.values() {
+    for (_, importedModule) in self.currentModule.imports {
       for alias in importedModule.aliases {
         if alias.name == label.name {
           return Some(TypeError(position: label.position, kind: TypeErrorKind.DuplicateName(original: alias)))
@@ -1644,7 +1643,7 @@ export type Typechecker {
 
     if isExported {
       variable.isExported = true
-      self.currentModuleExports[struct.label.name] = Export.Type(StructOrEnum.Struct(struct), variable)
+      self.currentModule.exports[struct.label.name] = Export.Type(StructOrEnum.Struct(struct), variable)
     }
 
     Ok(0) // <- unnecessary 0
@@ -1661,7 +1660,7 @@ export type Typechecker {
 
     if isExported {
       variable.isExported = true
-      self.currentModuleExports[enum_.label.name] = Export.Type(StructOrEnum.Enum(enum_), variable)
+      self.currentModule.exports[enum_.label.name] = Export.Type(StructOrEnum.Enum(enum_), variable)
     }
 
     Ok(0) // <- unnecessary 0
@@ -1674,7 +1673,7 @@ export type Typechecker {
   }
 
   func _findModuleByAlias(self, name: String): Result<(TypedModule, Label)?, TypeError> {
-    for (importModulePath, importedModule) in self.currentModuleImports {
+    for (importModulePath, importedModule) in self.currentModule.imports {
       if importedModule.aliases.find(a => a.name == name) |alias| {
         val mod = try self.project.modules[importModulePath] else unreachable("unknown module '$importModulePath'")
         return Ok(Some((mod, alias)))
@@ -1764,7 +1763,7 @@ export type Typechecker {
           }
         }
 
-        for (moduleName, importedModule) in self.currentModuleImports {
+        for (moduleName, importedModule) in self.currentModule.imports {
           for (importName, imp) in importedModule.imports {
             if importName == label.name {
               match imp.kind {
@@ -1809,7 +1808,7 @@ export type Typechecker {
             val ident = IdentifierMeta(
               name: aliasLabel.name,
               kind: IdentifierKindMeta.Module(mod.name),
-              definitionPosition: Some((IdentifierMetaModule.Module(self.currentModuleName), aliasLabel.position)),
+              definitionPosition: Some((IdentifierMetaModule.Module(self.currentModule.name), aliasLabel.position)),
             )
             self._addLSPIdent(firstSeg.position, ident)
           }
@@ -1996,7 +1995,7 @@ export type Typechecker {
       }
     }
 
-    for (name, importedModule) in self.currentModuleImports {
+    for (name, importedModule) in self.currentModule.imports {
       for (importedName, importedValue) in importedModule.imports {
         if importedName == ident {
           val v = match importedValue.kind {
@@ -2159,7 +2158,7 @@ export type Typechecker {
   }
 
   func _nextLambdaName(self): String {
-    val name = "lambda_${self.currentModuleId}_${self.numLambdas}"
+    val name = "lambda_${self.currentModule.id}_${self.numLambdas}"
     self.numLambdas += 1
     name
   }
@@ -2170,7 +2169,7 @@ export type Typechecker {
     val defMod = if struct.scope.parent == Some(self.project.preludeScope) {
       IdentifierMetaModule.Prelude
     } else {
-      IdentifierMetaModule.Module(importMod?.name ?: self.currentModuleName)
+      IdentifierMetaModule.Module(importMod?.name ?: self.currentModule.name)
     }
 
     val ident = IdentifierMeta(
@@ -2186,7 +2185,7 @@ export type Typechecker {
     val defMod = if enum_.scope.parent == Some(self.project.preludeScope) {
       IdentifierMetaModule.Prelude
     } else {
-      IdentifierMetaModule.Module(importMod?.name ?: self.currentModuleName)
+      IdentifierMetaModule.Module(importMod?.name ?: self.currentModule.name)
     }
 
     val ident = IdentifierMeta(
@@ -2281,6 +2280,7 @@ export type Typechecker {
     // this module's imports; this ensures that sorting the final list of modules by id results in a resolved
     // dependency graph.
     val mod = TypedModule(id: -1, name: modulePathAbs, code: [], rootScope: Scope.bogus())
+    self.currentModule = mod
     self.project.modules[modulePathAbs] = mod
 
     val parsedModule = try self._tokenizeAndParse(modulePathAbs)
@@ -2333,9 +2333,6 @@ export type Typechecker {
     }
 
     val moduleId = self.project.modules.values().filter(m => m.id != -1).length
-    self.currentModuleId = moduleId
-    self.currentModuleName = modulePathAbs
-
     val moduleScope = if self.typecheckingBuiltin == Some(BuiltinModule.Prelude) {
       self.project.preludeScope.kind = ScopeKind.Module(id: moduleId, name: modulePathAbs)
       self.project.preludeScope
@@ -2358,12 +2355,6 @@ export type Typechecker {
       Ok(v) => v
       Err(e) => return Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(e)))
     }
-
-    mod.imports = self.currentModuleImports
-    self.currentModuleImports = {} // is this necessary?
-
-    mod.exports = self.currentModuleExports
-    self.currentModuleExports = {} // is this necessary?
 
     self.currentScope = prevScope
 
@@ -2681,7 +2672,8 @@ export type Typechecker {
 
     self.currentScope = prevScope
 
-    val struct = Struct(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
+    val currentModuleId = self.currentModule.id
+    val struct = Struct(moduleId: currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
     try self._addStructToScope(struct, isPublic)
 
     Ok(struct)
@@ -2876,7 +2868,8 @@ export type Typechecker {
 
     self.currentScope = prevScope
 
-    val enum_ = Enum(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
+    val currentModuleId = self.currentModule.id
+    val enum_ = Enum(moduleId: currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
     try self._addEnumToScope(enum_, isPublic)
 
     Ok(enum_)
@@ -3006,12 +2999,12 @@ export type Typechecker {
   }
 
   func _typecheckImport(self, mod: TypedModule, node: ImportNode): Result<Int, TypeError> {
-    val importedModule = self.currentModuleImports.getOrInsert(mod.name, () => ImportedModule())
+    val importedModule = self.currentModule.imports.getOrInsert(mod.name, () => ImportedModule())
 
     match node.kind {
       ImportKind.List(importNames) => {
         for imp in importNames {
-          for importedModule in self.currentModuleImports.values() {
+          for (_, importedModule) in self.currentModule.imports {
             for (importedName, importedValue) in importedModule.imports {
               if importedName == imp.name {
                 return Err(TypeError(position: imp.position, kind: TypeErrorKind.DuplicateName(original: importedValue.label)))
@@ -3102,7 +3095,7 @@ export type Typechecker {
       functionsPass1.push((fn, aliasVar, node))
       if isPublic {
         aliasVar.isExported = true
-        self.currentModuleExports[fn.label.name] = Export.Function(aliasVar)
+        self.currentModule.exports[fn.label.name] = Export.Function(aliasVar)
       }
     }
 
@@ -3221,7 +3214,7 @@ export type Typechecker {
           val ident = IdentifierMeta(
             name: label.name,
             kind: IdentifierKindMeta.Variable(mutable: mutable, typeRepr: ty.repr()),
-            definitionPosition: Some((IdentifierMetaModule.Module(self.currentModuleName), label.position)),
+            definitionPosition: Some((IdentifierMetaModule.Module(self.currentModule.name), label.position)),
           )
           self._addLSPIdent(label.position, ident)
         }
@@ -3310,7 +3303,7 @@ export type Typechecker {
     for v in variables {
       if isPublic {
         v.isExported = true
-        self.currentModuleExports[v.label.name] = Export.Variable(v)
+        self.currentModule.exports[v.label.name] = Export.Variable(v)
       }
     }
 
@@ -3840,7 +3833,7 @@ export type Typechecker {
                         val ident = IdentifierMeta(
                           name: arg.name,
                           kind: IdentifierKindMeta.Variable(mutable: false, typeRepr: variableTy.repr()),
-                          definitionPosition: Some((IdentifierMetaModule.Module(self.currentModuleName), arg.position)),
+                          definitionPosition: Some((IdentifierMetaModule.Module(self.currentModule.name), arg.position)),
                         )
                         self._addLSPIdent(arg.position, ident)
                       }
@@ -4233,7 +4226,7 @@ export type Typechecker {
       val defMod = if variable.scope == self.project.preludeScope {
         IdentifierMetaModule.Prelude
       } else {
-        IdentifierMetaModule.Module(varImportMod?.name ?: self.currentModuleName)
+        IdentifierMetaModule.Module(varImportMod?.name ?: self.currentModule.name)
       }
 
       val ident = IdentifierMeta(

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -2151,10 +2151,10 @@ export type Typechecker {
     }
   }
 
-  func _ensureValidExportScope(self, exportToken: Token): Result<Int, TypeError> {
+  func _ensureValidExportScope(self, pubToken: Token): Result<Int, TypeError> {
     match self.currentScope.kind {
       ScopeKind.Module => Ok(0) // <-- unnecessary int
-      _ => Err(TypeError(position: exportToken.position, kind: TypeErrorKind.IllegalExportScope))
+      _ => Err(TypeError(position: pubToken.position, kind: TypeErrorKind.IllegalExportScope))
     }
   }
 
@@ -2655,8 +2655,8 @@ export type Typechecker {
   }
 
   func _typecheckStructPass1(self, node: TypeDeclarationNode): Result<Struct, TypeError> {
-    val isExported = if node.exportToken |exportToken| {
-      try self._ensureValidExportScope(exportToken)
+    val isPublic = if node.pubToken |pubToken| {
+      try self._ensureValidExportScope(pubToken)
       true
     } else {
       false
@@ -2682,7 +2682,7 @@ export type Typechecker {
     self.currentScope = prevScope
 
     val struct = Struct(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
-    try self._addStructToScope(struct, isExported)
+    try self._addStructToScope(struct, isPublic)
 
     Ok(struct)
   }
@@ -2850,8 +2850,8 @@ export type Typechecker {
   }
 
   func _typecheckEnumPass1(self, node: EnumDeclarationNode): Result<Enum, TypeError> {
-    val isExported = if node.exportToken |exportToken| {
-      try self._ensureValidExportScope(exportToken)
+    val isPublic = if node.pubToken |pubToken| {
+      try self._ensureValidExportScope(pubToken)
       true
     } else {
       false
@@ -2877,7 +2877,7 @@ export type Typechecker {
     self.currentScope = prevScope
 
     val enum_ = Enum(moduleId: self.currentModuleId, label: node.name, scope: typeScope, typeParams: typeParams, builtin: self.typecheckingBuiltin)
-    try self._addEnumToScope(enum_, isExported)
+    try self._addEnumToScope(enum_, isPublic)
 
     Ok(enum_)
   }
@@ -3089,8 +3089,8 @@ export type Typechecker {
 
     val functionsPass1: (Function, Variable, FunctionDeclarationNode)[] = []
     for node in funcDecls {
-      val isExported = if node.exportToken |exportToken| {
-        try self._ensureValidExportScope(exportToken)
+      val isPublic = if node.pubToken |pubToken| {
+        try self._ensureValidExportScope(pubToken)
         true
       } else {
         false
@@ -3100,7 +3100,7 @@ export type Typechecker {
       val aliasVar = Variable(label: fn.label, scope: self.currentScope, mutable: false, ty: fn.getType(), alias: Some(VariableAlias.Function(fn)))
       self.currentScope.variables.push(aliasVar)
       functionsPass1.push((fn, aliasVar, node))
-      if isExported {
+      if isPublic {
         aliasVar.isExported = true
         self.currentModuleExports[fn.label.name] = Export.Function(aliasVar)
       }
@@ -3259,8 +3259,8 @@ export type Typechecker {
 
   func _typecheckBindingDeclaration(self, token: Token, node: BindingDeclarationNode): Result<TypedAstNode, TypeError> {
     val isMutable = token.kind == TokenKind.Var
-    val isExported = if node.exportToken |exportToken| {
-      try self._ensureValidExportScope(exportToken)
+    val isPublic = if node.pubToken |pubToken| {
+      try self._ensureValidExportScope(pubToken)
       true
     } else {
       false
@@ -3308,7 +3308,7 @@ export type Typechecker {
 
     val variables = try self._typecheckBindingPattern(isMutable, node.bindingPattern, ty)
     for v in variables {
-      if isExported {
+      if isPublic {
         v.isExported = true
         self.currentModuleExports[v.label.name] = Export.Variable(v)
       }

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -213,6 +213,7 @@ export type Field {
   name: Label
   ty: Type
   initializer: TypedAstNode?
+  isPublic: Bool
 }
 
 export type Struct {
@@ -245,7 +246,7 @@ export type Struct {
       label: Label(name: name, position: bogusPosition),
       scope: bogusScope,
       typeParams: typeParams,
-      fields: fields.map(_f => Field(name: Label(name: _f[0], position: bogusPosition), ty: _f[1], initializer: None)),
+      fields: fields.map(_f => Field(name: Label(name: _f[0], position: bogusPosition), ty: _f[1], initializer: None, isPublic: false)),
       instanceMethods: [],
       staticMethods: [],
     )
@@ -253,9 +254,9 @@ export type Struct {
     val structOrEnum = StructOrEnum.Struct(struct)
     val selfInstanceType = struct.asInstanceType()
 
-    struct.instanceMethods.push(Function.generated(bogusScope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(Some(structOrEnum))))
-    struct.instanceMethods.push(Function.generated(bogusScope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(Some(structOrEnum))))
-    struct.instanceMethods.push(Function.generated(bogusScope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(structOrEnum))))
+    struct.instanceMethods.push(Function.generated(bogusScope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(Some(structOrEnum), true)))
+    struct.instanceMethods.push(Function.generated(bogusScope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(Some(structOrEnum), true)))
+    struct.instanceMethods.push(Function.generated(bogusScope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(structOrEnum), true)))
 
     struct
   }
@@ -669,8 +670,8 @@ type TypedFunctionParam {
 
 export enum FunctionKind {
   Standalone
-  InstanceMethod(structOrEnum: StructOrEnum?)
-  StaticMethod(structOrEnum: StructOrEnum)
+  InstanceMethod(structOrEnum: StructOrEnum?, isPublic: Bool)
+  StaticMethod(structOrEnum: StructOrEnum, isPublic: Bool)
 }
 
 export type Function {
@@ -2117,7 +2118,7 @@ export type Typechecker {
       }
 
       match fn.kind {
-        FunctionKind.InstanceMethod(typeDecl) => {
+        FunctionKind.InstanceMethod(typeDecl, _) => {
           val genericNames = match typeDecl {
             StructOrEnum.Struct(struct) => struct.typeParams,
             StructOrEnum.Enum(enum_) => enum_.typeParams,
@@ -2417,12 +2418,12 @@ export type Typechecker {
     val selfParam = if node.params[0] |param| { if param.label.name == "self" Some(param) else None } else None
     val fnKind = if selfParam |selfParam| {
       if self.currentTypeDecl |selfType| {
-        FunctionKind.InstanceMethod(Some(selfType))
+        FunctionKind.InstanceMethod(Some(selfType), !!node.pubToken)
       } else {
         return Err(TypeError(position: selfParam.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
       }
     } else if self.currentTypeDecl |parentType| {
-      FunctionKind.StaticMethod(parentType)
+      FunctionKind.StaticMethod(parentType, !!node.pubToken)
     } else {
       FunctionKind.Standalone
     }
@@ -2693,7 +2694,7 @@ export type Typechecker {
       seenFields[field.name.name] = field.name
 
       val ty = try self._resolveTypeIdentifier(field.typeAnnotation)
-      struct.fields.push(Field(name: field.name, ty: ty, initializer: None))
+      struct.fields.push(Field(name: field.name, ty: ty, initializer: None, isPublic: !!field.pubToken))
     }
 
     for funcDeclNode in node.methods {
@@ -2771,9 +2772,9 @@ export type Typechecker {
 
     // Ensure toString/hash/eq methods exist (include generated stubs if not), and sure the proper order
     val reorderedInstanceMethods = [
-      toStringFn ?: Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(Some(structOrEnum))),
-      hashFn ?: Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(Some(structOrEnum))),
-      eqFn ?: Function.generated(scope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(structOrEnum))),
+      toStringFn ?: Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(Some(structOrEnum), true)),
+      hashFn ?: Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(Some(structOrEnum), true)),
+      eqFn ?: Function.generated(scope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(structOrEnum), true)),
     ]
     for m in instanceMethods {
       if m.label.name == "toString" || m.label.name == "hash" || m.label.name == "eq" continue
@@ -2907,7 +2908,7 @@ export type Typechecker {
 
             val ty = try self._resolveTypeIdentifier(field.typeAnnotation)
             // The initializer (if present) will be filled in during the next pass
-            typedFields.push(Field(name: field.name, ty: ty, initializer: None))
+            typedFields.push(Field(name: field.name, ty: ty, initializer: None, isPublic: true))
           }
 
           enum_.variants.push(TypedEnumVariant(label: label, kind: EnumVariantKind.Container(typedFields)))
@@ -4243,11 +4244,11 @@ export type Typechecker {
   func _resolveAccessorPathSegmentAny(self, label: Label, optSafe: Bool, typeHint: Type?): AccessorPathSegment? {
     val scope = self.project.preludeScope.makeChild("Any", ScopeKind.Type)
     val method: Function? = if label.name == "toString" {
-      Some(Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(None)))
+      Some(Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(None, true)))
     } else if label.name == "hash" {
-      Some(Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(None)))
+      Some(Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(None, true)))
     } else if label.name == "eq" {
-      Some(Function.generated(scope, "eq", [("other", Type(kind: TypeKind.Any))], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(None)))
+      Some(Function.generated(scope, "eq", [("other", Type(kind: TypeKind.Any))], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(None, true)))
     } else {
       None
     }

--- a/projects/compiler/src/typechecker_test_utils.abra
+++ b/projects/compiler/src/typechecker_test_utils.abra
@@ -237,6 +237,11 @@ export type Jsonifier {
 
     self.print("\"initializer\": ")
     self.opt(field.initializer, n => self.printNode(n))
+
+    if field.isPublic {
+      println(",")
+      self.print("\"isPublic\": true")
+    }
     println()
 
     self.indentDec()
@@ -859,8 +864,16 @@ export type Jsonifier {
     self.print("\"kind\": ")
     match function.kind {
       FunctionKind.Standalone => print("\"FunctionKind.Standalone\"")
-      FunctionKind.InstanceMethod => print("\"FunctionKind.InstanceMethod\"")
-      FunctionKind.StaticMethod => print("\"FunctionKind.StaticMethod\"")
+      FunctionKind.InstanceMethod(_, isPublic) => {
+        print("\"FunctionKind.InstanceMethod\"")
+        println(",")
+        self.print("\"isPublic\": $isPublic")
+      }
+      FunctionKind.StaticMethod(_, isPublic) => {
+        print("\"FunctionKind.StaticMethod\"")
+        println(",")
+        self.print("\"isPublic\": $isPublic")
+      }
     }
     println(",")
 

--- a/projects/compiler/test/lexer/keywords.abra
+++ b/projects/compiler/test/lexer/keywords.abra
@@ -1,1 +1,1 @@
-true false val var if else func while break for in type enum self match readonly import export from as try continue
+true false val var if else func while break for in type enum self match readonly import export from as try continue pub

--- a/projects/compiler/test/lexer/keywords.out.json
+++ b/projects/compiler/test/lexer/keywords.out.json
@@ -132,5 +132,11 @@
     "kind": {
       "name": "Continue"
     }
+  },
+  {
+    "position": [1, 117],
+    "kind": {
+      "name": "Pub"
+    }
   }
 ]

--- a/projects/compiler/test/parser/bindingdecl.out.json
+++ b/projects/compiler/test/parser/bindingdecl.out.json
@@ -11,7 +11,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "a", "position": [1, 5] }
@@ -30,7 +30,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "b", "position": [2, 5] }
@@ -49,7 +49,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "a", "position": [3, 5] }
@@ -94,7 +94,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "c", "position": [4, 5] }
@@ -150,7 +150,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "c", "position": [6, 5] }
@@ -186,7 +186,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "d", "position": [7, 5] }

--- a/projects/compiler/test/parser/decorator.abra
+++ b/projects/compiler/test/parser/decorator.abra
@@ -14,3 +14,6 @@ export func foo() {}
 @Foo1("abc", 123, 4.56, true)
 @Foo2(a: "abc", b: 123, c: 4.56, d: true)
 func foo() {}
+
+@Foo
+pub func foo() {}

--- a/projects/compiler/test/parser/decorator.out.json
+++ b/projects/compiler/test/parser/decorator.out.json
@@ -16,7 +16,7 @@
             "arguments": []
           }
         ],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "a", "position": [2, 5] }
@@ -71,7 +71,7 @@
             ]
           }
         ],
-        "exportToken": {
+        "pubToken": {
           "position": [4, 1],
           "kind": {
             "name": "Export"
@@ -113,7 +113,7 @@
             "arguments": []
           }
         ],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "b", "position": [7, 5] }
@@ -168,7 +168,7 @@
             ]
           }
         ],
-        "exportToken": {
+        "pubToken": {
           "position": [9, 1],
           "kind": {
             "name": "Export"
@@ -210,7 +210,7 @@
             "arguments": []
           }
         ],
-        "exportToken": {
+        "pubToken": {
           "position": [12, 1],
           "kind": {
             "name": "Export"
@@ -379,8 +379,35 @@
             ]
           }
         ],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "foo", "position": [16, 6] },
+        "typeParams": [],
+        "params": [],
+        "body": []
+      }
+    },
+    {
+      "token": {
+        "position": [19, 5],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "kind": {
+        "name": "function",
+        "decorators": [
+          {
+            "name": { "name": "Foo", "position": [18, 2] },
+            "arguments": []
+          }
+        ],
+        "pubToken": {
+          "position": [19, 1],
+          "kind": {
+            "name": "Pub"
+          }
+        },
+        "ident": { "name": "foo", "position": [19, 10] },
         "typeParams": [],
         "params": [],
         "body": []

--- a/projects/compiler/test/parser/decorator_error_before_expr.out
+++ b/projects/compiler/test/parser/decorator_error_before_expr.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:2:1
-Unexpected token 'identifier', expected one of 'val', 'var', 'func', 'type', 'enum', '@', 'export':
+Unexpected token 'identifier', expected one of 'val', 'var', 'func', 'type', 'enum', '@', 'export', 'pub':
   |  abc()
      ^

--- a/projects/compiler/test/parser/decorator_error_before_invalid_stmt.out
+++ b/projects/compiler/test/parser/decorator_error_before_invalid_stmt.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:2:1
-Unexpected token 'while', expected one of 'val', 'var', 'func', 'type', 'enum', '@', 'export':
+Unexpected token 'while', expected one of 'val', 'var', 'func', 'type', 'enum', '@', 'export', 'pub':
   |  while true { }
      ^

--- a/projects/compiler/test/parser/enumdecl.out.json
+++ b/projects/compiler/test/parser/enumdecl.out.json
@@ -11,7 +11,7 @@
       "kind": {
         "name": "enumDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Foo", "position": [1, 6] },
         "typeParams": [],
         "variants": [],
@@ -30,7 +30,7 @@
       "kind": {
         "name": "enumDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Foo", "position": [2, 6] },
         "typeParams": [
           { "name": "A", "position": [2, 10] },
@@ -52,7 +52,7 @@
       "kind": {
         "name": "enumDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Foo", "position": [3, 6] },
         "typeParams": [
           { "name": "A", "position": [3, 10] }
@@ -82,7 +82,7 @@
       "kind": {
         "name": "enumDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Foo", "position": [4, 6] },
         "typeParams": [
           { "name": "A", "position": [4, 10] }
@@ -145,7 +145,7 @@
       "kind": {
         "name": "enumDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "FooBar123", "position": [9, 6] },
         "typeParams": [],
         "variants": [],
@@ -153,7 +153,7 @@
           {
             "name": "function",
             "decorators": [],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "foo", "position": [10, 8] },
             "typeParams": [],
             "params": [
@@ -196,7 +196,7 @@
             "arguments": []
           }
         ],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Outer", "position": [14, 6] },
         "typeParams": [],
         "variants": [
@@ -218,7 +218,7 @@
                 "arguments": []
               }
             ],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "foo", "position": [19, 8] },
             "typeParams": [],
             "params": [
@@ -251,7 +251,7 @@
                 "arguments": []
               }
             ],
-            "exportToken": null,
+            "pubToken": null,
             "typeName": { "name": "InnerType", "position": [25, 8] },
             "typeParams": [],
             "fields": [
@@ -288,7 +288,7 @@
                 "arguments": []
               }
             ],
-            "exportToken": null,
+            "pubToken": null,
             "typeName": { "name": "InnerEnum", "position": [22, 8] },
             "typeParams": [],
             "variants": [

--- a/projects/compiler/test/parser/export.abra
+++ b/projects/compiler/test/parser/export.abra
@@ -2,3 +2,5 @@ export val a = 123
 export var a = 123
 
 export func foo() {}
+
+pub func foo() {}

--- a/projects/compiler/test/parser/export.out.json
+++ b/projects/compiler/test/parser/export.out.json
@@ -11,7 +11,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": {
+        "pubToken": {
           "position": [1, 1],
           "kind": {
             "name": "Export"
@@ -48,7 +48,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": {
+        "pubToken": {
           "position": [2, 1],
           "kind": {
             "name": "Export"
@@ -85,13 +85,35 @@
       "kind": {
         "name": "function",
         "decorators": [],
-        "exportToken": {
+        "pubToken": {
           "position": [4, 1],
           "kind": {
             "name": "Export"
           }
         },
         "ident": { "name": "foo", "position": [4, 13] },
+        "typeParams": [],
+        "params": [],
+        "body": []
+      }
+    },
+    {
+      "token": {
+        "position": [6, 5],
+        "kind": {
+          "name": "Func"
+        }
+      },
+      "kind": {
+        "name": "function",
+        "decorators": [],
+        "pubToken": {
+          "position": [6, 1],
+          "kind": {
+            "name": "Pub"
+          }
+        },
+        "ident": { "name": "foo", "position": [6, 10] },
         "typeParams": [],
         "params": [],
         "body": []

--- a/projects/compiler/test/parser/for.out.json
+++ b/projects/compiler/test/parser/for.out.json
@@ -67,7 +67,7 @@
             "kind": {
               "name": "bindingDecl",
               "decorators": [],
-              "exportToken": null,
+              "pubToken": null,
               "bindingPattern": {
                 "kind": "variable",
                 "label": { "name": "x", "position": [2, 7] }
@@ -158,7 +158,7 @@
             "kind": {
               "name": "bindingDecl",
               "decorators": [],
-              "exportToken": null,
+              "pubToken": null,
               "bindingPattern": {
                 "kind": "variable",
                 "label": { "name": "x", "position": [6, 7] }

--- a/projects/compiler/test/parser/functiondecl.out.json
+++ b/projects/compiler/test/parser/functiondecl.out.json
@@ -11,7 +11,7 @@
       "kind": {
         "name": "function",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "foo", "position": [1, 6] },
         "typeParams": [],
         "params": [],
@@ -43,7 +43,7 @@
       "kind": {
         "name": "function",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "foo", "position": [2, 6] },
         "typeParams": [],
         "params": [],
@@ -75,7 +75,7 @@
       "kind": {
         "name": "function",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "foo", "position": [3, 6] },
         "typeParams": [],
         "params": [
@@ -101,7 +101,7 @@
             "kind": {
               "name": "bindingDecl",
               "decorators": [],
-              "exportToken": null,
+              "pubToken": null,
               "bindingPattern": {
                 "kind": "variable",
                 "label": { "name": "x", "position": [4, 7] }
@@ -161,7 +161,7 @@
       "kind": {
         "name": "function",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "foo", "position": [6, 6] },
         "typeParams": [],
         "params": [
@@ -229,7 +229,7 @@
             "kind": {
               "name": "bindingDecl",
               "decorators": [],
-              "exportToken": null,
+              "pubToken": null,
               "bindingPattern": {
                 "kind": "variable",
                 "label": { "name": "x", "position": [7, 7] }
@@ -289,7 +289,7 @@
       "kind": {
         "name": "function",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "foo", "position": [9, 6] },
         "typeParams": [
           { "name": "A", "position": [9, 10] },
@@ -309,7 +309,7 @@
       "kind": {
         "name": "function",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "foo", "position": [10, 6] },
         "typeParams": [],
         "params": [
@@ -345,7 +345,7 @@
             "arguments": []
           }
         ],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "stubbedFunc", "position": [13, 6] },
         "typeParams": [],
         "params": [],
@@ -385,7 +385,7 @@
             ]
           }
         ],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "stubbedFunc", "position": [16, 6] },
         "typeParams": [],
         "params": [],
@@ -425,7 +425,7 @@
             ]
           }
         ],
-        "exportToken": null,
+        "pubToken": null,
         "ident": { "name": "stubbedFunc", "position": [19, 6] },
         "typeParams": [],
         "params": [],

--- a/projects/compiler/test/parser/if.out.json
+++ b/projects/compiler/test/parser/if.out.json
@@ -60,7 +60,7 @@
             "kind": {
               "name": "bindingDecl",
               "decorators": [],
-              "exportToken": null,
+              "pubToken": null,
               "bindingPattern": {
                 "kind": "variable",
                 "label": { "name": "x", "position": [2, 7] }
@@ -170,7 +170,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "x", "position": [12, 5] }
@@ -258,7 +258,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "y", "position": [13, 5] }
@@ -343,7 +343,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "y", "position": [14, 5] }

--- a/projects/compiler/test/parser/invocation_transform_OptionSome.out.json
+++ b/projects/compiler/test/parser/invocation_transform_OptionSome.out.json
@@ -11,7 +11,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "x", "position": [1, 5] }

--- a/projects/compiler/test/parser/lambdas.out.json
+++ b/projects/compiler/test/parser/lambdas.out.json
@@ -98,7 +98,7 @@
             "kind": {
               "name": "bindingDecl",
               "decorators": [],
-              "exportToken": null,
+              "pubToken": null,
               "bindingPattern": {
                 "kind": "variable",
                 "label": { "name": "x", "position": [4, 7] }

--- a/projects/compiler/test/parser/match.out.json
+++ b/projects/compiler/test/parser/match.out.json
@@ -191,7 +191,7 @@
                 "kind": {
                   "name": "bindingDecl",
                   "decorators": [],
-                  "exportToken": null,
+                  "pubToken": null,
                   "bindingPattern": {
                     "kind": "variable",
                     "label": { "name": "a", "position": [7, 9] }
@@ -317,7 +317,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "x", "position": [15, 5] }

--- a/projects/compiler/test/parser/try.out.json
+++ b/projects/compiler/test/parser/try.out.json
@@ -11,7 +11,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "x", "position": [1, 5] }
@@ -66,7 +66,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "y", "position": [2, 5] }
@@ -144,7 +144,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "a", "position": [4, 5] }
@@ -215,7 +215,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "b", "position": [5, 5] }
@@ -319,7 +319,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "c", "position": [6, 5] }
@@ -375,7 +375,7 @@
                 "kind": {
                   "name": "bindingDecl",
                   "decorators": [],
-                  "exportToken": null,
+                  "pubToken": null,
                   "bindingPattern": {
                     "kind": "variable",
                     "label": { "name": "x", "position": [7, 7] }
@@ -480,7 +480,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "d", "position": [10, 5] }

--- a/projects/compiler/test/parser/typedecl.abra
+++ b/projects/compiler/test/parser/typedecl.abra
@@ -56,5 +56,5 @@ export type Outer {
 }
 
 pub type Outer2 {
-
+  pub a: Int
 }

--- a/projects/compiler/test/parser/typedecl.abra
+++ b/projects/compiler/test/parser/typedecl.abra
@@ -54,3 +54,7 @@ export type Outer {
   @Bar("c")
   type Inner { a: Int }
 }
+
+pub type Outer2 {
+
+}

--- a/projects/compiler/test/parser/typedecl.out.json
+++ b/projects/compiler/test/parser/typedecl.out.json
@@ -1018,7 +1018,23 @@
         },
         "typeName": { "name": "Outer2", "position": [58, 10] },
         "typeParams": [],
-        "fields": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [59, 7] },
+            "pubToken": {
+              "position": [59, 3],
+              "kind": {
+                "name": "Pub"
+              }
+            },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [59, 10] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
         "methods": [],
         "nestedTypes": [],
         "nestedEnums": []

--- a/projects/compiler/test/parser/typedecl.out.json
+++ b/projects/compiler/test/parser/typedecl.out.json
@@ -11,7 +11,7 @@
       "kind": {
         "name": "typeDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Foo", "position": [1, 6] },
         "typeParams": [],
         "fields": [],
@@ -30,7 +30,7 @@
       "kind": {
         "name": "typeDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Foo", "position": [2, 6] },
         "typeParams": [
           { "name": "A", "position": [2, 10] },
@@ -52,7 +52,7 @@
       "kind": {
         "name": "typeDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Foo", "position": [3, 6] },
         "typeParams": [
           { "name": "A", "position": [3, 10] }
@@ -92,7 +92,7 @@
       "kind": {
         "name": "typeDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Foo", "position": [4, 6] },
         "typeParams": [],
         "fields": [
@@ -143,7 +143,7 @@
       "kind": {
         "name": "typeDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "FooBar123", "position": [9, 6] },
         "typeParams": [],
         "fields": [],
@@ -151,7 +151,7 @@
           {
             "name": "function",
             "decorators": [],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "foo", "position": [10, 8] },
             "typeParams": [],
             "params": [
@@ -189,7 +189,7 @@
       "kind": {
         "name": "typeDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "FooBar123", "position": [13, 6] },
         "typeParams": [],
         "fields": [
@@ -207,7 +207,7 @@
           {
             "name": "function",
             "decorators": [],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "foo", "position": [16, 8] },
             "typeParams": [],
             "params": [
@@ -248,7 +248,7 @@
           {
             "name": "function",
             "decorators": [],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "bar", "position": [17, 8] },
             "typeParams": [],
             "params": [
@@ -356,7 +356,7 @@
       "kind": {
         "name": "typeDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "FooBar123", "position": [20, 6] },
         "typeParams": [],
         "fields": [
@@ -374,7 +374,7 @@
           {
             "name": "function",
             "decorators": [],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "foo", "position": [23, 8] },
             "typeParams": [],
             "params": [
@@ -420,7 +420,7 @@
                 "arguments": []
               }
             ],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "bar", "position": [26, 8] },
             "typeParams": [],
             "params": [
@@ -528,7 +528,7 @@
       "kind": {
         "name": "typeDeclaration",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "typeName": { "name": "Outer", "position": [29, 6] },
         "typeParams": [],
         "fields": [
@@ -546,7 +546,7 @@
           {
             "name": "function",
             "decorators": [],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "foo", "position": [32, 8] },
             "typeParams": [],
             "params": [
@@ -589,7 +589,7 @@
           {
             "name": "typeDeclaration",
             "decorators": [],
-            "exportToken": null,
+            "pubToken": null,
             "typeName": { "name": "InnerType", "position": [34, 8] },
             "typeParams": [],
             "fields": [
@@ -607,7 +607,7 @@
               {
                 "name": "function",
                 "decorators": [],
-                "exportToken": null,
+                "pubToken": null,
                 "ident": { "name": "bar", "position": [37, 10] },
                 "typeParams": [],
                 "params": [
@@ -709,7 +709,7 @@
           {
             "name": "enumDeclaration",
             "decorators": [],
-            "exportToken": null,
+            "pubToken": null,
             "typeName": { "name": "InnerEnum", "position": [40, 8] },
             "typeParams": [],
             "variants": [
@@ -733,7 +733,7 @@
               {
                 "name": "function",
                 "decorators": [],
-                "exportToken": null,
+                "pubToken": null,
                 "ident": { "name": "bar", "position": [43, 10] },
                 "typeParams": [],
                 "params": [
@@ -866,7 +866,7 @@
             ]
           }
         ],
-        "exportToken": {
+        "pubToken": {
           "position": [48, 1],
           "kind": {
             "name": "Export"
@@ -912,7 +912,7 @@
                 ]
               }
             ],
-            "exportToken": null,
+            "pubToken": null,
             "ident": { "name": "foo", "position": [52, 8] },
             "typeParams": [],
             "params": [
@@ -978,7 +978,7 @@
                 ]
               }
             ],
-            "exportToken": null,
+            "pubToken": null,
             "typeName": { "name": "Inner", "position": [55, 8] },
             "typeParams": [],
             "fields": [
@@ -997,6 +997,30 @@
             "nestedEnums": []
           }
         ],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [58, 5],
+        "kind": {
+          "name": "Type"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": {
+          "position": [58, 1],
+          "kind": {
+            "name": "Pub"
+          }
+        },
+        "typeName": { "name": "Outer2", "position": [58, 10] },
+        "typeParams": [],
+        "fields": [],
+        "methods": [],
+        "nestedTypes": [],
         "nestedEnums": []
       }
     }

--- a/projects/compiler/test/parser/typeidentifiers.out.json
+++ b/projects/compiler/test/parser/typeidentifiers.out.json
@@ -11,7 +11,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [1, 5] }
@@ -46,7 +46,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [4, 5] }
@@ -75,7 +75,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [5, 5] }
@@ -101,7 +101,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [6, 5] }
@@ -130,7 +130,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [7, 5] }
@@ -159,7 +159,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [8, 5] }
@@ -191,7 +191,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [10, 5] }
@@ -220,7 +220,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [11, 5] }
@@ -254,7 +254,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [12, 5] }
@@ -291,7 +291,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [13, 5] }
@@ -342,7 +342,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [15, 5] }
@@ -407,7 +407,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [17, 5] }
@@ -433,7 +433,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [18, 5] }
@@ -456,7 +456,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [19, 5] }
@@ -521,7 +521,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [21, 5] }
@@ -554,7 +554,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [22, 5] }
@@ -598,7 +598,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [23, 5] }
@@ -649,7 +649,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [24, 5] }
@@ -676,7 +676,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [25, 5] }
@@ -713,7 +713,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [26, 5] }
@@ -760,7 +760,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [27, 5] }
@@ -790,7 +790,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [28, 5] }
@@ -820,7 +820,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [29, 5] }
@@ -850,7 +850,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [30, 5] }
@@ -880,7 +880,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [32, 5] }
@@ -906,7 +906,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [33, 5] }
@@ -935,7 +935,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [34, 5] }
@@ -964,7 +964,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [35, 5] }
@@ -996,7 +996,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [36, 5] }
@@ -1028,7 +1028,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [37, 5] }
@@ -1071,7 +1071,7 @@
       "kind": {
         "name": "bindingDecl",
         "decorators": [],
-        "exportToken": null,
+        "pubToken": null,
         "bindingPattern": {
           "kind": "variable",
           "label": { "name": "_", "position": [39, 5] }

--- a/projects/compiler/test/parser/while.out.json
+++ b/projects/compiler/test/parser/while.out.json
@@ -204,7 +204,7 @@
             "kind": {
               "name": "bindingDecl",
               "decorators": [],
-              "exportToken": null,
+              "pubToken": null,
               "bindingPattern": {
                 "kind": "variable",
                 "label": { "name": "x", "position": [7, 7] }

--- a/projects/compiler/test/run-tests.js
+++ b/projects/compiler/test/run-tests.js
@@ -700,6 +700,7 @@ const TYPECHECKER_TESTS = [
   { test: "typechecker/typedecl/typedecl_exported.abra", assertions: "typechecker/typedecl/typedecl_exported.out.json" },
   { test: "typechecker/typedecl/typedecl.1.abra", assertions: "typechecker/typedecl/typedecl.1.out.json" },
   { test: "typechecker/typedecl/typedecl.2.abra", assertions: "typechecker/typedecl/typedecl.2.out.json" },
+  { test: "typechecker/typedecl/typedecl.3.abra", assertions: "typechecker/typedecl/typedecl.3.out.json" },
   { test: "typechecker/typedecl/error_duplicate_field.abra", assertions: "typechecker/typedecl/error_duplicate_field.out" },
   { test: "typechecker/typedecl/error_method_bad_self_position.abra", assertions: "typechecker/typedecl/error_method_bad_self_position.out" },
   { test: "typechecker/typedecl/error_field_initializer_type_mismatch.abra", assertions: "typechecker/typedecl/error_field_initializer_type_mismatch.out" },

--- a/projects/compiler/test/test-runner.js
+++ b/projects/compiler/test/test-runner.js
@@ -108,10 +108,10 @@ class TestRunner {
         case 'fail': {
           numFail += 1
           console.log(magenta(`  [FAIL] ${result.testFile}`))
-          console.log('EXPECTED')
-          console.log(result.expected)
-          console.log('ACTUAL')
-          console.log(result.actual)
+          // console.log('EXPECTED')
+          // console.log(result.expected)
+          // console.log('ACTUAL')
+          // console.log(result.actual)
           break
         }
         case 'error': {

--- a/projects/compiler/test/test-runner.js
+++ b/projects/compiler/test/test-runner.js
@@ -108,10 +108,10 @@ class TestRunner {
         case 'fail': {
           numFail += 1
           console.log(magenta(`  [FAIL] ${result.testFile}`))
-          // console.log('EXPECTED')
-          // console.log(result.expected)
-          // console.log('ACTUAL')
-          // console.log(result.actual)
+          console.log('EXPECTED')
+          console.log(result.expected)
+          console.log('ACTUAL')
+          console.log(result.actual)
           break
         }
         case 'error': {

--- a/projects/compiler/test/typechecker/accessor/accessor.1.out.json
+++ b/projects/compiler/test/typechecker/accessor/accessor.1.out.json
@@ -40,6 +40,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -58,6 +59,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -76,6 +78,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/accessor/accessor.2.out.json
+++ b/projects/compiler/test/typechecker/accessor/accessor.2.out.json
@@ -41,6 +41,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -59,6 +60,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -77,6 +79,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -139,6 +142,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -157,6 +161,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -175,6 +180,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/accessor/accessor.3.out.json
+++ b/projects/compiler/test/typechecker/accessor/accessor.3.out.json
@@ -40,6 +40,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -58,6 +59,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -76,6 +78,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -122,6 +125,7 @@
                 "types": []
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [
                 {
@@ -284,6 +288,7 @@
                 "types": []
               },
               "kind": "FunctionKind.StaticMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/accessor/accessor.4.out.json
+++ b/projects/compiler/test/typechecker/accessor/accessor.4.out.json
@@ -36,6 +36,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -54,6 +55,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -72,6 +74,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/assignment/assignment_accessor.out.json
+++ b/projects/compiler/test/typechecker/assignment/assignment_accessor.out.json
@@ -54,6 +54,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -72,6 +73,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -90,6 +92,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/binary/and_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/and_eq.out.json
@@ -294,6 +294,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -312,6 +313,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -330,6 +332,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/binary/divide_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/divide_eq.out.json
@@ -286,6 +286,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -304,6 +305,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -322,6 +324,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/binary/minus_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/minus_eq.out.json
@@ -286,6 +286,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -304,6 +305,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -322,6 +324,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/binary/or_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/or_eq.out.json
@@ -294,6 +294,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -312,6 +313,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -330,6 +332,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/binary/plus_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/plus_eq.out.json
@@ -494,6 +494,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -512,6 +513,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -530,6 +532,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/binary/times_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/times_eq.out.json
@@ -286,6 +286,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -304,6 +305,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -322,6 +324,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/bindingdecl/error_export_bad_scope.out
+++ b/projects/compiler/test/typechecker/bindingdecl/error_export_bad_scope.out
@@ -1,5 +1,5 @@
 Error at %FILE_NAME%:2:3
-Invalid export modifier
+Invalid visibility modifier
   |    export val a = 1
        ^
 Exported values may only appear at the top level scope in a module

--- a/projects/compiler/test/typechecker/enumdecl/enumdecl_exported.out.json
+++ b/projects/compiler/test/typechecker/enumdecl/enumdecl_exported.out.json
@@ -42,6 +42,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -60,6 +61,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -78,6 +80,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_accessor.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_accessor.out.json
@@ -40,6 +40,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -58,6 +59,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -76,6 +78,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/if/expr.out.json
+++ b/projects/compiler/test/typechecker/if/expr.out.json
@@ -2563,6 +2563,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -2581,6 +2582,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -2599,6 +2601,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -2850,6 +2853,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -2868,6 +2872,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -2886,6 +2891,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/import/error_alias_unknown_import.out
+++ b/projects/compiler/test/typechecker/import/error_alias_unknown_import.out
@@ -1,5 +1,5 @@
 Error at %FILE_NAME%:3:3
-Unknown exported name for aliased module
+Unknown member 'bogus'
   |  a.bogus()
        ^
 There's no exported value named 'bogus' in module aliased as 'a' at:

--- a/projects/compiler/test/typechecker/import/import.1.out.json
+++ b/projects/compiler/test/typechecker/import/import.1.out.json
@@ -229,6 +229,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -247,6 +248,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -265,6 +267,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [
                   {
@@ -303,6 +306,7 @@
                   "types": []
                 },
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": false,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -461,7 +465,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   },
                   {
                     "name": { "name": "g", "position": [16, 15] },
@@ -469,7 +474,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   },
                   {
                     "name": { "name": "b", "position": [16, 23] },
@@ -477,7 +483,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   }
                 ]
               }
@@ -493,6 +500,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -511,6 +519,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -529,6 +538,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [
                   {

--- a/projects/compiler/test/typechecker/import/import.2.out.json
+++ b/projects/compiler/test/typechecker/import/import.2.out.json
@@ -229,6 +229,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -247,6 +248,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -265,6 +267,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [
                   {
@@ -303,6 +306,7 @@
                   "types": []
                 },
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": false,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -461,7 +465,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   },
                   {
                     "name": { "name": "g", "position": [16, 15] },
@@ -469,7 +474,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   },
                   {
                     "name": { "name": "b", "position": [16, 23] },
@@ -477,7 +483,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   }
                 ]
               }
@@ -493,6 +500,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -511,6 +519,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -529,6 +538,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [
                   {

--- a/projects/compiler/test/typechecker/import/import_type_identifier.1.out.json
+++ b/projects/compiler/test/typechecker/import/import_type_identifier.1.out.json
@@ -229,6 +229,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -247,6 +248,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -265,6 +267,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [
                   {
@@ -303,6 +306,7 @@
                   "types": []
                 },
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": false,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -461,7 +465,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   },
                   {
                     "name": { "name": "g", "position": [16, 15] },
@@ -469,7 +474,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   },
                   {
                     "name": { "name": "b", "position": [16, 23] },
@@ -477,7 +483,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   }
                 ]
               }
@@ -493,6 +500,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -511,6 +519,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -529,6 +538,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [
                   {

--- a/projects/compiler/test/typechecker/import/import_type_identifier.2.out.json
+++ b/projects/compiler/test/typechecker/import/import_type_identifier.2.out.json
@@ -229,6 +229,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -247,6 +248,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -265,6 +267,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [
                   {
@@ -303,6 +306,7 @@
                   "types": []
                 },
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": false,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -461,7 +465,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   },
                   {
                     "name": { "name": "g", "position": [16, 15] },
@@ -469,7 +474,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   },
                   {
                     "name": { "name": "b", "position": [16, 23] },
@@ -477,7 +483,8 @@
                       "kind": "primitive",
                       "primitive": "Int"
                     },
-                    "initializer": null
+                    "initializer": null,
+                    "isPublic": true
                   }
                 ]
               }
@@ -493,6 +500,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -511,6 +519,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [],
                 "returnType": {
@@ -529,6 +538,7 @@
                 },
                 "isGenerated": true,
                 "kind": "FunctionKind.InstanceMethod",
+                "isPublic": true,
                 "typeParameters": [],
                 "parameters": [
                   {

--- a/projects/compiler/test/typechecker/invocation/invocation_enum_variant.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_enum_variant.1.out.json
@@ -34,7 +34,8 @@
                     "kind": "primitive",
                     "primitive": "Int"
                   },
-                  "initializer": null
+                  "initializer": null,
+                  "isPublic": true
                 },
                 {
                   "name": { "name": "b", "position": [3, 15] },
@@ -42,7 +43,8 @@
                     "kind": "primitive",
                     "primitive": "String"
                   },
-                  "initializer": null
+                  "initializer": null,
+                  "isPublic": true
                 }
               ]
             }
@@ -58,6 +60,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -76,6 +79,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -94,6 +98,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_enum_variant.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_enum_variant.2.out.json
@@ -30,7 +30,8 @@
                     "kind": "primitive",
                     "primitive": "Int"
                   },
-                  "initializer": null
+                  "initializer": null,
+                  "isPublic": true
                 },
                 {
                   "name": { "name": "b", "position": [2, 15] },
@@ -54,7 +55,8 @@
                       "kind": "literal",
                       "value": "abc"
                     }
-                  }
+                  },
+                  "isPublic": true
                 }
               ]
             }
@@ -70,6 +72,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -88,6 +91,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -106,6 +110,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_enum_variant.3.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_enum_variant.3.out.json
@@ -32,7 +32,8 @@
                     "kind": "generic",
                     "name": "T"
                   },
-                  "initializer": null
+                  "initializer": null,
+                  "isPublic": true
                 }
               ]
             }
@@ -48,6 +49,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -66,6 +68,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -84,6 +87,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_enum_variant.4.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_enum_variant.4.out.json
@@ -38,7 +38,8 @@
                       }
                     ]
                   },
-                  "initializer": null
+                  "initializer": null,
+                  "isPublic": true
                 }
               ]
             }
@@ -54,6 +55,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -72,6 +74,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -90,6 +93,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_field.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_field.out.json
@@ -52,6 +52,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -70,6 +71,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -88,6 +90,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_field_generics.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_field_generics.1.out.json
@@ -54,6 +54,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -72,6 +73,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -90,6 +92,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_instantiation.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_instantiation.1.out.json
@@ -48,6 +48,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -66,6 +67,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -84,6 +86,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_instantiation_generics.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_instantiation_generics.1.out.json
@@ -42,6 +42,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -60,6 +61,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -78,6 +80,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_instantiation_generics.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_instantiation_generics.2.out.json
@@ -99,6 +99,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -117,6 +118,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -135,6 +137,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_method.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_method.1.out.json
@@ -40,6 +40,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -58,6 +59,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -76,6 +78,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -130,6 +133,7 @@
                 "types": []
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_method.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_method.2.out.json
@@ -40,6 +40,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -58,6 +59,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -76,6 +78,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -130,6 +133,7 @@
                 "types": []
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [
                 {
@@ -305,6 +309,7 @@
                 "types": []
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [
                 {
@@ -446,6 +451,7 @@
                 "types": []
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_method_generics.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_method_generics.1.out.json
@@ -42,6 +42,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -60,6 +61,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -78,6 +80,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -134,6 +137,7 @@
                 "types": []
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/invocation/invocation_method_generics.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_method_generics.2.out.json
@@ -42,6 +42,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -60,6 +61,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -78,6 +80,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -147,6 +150,7 @@
                 ]
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [
                 {
                   "label": { "name": "U", "position": [4, 12] },

--- a/projects/compiler/test/typechecker/match/match_expr.out.json
+++ b/projects/compiler/test/typechecker/match/match_expr.out.json
@@ -1268,6 +1268,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -1286,6 +1287,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -1304,6 +1306,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -1871,7 +1874,8 @@
                     "kind": "primitive",
                     "primitive": "Int"
                   },
-                  "initializer": null
+                  "initializer": null,
+                  "isPublic": true
                 },
                 {
                   "name": { "name": "g", "position": [45, 27] },
@@ -1879,7 +1883,8 @@
                     "kind": "primitive",
                     "primitive": "Int"
                   },
-                  "initializer": null
+                  "initializer": null,
+                  "isPublic": true
                 },
                 {
                   "name": { "name": "b", "position": [45, 35] },
@@ -1887,7 +1892,8 @@
                     "kind": "primitive",
                     "primitive": "Int"
                   },
-                  "initializer": null
+                  "initializer": null,
+                  "isPublic": true
                 }
               ]
             }
@@ -1903,6 +1909,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -1921,6 +1928,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -1939,6 +1947,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/typedecl/typedecl.1.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl.1.out.json
@@ -64,6 +64,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -82,6 +83,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -100,6 +102,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -138,6 +141,7 @@
                 "types": []
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -175,6 +179,7 @@
                 "types": []
               },
               "kind": "FunctionKind.StaticMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [],
               "returnType": {

--- a/projects/compiler/test/typechecker/typedecl/typedecl.2.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl.2.out.json
@@ -92,6 +92,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -110,6 +111,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -128,6 +130,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {
@@ -174,6 +177,7 @@
                 "types": []
               },
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": false,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/typedecl/typedecl.3.abra
+++ b/projects/compiler/test/typechecker/typedecl/typedecl.3.abra
@@ -1,0 +1,11 @@
+type Foo {
+  pub a: Int
+  b: String = "abcd"
+
+  func foo(self): Int = 123
+  pub func fooPub(self): Int = 123
+  func fooStatic(): Int = 123
+  pub func fooStaticPub(): Int = 123
+}
+
+var f: Foo

--- a/projects/compiler/test/typechecker/typedecl/typedecl.3.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl.3.out.json
@@ -1,12 +1,12 @@
 {
   "id": 3,
-  "name": "%FILE_NAME%",
+  "name": "/Users/kengorab/Desktop/abra-lang/projects/compiler/test/typechecker/typedecl/typedecl.3.abra",
   "code": [
     {
       "token": {
         "position": [1, 1],
         "kind": {
-          "name": "Enum"
+          "name": "Type"
         }
       },
       "type": {
@@ -14,70 +14,44 @@
         "primitive": "Unit"
       },
       "node": {
-        "kind": "enumDeclaration",
-        "enum": {
+        "kind": "typeDeclaration",
+        "struct": {
           "moduleId": 3,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
-          "variants": [
+          "fields": [
             {
-              "label": { "name": "Bar", "position": [2, 3] },
-              "kind": "constant"
+              "name": { "name": "a", "position": [2, 7] },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "initializer": null,
+              "isPublic": true
             },
             {
-              "label": { "name": "Baz", "position": [3, 3] },
-              "kind": "container",
-              "fields": [
-                {
-                  "name": { "name": "a", "position": [3, 7] },
-                  "type": {
-                    "kind": "primitive",
-                    "primitive": "Int"
-                  },
-                  "initializer": null,
-                  "isPublic": true
-                }
-              ]
-            },
-            {
-              "label": { "name": "Qux", "position": [4, 3] },
-              "kind": "container",
-              "fields": [
-                {
-                  "name": { "name": "a", "position": [4, 7] },
-                  "type": {
-                    "kind": "primitive",
-                    "primitive": "Int"
-                  },
-                  "initializer": null,
-                  "isPublic": true
+              "name": { "name": "b", "position": [3, 3] },
+              "type": {
+                "kind": "primitive",
+                "primitive": "String"
+              },
+              "initializer": {
+                "token": {
+                  "position": [3, 15],
+                  "kind": {
+                    "name": "String",
+                    "value": "abcd"
+                  }
                 },
-                {
-                  "name": { "name": "b", "position": [4, 15] },
-                  "type": {
-                    "kind": "primitive",
-                    "primitive": "String"
-                  },
-                  "initializer": {
-                    "token": {
-                      "position": [4, 27],
-                      "kind": {
-                        "name": "String",
-                        "value": "abcd"
-                      }
-                    },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "String"
-                    },
-                    "node": {
-                      "kind": "literal",
-                      "value": "abcd"
-                    }
-                  },
-                  "isPublic": true
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "String"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": "abcd"
                 }
-              ]
+              }
             }
           ],
           "instanceMethods": [
@@ -135,8 +109,8 @@
                 {
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
-                    "kind": "enumInstance",
-                    "enum": { "moduleId": 3, "name": "Foo" },
+                    "kind": "instance",
+                    "struct": { "moduleId": 3, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -150,16 +124,16 @@
               "body": []
             },
             {
-              "label": { "name": "foo", "position": [6, 8] },
+              "label": { "name": "foo", "position": [5, 8] },
               "scope": {
                 "name": "$root::module_3::Foo::foo",
                 "variables": [
                   {
-                    "label": { "name": "self", "position": [6, 12] },
+                    "label": { "name": "self", "position": [5, 12] },
                     "mutable": false,
                     "type": {
-                      "kind": "enumInstance",
-                      "enum": { "moduleId": 3, "name": "Foo" },
+                      "kind": "instance",
+                      "struct": { "moduleId": 3, "name": "Foo" },
                       "typeParams": []
                     }
                   }
@@ -178,7 +152,53 @@
               "body": [
                 {
                   "token": {
-                    "position": [6, 25],
+                    "position": [5, 25],
+                    "kind": {
+                      "name": "Int",
+                      "value": 123
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": 123
+                  }
+                }
+              ]
+            },
+            {
+              "label": { "name": "fooPub", "position": [6, 12] },
+              "scope": {
+                "name": "$root::module_3::Foo::fooPub",
+                "variables": [
+                  {
+                    "label": { "name": "self", "position": [6, 19] },
+                    "mutable": false,
+                    "type": {
+                      "kind": "instance",
+                      "struct": { "moduleId": 3, "name": "Foo" },
+                      "typeParams": []
+                    }
+                  }
+                ],
+                "functions": [],
+                "types": []
+              },
+              "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "body": [
+                {
+                  "token": {
+                    "position": [6, 32],
                     "kind": {
                       "name": "Int",
                       "value": 123
@@ -232,6 +252,42 @@
                   }
                 }
               ]
+            },
+            {
+              "label": { "name": "fooStaticPub", "position": [8, 12] },
+              "scope": {
+                "name": "$root::module_3::Foo::fooStaticPub",
+                "variables": [],
+                "functions": [],
+                "types": []
+              },
+              "kind": "FunctionKind.StaticMethod",
+              "isPublic": true,
+              "typeParameters": [],
+              "parameters": [],
+              "returnType": {
+                "kind": "primitive",
+                "primitive": "Int"
+              },
+              "body": [
+                {
+                  "token": {
+                    "position": [8, 34],
+                    "kind": {
+                      "name": "Int",
+                      "value": 123
+                    }
+                  },
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  },
+                  "node": {
+                    "kind": "literal",
+                    "value": 123
+                  }
+                }
+              ]
             }
           ]
         }
@@ -239,7 +295,7 @@
     },
     {
       "token": {
-        "position": [10, 1],
+        "position": [11, 1],
         "kind": {
           "name": "Var"
         }
@@ -252,15 +308,15 @@
         "kind": "bindingDeclaration",
         "pattern": {
           "kind": "variable",
-          "label": { "name": "f", "position": [10, 5] }
+          "label": { "name": "f", "position": [11, 5] }
         },
         "variables": [
           {
-            "label": { "name": "f", "position": [10, 5] },
+            "label": { "name": "f", "position": [11, 5] },
             "mutable": true,
             "type": {
-              "kind": "enumInstance",
-              "enum": { "moduleId": 3, "name": "Foo" },
+              "kind": "instance",
+              "struct": { "moduleId": 3, "name": "Foo" },
               "typeParams": []
             }
           }

--- a/projects/compiler/test/typechecker/typedecl/typedecl.3.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl.3.out.json
@@ -1,6 +1,6 @@
 {
   "id": 3,
-  "name": "/Users/kengorab/Desktop/abra-lang/projects/compiler/test/typechecker/typedecl/typedecl.3.abra",
+  "name": "%FILE_NAME%",
   "code": [
     {
       "token": {

--- a/projects/compiler/test/typechecker/typedecl/typedecl_exported.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl_exported.out.json
@@ -46,6 +46,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -64,6 +65,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [],
               "returnType": {
@@ -82,6 +84,7 @@
               },
               "isGenerated": true,
               "kind": "FunctionKind.InstanceMethod",
+              "isPublic": true,
               "typeParameters": [],
               "parameters": [
                 {

--- a/projects/compiler/test/typechecker/typeidentifier/error_modalias_unknown_type.out
+++ b/projects/compiler/test/typechecker/typeidentifier/error_modalias_unknown_type.out
@@ -1,5 +1,5 @@
 Error at %FILE_NAME%:3:10
-Unknown exported name for aliased module
+Unknown member 'Bar'
   |  val _: e.Bar[] = []
               ^
 There's no exported value named 'Bar' in module aliased as 'e' at:


### PR DESCRIPTION
The first pass is to replace the `export` keyword with `pub`. This saves from having two keywords (`export` for use at the top-level, and `pub` for type fields/methods) and instead the usage of `pub` at the top-level indicates that the value is exported (aka, visible outside of the current module, similarly to how `pub` fields/methods are visible outside of the current type/enum).