### PR TITLE
Visibility modifiers for methods

### DIFF
--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -9,7 +9,7 @@ type CompilationError {
   modulePath: String
   error: CompileError
 
-  func getMessage(self): String {
+  pub func getMessage(self): String {
     val contents = match fs.readFile(self.modulePath) {
       Ok(v) => v
       Err => return "Could not read file '${self.modulePath}'"
@@ -183,7 +183,7 @@ pub type Compiler {
   _functionStructs: Map<String, (Struct, Function)> = {}
   _aliasedTypeNames: Map<String, String> = {}
 
-  func compile(project: Project): Result<ModuleBuilder, CompilationError> {
+  pub func compile(project: Project): Result<ModuleBuilder, CompilationError> {
     val builder = ModuleBuilder()
 
     val mainFn = builder.buildFunction(name: "main", returnType: Some(QbeType.U32), exported: true)

--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -4,7 +4,7 @@ pub type Position {
   pub line: Int
   pub col: Int
 
-  func bogus(): Position = Position(line: 0, col: 0)
+  pub func bogus(): Position = Position(line: 0, col: 0)
 }
 
 pub type Token {
@@ -89,7 +89,7 @@ pub enum TokenKind {
   QuestionDot
   At
 
-  func repr(self): String = match self {
+  pub func repr(self): String = match self {
     TokenKind.Int => "int"
     TokenKind.Float => "float"
     TokenKind.Bool(value) => value.toString()
@@ -180,7 +180,7 @@ pub type LexerError {
   pub position: Position
   kind: LexerErrorKind
 
-  func getMessage(self, filePath: String, contents: String): String {
+  pub func getMessage(self, filePath: String, contents: String): String {
     val lines = ["Error at $filePath:${self.position.line}:${self.position.col}"]
 
     match self.kind {
@@ -236,7 +236,7 @@ pub type Lexer {
   _line: Int = 1
   _col: Int = 1
 
-  func tokenize(contents: String): Result<Token[], LexerError> {
+  pub func tokenize(contents: String): Result<Token[], LexerError> {
     val tokens: Token[] = []
 
     val lexer = Lexer(_input: contents)

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -56,7 +56,7 @@ pub enum BinaryOp {
   GTE
   Shr
 
-  func repr(self): String = match self {
+  pub func repr(self): String = match self {
     BinaryOp.Add => "+"
     BinaryOp.Sub => "-"
     BinaryOp.Mul => "*"
@@ -129,7 +129,7 @@ pub type InvocationArgument {
   pub label: Label?
   pub value: AstNode
 
-  func position(self): Position = self.label?.position ?: self.value.token.position
+  pub func position(self): Position = self.label?.position ?: self.value.token.position
 }
 
 pub type InvocationAstNode {
@@ -175,7 +175,7 @@ pub enum BindingPattern {
   Variable(label: Label)
   Tuple(lParenTok: Token, patterns: BindingPattern[])
 
-  func position(self): Position {
+  pub func position(self): Position {
     match self {
       BindingPattern.Variable(label) => label.position
       BindingPattern.Tuple(lParenTok, _) => lParenTok.position
@@ -301,7 +301,7 @@ pub type ParseError {
   pub position: Position
   kind: ParseErrorKind
 
-  func getMessage(self, filePath: String, contents: String): String {
+  pub func getMessage(self, filePath: String, contents: String): String {
     val lines = ["Error at $filePath:${self.position.line}:${self.position.col}"]
 
     match self.kind {
@@ -354,7 +354,7 @@ pub type Parser {
   _seenDecorators: DecoratorNode[] = []
   _pubToken: Token? = None
 
-  func parse(tokens: Token[]): Result<ParsedModule, ParseError> {
+  pub func parse(tokens: Token[]): Result<ParsedModule, ParseError> {
     val parser = Parser(_tokens: tokens)
 
     val imports: ImportNode[] = []
@@ -741,10 +741,14 @@ pub type Parser {
           fieldPubToken = None
         }
         TokenKind.Pub => {
-          if fieldPubToken |token| {
-            return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], nextToken.kind)))
+          if fieldPubToken |token| return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken([TokenKind.Ident("")], nextToken.kind)))
+
+          // If the token after 'pub' is an identifier, consume 'pub'. Otherwise leave it and it'll be picked up while parsing inner decls
+          match self._peek(ahead: 1)?.kind {
+            TokenKind.Ident => self._advance()
+            else => break
           }
-          self._advance() // consume 'pub' token
+
           fieldPubToken = Some(nextToken)
         }
         _ => break

--- a/projects/compiler/src/qbe.abra
+++ b/projects/compiler/src/qbe.abra
@@ -7,7 +7,7 @@ pub type ModuleBuilder {
   _functions: QbeFunction[] = []
   _functionsByName: Map<String, QbeFunction> = {}
 
-  func writeToFile(self, file: File) {
+  pub func writeToFile(self, file: File) {
     for data, idx in self._data {
       data.encode(file)
       file.writeln()
@@ -20,9 +20,9 @@ pub type ModuleBuilder {
     }
   }
 
-  func getFunction(self, name: String): QbeFunction? = self._functionsByName[name]
+  pub func getFunction(self, name: String): QbeFunction? = self._functionsByName[name]
 
-  func buildFunction(self, name: String, returnType: QbeType?, exported = false): QbeFunction {
+  pub func buildFunction(self, name: String, returnType: QbeType?, exported = false): QbeFunction {
     if self._functionsByName[name] |fn| return fn
 
     val block = Block.new(name: name)
@@ -33,7 +33,7 @@ pub type ModuleBuilder {
     fn
   }
 
-  func buildGlobalString(self, string: String, name: String? = None): Value {
+  pub func buildGlobalString(self, string: String, name: String? = None): Value {
     if self._globalStrs[string] |ptr| return ptr
 
     val dataName = name ?: "_${self._data.length}"
@@ -44,9 +44,9 @@ pub type ModuleBuilder {
     ptr
   }
 
-  func getData(self, name: String): Value? = self._dataByName[name]
+  pub func getData(self, name: String): Value? = self._dataByName[name]
 
-  func addData(self, data: QbeData): (Value, Int) {
+  pub func addData(self, data: QbeData): (Value, Int) {
     val idx = self._data.length
     self._data.push(data)
     val dataGlobal = Value.Global(data.name, QbeType.Pointer)
@@ -54,7 +54,7 @@ pub type ModuleBuilder {
     (dataGlobal, idx)
   }
 
-  func setData(self, idx: Int, newData: QbeDataKind) {
+  pub func setData(self, idx: Int, newData: QbeDataKind) {
     if self._data[idx] |data| {
       data.kind = newData
     }
@@ -163,7 +163,7 @@ pub type Block {
     self.body.push(instr)
   }
 
-  func verify(self): Result<Int, String> {
+  pub func verify(self): Result<Int, String> {
     val errors: String[] = []
     for label in self._usedLabels {
       if !label.offset {
@@ -188,12 +188,12 @@ pub type Block {
     comments.insert(comment)
   }
 
-  func addComment(self, comment: String) = self._addComment(comment)
+  pub func addComment(self, comment: String) = self._addComment(comment)
 
   // todo: ew
-  func addCommentBefore(self, comment: String, numBack = 1) = self._addComment(comment, if self.body.length - numBack < 0 { 0 } else { self.body.length - numBack })
+  pub func addCommentBefore(self, comment: String, numBack = 1) = self._addComment(comment, if self.body.length - numBack < 0 { 0 } else { self.body.length - numBack })
 
-  func addLabel(self, name: String): Label {
+  pub func addLabel(self, name: String): Label {
     if self._labelNames[name] |count| {
       self._labelNames[name] = count + 1
       Label(name: "${name}_$count")
@@ -203,7 +203,7 @@ pub type Block {
     }
   }
 
-  func registerLabel(self, label: Label): Result<Label, String> {
+  pub func registerLabel(self, label: Label): Result<Label, String> {
     if label.offset |offset| return Err("Label ${label.name} already registered with offset $offset")
 
     val offset = self.body.length
@@ -216,7 +216,7 @@ pub type Block {
     Ok(label)
   }
 
-  func addVar(self, v: Var, name: String? = None): String {
+  pub func addVar(self, v: Var, name: String? = None): String {
     val varsForName = self.variables.getOrInsert(v.name, () => ({}))
 
     val varName = name ?: "${v.name}.${varsForName.size}.slot"
@@ -224,11 +224,11 @@ pub type Block {
     varName
   }
 
-  func lookupVarName(self, v: Var): String? = if self.variables[v.name] |varsForName| varsForName[v] else None
+  pub func lookupVarName(self, v: Var): String? = if self.variables[v.name] |varsForName| varsForName[v] else None
 
   // instruction builders
 
-  func buildAdd(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildAdd(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'add' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -241,7 +241,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildSub(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildSub(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'sub' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -254,7 +254,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildDiv(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildDiv(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'div' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -267,7 +267,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildMul(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildMul(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'mul' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -280,7 +280,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildNeg(self, expr: Value, dst: String? = None): Result<Value, String> {
+  pub func buildNeg(self, expr: Value, dst: String? = None): Result<Value, String> {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, expr.ty())
 
@@ -289,7 +289,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildRem(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildRem(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'rem' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -302,7 +302,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildAnd(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildAnd(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'and' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -315,7 +315,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildOr(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildOr(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'or' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -328,7 +328,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildXor(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildXor(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'xor' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -341,7 +341,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildShl(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildShl(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'shl' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -354,7 +354,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildShr(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildShr(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'shr' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else lty
@@ -367,7 +367,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildAlloc4(self, size: Int, dst: String? = None): Value {
+  pub func buildAlloc4(self, size: Int, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.Pointer)
 
@@ -376,7 +376,7 @@ pub type Block {
     local
   }
 
-  func buildAlloc8(self, size: Int, dst: String? = None): Value {
+  pub func buildAlloc8(self, size: Int, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.Pointer)
 
@@ -385,7 +385,7 @@ pub type Block {
     local
   }
 
-  func buildLToF(self, v: Value, signed = true, dst: String? = None): Value {
+  pub func buildLToF(self, v: Value, signed = true, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.F64)
 
@@ -394,7 +394,7 @@ pub type Block {
     local
   }
 
-  func buildCompareEq(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildCompareEq(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'ceqw' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else QbeType.U32
@@ -407,7 +407,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildCompareNeq(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildCompareNeq(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'cnew' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else QbeType.U32
@@ -420,7 +420,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildCompareLt(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildCompareLt(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'lt' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else QbeType.U32
@@ -433,7 +433,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildCompareLte(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildCompareLte(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'lte' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else QbeType.U32
@@ -446,7 +446,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildCompareGt(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildCompareGt(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'gt' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else QbeType.U32
@@ -459,7 +459,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildCompareGte(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
+  pub func buildCompareGte(self, left: Value, right: Value, dst: String? = None): Result<Value, String> {
     val lty = left.ty()
     val rty = right.ty()
     val resTy = if lty.repr() != rty.repr() return Err("incompatible types for 'gte' instruction: ${lty.repr()}, ${rty.repr()} ($left, $right)") else QbeType.U32
@@ -472,7 +472,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildLoad(self, ty: QbeType, mem: Value, dst: String? = None): Value {
+  pub func buildLoad(self, ty: QbeType, mem: Value, dst: String? = None): Value {
     match ty {
       QbeType.U8 => self.buildLoadB(mem, dst)
       QbeType.U16 => self.buildLoadW(mem, dst)
@@ -491,7 +491,7 @@ pub type Block {
     }
   }
 
-  func buildLoadB(self, mem: Value, dst: String? = None): Value {
+  pub func buildLoadB(self, mem: Value, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.U64)
 
@@ -501,7 +501,7 @@ pub type Block {
     local
   }
 
-  func buildLoadW(self, mem: Value, dst: String? = None): Value {
+  pub func buildLoadW(self, mem: Value, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.U32)
 
@@ -511,7 +511,7 @@ pub type Block {
     local
   }
 
-  func buildLoadL(self, mem: Value, dst: String? = None): Value {
+  pub func buildLoadL(self, mem: Value, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.U64)
 
@@ -520,7 +520,7 @@ pub type Block {
     local
   }
 
-  func buildLoadS(self, mem: Value, dst: String? = None): Value {
+  pub func buildLoadS(self, mem: Value, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.F32)
 
@@ -529,7 +529,7 @@ pub type Block {
     local
   }
 
-  func buildLoadD(self, mem: Value, dst: String? = None): Value {
+  pub func buildLoadD(self, mem: Value, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.F64)
 
@@ -538,7 +538,7 @@ pub type Block {
     local
   }
 
-  func buildStore(self, ty: QbeType, value: Value, mem: Value) {
+  pub func buildStore(self, ty: QbeType, value: Value, mem: Value) {
     match ty {
       QbeType.U8 => self.buildStoreB(value, mem)
       QbeType.U16 => self.buildStoreW(value, mem)
@@ -550,29 +550,29 @@ pub type Block {
     }
   }
 
-  func buildStoreB(self, value: Value, mem: Value) {
+  pub func buildStoreB(self, value: Value, mem: Value) {
     // TODO: condense these methods into one which automatically switches on the type of `value`
     self.append(Instruction.StoreB(value: value, mem: mem))
   }
 
-  func buildStoreW(self, value: Value, mem: Value) {
+  pub func buildStoreW(self, value: Value, mem: Value) {
     // TODO: condense these methods into one which automatically switches on the type of `value`
     self.append(Instruction.StoreW(value: value, mem: mem))
   }
 
-  func buildStoreL(self, value: Value, mem: Value) {
+  pub func buildStoreL(self, value: Value, mem: Value) {
     self.append(Instruction.StoreL(value: value, mem: mem))
   }
 
-  func buildStoreS(self, value: Value, mem: Value) {
+  pub func buildStoreS(self, value: Value, mem: Value) {
     self.append(Instruction.StoreS(value: value, mem: mem))
   }
 
-  func buildStoreD(self, value: Value, mem: Value) {
+  pub func buildStoreD(self, value: Value, mem: Value) {
     self.append(Instruction.StoreD(value: value, mem: mem))
   }
 
-  func buildExt(self, value: Value, signed = true, dst: String? = None): Value {
+  pub func buildExt(self, value: Value, signed = true, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.U64)
 
@@ -581,7 +581,7 @@ pub type Block {
     local
   }
 
-  func buildFToL(self, v: Value, signed = true, dst: String? = None): Value {
+  pub func buildFToL(self, v: Value, signed = true, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.U64)
 
@@ -590,7 +590,7 @@ pub type Block {
     local
   }
 
-  func buildCastD(self, value: Value, dst: String? = None): Value {
+  pub func buildCastD(self, value: Value, dst: String? = None): Value {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, QbeType.U64)
 
@@ -599,7 +599,7 @@ pub type Block {
     local
   }
 
-  func buildCall(self, callable: Callable, arguments: Value[], dst: String? = None, envPtr: Value? = None): Result<Value, String> {
+  pub func buildCall(self, callable: Callable, arguments: Value[], dst: String? = None, envPtr: Value? = None): Result<Value, String> {
     val dest = dst ?: self._nextLocal()
 
     val returnType = match callable {
@@ -628,7 +628,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildCallRaw(self, fnName: String, returnType: QbeType, arguments: Value[], dst: String? = None): Result<Value, String> {
+  pub func buildCallRaw(self, fnName: String, returnType: QbeType, arguments: Value[], dst: String? = None): Result<Value, String> {
     val dest = dst ?: self._nextLocal()
     val local = Value.Ident(dest, returnType)
 
@@ -637,7 +637,7 @@ pub type Block {
     Ok(local)
   }
 
-  func buildVoidCall(self, callable: Callable, arguments: Value[], envPtr: Value? = None) {
+  pub func buildVoidCall(self, callable: Callable, arguments: Value[], envPtr: Value? = None) {
     match callable {
       Callable.Function(fn) => {
         val fnIdent = Value.Global(fn.name, QbeType.Pointer)
@@ -653,11 +653,11 @@ pub type Block {
     }
   }
 
-  func buildVoidCallRaw(self, fnName: String, arguments: Value[]) {
+  pub func buildVoidCallRaw(self, fnName: String, arguments: Value[]) {
     self.append(Instruction.Call(dst: None, fn: Value.Global(fnName, QbeType.Pointer), args: arguments, env: None))
   }
 
-  func buildPhi(self, cases: (Label, Value)[], dst: String? = None): Result<Value, String> {
+  pub func buildPhi(self, cases: (Label, Value)[], dst: String? = None): Result<Value, String> {
     var ty = if cases[0] |(_, value)| value.ty() else return Err("phi requires at least 1 label")
     for (label, value) in cases {
       if ty != value.ty() return Err("phi case type mismatch: @${label.name} (type: ${value.ty()}) doesn't match previous (type: $ty)")
@@ -673,22 +673,22 @@ pub type Block {
     Ok(local)
   }
 
-  func buildJmp(self, label: Label) {
+  pub func buildJmp(self, label: Label) {
     self._usedLabels.insert(label)
     self.append(Instruction.Jmp(label))
   }
 
-  func buildJnz(self, cond: Value, ifNonZero: Label, ifZero: Label) {
+  pub func buildJnz(self, cond: Value, ifNonZero: Label, ifZero: Label) {
     self._usedLabels.insert(ifNonZero)
     self._usedLabels.insert(ifZero)
     self.append(Instruction.Jnz(cond, ifNonZero, ifZero))
   }
 
-  func buildReturn(self, value: Value? = None) {
+  pub func buildReturn(self, value: Value? = None) {
     self.append(Instruction.Return(value))
   }
 
-  func buildHalt(self) {
+  pub func buildHalt(self) {
     self.append(Instruction.Hlt)
   }
 }
@@ -707,7 +707,7 @@ pub enum QbeType {
   F32     // 's'
   F64     // 'd'
 
-  func size(self): Int {
+  pub func size(self): Int {
     match self {
       QbeType.U8 => 1
       QbeType.U16 => 2
@@ -731,7 +731,7 @@ pub enum QbeType {
     }
   }
 
-  func zeroValue(self): Value {
+  pub func zeroValue(self): Value {
     match self {
       QbeType.U8 => Value.Int32(0)
       QbeType.U16 => Value.Int32(0)
@@ -759,7 +759,7 @@ pub type QbeFunction {
   _comments: String[] = []
   pub env: Value? = None
 
-  func spec(name: String, returnType: QbeType? = None, parameters: (String, QbeType)[] = [], variadicIdx: Int? = None): QbeFunction {
+  pub func spec(name: String, returnType: QbeType? = None, parameters: (String, QbeType)[] = [], variadicIdx: Int? = None): QbeFunction {
     QbeFunction(name: name, block: Block.new(name), returnType: returnType, _parameters: parameters, variadicIdx: variadicIdx)
   }
 
@@ -795,20 +795,20 @@ pub type QbeFunction {
     file.writeln("}")
   }
 
-  func addComment(self, comment: String) {
+  pub func addComment(self, comment: String) {
     self._comments.push(comment)
   }
 
-  func addCommentMultiline(self, comment: String[]) {
+  pub func addCommentMultiline(self, comment: String[]) {
     for line in comment self._comments.push(line)
   }
 
-  func addParameter(self, name: String, ty: QbeType): Value {
+  pub func addParameter(self, name: String, ty: QbeType): Value {
     self._parameters.push((name, ty))
     Value.Ident(name, ty)
   }
 
-  func addEnv(self): Value {
+  pub func addEnv(self): Value {
     val env = Value.Ident("__env__", QbeType.Pointer)
     self.env = Some(env)
     env
@@ -834,7 +834,7 @@ pub enum Value {
     }
   }
 
-  func ty(self): QbeType = match self {
+  pub func ty(self): QbeType = match self {
       Value.Ident(_, ty) => ty
       Value.Global(_, ty) => ty
       Value.Int32 => QbeType.U32
@@ -843,7 +843,7 @@ pub enum Value {
       Value.Float => QbeType.F64
   }
 
-  func repr(self): String {
+  pub func repr(self): String {
     match self {
       Value.Ident(name, _) => "%$name"
       Value.Global(name, _) => "\$$name"

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -28,7 +28,7 @@ pub type ModuleLoader {
 
   func hasSeenModule(self, modulePathAbs: String): Bool = self.parsedModules.containsKey(modulePathAbs)
 
-  func invalidateModule(self, modulePathAbs: String) {
+  pub func invalidateModule(self, modulePathAbs: String) {
     self.parsedModules.remove(modulePathAbs)
   }
 
@@ -142,7 +142,7 @@ pub type Variable {
     Variable(label: label, scope: Scope.bogus(), mutable: false, ty: Type(kind: TypeKind.Never))
   }
 
-  func isGlobal(self): Int? = match self.scope.kind { ScopeKind.Module(id, _) => Some(id), _ => None }
+  pub func isGlobal(self): Int? = match self.scope.kind { ScopeKind.Module(id, _) => Some(id), _ => None }
 }
 
 pub enum Terminator {
@@ -184,14 +184,14 @@ pub type Scope {
   pub terminator: Terminator? = None
   numLambdas: Int = 0
 
-  func bogus(name = ""): Scope {
+  pub func bogus(name = ""): Scope {
     val scopeName = if name == "" "bogus" else "bogus($name)"
     Scope(name: scopeName)
   }
 
-  func eq(self, other: Scope): Bool = self.name == other.name
+  pub func eq(self, other: Scope): Bool = self.name == other.name
 
-  func makeChild(self, name: String, kind: ScopeKind): Scope = Scope(name: "${self.name}::$name", kind: kind, parent: Some(self))
+  pub func makeChild(self, name: String, kind: ScopeKind): Scope = Scope(name: "${self.name}::$name", kind: kind, parent: Some(self))
 
   func contains(self, other: Scope): Bool {
     var child = Some(other)
@@ -226,18 +226,7 @@ pub type Struct {
   pub staticMethods: Function[] = []
   pub builtin: BuiltinModule? = None
 
-  // Override eq method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
-  func eq(self, other: Struct): Bool = self.moduleId == other.moduleId && self.label == other.label
-
-  // Override hash method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
-  func hash(self): Int = self.moduleId + self.label.hash() * 17
-
-  func asInstanceType(self): Type {
-    val typeArgs = self.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
-    Type(kind: TypeKind.Instance(StructOrEnum.Struct(self), typeArgs))
-  }
-
-  func makeDummy(moduleId: Int, name: String, typeParams: String[] = [], fields: (String, Type)[] = []): Struct {
+  pub func makeDummy(moduleId: Int, name: String, typeParams: String[] = [], fields: (String, Type)[] = []): Struct {
     val bogusPosition = Position.bogus()
     val bogusScope = Scope.bogus(name)
 
@@ -259,6 +248,17 @@ pub type Struct {
     struct.instanceMethods.push(Function.generated(bogusScope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(structOrEnum), true)))
 
     struct
+  }
+
+  // Override eq method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
+  pub func eq(self, other: Struct): Bool = self.moduleId == other.moduleId && self.label == other.label
+
+  // Override hash method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
+  pub func hash(self): Int = self.moduleId + self.label.hash() * 17
+
+  func asInstanceType(self): Type {
+    val typeArgs = self.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
+    Type(kind: TypeKind.Instance(StructOrEnum.Struct(self), typeArgs))
   }
 }
 
@@ -317,7 +317,7 @@ pub type Project {
   pub preludeOptionEnum: Enum = Enum(moduleId: 0, label: Label(name: "Option", position: Position.bogus()), scope: Scope(name: "Option"), typeParams: ["T"])
   pub preludeResultEnum: Enum = Enum(moduleId: 0, label: Label(name: "Result", position: Position.bogus()), scope: Scope(name: "Result"), typeParams: ["V", "E"])
 
-  func typesAreEquivalent(self, ty: Type, other: Type): Bool {
+  pub func typesAreEquivalent(self, ty: Type, other: Type): Bool {
     match ty.kind {
       TypeKind.Hole => other.kind == TypeKind.Hole
       TypeKind.Generic(n1) => match other.kind {
@@ -406,7 +406,7 @@ pub type Project {
 pub type Type {
   pub kind: TypeKind
 
-  func repr(self, shorthand = true): String {
+  pub func repr(self, shorthand = true): String {
     match self.kind {
       TypeKind.Any => "Any"
       TypeKind.PrimitiveUnit => "Unit"
@@ -606,7 +606,7 @@ pub type Type {
     true
   }
 
-  func extractGenerics(self, template: Type): (String, Type)[] {
+  pub func extractGenerics(self, template: Type): (String, Type)[] {
     val extracted: (String, Type)[] = []
     if !self._extractGenerics(template, extracted) return []
 
@@ -688,7 +688,7 @@ pub type Function {
   pub captures: Variable[] = []
   pub capturedClosures: Function[] = []
 
-  func generated(
+  pub func generated(
     scope: Scope,
     name: String,
     params: (String, Type)[],
@@ -736,7 +736,7 @@ pub type Function {
     Function(label: variantLabel, scope: fnScope, kind: FunctionKind.Standalone, typeParams: typeParams, params: params, returnType: returnType, body: [], isGenerated: true)
   }
 
-  func getType(self): Type = Type(kind: TypeKind.Func(paramTypes: self.params.map(p => (p.ty, !p.defaultValue)), returnType: self.returnType))
+  pub func getType(self): Type = Type(kind: TypeKind.Func(paramTypes: self.params.map(p => (p.ty, !p.defaultValue)), returnType: self.returnType))
 
   func withSubstitutedGenerics(self, resolvedGenerics: Map<String, Type>, retainUnknown: Bool, genericsInScope: Set<String>): Function {
     val params = self.params.map(p => {
@@ -761,7 +761,7 @@ pub type Function {
     )
   }
 
-  func isClosure(self): Bool = !self.captures.isEmpty() || !self.capturedClosures.isEmpty()
+  pub func isClosure(self): Bool = !self.captures.isEmpty() || !self.capturedClosures.isEmpty()
 }
 
 pub enum TypedInvokee {
@@ -856,7 +856,7 @@ type TypecheckerError {
   pub modulePath: String
   pub kind: TypecheckerErrorKind
 
-  func getMessage(self): String {
+  pub func getMessage(self): String {
     match self.kind {
       // TODO: Better error message, once imports are a thing
       TypecheckerErrorKind.ReadFileError(path) => "Could not read file '$path'"
@@ -913,7 +913,7 @@ type TypeError {
     }
   }
 
-  func getMessage(self, filePath: String, contents: String): String {
+  pub func getMessage(self, filePath: String, contents: String): String {
     val lines = ["Error at $filePath:${self.position.line}:${self.position.col}"]
 
     match self.kind {
@@ -1539,7 +1539,7 @@ pub type Typechecker {
   pub lspMode: Bool = false
   identsByLine: Map<Int, (Int, Int, IdentifierMeta)[]> = {}
 
-  func typecheckEntrypoint(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
+  pub func typecheckEntrypoint(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
     val preludeModulePathSegs = getAbsolutePath(self.moduleLoader.stdRoot + "/prelude.abra")
     val preludeModulePathAbs = "/" + preludeModulePathSegs.join("/")
 
@@ -4290,7 +4290,7 @@ pub type Typechecker {
       TypeKind.Never => None
       TypeKind.Generic => self._resolveAccessorPathSegmentAny(label, optSafe, typeHint)
       TypeKind.Instance(structOrEnum, generics) => {
-        val (instanceMethods, typeParams) = match structOrEnum {
+        val (instanceMethods, typeParams, instanceTypeModuleId) = match structOrEnum {
           StructOrEnum.Struct(struct) => {
             for field in struct.fields {
               if field.name.name == label.name {
@@ -4310,13 +4310,21 @@ pub type Typechecker {
               }
             }
 
-            (struct.instanceMethods, struct.typeParams)
+            (struct.instanceMethods, struct.typeParams, struct.moduleId)
           }
-          StructOrEnum.Enum(enum_) => (enum_.instanceMethods, enum_.typeParams)
+          StructOrEnum.Enum(enum_) => (enum_.instanceMethods, enum_.typeParams, enum_.moduleId)
         }
 
         for fn in instanceMethods {
           if fn.label.name == label.name {
+            val isPublic = match fn.kind {
+              FunctionKind.InstanceMethod(_, isPublic) => isPublic
+              else => unreachable("Function '${fn.label.name}' should be an instance method here")
+            }
+            if !isPublic && self._isIllegalAccessForMember(instanceTypeModuleId) {
+              return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAccess(name: fn.label.name, kind: "method", parentTy: ty)))
+            }
+
             val resolvedGenerics: Map<String, Type> = {}
             for name, idx in typeParams {
               resolvedGenerics[name] = try generics[idx] else unreachable("typeParams.length != generics.length")
@@ -4333,8 +4341,8 @@ pub type Typechecker {
       TypeKind.Type(structOrEnum) => {
         // TODO: static fields
 
-        val staticMethods = match structOrEnum {
-          StructOrEnum.Struct(struct) => struct.staticMethods
+        val (staticMethods, typeModuleId) = match structOrEnum {
+          StructOrEnum.Struct(struct) => (struct.staticMethods, struct.moduleId)
           StructOrEnum.Enum(enum_) => {
             for variant in enum_.variants {
               if variant.label.name == label.name {
@@ -4350,15 +4358,12 @@ pub type Typechecker {
                   template.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
                 } else {
                   match variant.kind {
-                    EnumVariantKind.Container => {
-                      Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
-                    }
-                    EnumVariantKind.Constant => {
-                      Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), enum_.typeParams.map(() => Type(kind: TypeKind.Hole))))
-                    }
+                    EnumVariantKind.Container => Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
+                    EnumVariantKind.Constant => Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), enum_.typeParams.map(() => Type(kind: TypeKind.Hole))))
                   }
                 }
 
+                // TODO: move this above, to bail earlier?
                 match variant.kind {
                   EnumVariantKind.Container => {
                     if !self.isEnumContainerValueAllowed return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalNonConstantEnumVariant))
@@ -4370,12 +4375,22 @@ pub type Typechecker {
               }
             }
 
-            enum_.staticMethods
+            (enum_.staticMethods, enum_.moduleId)
           }
         }
 
         for method in staticMethods {
-          if method.label.name == label.name return Ok(Some(AccessorPathSegment.Method(label, method, optSafe, typeHint)))
+          if method.label.name == label.name {
+            val isPublic = match method.kind {
+              FunctionKind.StaticMethod(_, isPublic) => isPublic
+              else => unreachable("Function '${method.label.name}' should be a static method here")
+            }
+            if !isPublic && self._isIllegalAccessForMember(typeModuleId) {
+              return Err(TypeError(position: label.position, kind: TypeErrorKind.IllegalAccess(name: method.label.name, kind: "static method", parentTy: ty)))
+            }
+
+            return Ok(Some(AccessorPathSegment.Method(label, method, optSafe, typeHint)))
+          }
         }
 
         None

--- a/projects/compiler/src/typechecker_test_utils.abra
+++ b/projects/compiler/src/typechecker_test_utils.abra
@@ -5,7 +5,7 @@ import printTokenAsJson, printLabelAsJson, printBindingPatternAsJson from "./tes
 pub type Jsonifier {
   indentLevel: Int = 0
 
-  func printModules(self, modules: TypedModule[]) {
+  pub func printModules(self, modules: TypedModule[]) {
     val manyModules = modules.length > 1
 
     if manyModules {

--- a/projects/lsp/src/language_service.abra
+++ b/projects/lsp/src/language_service.abra
@@ -14,7 +14,7 @@ pub type AbraLanguageService {
   _initialized: Bool = false
   _root: String = ""
 
-  func new(abraStdRoot: String): AbraLanguageService {
+  pub func new(abraStdRoot: String): AbraLanguageService {
     // val virtualFileSystem: Map<String, String> = {}
     // val moduleLoader = ModuleLoader.usingVirtualFileSystem(stdRoot: abraStdRoot, fileMap: virtualFileSystem)
     val moduleLoader = ModuleLoader(stdRoot: abraStdRoot)
@@ -324,7 +324,7 @@ pub type AbraLanguageService {
 
   // Dispatch
 
-  func handleRequest(self, req: RequestMessage): ResponseMessage {
+  pub func handleRequest(self, req: RequestMessage): ResponseMessage {
     match req {
       RequestMessage.Initialize(id, processId, rootPath) => self._initialize(id, processId, rootPath)
       RequestMessage.Hover(id, textDocument, position) => self._hover(id, textDocument, position)
@@ -332,7 +332,7 @@ pub type AbraLanguageService {
     }
   }
 
-  func handleNotification(self, req: NotificationMessage) {
+  pub func handleNotification(self, req: NotificationMessage) {
     match req {
       NotificationMessage.Initialized => { /* no-op */ }
       NotificationMessage.TextDocumentDidOpen(textDocument) => self._textDocumentDidOpen(textDocument)
@@ -341,7 +341,7 @@ pub type AbraLanguageService {
     }
   }
 
-  func sendResponse(self, res: ResponseMessage) {
+  pub func sendResponse(self, res: ResponseMessage) {
     self._sendJson(res.toJson())
   }
 

--- a/projects/lsp/src/lsp_spec.abra
+++ b/projects/lsp/src/lsp_spec.abra
@@ -6,7 +6,7 @@ pub enum RequestMessage {
   Hover(id: Int, textDocument: TextDocumentIdentifier, position: Position)
   Definition(id: Int, textDocument: TextDocumentIdentifier, position: Position)
 
-  func fromJson(json: JsonValue): Result<RequestMessage?, JsonError> {
+  pub func fromJson(json: JsonValue): Result<RequestMessage?, JsonError> {
     val obj = try json.asObject()
     val id = match try obj.getNumberRequired("id") {
       Either.Left(int) => int
@@ -66,7 +66,7 @@ pub enum NotificationMessage {
   // Outgoing notifications
   TextDocumentPublishDiagnostics(uri: String, diagnostics: Diagnostic[])
 
-  func fromJson(json: JsonValue): Result<NotificationMessage?, JsonError> {
+  pub func fromJson(json: JsonValue): Result<NotificationMessage?, JsonError> {
     val obj = try json.asObject()
     val method = try obj.getStringRequired("method")
 
@@ -107,7 +107,7 @@ pub enum NotificationMessage {
     }
   }
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     match self {
       NotificationMessage.Initialized => unreachable("should not be serializing 'initialized' notification")
       NotificationMessage.TextDocumentDidOpen => unreachable("should not be serializing 'textDocument/didOpen' notification")
@@ -130,7 +130,7 @@ pub enum ResponseMessage {
   Success(id: Int, result: ResponseResult?)
   Error(id: Int, error: ResponseError)
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     val obj = JsonObject()
 
     match self {
@@ -155,7 +155,7 @@ pub enum ResponseResult {
   // Note: the actual response body for textDocument/definition requests is just a `Location` type, which is flattened here
   Definition(uri: String, range: Range)
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     val obj = match self {
       ResponseResult.Initialize(capabilities, serverInfo) => {
         JsonObject.of({
@@ -190,7 +190,7 @@ pub type ResponseError {
   pub code: ResponseErrorCode
   pub message: String
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     val obj = JsonObject()
 
     obj.set("code", JsonValue.Number(Either.Left(self.code.intVal())))
@@ -234,7 +234,7 @@ pub type ServerCapabilities {
   pub hoverProvider: Bool? = None
   pub definitionProvider: Bool? = None
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     val obj = JsonObject()
 
     if self.textDocumentSync |tds| {
@@ -262,7 +262,7 @@ pub type TextDocumentSyncOptions {
   pub change: TextDocumentSyncKind? = None
   pub save: SaveOptions? = None
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     val obj = JsonObject()
 
     if self.openClose |openClose| {
@@ -296,7 +296,7 @@ pub enum TextDocumentSyncKind {
 pub type SaveOptions {
   pub includeText: Bool? = None
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     val obj = JsonObject()
 
     if self.includeText |includeText| {
@@ -311,7 +311,7 @@ pub type DiagnosticOptions {
   pub interFileDependencies: Bool
   pub workspaceDiagnostics: Bool
 
-  func toJson(self): JsonValue = JsonValue.Object(JsonObject.of({
+  pub func toJson(self): JsonValue = JsonValue.Object(JsonObject.of({
     interFileDependencies: JsonValue.Boolean(self.interFileDependencies),
     workspaceDiagnostics: JsonValue.Boolean(self.workspaceDiagnostics),
   }))
@@ -321,7 +321,7 @@ pub type ServerInfo {
   pub name: String
   pub version: String? = None
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     val obj = JsonObject()
 
     obj.set("name", JsonValue.String(self.name))
@@ -399,7 +399,7 @@ pub type Position {
     Ok(Position(line: line, character: character))
   }
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     JsonValue.Object(JsonObject.of({
       line: JsonValue.Number(Either.Left(self.line)),
       character: JsonValue.Number(Either.Left(self.character)),
@@ -421,7 +421,7 @@ pub type Range {
     Ok(Range(start: start, end: end))
   }
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     JsonValue.Object(JsonObject.of({
       start: self.start.toJson(),
       end: self.end.toJson(),
@@ -453,7 +453,7 @@ pub type Diagnostic {
   pub severity: DiagnosticSeverity? = None
   pub message: String
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     val obj = JsonObject()
 
     obj.set("range", JsonValue.Object(JsonObject.of({
@@ -495,7 +495,7 @@ pub type MarkupContent {
   pub kind: MarkupKind
   pub value: String
 
-  func toJson(self): JsonValue {
+  pub func toJson(self): JsonValue {
     JsonValue.Object(JsonObject.of({
       kind: JsonValue.String(match self.kind {
         MarkupKind.PlainText => "plaintext"

--- a/projects/std/src/fs.abra
+++ b/projects/std/src/fs.abra
@@ -55,7 +55,7 @@ pub type File {
   accessMode: AccessMode
   path: String
 
-  func close(self): Result<Int, FileIOError> {
+  pub func close(self): Result<Int, FileIOError> {
     if libc.close(self._fd) == -1 {
       val errMsg = _strerror(libc.errno())
       return Err(error: FileIOError.CouldNotClose(message: "Could not close '${self.path}': $errMsg"))
@@ -64,12 +64,12 @@ pub type File {
     Ok(self._fd)
   }
 
-  func write(self, str: String) {
+  pub func write(self, str: String) {
     // TODO: handle error here (and also in prelude:stdoutWrite)
     libc.write(self._fd, str._buffer, str.length)
   }
 
-  func writeln(self, str: String = "") {
+  pub func writeln(self, str: String = "") {
     if !str.isEmpty() libc.write(self._fd, str._buffer, str.length)
     libc.write(self._fd, "\n"._buffer, 1)
   }

--- a/projects/std/src/json.abra
+++ b/projects/std/src/json.abra
@@ -6,7 +6,7 @@ pub enum JsonValue {
   Array(items: JsonValue[])
   Object(obj: JsonObject)
 
-  func encode(self): String {
+  pub func encode(self): String {
     match self {
       JsonValue.Null => "null"
       JsonValue.Number(value) => match value {
@@ -61,7 +61,7 @@ pub enum JsonValue {
     else => Err(JsonError.TypeMismatch(expected: JsonValueKind.Array, actual: self.kind()))
   }
 
-  func asObject(self): Result<JsonObject, JsonError> = match self {
+  pub func asObject(self): Result<JsonObject, JsonError> = match self {
     JsonValue.Object(v) => Ok(v)
     else => Err(JsonError.TypeMismatch(expected: JsonValueKind.Object, actual: self.kind()))
   }
@@ -75,19 +75,20 @@ pub enum JsonError {
 pub type JsonObject {
   _map: Map<String, JsonValue> = {}
 
-  func of(items: Map<String, JsonValue>): JsonObject {
+  pub func of(items: Map<String, JsonValue>): JsonObject {
     JsonObject(_map: items)
   }
 
-  func set(self, key: String, value: JsonValue) {
+  pub func set(self, key: String, value: JsonValue) {
     self._map[key] = value
   }
 
-  func getValueRequired(self, key: String): Result<JsonValue, JsonError> =
+  pub func getValueRequired(self, key: String): Result<JsonValue, JsonError> =
     if self._map[key] |v| Ok(v) else Err(JsonError.NoSuchKey(key))
-  func getValue(self, key: String): JsonValue? = self._map[key]
 
-  func getNumberRequired(self, key: String): Result<Either<Int, Float>, JsonError> {
+  pub func getValue(self, key: String): JsonValue? = self._map[key]
+
+  pub func getNumberRequired(self, key: String): Result<Either<Int, Float>, JsonError> {
     match self._map[key] {
       None => Err(JsonError.NoSuchKey(key))
       JsonValue.Number(v) => Ok(v)
@@ -95,10 +96,10 @@ pub type JsonObject {
     }
   }
 
-  func getNumber(self, key: String): Either<Int, Float>? =
+  pub func getNumber(self, key: String): Either<Int, Float>? =
     match self.getNumberRequired(key) { Ok(v) => Some(v), Err => None }
 
-  func getStringRequired(self, key: String): Result<String, JsonError> {
+  pub func getStringRequired(self, key: String): Result<String, JsonError> {
     match self._map[key] {
       None => Err(JsonError.NoSuchKey(key))
       JsonValue.String(v) => Ok(v)
@@ -106,10 +107,10 @@ pub type JsonObject {
     }
   }
 
-  func getString(self, key: String): String? =
+  pub func getString(self, key: String): String? =
     match self.getStringRequired(key) { Ok(v) => Some(v), Err => None }
 
-  func getBooleanRequired(self, key: String): Result<Bool, JsonError> {
+  pub func getBooleanRequired(self, key: String): Result<Bool, JsonError> {
     match self._map[key] {
       None => Err(JsonError.NoSuchKey(key))
       JsonValue.Boolean(v) => Ok(v)
@@ -117,7 +118,10 @@ pub type JsonObject {
     }
   }
 
-  func getArrayRequired(self, key: String): Result<JsonValue[], JsonError> {
+  pub func getBoolean(self, key: String): Bool? =
+    match self.getBooleanRequired(key) { Ok(v) => Some(v), Err => None }
+
+  pub func getArrayRequired(self, key: String): Result<JsonValue[], JsonError> {
     match self._map[key] {
       None => Err(JsonError.NoSuchKey(key))
       JsonValue.Array(v) => Ok(v)
@@ -125,7 +129,10 @@ pub type JsonObject {
     }
   }
 
-  func getObjectRequired(self, key: String): Result<JsonObject, JsonError> {
+  pub func getArray(self, key: String): JsonValue[]? =
+    match self.getArrayRequired(key) { Ok(v) => Some(v), Err => None }
+
+  pub func getObjectRequired(self, key: String): Result<JsonObject, JsonError> {
     match self._map[key] {
       None => Err(JsonError.NoSuchKey(key))
       JsonValue.Object(v) => Ok(v)
@@ -133,7 +140,7 @@ pub type JsonObject {
     }
   }
 
-  func getObject(self, key: String): JsonObject? =
+  pub func getObject(self, key: String): JsonObject? =
     match self.getObjectRequired(key) { Ok(v) => Some(v), Err => None }
 }
 
@@ -162,7 +169,7 @@ pub enum JsonParseError {
 pub type JsonParser {
   _chars: CharsIterator
 
-  func parseString(string: String): Result<JsonValue, JsonParseError> {
+  pub func parseString(string: String): Result<JsonValue, JsonParseError> {
     val charsIter = string.chars()
     val parser = JsonParser(_chars: charsIter)
 

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -33,8 +33,8 @@ pub enum Result<V, E> {
   Ok(value: V)
   Err(error: E)
 
-  func map<U>(self, fn: (V) => U): Result<U, E> = match self { Ok(v) => Ok(fn(v)), Err(e) => Err(e) }
-  func mapErr<F>(self, fn: (E) => F): Result<V, F> = match self { Ok(v) => Ok(v), Err(e) => Err(fn(e)) }
+  pub func map<U>(self, fn: (V) => U): Result<U, E> = match self { Ok(v) => Ok(fn(v)), Err(e) => Err(e) }
+  pub func mapErr<F>(self, fn: (E) => F): Result<V, F> = match self { Ok(v) => Ok(v), Err(e) => Err(fn(e)) }
 }
 
 func Ok<V, E>(value: V): Result<V, E> = Result.Ok(value)
@@ -51,7 +51,7 @@ type RangeIterator {
   stepBy: Int
   _i: Int = 0
 
-  func next(self): Int? {
+  pub func next(self): Int? {
     val offset = self._i * self.stepBy
     if self.start + offset >= self.end {
       None
@@ -62,16 +62,16 @@ type RangeIterator {
   }
 }
 
-func range(start: Int, end: Int, stepBy = 1): RangeIterator = RangeIterator(start: start, end: end, stepBy: stepBy)
+pub func range(start: Int, end: Int, stepBy = 1): RangeIterator = RangeIterator(start: start, end: end, stepBy: stepBy)
 
 type Int {
-  func asByte(self): Byte = Byte.fromInt(self)
+  pub func asByte(self): Byte = Byte.fromInt(self)
 
-  func asFloat(self): Float = intrinsics.intAsFloat(self)
+  pub func asFloat(self): Float = intrinsics.intAsFloat(self)
 
-  func abs(self): Int = if self < 0 { -self } else { self }
+  pub func abs(self): Int = if self < 0 { -self } else { self }
 
-  func asBase(self, base: Int): String? {
+  pub func asBase(self, base: Int): String? {
     if self == 0 return Some("0")
 
     if !((2 <= base && base <= 36) || base == 62) return None
@@ -107,15 +107,15 @@ type Int {
     Some(str)
   }
 
-  func binary(self): String = "0b" + (self.asBase(2) ?: "")
+  pub func binary(self): String = "0b" + (self.asBase(2) ?: "")
 
-  func hex(self): String = "0x" + (self.asBase(16) ?: "")
+  pub func hex(self): String = "0x" + (self.asBase(16) ?: "")
 
-  func isEven(self): Bool = self % 2 == 0
+  pub func isEven(self): Bool = self % 2 == 0
 
-  func isOdd(self): Bool = self % 2 != 0
+  pub func isOdd(self): Bool = self % 2 != 0
 
-  func isBetween(self, lower: Int, upper: Int, inclusive = false): Bool {
+  pub func isBetween(self, lower: Int, upper: Int, inclusive = false): Bool {
     if inclusive {
       lower <= self && self <= upper
     } else {
@@ -123,7 +123,7 @@ type Int {
     }
   }
 
-  func nextPowerOf2(self): Int {
+  pub func nextPowerOf2(self): Int {
     var pow = 1
     while pow < self {
       pow = pow << 1
@@ -131,21 +131,21 @@ type Int {
     pow
   }
 
-  func unsignedToString(self): String = intrinsics.u64ToString(self)
+  pub func unsignedToString(self): String = intrinsics.u64ToString(self)
 }
 
 type Float {
-  func asInt(self): Int = intrinsics.floatAsInt(self)
+  pub func asInt(self): Int = intrinsics.floatAsInt(self)
 
-  func abs(self): Float = if self < 0.0 { -self } else { self }
+  pub func abs(self): Float = if self < 0.0 { -self } else { self }
 
-  func floor(self): Int = intrinsics.floor(self)
+  pub func floor(self): Int = intrinsics.floor(self)
 
-  func ceil(self): Int = intrinsics.ceil(self)
+  pub func ceil(self): Int = intrinsics.ceil(self)
 
-  func round(self): Int = intrinsics.round(self)
+  pub func round(self): Int = intrinsics.round(self)
 
-  func withPrecision(self, precision: Int): Float {
+  pub func withPrecision(self, precision: Int): Float {
     if precision < 0 return self
     if precision == 0 return intrinsics.round(self).asFloat()
 
@@ -159,9 +159,9 @@ type Bool {
 }
 
 type Char {
-  func fromInt(value: Int): Char = intrinsics.intAsChar(value)
+  pub func fromInt(value: Int): Char = intrinsics.intAsChar(value)
 
-  func toString(self): String {
+  pub func toString(self): String {
     val byteVals = self.bytes()
     if byteVals.isEmpty() return "�"
 
@@ -174,9 +174,9 @@ type Char {
     str
   }
 
-  func asInt(self): Int = intrinsics.charAsInt(self)
+  pub func asInt(self): Int = intrinsics.charAsInt(self)
 
-  func bytes(self): Int[] {
+  pub func bytes(self): Int[] {
     val value = self.asInt()
 
     if !(value.isBetween(0, 0xD7FF, true) || value.isBetween(0xE000, 0x10FFFF, true)) return []
@@ -203,17 +203,17 @@ type Char {
     }
   }
 
-  func isDigit(self): Bool {
+  pub func isDigit(self): Bool {
     val ch = self.asInt()
     48 <= ch && ch <= 57
   }
 
-  func isAlpha(self): Bool {
+  pub func isAlpha(self): Bool {
     val ch = self.asInt()
     (65 <= ch && ch <= 90) || (97 <= ch && ch <= 122)
   }
 
-  func isAlphanumeric(self): Bool {
+  pub func isAlphanumeric(self): Bool {
     val ch = self.asInt()
     (48 <= ch && ch <= 57) || (65 <= ch && ch <= 90) || (97 <= ch && ch <= 122)
   }
@@ -225,7 +225,7 @@ type CharsIterator {
   _i: Int = 0
   _peekChar: Char? = None
 
-  func peek(self): Char? {
+  pub func peek(self): Char? {
     if self._peekChar return self._peekChar
 
     val peekChar = self._decodeChar()
@@ -233,7 +233,7 @@ type CharsIterator {
     peekChar
   }
 
-  func next(self): Char? {
+  pub func next(self): Char? {
     if self._peekChar {
       val peekChar = self._peekChar
       self._peekChar = None
@@ -284,14 +284,14 @@ type String {
   pub length: Int
   _buffer: Pointer<Byte>
 
-  func withLength(length: Int): String {
+  pub func withLength(length: Int): String {
     // Allocate length + 1 bytes; each String ends in a \0 byte. Even though we know the length, and memory-based
     // operations on a String instance should always use the length field, it should still always be the case that
     // `libc.strlen(self._buffer)` is equal to `self.length`.
     String(length: length, _buffer: Pointer.malloc(length + 1))
   }
 
-  func random(length: Int, choices = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"): String {
+  pub func random(length: Int, choices = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"): String {
     // TODO: this implementation is pretty bad, and it also relies on using `%` with libc.rand() which allows for skew.
     //       But it's fine for now.
 
@@ -305,7 +305,7 @@ type String {
     str
   }
 
-  func fromChars(chars: Char[]): String {
+  pub func fromChars(chars: Char[]): String {
     val bytes: Int[] = []
     for ch in chars {
       for b in ch.bytes() bytes.push(b)
@@ -321,7 +321,7 @@ type String {
     str
   }
 
-  func hash(self): Int {
+  pub func hash(self): Int {
     var hash = 31 * self.length
     for i in range(0, self.length) {
       val byte = self._buffer.offset(i).load()
@@ -330,7 +330,7 @@ type String {
     hash
   }
 
-  func eq(self, other: String): Bool {
+  pub func eq(self, other: String): Bool {
     if self.length != other.length { return false }
 
     for i in range(0, self.length) {
@@ -342,11 +342,11 @@ type String {
     true
   }
 
-  func byteAt(self, offset: Int): Byte = self._buffer.offset(offset).load()
+  pub func byteAt(self, offset: Int): Byte = self._buffer.offset(offset).load()
 
-  func isEmpty(self): Bool = self.length == 0
+  pub func isEmpty(self): Bool = self.length == 0
 
-  func toLower(self): String {
+  pub func toLower(self): String {
     val str = String.withLength(self.length)
     for i in range(0, self.length) {
       val ch = self._buffer.offset(i).load().asInt()
@@ -361,7 +361,7 @@ type String {
     str
   }
 
-  func toUpper(self): String {
+  pub func toUpper(self): String {
     val str = String.withLength(self.length)
     for i in range(0, self.length) {
       val ch = self._buffer.offset(i).load().asInt()
@@ -376,7 +376,7 @@ type String {
     str
   }
 
-  func isDigit(self): Bool {
+  pub func isDigit(self): Bool {
     // TODO: This method shouldn't be an instance method of String, but we don't have Chars yet so it'll have to do
     if self.length != 1 return false
 
@@ -384,7 +384,7 @@ type String {
     48 <= ch && ch <= 57
   }
 
-  func isAlpha(self): Bool {
+  pub func isAlpha(self): Bool {
     // TODO: This method shouldn't be an instance method of String, but we don't have Chars yet so it'll have to do
     if self.length != 1 return false
 
@@ -392,7 +392,7 @@ type String {
     (65 <= ch && ch <= 90) || (97 <= ch && ch <= 122)
   }
 
-  func isAlphanumeric(self): Bool {
+  pub func isAlphanumeric(self): Bool {
     // TODO: This method shouldn't be an instance method of String, but we don't have Chars yet so it'll have to do
 
     if self.length != 1 return false
@@ -403,7 +403,7 @@ type String {
 
   @Stub func padLeft(self, totalSize: Int, padding = " "): String
 
-  func trim(self): String {
+  pub func trim(self): String {
     var i = 0
     while i < self.length {
       val char = Char.fromInt(self._buffer.offset(i).load().asInt())
@@ -430,7 +430,7 @@ type String {
   @Stub func trimStart(self, pattern: String = ""): String
   @Stub func trimEnd(self, pattern: String = ""): String
 
-  func split(self, by = ""): String[] {
+  pub func split(self, by = ""): String[] {
     if by.isEmpty() {
       val arr: String[] = Array.withCapacity(self.length)
       var i = 0
@@ -481,9 +481,9 @@ type String {
 
   @Stub func splitAt(self, index: Int): (String, String)
 
-  func lines(self): String[] = self.split(by: "\n")
+  pub func lines(self): String[] = self.split(by: "\n")
 
-  func parseInt(self, radix = 10): Int? {
+  pub func parseInt(self, radix = 10): Int? {
     if radix != 10 todo("parsing non-decimal integer")
 
     var num = 0
@@ -499,7 +499,7 @@ type String {
 
   @Stub func parseFloat(self): Float?
 
-  func startsWith(self, prefix: String): Bool {
+  pub func startsWith(self, prefix: String): Bool {
     if self.length < prefix.length return false
     if prefix.isEmpty() return true
 
@@ -514,7 +514,7 @@ type String {
     true
   }
 
-  func endsWith(self, suffix: String): Bool {
+  pub func endsWith(self, suffix: String): Bool {
     if self.length < suffix.length return false
     if suffix.isEmpty() return true
 
@@ -530,7 +530,7 @@ type String {
     true
   }
 
-  func concat<T>(self, suffix: T, *others: Any[]): String {
+  pub func concat<T>(self, suffix: T, *others: Any[]): String {
     val suffixStr = suffix.toString()
     val othersRepr = others.join()
     var newLength = self.length + suffixStr.length + othersRepr.length
@@ -548,7 +548,7 @@ type String {
     newString
   }
 
-  func replaceAll(self, pattern: String, replacement: String): String {
+  pub func replaceAll(self, pattern: String, replacement: String): String {
     if pattern.isEmpty() && replacement.isEmpty() return self
 
     var cursor = 0
@@ -598,9 +598,9 @@ type String {
     newString
   }
 
-  func chars(self): CharsIterator = CharsIterator(_bytes: self._buffer, _numBytes: self.length)
+  pub func chars(self): CharsIterator = CharsIterator(_bytes: self._buffer, _numBytes: self.length)
 
-  func get(self, index: Int): String {
+  pub func get(self, index: Int): String {
     var idx = if index < 0 index + self.length else index
     if idx >= self.length || idx < 0 { return "" }
 
@@ -609,7 +609,7 @@ type String {
     str
   }
 
-  func getRange(self, startIndex = 0, endIndex = self.length): String {
+  pub func getRange(self, startIndex = 0, endIndex = self.length): String {
     val start = if startIndex < 0 startIndex + self.length else startIndex
     val end = if endIndex > self.length self.length else endIndex
     val length = end - start
@@ -619,7 +619,7 @@ type String {
     subString
   }
 
-  func repeat(self, times: Int): String {
+  pub func repeat(self, times: Int): String {
     if times <= 0 return ""
 
     val str = String.withLength(self.length * times)
@@ -634,7 +634,7 @@ type ArrayIterator<T> {
   array: Array<T>
   _i: Int = 0
 
-  func next(self): T? {
+  pub func next(self): T? {
     if self.array[self._i] |item| {
       self._i += 1
       Some(item)
@@ -649,12 +649,12 @@ type Array<T> {
   _buffer: Pointer<T> = Pointer.null()
   _capacity: Int = 0
 
-  func withCapacity<T>(initialCapacity: Int): T[] {
+  pub func withCapacity<T>(initialCapacity: Int): T[] {
     val capacity = if initialCapacity == 0 16 else initialCapacity
     Array(length: 0, _buffer: Pointer.malloc(capacity), _capacity: capacity)
   }
 
-  func fill<T>(length: Int, value: T): T[] {
+  pub func fill<T>(length: Int, value: T): T[] {
     val buffer = Pointer.malloc<T>(length)
     for i in range(0, length) {
       buffer.offset(i).store(value)
@@ -663,7 +663,7 @@ type Array<T> {
     Array(length: length, _buffer: buffer, _capacity: length)
   }
 
-  func fillBy<T>(length: Int, fn: (Int) => T): T[] {
+  pub func fillBy<T>(length: Int, fn: (Int) => T): T[] {
     val buffer = Pointer.malloc<T>(length)
     for i in range(0, length) {
       val item = fn(i)
@@ -673,7 +673,7 @@ type Array<T> {
     Array(length: length, _buffer: buffer, _capacity: length)
   }
 
-  func toString(self): String {
+  pub func toString(self): String {
     if self.isEmpty() return "[]"
 
     val reprs: String[] = Array.withCapacity(self.length)
@@ -716,7 +716,7 @@ type Array<T> {
     str
   }
 
-  func hash(self): Int {
+  pub func hash(self): Int {
     var hash = 31 * self.length
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
@@ -725,7 +725,7 @@ type Array<T> {
     hash
   }
 
-  func eq(self, other: Array<T>): Bool {
+  pub func eq(self, other: Array<T>): Bool {
     if self.length != other.length return false
 
     for i in range(0, self.length) {
@@ -738,13 +738,13 @@ type Array<T> {
     true
   }
 
-  func getCapacity(self): Int = self._capacity
+  pub func getCapacity(self): Int = self._capacity
 
-  func isEmpty(self): Bool = self.length == 0
+  pub func isEmpty(self): Bool = self.length == 0
 
-  func iterator(self): ArrayIterator<T> = ArrayIterator(array: self)
+  pub func iterator(self): ArrayIterator<T> = ArrayIterator(array: self)
 
-  func push(self, item: T) {
+  pub func push(self, item: T) {
     if self.length == self._capacity {
       self._capacity *= 2
 
@@ -755,7 +755,7 @@ type Array<T> {
     self.length += 1
   }
 
-  func pop(self): T? {
+  pub func pop(self): T? {
     if self.length == 0 {
       None
     } else {
@@ -767,7 +767,7 @@ type Array<T> {
   @Stub func popFront(self): T?
   @Stub func splitAt(self, index: Int): (T[], T[])
 
-  func concat(self, other: T[]): T[] {
+  pub func concat(self, other: T[]): T[] {
     val newArray: T[] = Array.withCapacity(self.length + other.length)
     newArray._buffer.copyFrom(self._buffer, self.length)
     newArray._buffer
@@ -777,7 +777,7 @@ type Array<T> {
     newArray
   }
 
-  func map<U>(self, fn: (T, Int) => U): U[] {
+  pub func map<U>(self, fn: (T, Int) => U): U[] {
     val newArray: U[] = Array.withCapacity(self.length)
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
@@ -788,7 +788,7 @@ type Array<T> {
     newArray
   }
 
-  func flatMap<U>(self, fn: (T, Int) => U[]): U[] {
+  pub func flatMap<U>(self, fn: (T, Int) => U[]): U[] {
     val newArray: U[] = Array.withCapacity(self.length)
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
@@ -801,7 +801,7 @@ type Array<T> {
     newArray
   }
 
-  func filter(self, fn: (T, Int) => Bool): T[] {
+  pub func filter(self, fn: (T, Int) => Bool): T[] {
     val newArray: T[] = Array.withCapacity(self.length)
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
@@ -813,7 +813,7 @@ type Array<T> {
     newArray
   }
 
-  func reduce<U>(self, initialValue: U, fn: (U, T, Int) => U): U {
+  pub func reduce<U>(self, initialValue: U, fn: (U, T, Int) => U): U {
     var acc = initialValue
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
@@ -823,14 +823,14 @@ type Array<T> {
     acc
   }
 
-  func forEach(self, fn: (T, Int) => Unit) {
+  pub func forEach(self, fn: (T, Int) => Unit) {
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
       fn(item, i)
     }
   }
 
-  func join(self, joiner = ""): String {
+  pub func join(self, joiner = ""): String {
     val reprs: String[] = Array.withCapacity(self.length)
     var length = 0
     for i in range(0, self.length) {
@@ -858,7 +858,7 @@ type Array<T> {
     str
   }
 
-  func contains(self, item: T): Bool {
+  pub func contains(self, item: T): Bool {
     for i in range(0, self.length) {
       val selfItem = self._buffer.offset(i).load()
       if selfItem == item return true
@@ -867,7 +867,7 @@ type Array<T> {
     false
   }
 
-  func find(self, fn: (T) => Bool): T? {
+  pub func find(self, fn: (T) => Bool): T? {
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
       if fn(item) return Some(item)
@@ -876,7 +876,7 @@ type Array<T> {
     None
   }
 
-  func findIndex(self, fn: (T) => Bool): (T, Int)? {
+  pub func findIndex(self, fn: (T) => Bool): (T, Int)? {
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
       if fn(item) return Some((item, i))
@@ -885,7 +885,7 @@ type Array<T> {
     None
   }
 
-  func any(self, fn: (T) => Bool): Bool {
+  pub func any(self, fn: (T) => Bool): Bool {
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
       if fn(item) return true
@@ -894,7 +894,7 @@ type Array<T> {
     false
   }
 
-  func all(self, fn: (T) => Bool): Bool {
+  pub func all(self, fn: (T) => Bool): Bool {
     for i in range(0, self.length) {
       val item = self._buffer.offset(i).load()
       if !fn(item) return false
@@ -939,7 +939,7 @@ type Array<T> {
     -1
   }
 
-  func sortBy(self, fn: (T) => Int, reverse = false): T[] {
+  pub func sortBy(self, fn: (T) => Int, reverse = false): T[] {
     val factor = if reverse { -1 } else { 1 }
 
     val arr: (Int, T)[] = Array.withCapacity(self.length)
@@ -971,7 +971,7 @@ type Array<T> {
   @Stub func tally(self): Map<T, Int>
   @Stub func tallyBy<U>(self, fn: (T) => U): Map<U, Int>
 
-  func keyBy<U>(self, fn: (T) => U): Map<U, T> {
+  pub func keyBy<U>(self, fn: (T) => U): Map<U, T> {
     val map: Map<U, T> = Map.new()
 
     for i in range(0, self.length) {
@@ -983,7 +983,7 @@ type Array<T> {
     map
   }
 
-  func indexBy<U>(self, fn: (T) => U): Map<U, T[]> {
+  pub func indexBy<U>(self, fn: (T) => U): Map<U, T[]> {
     val map: Map<U, T[]> = Map.new()
 
     for i in range(0, self.length) {
@@ -999,7 +999,7 @@ type Array<T> {
     map
   }
 
-  func asSet(self): Set<T> {
+  pub func asSet(self): Set<T> {
     val set: Set<T> = Set.new()
 
     for i in range(0, self.length) {
@@ -1010,7 +1010,7 @@ type Array<T> {
     set
   }
 
-  func get(self, index: Int): T? {
+  pub func get(self, index: Int): T? {
     val idx = if index < 0 index + self.length else index
     if idx >= self.length || idx < 0 {
       None
@@ -1022,7 +1022,7 @@ type Array<T> {
   @Stub func getOr(self, index: Int, default: T): T
   @Stub func getOrElse(self, index: Int, getDefault: () => T): T
 
-  func getRange(self, startIndex = 0, endIndex = self.length): T[] {
+  pub func getRange(self, startIndex = 0, endIndex = self.length): T[] {
     val start = if startIndex < 0 startIndex + self.length else startIndex
     val end = if endIndex > self.length
       self.length
@@ -1038,7 +1038,7 @@ type Array<T> {
     subArray
   }
 
-  func set(self, index: Int, value: T): T? {
+  pub func set(self, index: Int, value: T): T? {
     val idx = if index < 0 index + self.length else index
     if idx >= self.length || idx < 0 {
       None
@@ -1068,7 +1068,7 @@ pub func todo(message = "") {
 type SetIterator<T> {
   _mapIterator: MapIterator<T, Bool>
 
-  func next(self): T? {
+  pub func next(self): T? {
     if self._mapIterator.next() |item| {
       Some(item[0])
     } else {
@@ -1081,11 +1081,11 @@ type Set<T> {
   pub size: Int
   _map: Map<T, Bool> = Map.new()
 
-  func new<T>(initialCapacity = 16): Set<T> {
+  pub func new<T>(initialCapacity = 16): Set<T> {
     Set<T>(size: 0, _map: Map.new(initialCapacity))
   }
 
-  func toString(self): String {
+  pub func toString(self): String {
     if self.isEmpty() return "#{}"
 
     val reprs: String[] = Array.withCapacity(self._map.size)
@@ -1097,32 +1097,32 @@ type Set<T> {
     "#{$items}"
   }
 
-  func eq(self, other: Set<T>): Bool {
+  pub func eq(self, other: Set<T>): Bool {
     self._map == other._map
   }
 
-  func isEmpty(self): Bool {
+  pub func isEmpty(self): Bool {
     self._map.isEmpty()
   }
 
-  func iterator(self): SetIterator<T> = SetIterator(_mapIterator: self._map.iterator())
+  pub func iterator(self): SetIterator<T> = SetIterator(_mapIterator: self._map.iterator())
 
-  func contains(self, item: T): Bool {
+  pub func contains(self, item: T): Bool {
     self._map.containsKey(item)
   }
 
-  func insert(self, item: T) {
+  pub func insert(self, item: T) {
     self._map.insert(item, true)
     self.size = self._map.size
   }
 
-  func forEach(self, fn: (T) => Unit) {
+  pub func forEach(self, fn: (T) => Unit) {
     self._map.forEach(key => fn(key))
   }
 
   @Stub func remove(self, item: T): T?
 
-  func map<U>(self, fn: (T) => U): U[] {
+  pub func map<U>(self, fn: (T) => U): U[] {
     val arr: U[] = Array.withCapacity(self.size)
     for item in self {
       arr.push(fn(item))
@@ -1131,7 +1131,7 @@ type Set<T> {
     arr
   }
 
-  func filter(self, fn: (T) => Bool): Set<T> {
+  pub func filter(self, fn: (T) => Bool): Set<T> {
     val newSet: Set<T> = Set.new()
     for item in self {
       if fn(item) newSet.insert(item)
@@ -1142,7 +1142,7 @@ type Set<T> {
 
   @Stub func reduce<U>(self, initialValue: U, fn: (U, T) => U): U
 
-  func asArray(self): T[] {
+  pub func asArray(self): T[] {
     val arr: T[] = Array.withCapacity(self.size)
     for item in self {
       arr.push(item)
@@ -1151,11 +1151,11 @@ type Set<T> {
     arr
   }
 
-  func join(self, joiner = ""): String {
+  pub func join(self, joiner = ""): String {
     self.asArray().join(joiner)
   }
 
-  func union(self, other: Set<T>): Set<T> {
+  pub func union(self, other: Set<T>): Set<T> {
     val newSet: Set<T> = Set.new()
 
     for item in self { newSet.insert(item) }
@@ -1164,7 +1164,7 @@ type Set<T> {
     newSet
   }
 
-  func difference(self, other: Set<T>): Set<T> {
+  pub func difference(self, other: Set<T>): Set<T> {
     val newSet: Set<T> = Set.new()
     for item in self {
       if !other.contains(item) newSet.insert(item)
@@ -1173,7 +1173,7 @@ type Set<T> {
     newSet
   }
 
-  func intersection(self, other: Set<T>): Set<T> {
+  pub func intersection(self, other: Set<T>): Set<T> {
     val newSet: Set<T> = Set.new()
     for item in self {
       if other.contains(item) newSet.insert(item)
@@ -1221,7 +1221,7 @@ type MapIterator<K, V> {
   _i: Int = -1
   _cursor: MapEntry<K, V>? = None
 
-  func next(self): (K, V)? {
+  pub func next(self): (K, V)? {
     while self._i < self.map._entries.length && !self._cursor {
       self._i += 1
       if self.map._entries[self._i] |entry| {
@@ -1246,7 +1246,7 @@ type Map<K, V> {
   _capacity: Int = 16
   _loadFactor: Float = 0.75
 
-  func new<K, V>(initialCapacity = 16): Map<K, V> {
+  pub func new<K, V>(initialCapacity = 16): Map<K, V> {
     // Find a power of 2 >= initialCapacity, if non-default value provided
     val capacity = if initialCapacity != 16 {
       initialCapacity.nextPowerOf2()
@@ -1262,7 +1262,7 @@ type Map<K, V> {
     Map(size: 0, _capacity: capacity, _entries: entries)
   }
 
-  func fromPairs<K, V>(pairs: (K, V)[]): Map<K, V> {
+  pub func fromPairs<K, V>(pairs: (K, V)[]): Map<K, V> {
     val map: Map<K, V> = Map.new(pairs.length)
     for pair in pairs {
       map.insert(pair[0], pair[1])
@@ -1270,7 +1270,7 @@ type Map<K, V> {
     map
   }
 
-  func toString(self): String {
+  pub func toString(self): String {
     if self.isEmpty() return "{}"
 
     val reprs: String[] = Array.withCapacity(self.size)
@@ -1290,7 +1290,7 @@ type Map<K, V> {
     "{ $items }"
   }
 
-  func eq(self, other: Map<K, V>): Bool {
+  pub func eq(self, other: Map<K, V>): Bool {
     if self.size != other.size return false
 
     for i in range(0, self._entries.length) {
@@ -1313,11 +1313,11 @@ type Map<K, V> {
     true
   }
 
-  func getCapacity(self): Int = self._capacity
+  pub func getCapacity(self): Int = self._capacity
 
-  func isEmpty(self): Bool = self.size == 0
+  pub func isEmpty(self): Bool = self.size == 0
 
-  func forEach(self, fn: (K, V) => Unit) {
+  pub func forEach(self, fn: (K, V) => Unit) {
     for i in range(0, self._entries.length) {
       if self._entries[i] |bucket| {
         if bucket._empty continue
@@ -1331,9 +1331,9 @@ type Map<K, V> {
     }
   }
 
-  func iterator(self): MapIterator<K, V> = MapIterator(map: self)
+  pub func iterator(self): MapIterator<K, V> = MapIterator(map: self)
 
-  func keys(self): Set<K> {
+  pub func keys(self): Set<K> {
     val keys: Set<K> = #{}
 
     for pair in self {
@@ -1343,7 +1343,7 @@ type Map<K, V> {
     keys
   }
 
-  func values(self): V[] {
+  pub func values(self): V[] {
     val values: V[] = []
 
     for pair in self {
@@ -1353,7 +1353,7 @@ type Map<K, V> {
     values
   }
 
-  func entries(self): Set<(K, V)> {
+  pub func entries(self): Set<(K, V)> {
     val entries: Set<(K, V)> = Set.new()
     for pair in self {
       entries.insert(pair)
@@ -1362,11 +1362,11 @@ type Map<K, V> {
     entries
   }
 
-  func _getKeyHash(self, key: K, numEntries = self._entries._capacity): Int = key.hash() && (numEntries - 1)
+  pub func _getKeyHash(self, key: K, numEntries = self._entries._capacity): Int = key.hash() && (numEntries - 1)
 
-  func containsKey(self, key: K): Bool = if self._getEntry(key) true else false
+  pub func containsKey(self, key: K): Bool = if self._getEntry(key) true else false
 
-  func mapValues<U>(self, fn: (K, V) => U): Map<K, U> {
+  pub func mapValues<U>(self, fn: (K, V) => U): Map<K, U> {
     val newMap: Map<K, U> = Map.new()
     for i in range(0, self._entries.length) {
       if self._entries[i] |bucket| {
@@ -1383,7 +1383,7 @@ type Map<K, V> {
     newMap
   }
 
-  func insert(self, key: K, value: V): V? {
+  pub func insert(self, key: K, value: V): V? {
     val (oldValue, valueAdded) = self._insertInto(key, value, self._entries)
     if valueAdded { self.size += 1 }
 
@@ -1392,9 +1392,9 @@ type Map<K, V> {
     oldValue
   }
 
-  func _needsResize(self): Bool = self.size > self._capacity * self._loadFactor
+  pub func _needsResize(self): Bool = self.size > self._capacity * self._loadFactor
 
-  func _insertInto(self, key: K, value: V, entries: MapEntry<K, V>[]): (V?, Bool) {
+  pub func _insertInto(self, key: K, value: V, entries: MapEntry<K, V>[]): (V?, Bool) {
     val hash = self._getKeyHash(key, entries._capacity)
 
     if entries[hash] |bucket| {
@@ -1428,7 +1428,7 @@ type Map<K, V> {
     }
   }
 
-  func _resize(self) {
+  pub func _resize(self) {
     val newCapacity = self._capacity * 2
 
     val newEntries: MapEntry<K, V>[] = Array.withCapacity(newCapacity)
@@ -1446,7 +1446,7 @@ type Map<K, V> {
     self._entries = newEntries
   }
 
-  func _getEntry(self, key: K): MapEntry<K, V>? {
+  pub func _getEntry(self, key: K): MapEntry<K, V>? {
     val hash = self._getKeyHash(key)
 
     val bucketRootEntry = try self._entries[hash]
@@ -1464,7 +1464,7 @@ type Map<K, V> {
     None
   }
 
-  func get(self, key: K): V? {
+  pub func get(self, key: K): V? {
     if self._getEntry(key) |entry| {
       Some(entry.value)
     } else {
@@ -1472,15 +1472,15 @@ type Map<K, V> {
     }
   }
 
-  func getOr(self, key: K, default: V): V {
+  pub func getOr(self, key: K, default: V): V {
     self.get(key) ?: default
   }
 
-  func getOrElse(self, key: K, getDefault: () => V): V {
+  pub func getOrElse(self, key: K, getDefault: () => V): V {
     self.get(key) ?: getDefault()
   }
 
-  func getOrInsert(self, key: K, getDefault: () => V): V {
+  pub func getOrInsert(self, key: K, getDefault: () => V): V {
     try self.get(key) else {
       val default = getDefault()
       self.insert(key, default)
@@ -1488,7 +1488,7 @@ type Map<K, V> {
     }
   }
 
-  func update(self, key: K, updater: (V) => V): V? {
+  pub func update(self, key: K, updater: (V) => V): V? {
     if self._getEntry(key) |entry| {
       val oldVal = entry.value
       entry.value = updater(oldVal)
@@ -1498,7 +1498,7 @@ type Map<K, V> {
     }
   }
 
-  func remove(self, key: K): V? {
+  pub func remove(self, key: K): V? {
     val hash = self._getKeyHash(key)
 
     val bucketRootEntry = try self._entries[hash]

--- a/projects/std/src/process.abra
+++ b/projects/std/src/process.abra
@@ -205,7 +205,7 @@ func getFunctionNames(): String[] {
 type Stdin {
   _buf: Pointer<Byte> = Pointer.malloc(1024)
 
-  func readAsString(self): String? {
+  pub func readAsString(self): String? {
     var nread = libc.read(libc.STDIN_FILENO, self._buf, 1024)
     if nread == 0 return None
 


### PR DESCRIPTION
Enforce visibility modifiers for instance methods and static methods for types and enums. This required modifying a lot of builtin modules as well as the compiler and lsp itself.