### PR TITLE
Enforcing `pub` visibility for fields

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,8 +1,3 @@
-// type Foo {
-//   a: Int
-// }
-
-// val f = Foo(a: 123)
 val a = [1, 2, 3]
 
 println(a.length)

--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -1961,7 +1961,7 @@ pub type Compiler {
     if variable.isGlobal() unreachable("Global variables are never included in a function's captures")
 
     if self._currentFunction |fn| {
-      if self._currentFn._env |env| {
+      if self._currentFn.env |env| {
         for v, idx in fn.captures {
           if v.label.name == variable.label.name {
             // When loading the captured variable from the closure env, if the captured variable is immutable then we
@@ -2049,7 +2049,7 @@ pub type Compiler {
       val currentFunc = try self._currentFunction else unreachable("we must be within a function to enter this case")
 
       val idx = if currentFunc.capturedClosures.findIndex(f => f.label.name == fn.label.name) |(_, idx)| idx else unreachable("closure '${fn.label.name}' called within function '${currentFunc.label.name}', but not tracked in its capturedClosures")
-      val env = try self._currentFn._env else unreachable("expected currentFn ('${self._currentFn.name}') to have an `_env`, but it didn't")
+      val env = try self._currentFn.env else unreachable("expected currentFn ('${self._currentFn.name}') to have an `env`, but it didn't")
       val offset = QbeType.Pointer.size() * (currentFunc.captures.length + idx)
 
       val ptr = try self._currentFn.block.buildAdd(Value.Int(offset), env) else |e| return qbeError(e)

--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -1,15 +1,15 @@
 import valueIfValidHexDigit from "./utils"
 
 pub type Position {
-  line: Int
-  col: Int
+  pub line: Int
+  pub col: Int
 
   func bogus(): Position = Position(line: 0, col: 0)
 }
 
 pub type Token {
-  position: Position
-  kind: TokenKind
+  pub position: Position
+  pub kind: TokenKind
 }
 
 pub enum TokenKind {
@@ -177,7 +177,7 @@ pub enum LexerErrorKind {
 }
 
 pub type LexerError {
-  position: Position
+  pub position: Position
   kind: LexerErrorKind
 
   func getMessage(self, filePath: String, contents: String): String {
@@ -355,7 +355,7 @@ pub type Lexer {
         var isFirstChar = true
         var num = 0
         while self._cursor < self._input.length {
-          val ch = self._input._buffer.offset(self._cursor).load().asInt()
+          val ch = self._input.raw().offset(self._cursor).load().asInt()
           val v = try valueIfValidHexDigit(ch) else break
 
           num = (num << 4) + v
@@ -383,7 +383,7 @@ pub type Lexer {
         var isFirstChar = true
         var num = 0
         while self._cursor < self._input.length {
-          val ch = self._input._buffer.offset(self._cursor).load().asInt()
+          val ch = self._input.raw().offset(self._cursor).load().asInt()
           val v = if ch == 48 || ch == 49 { ch - 48 } else break
 
           num = (num << 1) + v
@@ -412,11 +412,11 @@ pub type Lexer {
     }
 
     // ord('0') = 48
-    var num = ch._buffer.load().asInt() - 48
+    var num = ch.raw().load().asInt() - 48
     self._advance()
     while self._input[self._cursor].isDigit() {
       num *= 10
-      num += self._input._buffer.offset(self._cursor).load().asInt() - 48
+      num += self._input.raw().offset(self._cursor).load().asInt() - 48
       self._advance()
     }
 
@@ -431,11 +431,11 @@ pub type Lexer {
     self._advance() // consume '.'
 
     var pow = 1
-    var num = self._input._buffer.offset(self._cursor).load().asInt() - 48
+    var num = self._input.raw().offset(self._cursor).load().asInt() - 48
     self._advance()
     while self._input[self._cursor].isDigit() {
       num *= 10
-      num += self._input._buffer.offset(self._cursor).load().asInt() - 48
+      num += self._input.raw().offset(self._cursor).load().asInt() - 48
       self._advance()
       pow += 1
     }
@@ -476,7 +476,7 @@ pub type Lexer {
       }
     } else {
       // TODO: once characters are supported, there should be no need for low-level byte manipulation like this
-      ch._buffer.offset(0).load().asInt()
+      ch.raw().offset(0).load().asInt()
     }
 
     self._advance()
@@ -623,7 +623,7 @@ pub type Lexer {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
         return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: escSeq, isUnicode: true)))
       }
-      val ch = self._input._buffer.offset(self._cursor + i).load().asInt()
+      val ch = self._input.raw().offset(self._cursor + i).load().asInt()
       val v = try valueIfValidHexDigit(ch) else {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
         return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: escSeq, isUnicode: true)))

--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -355,7 +355,7 @@ pub type Lexer {
         var isFirstChar = true
         var num = 0
         while self._cursor < self._input.length {
-          val ch = self._input.raw().offset(self._cursor).load().asInt()
+          val ch = self._input.byteAt(self._cursor).asInt()
           val v = try valueIfValidHexDigit(ch) else break
 
           num = (num << 4) + v
@@ -383,7 +383,7 @@ pub type Lexer {
         var isFirstChar = true
         var num = 0
         while self._cursor < self._input.length {
-          val ch = self._input.raw().offset(self._cursor).load().asInt()
+          val ch = self._input.byteAt(self._cursor).asInt()
           val v = if ch == 48 || ch == 49 { ch - 48 } else break
 
           num = (num << 1) + v
@@ -412,11 +412,11 @@ pub type Lexer {
     }
 
     // ord('0') = 48
-    var num = ch.raw().load().asInt() - 48
+    var num = ch.byteAt(0).asInt() - 48
     self._advance()
     while self._input[self._cursor].isDigit() {
       num *= 10
-      num += self._input.raw().offset(self._cursor).load().asInt() - 48
+      num += self._input.byteAt(self._cursor).asInt() - 48
       self._advance()
     }
 
@@ -431,11 +431,11 @@ pub type Lexer {
     self._advance() // consume '.'
 
     var pow = 1
-    var num = self._input.raw().offset(self._cursor).load().asInt() - 48
+    var num = self._input.byteAt(self._cursor).asInt() - 48
     self._advance()
     while self._input[self._cursor].isDigit() {
       num *= 10
-      num += self._input.raw().offset(self._cursor).load().asInt() - 48
+      num += self._input.byteAt(self._cursor).asInt() - 48
       self._advance()
       pow += 1
     }
@@ -476,7 +476,7 @@ pub type Lexer {
       }
     } else {
       // TODO: once characters are supported, there should be no need for low-level byte manipulation like this
-      ch.raw().offset(0).load().asInt()
+      ch.byteAt(0).asInt()
     }
 
     self._advance()
@@ -623,7 +623,7 @@ pub type Lexer {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
         return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: escSeq, isUnicode: true)))
       }
-      val ch = self._input.raw().offset(self._cursor + i).load().asInt()
+      val ch = self._input.byteAt(self._cursor + i).asInt()
       val v = try valueIfValidHexDigit(ch) else {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
         return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: escSeq, isUnicode: true)))

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -1,8 +1,8 @@
 import Token, TokenKind, Position, StringInterpolationChunk from "./lexer"
 
 pub type ParsedModule {
-  imports: ImportNode[]
-  nodes: AstNode[]
+  pub imports: ImportNode[]
+  pub nodes: AstNode[]
 }
 
 pub enum ImportKind {
@@ -11,14 +11,14 @@ pub enum ImportKind {
 }
 
 pub type ImportNode {
-  token: Token
-  kind: ImportKind
-  moduleName: Label
+  pub token: Token
+  pub kind: ImportKind
+  pub moduleName: Label
 }
 
 pub type AstNode {
-  token: Token
-  kind: AstNodeKind
+  pub token: Token
+  pub kind: AstNodeKind
 }
 
 pub enum LiteralAstNode {
@@ -32,8 +32,8 @@ pub enum LiteralAstNode {
 pub enum UnaryOp { Minus, Negate }
 
 pub type UnaryAstNode {
-  op: UnaryOp
-  expr: AstNode
+  pub op: UnaryOp
+  pub expr: AstNode
 }
 
 pub enum BinaryOp {
@@ -103,9 +103,9 @@ pub enum AssignOp {
 }
 
 pub type BinaryAstNode {
-  left: AstNode
-  op: BinaryOp
-  right: AstNode
+  pub left: AstNode
+  pub op: BinaryOp
+  pub right: AstNode
 }
 
 pub enum IdentifierKind {
@@ -116,26 +116,26 @@ pub enum IdentifierKind {
 }
 
 pub type Label {
-  name: String
-  position: Position
+  pub name: String
+  pub position: Position
 }
 
 pub type AccessorAstNode {
-  root: AstNode
-  path: (Token, Label)[]
+  pub root: AstNode
+  pub path: (Token, Label)[]
 }
 
 pub type InvocationArgument {
-  label: Label?
-  value: AstNode
+  pub label: Label?
+  pub value: AstNode
 
   func position(self): Position = self.label?.position ?: self.value.token.position
 }
 
 pub type InvocationAstNode {
-  invokee: AstNode
-  typeArguments: TypeIdentifier[]
-  arguments: InvocationArgument[]
+  pub invokee: AstNode
+  pub typeArguments: TypeIdentifier[]
+  pub arguments: InvocationArgument[]
 }
 
 pub enum IndexingMode<N> {
@@ -157,10 +157,10 @@ pub enum MatchCaseKind {
 }
 
 pub type MatchCase {
-  kind: MatchCaseKind
-  position: Position
-  binding: Label?
-  body: AstNode[]
+  pub kind: MatchCaseKind
+  pub position: Position
+  pub binding: Label?
+  pub body: AstNode[]
 }
 
 pub enum TypeIdentifier {
@@ -184,51 +184,51 @@ pub enum BindingPattern {
 }
 
 pub type BindingDeclarationNode {
-  decorators: DecoratorNode[]
-  pubToken: Token?
-  bindingPattern: BindingPattern
-  typeAnnotation: TypeIdentifier?
-  expr: AstNode?
+  pub decorators: DecoratorNode[]
+  pub pubToken: Token?
+  pub bindingPattern: BindingPattern
+  pub typeAnnotation: TypeIdentifier?
+  pub expr: AstNode?
 }
 
 pub type FunctionParam {
-  label: Label
-  isVariadic: Bool = false
-  typeAnnotation: TypeIdentifier? = None
-  defaultValue: AstNode? = None
+  pub label: Label
+  pub isVariadic: Bool = false
+  pub typeAnnotation: TypeIdentifier? = None
+  pub defaultValue: AstNode? = None
 }
 
 pub type LambdaNode {
-  params: FunctionParam[]
-  body: AstNode[]
+  pub params: FunctionParam[]
+  pub body: AstNode[]
 }
 
 pub type FunctionDeclarationNode {
-  decorators: DecoratorNode[]
-  pubToken: Token?
-  name: Label
-  typeParams: Label[]
-  params: FunctionParam[]
-  returnTypeAnnotation: TypeIdentifier?
-  body: AstNode[]
+  pub decorators: DecoratorNode[]
+  pub pubToken: Token?
+  pub name: Label
+  pub typeParams: Label[]
+  pub params: FunctionParam[]
+  pub returnTypeAnnotation: TypeIdentifier?
+  pub body: AstNode[]
 }
 
 type TypeField {
-  name: Label
-  typeAnnotation: TypeIdentifier
-  initializer: AstNode?
-  pubToken: Token?
+  pub name: Label
+  pub typeAnnotation: TypeIdentifier
+  pub initializer: AstNode?
+  pub pubToken: Token?
 }
 
 pub type TypeDeclarationNode {
-  decorators: DecoratorNode[]
-  pubToken: Token?
-  name: Label
-  typeParams: Label[]
-  fields: TypeField[]
-  methods: FunctionDeclarationNode[]
-  types: TypeDeclarationNode[]
-  enums: EnumDeclarationNode[]
+  pub decorators: DecoratorNode[]
+  pub pubToken: Token?
+  pub name: Label
+  pub typeParams: Label[]
+  pub fields: TypeField[]
+  pub methods: FunctionDeclarationNode[]
+  pub types: TypeDeclarationNode[]
+  pub enums: EnumDeclarationNode[]
 }
 
 pub enum EnumVariant {
@@ -237,19 +237,19 @@ pub enum EnumVariant {
 }
 
 pub type EnumDeclarationNode {
-  decorators: DecoratorNode[]
-  pubToken: Token?
-  name: Label
-  typeParams: Label[]
-  variants: EnumVariant[]
-  methods: FunctionDeclarationNode[]
-  types: TypeDeclarationNode[]
-  enums: EnumDeclarationNode[]
+  pub decorators: DecoratorNode[]
+  pub pubToken: Token?
+  pub name: Label
+  pub typeParams: Label[]
+  pub variants: EnumVariant[]
+  pub methods: FunctionDeclarationNode[]
+  pub types: TypeDeclarationNode[]
+  pub enums: EnumDeclarationNode[]
 }
 
 pub type DecoratorNode {
-  name: Label
-  arguments: InvocationArgument[]
+  pub name: Label
+  pub arguments: InvocationArgument[]
 }
 
 pub enum AstNodeKind {
@@ -298,7 +298,7 @@ enum ParseErrorKind {
 }
 
 pub type ParseError {
-  position: Position
+  pub position: Position
   kind: ParseErrorKind
 
   func getMessage(self, filePath: String, contents: String): String {

--- a/projects/compiler/src/qbe.abra
+++ b/projects/compiler/src/qbe.abra
@@ -27,7 +27,7 @@ pub type ModuleBuilder {
 
     val block = Block.new(name: name)
 
-    val fn = QbeFunction(exported: exported, name: name, block: block, returnType: returnType, _parameters: [], variadicIdx: None, isVariadic: false, _comments: [], _env: None)
+    val fn = QbeFunction(exported: exported, name: name, block: block, returnType: returnType, _parameters: [], variadicIdx: None, isVariadic: false, _comments: [], env: None)
     self._functions.push(fn)
     self._functionsByName[name] = fn
     fn
@@ -126,7 +126,7 @@ pub type Var {
 
 pub type Block {
   name: String
-  currentLabel: Label
+  pub currentLabel: Label
   body: Instruction[] = []
   labelsByLine: Map<Int, Label[]> = {}
   _usedLabels: Set<Label> = #{}
@@ -750,14 +750,14 @@ pub enum QbeType {
 
 pub type QbeFunction {
   exported: Bool = false
-  name: String
-  block: Block,
-  returnType: QbeType? = None
+  pub name: String
+  pub block: Block,
+  pub returnType: QbeType? = None
   _parameters: (String, QbeType)[] = []
   variadicIdx: Int? = None
-  isVariadic: Bool = false
+  pub isVariadic: Bool = false
   _comments: String[] = []
-  _env: Value? = None
+  pub env: Value? = None
 
   func spec(name: String, returnType: QbeType? = None, parameters: (String, QbeType)[] = [], variadicIdx: Int? = None): QbeFunction {
     QbeFunction(name: name, block: Block.new(name), returnType: returnType, _parameters: parameters, variadicIdx: variadicIdx)
@@ -772,7 +772,7 @@ pub type QbeFunction {
     self.returnType?.encode(file)
     file.write(" \$${self.name}")
     file.write("(")
-    if self._env |env| {
+    if self.env |env| {
       file.write("env ")
       env.encode(file)
       if !self._parameters.isEmpty() file.write(", ")
@@ -810,7 +810,7 @@ pub type QbeFunction {
 
   func addEnv(self): Value {
     val env = Value.Ident("__env__", QbeType.Pointer)
-    self._env = Some(env)
+    self.env = Some(env)
     env
   }
 }

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -10,7 +10,7 @@ enum TokenizeAndParseError {
 }
 
 pub type ModuleLoader {
-  stdRoot: String
+  pub stdRoot: String
   parsedModules: Map<String, ParsedModule> = {}
   _virtualFileSystem: Map<String, String>? = None
 
@@ -103,20 +103,20 @@ pub enum IdentifierMetaModule {
 }
 
 pub type IdentifierMeta {
-  name: String
-  kind: IdentifierKindMeta
-  definitionPosition: (IdentifierMetaModule, Position)? = None
+  pub name: String
+  pub kind: IdentifierKindMeta
+  pub definitionPosition: (IdentifierMetaModule, Position)? = None
 }
 
 pub type TypedModule {
-  id: Int
-  name: String
-  code: TypedAstNode[]
+  pub id: Int
+  pub name: String
+  pub code: TypedAstNode[]
   rootScope: Scope
   complete: Bool = false
   imports: Map<String, ImportedModule> = {}
-  exports: Map<String, Export> = {}
-  identsByLine: Map<Int, (Int, Int, IdentifierMeta)[]> = {}
+  pub exports: Map<String, Export> = {}
+  pub identsByLine: Map<Int, (Int, Int, IdentifierMeta)[]> = {}
 
   func bogus(): TypedModule = TypedModule(id: -1, name: "bogus", code: [], rootScope: Scope.bogus())
 }
@@ -128,14 +128,14 @@ pub enum VariableAlias {
 }
 
 pub type Variable {
-  label: Label
+  pub label: Label
   scope: Scope
-  mutable: Bool
-  ty: Type
-  alias: VariableAlias? = None
-  isExported: Bool = false
-  isParameter: Bool = false
-  isCaptured: Bool = false
+  pub mutable: Bool
+  pub ty: Type
+  pub alias: VariableAlias? = None
+  pub isExported: Bool = false
+  pub isParameter: Bool = false
+  pub isCaptured: Bool = false
 
   func bogus(): Variable {
     val label = Label(name: "_bogus", position: Position.bogus())
@@ -173,15 +173,15 @@ pub enum ScopeKind {
 }
 
 pub type Scope {
-  name: String
-  variables: Variable[] = []
-  functions: Function[] = []
-  types: Type[] = []
+  pub name: String
+  pub variables: Variable[] = []
+  pub functions: Function[] = []
+  pub types: Type[] = []
   structs: Struct[] = []
   enums: Enum[] = []
-  kind: ScopeKind = ScopeKind.Root
-  parent: Scope? = None
-  terminator: Terminator? = None
+  pub kind: ScopeKind = ScopeKind.Root
+  pub parent: Scope? = None
+  pub terminator: Terminator? = None
   numLambdas: Int = 0
 
   func bogus(name = ""): Scope {
@@ -210,21 +210,21 @@ pub enum BuiltinModule {
 }
 
 pub type Field {
-  name: Label
-  ty: Type
-  initializer: TypedAstNode?
-  isPublic: Bool
+  pub name: Label
+  pub ty: Type
+  pub initializer: TypedAstNode?
+  pub isPublic: Bool
 }
 
 pub type Struct {
-  moduleId: Int
-  label: Label
-  scope: Scope
-  typeParams: String[] = []
-  fields: Field[] = []
-  instanceMethods: Function[] = []
-  staticMethods: Function[] = []
-  builtin: BuiltinModule? = None
+  pub moduleId: Int
+  pub label: Label
+  pub scope: Scope
+  pub typeParams: String[] = []
+  pub fields: Field[] = []
+  pub instanceMethods: Function[] = []
+  pub staticMethods: Function[] = []
+  pub builtin: BuiltinModule? = None
 
   // Override eq method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
   func eq(self, other: Struct): Bool = self.moduleId == other.moduleId && self.label == other.label
@@ -263,8 +263,8 @@ pub type Struct {
 }
 
 pub type TypedEnumVariant {
-  label: Label
-  kind: EnumVariantKind
+  pub label: Label
+  pub kind: EnumVariantKind
 }
 
 pub enum EnumVariantKind {
@@ -273,13 +273,13 @@ pub enum EnumVariantKind {
 }
 
 pub type Enum {
-  moduleId: Int
-  label: Label
+  pub moduleId: Int
+  pub label: Label
   scope: Scope
-  typeParams: String[] = []
-  variants: TypedEnumVariant[] = []
-  instanceMethods: Function[] = []
-  staticMethods: Function[] = []
+  pub typeParams: String[] = []
+  pub variants: TypedEnumVariant[] = []
+  pub instanceMethods: Function[] = []
+  pub staticMethods: Function[] = []
   builtin: BuiltinModule? = None
 
   func toString(self): String = "Enum(moduleId: ${self.moduleId}, label: ${self.label})"
@@ -304,18 +304,18 @@ enum Instantiatable {
 
 
 pub type Project {
-  modules: Map<String, TypedModule> = {}
-  preludeScope: Scope = Scope.bogus()
-  preludeIntStruct: Struct = Struct(moduleId: 0, label: Label(name: "Int", position: Position.bogus()), scope: Scope(name: "Int"))
-  preludeFloatStruct: Struct = Struct(moduleId: 0, label: Label(name: "Float", position: Position.bogus()), scope: Scope(name: "Float"))
-  preludeBoolStruct: Struct = Struct(moduleId: 0, label: Label(name: "Bool", position: Position.bogus()), scope: Scope(name: "Bool"))
-  preludeCharStruct: Struct = Struct(moduleId: 0, label: Label(name: "Char", position: Position.bogus()), scope: Scope(name: "Char"))
-  preludeStringStruct: Struct = Struct(moduleId: 0, label: Label(name: "String", position: Position.bogus()), scope: Scope(name: "String"))
-  preludeArrayStruct: Struct = Struct(moduleId: 0, label: Label(name: "Array", position: Position.bogus()), scope: Scope(name: "Array"), typeParams: ["T"])
-  preludeMapStruct: Struct = Struct(moduleId: 0, label: Label(name: "Map", position: Position.bogus()), scope: Scope(name: "Array"), typeParams: ["K", "V"])
-  preludeSetStruct: Struct = Struct(moduleId: 0, label: Label(name: "Set", position: Position.bogus()), scope: Scope(name: "Set"), typeParams: ["T"])
-  preludeOptionEnum: Enum = Enum(moduleId: 0, label: Label(name: "Option", position: Position.bogus()), scope: Scope(name: "Option"), typeParams: ["T"])
-  preludeResultEnum: Enum = Enum(moduleId: 0, label: Label(name: "Result", position: Position.bogus()), scope: Scope(name: "Result"), typeParams: ["V", "E"])
+  pub modules: Map<String, TypedModule> = {}
+  pub preludeScope: Scope = Scope.bogus()
+  pub preludeIntStruct: Struct = Struct(moduleId: 0, label: Label(name: "Int", position: Position.bogus()), scope: Scope(name: "Int"))
+  pub preludeFloatStruct: Struct = Struct(moduleId: 0, label: Label(name: "Float", position: Position.bogus()), scope: Scope(name: "Float"))
+  pub preludeBoolStruct: Struct = Struct(moduleId: 0, label: Label(name: "Bool", position: Position.bogus()), scope: Scope(name: "Bool"))
+  pub preludeCharStruct: Struct = Struct(moduleId: 0, label: Label(name: "Char", position: Position.bogus()), scope: Scope(name: "Char"))
+  pub preludeStringStruct: Struct = Struct(moduleId: 0, label: Label(name: "String", position: Position.bogus()), scope: Scope(name: "String"))
+  pub preludeArrayStruct: Struct = Struct(moduleId: 0, label: Label(name: "Array", position: Position.bogus()), scope: Scope(name: "Array"), typeParams: ["T"])
+  pub preludeMapStruct: Struct = Struct(moduleId: 0, label: Label(name: "Map", position: Position.bogus()), scope: Scope(name: "Array"), typeParams: ["K", "V"])
+  pub preludeSetStruct: Struct = Struct(moduleId: 0, label: Label(name: "Set", position: Position.bogus()), scope: Scope(name: "Set"), typeParams: ["T"])
+  pub preludeOptionEnum: Enum = Enum(moduleId: 0, label: Label(name: "Option", position: Position.bogus()), scope: Scope(name: "Option"), typeParams: ["T"])
+  pub preludeResultEnum: Enum = Enum(moduleId: 0, label: Label(name: "Result", position: Position.bogus()), scope: Scope(name: "Result"), typeParams: ["V", "E"])
 
   func typesAreEquivalent(self, ty: Type, other: Type): Bool {
     match ty.kind {
@@ -404,7 +404,7 @@ pub type Project {
 }
 
 pub type Type {
-  kind: TypeKind
+  pub kind: TypeKind
 
   func repr(self, shorthand = true): String {
     match self.kind {
@@ -644,28 +644,28 @@ pub enum TypeKind {
 }
 
 pub type TypedAstNode {
-  token: Token
-  ty: Type
-  kind: TypedAstNodeKind
+  pub token: Token
+  pub ty: Type
+  pub kind: TypedAstNodeKind
 }
 
 pub type Decorator {
-  label: Label
-  arguments: LiteralAstNode[]
+  pub label: Label
+  pub arguments: LiteralAstNode[]
 }
 
 type TypedBindingDeclarationNode {
-  bindingPattern: BindingPattern
-  variables: Variable[]
-  expr: TypedAstNode?
+  pub bindingPattern: BindingPattern
+  pub variables: Variable[]
+  pub expr: TypedAstNode?
 }
 
 type TypedFunctionParam {
-  label: Label
-  ty: Type
-  defaultValue: TypedAstNode? = None
-  isVariadic: Bool = false
-  variable: Variable
+  pub label: Label
+  pub ty: Type
+  pub defaultValue: TypedAstNode? = None
+  pub isVariadic: Bool = false
+  pub variable: Variable
 }
 
 pub enum FunctionKind {
@@ -675,18 +675,18 @@ pub enum FunctionKind {
 }
 
 pub type Function {
-  label: Label
-  scope: Scope
-  kind: FunctionKind
-  typeParams: (Type, Label)[] = []
-  params: TypedFunctionParam[] = []
-  returnType: Type
-  body: TypedAstNode[] = []
-  isGenerated: Bool = false
+  pub label: Label
+  pub scope: Scope
+  pub kind: FunctionKind
+  pub typeParams: (Type, Label)[] = []
+  pub params: TypedFunctionParam[] = []
+  pub returnType: Type
+  pub body: TypedAstNode[] = []
+  pub isGenerated: Bool = false
   isLambda: Bool = false
-  decorators: Decorator[] = []
-  captures: Variable[] = []
-  capturedClosures: Function[] = []
+  pub decorators: Decorator[] = []
+  pub captures: Variable[] = []
+  pub capturedClosures: Function[] = []
 
   func generated(
     scope: Scope,
@@ -793,17 +793,17 @@ pub enum TypedMatchCaseKind {
 }
 
 pub type TypedMatchCase {
-  kind: TypedMatchCaseKind
-  binding: Variable?
-  body: TypedAstNode[]
-  terminator: Terminator?
+  pub kind: TypedMatchCaseKind
+  pub binding: Variable?
+  pub body: TypedAstNode[]
+  pub terminator: Terminator?
 }
 
 type TypedTryElseClause {
-  pattern: (BindingPattern, Variable[])?
-  errorType: Type
-  block: TypedAstNode[]
-  terminator: Terminator?
+  pub pattern: (BindingPattern, Variable[])?
+  pub errorType: Type
+  pub block: TypedAstNode[]
+  pub terminator: Terminator?
 }
 
 pub enum TypedAstNodeKind {
@@ -853,8 +853,8 @@ pub enum AccessorPathSegment {
 }
 
 type TypecheckerError {
-  modulePath: String
-  kind: TypecheckerErrorKind
+  pub modulePath: String
+  pub kind: TypecheckerErrorKind
 
   func getMessage(self): String {
     match self.kind {
@@ -893,7 +893,7 @@ pub enum TypecheckerErrorKind {
 }
 
 type TypeError {
-  position: Position
+  pub position: Position
   kind: TypeErrorKind
 
   // Note: this is different than `Typechecker#_typeIsOption`, because we don't have access to the Project here to
@@ -976,6 +976,13 @@ type TypeError {
             }
           }
         }
+      }
+      TypeErrorKind.IllegalAccess(name, kind, parentTy) => {
+        lines.push("Illegal access for $kind '$name'")
+        lines.push(self._getCursorLine(self.position, contents))
+
+        val capitalized = kind[0].toUpper() + kind[1:]
+        lines.push("$capitalized '$name' is not marked as 'pub' within type '${parentTy.repr()}'")
       }
       TypeErrorKind.MissingValExpr(name) => {
         if name |name| {
@@ -1466,6 +1473,7 @@ enum TypeErrorKind {
   DuplicateName(original: Label)
   UnknownName(name: String, kind: String)
   UnknownField(ty: Type, name: String, specialCase: UnknownFieldSpecialCase?)
+  IllegalAccess(name: String, kind: String, parentTy: Type)
   MissingValExpr(name: String?)
   MissingVarExprAndTypeAnn(name: String?)
   IllegalNonConstantEnumVariant
@@ -4276,6 +4284,10 @@ pub type Typechecker {
           StructOrEnum.Struct(struct) => {
             for field in struct.fields {
               if field.name.name == label.name {
+                if !field.isPublic && struct.moduleId != self.currentModule.id {
+                  return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAccess(name: field.name.name, kind: "field", parentTy: ty)))
+                }
+
                 val resolvedGenerics: Map<String, Type> = {}
                 for name, idx in struct.typeParams {
                   resolvedGenerics[name] = try generics[idx] else unreachable("typeParams.length != generics.length")

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -4284,8 +4284,12 @@ pub type Typechecker {
           StructOrEnum.Struct(struct) => {
             for field in struct.fields {
               if field.name.name == label.name {
+                // Non-public fields are only allowed to be accessed within the file in which they're defined
                 if !field.isPublic && struct.moduleId != self.currentModule.id {
-                  return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAccess(name: field.name.name, kind: "field", parentTy: ty)))
+                  // For performance reasons, all fields within standard lib modules is visible to each other
+                  if !self.currentModule.name.startsWith(self.moduleLoader.stdRoot) {
+                    return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAccess(name: field.name.name, kind: "field", parentTy: ty)))
+                  }
                 }
 
                 val resolvedGenerics: Map<String, Type> = {}

--- a/projects/compiler/src/typechecker_test_utils.abra
+++ b/projects/compiler/src/typechecker_test_utils.abra
@@ -91,7 +91,6 @@ pub type Jsonifier {
     println("{")
     self.indentInc()
 
-    // self.println("\"nullable\": ${ty.nullable},")
     match ty.kind {
       TypeKind.Any => {
         self.println("\"kind\": \"primitive\",")

--- a/projects/compiler/test/compiler/arrays.abra
+++ b/projects/compiler/test/compiler/arrays.abra
@@ -217,28 +217,28 @@ for ch in ["a", "b", "c"] println(ch)
 (() => {
   val intArr = [1, 2, 3]
   /// Expect: [1, 2, 3] 3 4
-  println(intArr, intArr.length, intArr._capacity)
+  println(intArr, intArr.length, intArr.getCapacity())
   // Pushing beyond the capacity should expand the array
   intArr.push(4)
   intArr.push(5)
   /// Expect: [1, 2, 3, 4, 5] 5 8
-  println(intArr, intArr.length, intArr._capacity)
+  println(intArr, intArr.length, intArr.getCapacity())
 
   // Popping element should leave _capacity
   intArr.pop()
   intArr.pop()
   /// Expect: [1, 2, 3] 3 8
-  println(intArr, intArr.length, intArr._capacity)
+  println(intArr, intArr.length, intArr.getCapacity())
 
   val strArr = ["a", "b", "c"]
   val arrArr = [strArr, strArr]
   /// Expect: [[a, b, c], [a, b, c]] 3 4
-  println(arrArr, strArr.length, strArr._capacity)
+  println(arrArr, strArr.length, strArr.getCapacity())
   // Pushing beyond the capacity should expand the array
   strArr.push("d")
   strArr.push("e")
   /// Expect: [[a, b, c, d, e], [a, b, c, d, e]] 5 8
-  println(arrArr, strArr.length, strArr._capacity)
+  println(arrArr, strArr.length, strArr.getCapacity())
 })()
 
 // Array#pop

--- a/projects/compiler/test/compiler/maps.abra
+++ b/projects/compiler/test/compiler/maps.abra
@@ -18,7 +18,7 @@
   // Forcing a hash-collision
   val m3: Map<Int, String> = Map.new()
   m3.insert(1, "hello")
-  m3.insert(m3._capacity + 1, "world")
+  m3.insert(m3.getCapacity() + 1, "world")
   /// Expect: { 1: hello, 17: world }
   println(m3)
 })()
@@ -269,7 +269,7 @@ for ch, idx in { a: 1, b: 2, c: 3 } { println(ch, idx) }
 
   // Kinda dirty, but needed in order to test removing keys with the same hash
   /// Expect: true
-  println(m._getKeyHash("c", m._entries._capacity) == m._getKeyHash("s", m._entries._capacity))
+  println(m._getKeyHash("c") == m._getKeyHash("s"))
 
   /// Expect: Option.Some(value: 5)
   println(m.remove("s"))
@@ -285,7 +285,7 @@ for ch, idx in { a: 1, b: 2, c: 3 } { println(ch, idx) }
   println(m.size)
 
   /// Expect: true
-  println(m._getKeyHash("d", m._entries._capacity) == m._getKeyHash("t", m._entries._capacity))
+  println(m._getKeyHash("d") == m._getKeyHash("t"))
 
   /// Expect: Option.Some(value: 4)
   println(m.remove("d"))

--- a/projects/compiler/test/compiler/process_callstack.abra
+++ b/projects/compiler/test/compiler/process_callstack.abra
@@ -26,7 +26,7 @@ val arr = [1].map((i, _) => {
 /// Expect:   at baz (%TEST_DIR%/compiler/process_callstack.abra:10)
 /// Expect:   at bar (%TEST_DIR%/compiler/process_callstack.abra:5)
 /// Expect:   at foo (%TEST_DIR%/compiler/process_callstack.abra:19)
-/// Expect:   at <expression> (%STD_DIR%/prelude.abra:780)
+/// Expect:   at <expression> (%STD_DIR%/prelude.abra:784)
 /// Expect:   at Array.map (%TEST_DIR%/compiler/process_callstack.abra:18)
 
 type OneTwoThreeIterator {

--- a/projects/compiler/test/typechecker/import/_exports.abra
+++ b/projects/compiler/test/typechecker/import/_exports.abra
@@ -3,7 +3,7 @@ pub val a = 123
 pub func add(a: Int, b: Int): Int = a + b
 
 pub type Foo {
-  color: Color
+  pub color: Color
 
   func foo(self): Int = 123
 }

--- a/projects/compiler/test/typechecker/import/import.1.out.json
+++ b/projects/compiler/test/typechecker/import/import.1.out.json
@@ -209,13 +209,14 @@
             "typeParams": [],
             "fields": [
               {
-                "name": { "name": "color", "position": [6, 3] },
+                "name": { "name": "color", "position": [6, 7] },
                 "type": {
                   "kind": "enumInstance",
                   "enum": { "moduleId": 3, "name": "Color" },
                   "typeParams": []
                 },
-                "initializer": null
+                "initializer": null,
+                "isPublic": true
               }
             ],
             "instanceMethods": [

--- a/projects/compiler/test/typechecker/import/import.2.out.json
+++ b/projects/compiler/test/typechecker/import/import.2.out.json
@@ -209,13 +209,14 @@
             "typeParams": [],
             "fields": [
               {
-                "name": { "name": "color", "position": [6, 3] },
+                "name": { "name": "color", "position": [6, 7] },
                 "type": {
                   "kind": "enumInstance",
                   "enum": { "moduleId": 3, "name": "Color" },
                   "typeParams": []
                 },
-                "initializer": null
+                "initializer": null,
+                "isPublic": true
               }
             ],
             "instanceMethods": [

--- a/projects/compiler/test/typechecker/import/import_type_identifier.1.out.json
+++ b/projects/compiler/test/typechecker/import/import_type_identifier.1.out.json
@@ -209,13 +209,14 @@
             "typeParams": [],
             "fields": [
               {
-                "name": { "name": "color", "position": [6, 3] },
+                "name": { "name": "color", "position": [6, 7] },
                 "type": {
                   "kind": "enumInstance",
                   "enum": { "moduleId": 3, "name": "Color" },
                   "typeParams": []
                 },
-                "initializer": null
+                "initializer": null,
+                "isPublic": true
               }
             ],
             "instanceMethods": [

--- a/projects/compiler/test/typechecker/import/import_type_identifier.2.out.json
+++ b/projects/compiler/test/typechecker/import/import_type_identifier.2.out.json
@@ -209,13 +209,14 @@
             "typeParams": [],
             "fields": [
               {
-                "name": { "name": "color", "position": [6, 3] },
+                "name": { "name": "color", "position": [6, 7] },
                 "type": {
                   "kind": "enumInstance",
                   "enum": { "moduleId": 3, "name": "Color" },
                   "typeParams": []
                 },
-                "initializer": null
+                "initializer": null,
+                "isPublic": true
               }
             ],
             "instanceMethods": [

--- a/projects/compiler/test/typechecker/lambda/lambda.2.abra
+++ b/projects/compiler/test/typechecker/lambda/lambda.2.abra
@@ -6,7 +6,7 @@ val _: Float[] = arr2
 
 // Test lambdas whose parameter is generic
 func forEach<T>(set: Set<T>, fn: (T) => Unit) {
-  set._map.forEach(key => fn(key))
+  set.forEach(key => fn(key))
 }
 func map<T, U>(arr: T[], fn: (T) => U): U[] {
   val mapped = arr.map(v => fn(v))

--- a/projects/compiler/test/typechecker/lambda/lambda.2.out.json
+++ b/projects/compiler/test/typechecker/lambda/lambda.2.out.json
@@ -584,7 +584,7 @@
           "body": [
             {
               "token": {
-                "position": [9, 19],
+                "position": [9, 14],
                 "kind": {
                   "name": "LParen"
                 }
@@ -611,13 +611,6 @@
                                 "kind": "generic",
                                 "name": "T"
                               }
-                            },
-                            {
-                              "required": true,
-                              "type": {
-                                "kind": "primitive",
-                                "primitive": "Bool"
-                              }
                             }
                           ],
                           "returnType": {
@@ -635,76 +628,32 @@
                   "isOptSafe": false,
                   "self": {
                     "token": {
-                      "position": [9, 19],
+                      "position": [9, 3],
                       "kind": {
-                        "name": "LParen"
+                        "name": "Ident",
+                        "value": "set"
                       }
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 2, "name": "Map" },
+                      "struct": { "moduleId": 2, "name": "Set" },
                       "typeParams": [
                         {
                           "kind": "generic",
                           "name": "T"
-                        },
-                        {
-                          "kind": "primitive",
-                          "primitive": "Bool"
                         }
                       ]
                     },
                     "node": {
-                      "kind": "accessor",
-                      "head": {
-                        "token": {
-                          "position": [9, 3],
-                          "kind": {
-                            "name": "Ident",
-                            "value": "set"
-                          }
-                        },
-                        "type": {
-                          "kind": "instance",
-                          "struct": { "moduleId": 2, "name": "Set" },
-                          "typeParams": [
-                            {
-                              "kind": "generic",
-                              "name": "T"
-                            }
-                          ]
-                        },
-                        "node": {
-                          "kind": "identifier",
-                          "name": "set"
-                        }
-                      },
-                      "middle": [],
-                      "tail": {
-                        "kind": "field",
-                        "name": "_map",
-                        "type": {
-                          "kind": "instance",
-                          "struct": { "moduleId": 2, "name": "Map" },
-                          "typeParams": [
-                            {
-                              "kind": "generic",
-                              "name": "T"
-                            },
-                            {
-                              "kind": "primitive",
-                              "primitive": "Bool"
-                            }
-                          ]
-                        }
-                      }
+                      "kind": "identifier",
+                      "name": "set"
                     }
                   }
                 },
                 "arguments": [
                   {
                     "token": {
-                      "position": [9, 24],
+                      "position": [9, 19],
                       "kind": {
                         "name": "Arrow"
                       }
@@ -728,12 +677,12 @@
                     "node": {
                       "kind": "lambda",
                       "function": {
-                        "label": { "name": "lambda_3_2", "position": [9, 24] },
+                        "label": { "name": "lambda_3_2", "position": [9, 19] },
                         "scope": {
                           "name": "$root::module_3::forEach::lambda_3_2",
                           "variables": [
                             {
-                              "label": { "name": "key", "position": [9, 20] },
+                              "label": { "name": "key", "position": [9, 15] },
                               "mutable": false,
                               "type": {
                                 "kind": "generic",
@@ -748,7 +697,7 @@
                         "typeParameters": [],
                         "parameters": [
                           {
-                            "label": { "name": "key", "position": [9, 20] },
+                            "label": { "name": "key", "position": [9, 15] },
                             "type": {
                               "kind": "generic",
                               "name": "T"
@@ -787,7 +736,7 @@
                         "body": [
                           {
                             "token": {
-                              "position": [9, 29],
+                              "position": [9, 24],
                               "kind": {
                                 "name": "LParen"
                               }
@@ -800,7 +749,7 @@
                               "kind": "invocation",
                               "invokee": {
                                 "token": {
-                                  "position": [9, 27],
+                                  "position": [9, 22],
                                   "kind": {
                                     "name": "Ident",
                                     "value": "fn"
@@ -830,7 +779,7 @@
                               "arguments": [
                                 {
                                   "token": {
-                                    "position": [9, 30],
+                                    "position": [9, 25],
                                     "kind": {
                                       "name": "Ident",
                                       "value": "key"

--- a/projects/lsp/src/lsp_spec.abra
+++ b/projects/lsp/src/lsp_spec.abra
@@ -334,7 +334,7 @@ pub type ServerInfo {
 }
 
 pub type TextDocumentItem {
-  uri: String
+  pub uri: String
   languageId: String
   version: Int
   text: String
@@ -354,7 +354,7 @@ pub type TextDocumentItem {
 }
 
 pub type TextDocumentIdentifier {
-  uri: String
+  pub uri: String
 
   func fromJson(json: JsonValue): Result<TextDocumentIdentifier, JsonError> {
     val obj = try json.asObject()
@@ -365,7 +365,7 @@ pub type TextDocumentIdentifier {
 }
 
 pub type VersionedTextDocumentIdentifier {
-  uri: String
+  pub uri: String
   version: Int
 
   func fromJson(json: JsonValue): Result<VersionedTextDocumentIdentifier, JsonError> {
@@ -382,8 +382,8 @@ pub type VersionedTextDocumentIdentifier {
 
 pub type Position {
   // line and character are both zero-based
-  line: Int
-  character: Int
+  pub line: Int
+  pub character: Int
 
   func fromJson(json: JsonValue): Result<Position, JsonError> {
     val obj = try json.asObject()

--- a/projects/std/src/fs.abra
+++ b/projects/std/src/fs.abra
@@ -9,7 +9,7 @@ pub enum FileIOError {
 }
 
 pub func readFile(path: String): Result<String, FileIOError> {
-  val fd = libc.open(path._buffer, libc.O_RDONLY, 0)
+  val fd = libc.open(path.raw(), libc.O_RDONLY, 0)
   if fd == -1 {
     val errMsg = _strerror(libc.errno())
     return Err(error: FileIOError.CouldNotOpen(message: "Could not open '$path': $errMsg"))
@@ -26,7 +26,7 @@ pub func readFile(path: String): Result<String, FileIOError> {
   }
 
   val str = String.withLength(len)
-  if libc.read(fd, str._buffer, len) == -1 {
+  if libc.read(fd, str.raw(), len) == -1 {
     val errMsg = _strerror(libc.errno())
     return Err(error: FileIOError.CouldNotRead(message: "Could not read '$path': $errMsg"))
   }
@@ -66,18 +66,18 @@ pub type File {
 
   func write(self, str: String) {
     // TODO: handle error here (and also in prelude:stdoutWrite)
-    libc.write(self._fd, str._buffer, str.length)
+    libc.write(self._fd, str.raw(), str.length)
   }
 
   func writeln(self, str: String = "") {
-    if !str.isEmpty() libc.write(self._fd, str._buffer, str.length)
-    libc.write(self._fd, "\n"._buffer, 1)
+    if !str.isEmpty() libc.write(self._fd, str.raw(), str.length)
+    libc.write(self._fd, "\n".raw(), 1)
   }
 }
 
 pub func openFile(path: String, accessMode: AccessMode): Result<File, FileIOError> {
   val oflag = accessMode._toUnderlying()
-  val fd = libc.open(path._buffer, oflag, 0)
+  val fd = libc.open(path.raw(), oflag, 0)
   if fd == -1 {
     val errMsg = _strerror(libc.errno())
     return Err(error: FileIOError.CouldNotOpen(message: "Could not open '$path': $errMsg"))
@@ -90,7 +90,7 @@ pub func createFile(path: String, accessMode: AccessMode): Result<File, FileIOEr
   var oflag = accessMode._toUnderlying() || libc.O_CREAT
 
   val mode = 420 // 420 is 0644, but octal numbers aren't supported yet...
-  val fd = libc.open(path._buffer, oflag, mode)
+  val fd = libc.open(path.raw(), oflag, mode)
   if fd == -1 {
     val errMsg = _strerror(libc.errno())
     return Err(error: FileIOError.CouldNotOpen(message: "Could not open '$path': $errMsg"))
@@ -106,7 +106,7 @@ pub func getCurrentWorkingDirectory(): String {
   val len = libc.strlen(buf)
 
   val str = String.withLength(len)
-  str._buffer.copyFrom(buf, len)
+  str.raw().copyFrom(buf, len)
   str
 }
 
@@ -114,6 +114,6 @@ func _strerror(errno: Int): String {
   val buf = libc.strerror(errno)
   val len = libc.strlen(buf)
   val str = String.withLength(len)
-  str._buffer.copyFrom(buf, len)
+  str.raw().copyFrom(buf, len)
   str
 }

--- a/projects/std/src/fs.abra
+++ b/projects/std/src/fs.abra
@@ -9,7 +9,7 @@ pub enum FileIOError {
 }
 
 pub func readFile(path: String): Result<String, FileIOError> {
-  val fd = libc.open(path.raw(), libc.O_RDONLY, 0)
+  val fd = libc.open(path._buffer, libc.O_RDONLY, 0)
   if fd == -1 {
     val errMsg = _strerror(libc.errno())
     return Err(error: FileIOError.CouldNotOpen(message: "Could not open '$path': $errMsg"))
@@ -26,7 +26,7 @@ pub func readFile(path: String): Result<String, FileIOError> {
   }
 
   val str = String.withLength(len)
-  if libc.read(fd, str.raw(), len) == -1 {
+  if libc.read(fd, str._buffer, len) == -1 {
     val errMsg = _strerror(libc.errno())
     return Err(error: FileIOError.CouldNotRead(message: "Could not read '$path': $errMsg"))
   }
@@ -66,18 +66,18 @@ pub type File {
 
   func write(self, str: String) {
     // TODO: handle error here (and also in prelude:stdoutWrite)
-    libc.write(self._fd, str.raw(), str.length)
+    libc.write(self._fd, str._buffer, str.length)
   }
 
   func writeln(self, str: String = "") {
-    if !str.isEmpty() libc.write(self._fd, str.raw(), str.length)
-    libc.write(self._fd, "\n".raw(), 1)
+    if !str.isEmpty() libc.write(self._fd, str._buffer, str.length)
+    libc.write(self._fd, "\n"._buffer, 1)
   }
 }
 
 pub func openFile(path: String, accessMode: AccessMode): Result<File, FileIOError> {
   val oflag = accessMode._toUnderlying()
-  val fd = libc.open(path.raw(), oflag, 0)
+  val fd = libc.open(path._buffer, oflag, 0)
   if fd == -1 {
     val errMsg = _strerror(libc.errno())
     return Err(error: FileIOError.CouldNotOpen(message: "Could not open '$path': $errMsg"))
@@ -90,7 +90,7 @@ pub func createFile(path: String, accessMode: AccessMode): Result<File, FileIOEr
   var oflag = accessMode._toUnderlying() || libc.O_CREAT
 
   val mode = 420 // 420 is 0644, but octal numbers aren't supported yet...
-  val fd = libc.open(path.raw(), oflag, mode)
+  val fd = libc.open(path._buffer, oflag, mode)
   if fd == -1 {
     val errMsg = _strerror(libc.errno())
     return Err(error: FileIOError.CouldNotOpen(message: "Could not open '$path': $errMsg"))
@@ -106,7 +106,7 @@ pub func getCurrentWorkingDirectory(): String {
   val len = libc.strlen(buf)
 
   val str = String.withLength(len)
-  str.raw().copyFrom(buf, len)
+  str._buffer.copyFrom(buf, len)
   str
 }
 
@@ -114,6 +114,6 @@ func _strerror(errno: Int): String {
   val buf = libc.strerror(errno)
   val len = libc.strlen(buf)
   val str = String.withLength(len)
-  str.raw().copyFrom(buf, len)
+  str._buffer.copyFrom(buf, len)
   str
 }

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -281,7 +281,7 @@ type CharsIterator {
 }
 
 type String {
-  length: Int
+  pub length: Int
   _buffer: Pointer<Byte>
 
   func withLength(length: Int): String {
@@ -341,6 +341,8 @@ type String {
 
     true
   }
+
+  func raw(self): Pointer<Byte> = self._buffer
 
   func isEmpty(self): Bool = self.length == 0
 
@@ -643,7 +645,7 @@ type ArrayIterator<T> {
 }
 
 type Array<T> {
-  length: Int
+  pub length: Int
   _buffer: Pointer<T> = Pointer.null()
   _capacity: Int = 0
 
@@ -735,6 +737,8 @@ type Array<T> {
 
     true
   }
+
+  func getCapacity(self): Int = self._capacity
 
   func isEmpty(self): Bool = self.length == 0
 
@@ -1074,7 +1078,7 @@ type SetIterator<T> {
 }
 
 type Set<T> {
-  size: Int
+  pub size: Int
   _map: Map<T, Bool> = Map.new()
 
   func new<T>(initialCapacity = 16): Set<T> {
@@ -1237,7 +1241,7 @@ type MapIterator<K, V> {
 }
 
 type Map<K, V> {
-  size: Int
+  pub size: Int
   _entries: MapEntry<K, V>[] = []
   _capacity: Int = 16
   _loadFactor: Float = 0.75
@@ -1309,6 +1313,8 @@ type Map<K, V> {
     true
   }
 
+  func getCapacity(self): Int = self._capacity
+
   func isEmpty(self): Bool = self.size == 0
 
   func forEach(self, fn: (K, V) => Unit) {
@@ -1356,7 +1362,7 @@ type Map<K, V> {
     entries
   }
 
-  func _getKeyHash(self, key: K, numEntries: Int): Int = key.hash() && (numEntries - 1)
+  func _getKeyHash(self, key: K, numEntries = self._entries._capacity): Int = key.hash() && (numEntries - 1)
 
   func containsKey(self, key: K): Bool = if self._getEntry(key) true else false
 
@@ -1441,7 +1447,7 @@ type Map<K, V> {
   }
 
   func _getEntry(self, key: K): MapEntry<K, V>? {
-    val hash = self._getKeyHash(key, self._entries._capacity)
+    val hash = self._getKeyHash(key)
 
     val bucketRootEntry = try self._entries[hash]
     if bucketRootEntry._empty return None
@@ -1493,7 +1499,7 @@ type Map<K, V> {
   }
 
   func remove(self, key: K): V? {
-    val hash = self._getKeyHash(key, self._entries._capacity)
+    val hash = self._getKeyHash(key)
 
     val bucketRootEntry = try self._entries[hash]
     if bucketRootEntry._empty return None

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -342,7 +342,7 @@ type String {
     true
   }
 
-  func raw(self): Pointer<Byte> = self._buffer
+  func byteAt(self, offset: Int): Byte = self._buffer.offset(offset).load()
 
   func isEmpty(self): Bool = self.length == 0
 

--- a/projects/std/src/process.abra
+++ b/projects/std/src/process.abra
@@ -21,7 +21,7 @@ pub func args(): String[] {
 }
 
 pub func getEnvVar(name: String): String? {
-  val str = libc.getenv(name.raw())
+  val str = libc.getenv(name._buffer)
   if str.isNullPtr() return None
 
   val len = libc.strlen(str)
@@ -48,7 +48,7 @@ pub func uname(): Uname {
 
   val sysnameLen = libc.strlen(utsnameBuf)
   val sysname = String.withLength(sysnameLen)
-  sysname.raw().copyFrom(utsnameBuf, sysnameLen)
+  sysname._buffer.copyFrom(utsnameBuf, sysnameLen)
 
   // The utsname struct has 5 fields (6 on some platforms), of constant and equal sizes, but the size of
   // each field differs per platform. After extracting the first string, skip over the \0 bytes until we
@@ -63,22 +63,22 @@ pub func uname(): Uname {
 
   val nodenameLen = libc.strlen(utsnameBuf)
   val nodename = String.withLength(nodenameLen)
-  nodename.raw().copyFrom(utsnameBuf, nodenameLen)
+  nodename._buffer.copyFrom(utsnameBuf, nodenameLen)
   utsnameBuf = utsnameBuf.offset(offset)
 
   val releaseLen = libc.strlen(utsnameBuf)
   val release = String.withLength(releaseLen)
-  release.raw().copyFrom(utsnameBuf, releaseLen)
+  release._buffer.copyFrom(utsnameBuf, releaseLen)
   utsnameBuf = utsnameBuf.offset(offset)
 
   val versionLen = libc.strlen(utsnameBuf)
   val version = String.withLength(versionLen)
-  version.raw().copyFrom(utsnameBuf, versionLen)
+  version._buffer.copyFrom(utsnameBuf, versionLen)
   utsnameBuf = utsnameBuf.offset(offset)
 
   val machineLen = libc.strlen(utsnameBuf)
   val machine = String.withLength(machineLen)
-  machine.raw().copyFrom(utsnameBuf, machineLen)
+  machine._buffer.copyFrom(utsnameBuf, machineLen)
 
   val uname = Uname(sysname: sysname, nodename: nodename, release: release, version: version, machine: machine)
   _uname = Some(uname)
@@ -156,7 +156,7 @@ func getModuleNames(): String[] {
       if len == 0 break
 
       val str = String.withLength(len)
-      str.raw().copyFrom(buf.offset(idx - len), len)
+      str._buffer.copyFrom(buf.offset(idx - len), len)
       moduleNames.push(str)
 
       idx += 1
@@ -186,7 +186,7 @@ func getFunctionNames(): String[] {
       if len == 0 break
 
       val str = String.withLength(len)
-      str.raw().copyFrom(buf.offset(idx - len), len)
+      str._buffer.copyFrom(buf.offset(idx - len), len)
       functionNames.push(str)
 
       idx += 1
@@ -210,7 +210,7 @@ type Stdin {
     if nread == 0 return None
 
     val str = String.withLength(nread)
-    str.raw().copyFrom(self._buf, nread)
+    str._buffer.copyFrom(self._buf, nread)
     return Some(str)
   }
 }

--- a/projects/std/src/process.abra
+++ b/projects/std/src/process.abra
@@ -21,7 +21,7 @@ pub func args(): String[] {
 }
 
 pub func getEnvVar(name: String): String? {
-  val str = libc.getenv(name._buffer)
+  val str = libc.getenv(name.raw())
   if str.isNullPtr() return None
 
   val len = libc.strlen(str)
@@ -29,11 +29,11 @@ pub func getEnvVar(name: String): String? {
 }
 
 pub type Uname {
-  sysname: String
-  nodename: String
-  release: String
-  version: String
-  machine: String
+  pub sysname: String
+  pub nodename: String
+  pub release: String
+  pub version: String
+  pub machine: String
 }
 
 var _uname: Uname? = None
@@ -48,7 +48,7 @@ pub func uname(): Uname {
 
   val sysnameLen = libc.strlen(utsnameBuf)
   val sysname = String.withLength(sysnameLen)
-  sysname._buffer.copyFrom(utsnameBuf, sysnameLen)
+  sysname.raw().copyFrom(utsnameBuf, sysnameLen)
 
   // The utsname struct has 5 fields (6 on some platforms), of constant and equal sizes, but the size of
   // each field differs per platform. After extracting the first string, skip over the \0 bytes until we
@@ -63,22 +63,22 @@ pub func uname(): Uname {
 
   val nodenameLen = libc.strlen(utsnameBuf)
   val nodename = String.withLength(nodenameLen)
-  nodename._buffer.copyFrom(utsnameBuf, nodenameLen)
+  nodename.raw().copyFrom(utsnameBuf, nodenameLen)
   utsnameBuf = utsnameBuf.offset(offset)
 
   val releaseLen = libc.strlen(utsnameBuf)
   val release = String.withLength(releaseLen)
-  release._buffer.copyFrom(utsnameBuf, releaseLen)
+  release.raw().copyFrom(utsnameBuf, releaseLen)
   utsnameBuf = utsnameBuf.offset(offset)
 
   val versionLen = libc.strlen(utsnameBuf)
   val version = String.withLength(versionLen)
-  version._buffer.copyFrom(utsnameBuf, versionLen)
+  version.raw().copyFrom(utsnameBuf, versionLen)
   utsnameBuf = utsnameBuf.offset(offset)
 
   val machineLen = libc.strlen(utsnameBuf)
   val machine = String.withLength(machineLen)
-  machine._buffer.copyFrom(utsnameBuf, machineLen)
+  machine.raw().copyFrom(utsnameBuf, machineLen)
 
   val uname = Uname(sysname: sysname, nodename: nodename, release: release, version: version, machine: machine)
   _uname = Some(uname)
@@ -156,7 +156,7 @@ func getModuleNames(): String[] {
       if len == 0 break
 
       val str = String.withLength(len)
-      str._buffer.copyFrom(buf.offset(idx - len), len)
+      str.raw().copyFrom(buf.offset(idx - len), len)
       moduleNames.push(str)
 
       idx += 1
@@ -186,7 +186,7 @@ func getFunctionNames(): String[] {
       if len == 0 break
 
       val str = String.withLength(len)
-      str._buffer.copyFrom(buf.offset(idx - len), len)
+      str.raw().copyFrom(buf.offset(idx - len), len)
       functionNames.push(str)
 
       idx += 1
@@ -210,7 +210,7 @@ type Stdin {
     if nread == 0 return None
 
     val str = String.withLength(nread)
-    str._buffer.copyFrom(self._buf, nread)
+    str.raw().copyFrom(self._buf, nread)
     return Some(str)
   }
 }


### PR DESCRIPTION
Ensure that a non-`pub` field on a type cannot be accessed outside of the module (file) in which it was defined.

This involved a lot of changes across a ton of files in order to maintain compliance. There will be even more things that change once methods' visibility with `pub` are also enforced.