### PR TITLE
LSP: Handle `textDocument/documentSymbol`

### DIFF
--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -289,7 +289,7 @@ pub type Lexer {
 
     var sawNewline = false
     var ch = self._input[self._cursor]
-    while ch == " " || ch == "\n" {
+    while ch == " " || ch == "\n" || ch == "\t" {
       self._advance()
       if ch == "\n" {
         self._line += 1

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -177,8 +177,8 @@ pub type Scope {
   pub variables: Variable[] = []
   pub functions: Function[] = []
   pub types: Type[] = []
-  structs: Struct[] = []
-  enums: Enum[] = []
+  pub structs: Struct[] = []
+  pub enums: Enum[] = []
   pub kind: ScopeKind = ScopeKind.Root
   pub parent: Scope? = None
   pub terminator: Terminator? = None
@@ -249,6 +249,9 @@ pub type Struct {
 
     struct
   }
+
+  // Override toString method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
+  pub func toString(self): String = "Struct(moduleId: ${self.moduleId}, label: ${self.label}, ...)"
 
   // Override eq method since default implementation recurses infinitely (scope -> variables -> TypeKind.Struct)
   pub func eq(self, other: Struct): Bool = self.moduleId == other.moduleId && self.label == other.label

--- a/projects/compiler/src/utils.abra
+++ b/projects/compiler/src/utils.abra
@@ -47,6 +47,7 @@ pub func resolveRelativePath(path: String, relativeTo: String): String[] {
     if part.isEmpty() || part == "." continue
     if part == ".." {
       absParentPath.pop()
+      continue
     }
 
     absParentPath.push(part)

--- a/projects/lsp/src/language_service.abra
+++ b/projects/lsp/src/language_service.abra
@@ -1,30 +1,24 @@
 import "fs" as fs
 import JsonValue from "json"
 import log from "./log"
-import ModuleLoader, Project, Typechecker, TypecheckerErrorKind, IdentifierMeta, IdentifierKindMeta, IdentifierMetaModule from "../../compiler/src/typechecker"
-import RequestMessage, NotificationMessage, ResponseMessage, ResponseResult, ResponseError, ResponseErrorCode, ServerCapabilities, TextDocumentSyncOptions, TextDocumentSyncKind, SaveOptions, ServerInfo, TextDocumentItem, TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity, Position, Range, MarkupContent, MarkupKind from "./lsp_spec"
+import Label from "../../compiler/src/parser"
+import TypedModule, ModuleLoader, Project, Typechecker, TypecheckerErrorKind, IdentifierMeta, IdentifierKindMeta, IdentifierMetaModule from "../../compiler/src/typechecker"
+import RequestMessage, NotificationMessage, ResponseMessage, ResponseResult, ResponseError, ResponseErrorCode, ServerCapabilities, TextDocumentSyncOptions, TextDocumentSyncKind, SaveOptions, ServerInfo, TextDocumentItem, TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity, Position, Range, MarkupContent, MarkupKind, DocumentSymbol, SymbolKind from "./lsp_spec"
 
 pub val contentLengthHeader = "Content-Length: "
 pub val bogusMessageId = -999
 
 pub type AbraLanguageService {
-  // _virtualFileSystem: Map<String, String>
   _moduleLoader: ModuleLoader
   _project: Project
   _initialized: Bool = false
   _root: String = ""
 
   pub func new(abraStdRoot: String): AbraLanguageService {
-    // val virtualFileSystem: Map<String, String> = {}
-    // val moduleLoader = ModuleLoader.usingVirtualFileSystem(stdRoot: abraStdRoot, fileMap: virtualFileSystem)
     val moduleLoader = ModuleLoader(stdRoot: abraStdRoot)
     val project = Project()
 
-    AbraLanguageService(
-      // _virtualFileSystem: virtualFileSystem,
-      _moduleLoader: moduleLoader,
-      _project: project,
-    )
+    AbraLanguageService(_moduleLoader: moduleLoader, _project: project)
   }
 
   // Request Message handlers
@@ -50,6 +44,7 @@ pub type AbraLanguageService {
         )),
         hoverProvider: Some(true),
         definitionProvider: Some(true),
+        documentSymbolProvider: Some(true),
       ),
       serverInfo: ServerInfo(name: "abra-lsp", version: Some("0.0.1"))
     )
@@ -60,7 +55,7 @@ pub type AbraLanguageService {
     // todo: what happens if it's not a `file://` uri?
     val filePath = textDocument.uri.replaceAll("file://", "")
 
-    val (line, identColStart, identColEnd, ident) = try self._findIdentAtPosition(filePath, position) else {
+    val (line, identColStart, identColEnd, ident) = try self._findIdentAtPosition(textDocument.uri, position) else {
       return ResponseMessage.Success(id: id, result: None)
     }
 
@@ -195,7 +190,7 @@ pub type AbraLanguageService {
     // todo: what happens if it's not a `file://` uri?
     val filePath = textDocument.uri.replaceAll("file://", "")
 
-    val ident = if self._findIdentAtPosition(filePath, position) |(_, _, _, ident)| ident else return ResponseMessage.Success(id: id, result: None)
+    val ident = if self._findIdentAtPosition(textDocument.uri, position) |(_, _, _, ident)| ident else return ResponseMessage.Success(id: id, result: None)
     val result = if ident.definitionPosition |(definitionModule, pos)| {
       val line = pos.line - 1
       val character = pos.col - 1
@@ -213,50 +208,163 @@ pub type AbraLanguageService {
     ResponseMessage.Success(id: id, result: result)
   }
 
+  func _symbols(self, id: Int, textDocument: TextDocumentIdentifier): ResponseMessage {
+    // todo: what happens if it's not a `file://` uri?
+    val filePath = textDocument.uri.replaceAll("file://", "")
+    val module = try self.getModuleOrTypecheck(textDocument.uri) else return ResponseMessage.Success(id: id, result: Some(ResponseResult.Symbols([])))
+
+    val scope = module.rootScope
+
+    val rangesFromLabel: (Label) => (Range, Range) = label => {
+      val line = label.position.line - 1
+      val col = label.position.col - 1
+      val range = Range(start: Position(line: line, character: 0), end: Position(line: line, character: col + label.name.length))
+      val selectionRange = Range(start: Position(line: line, character: col), end: Position(line: line, character: col + label.name.length - 1))
+
+      (range, selectionRange)
+    }
+
+    val symbols: DocumentSymbol[] = []
+
+    for v in scope.variables {
+      if v.alias continue
+
+      val (range, selectionRange) = rangesFromLabel(v.label)
+      val kind = if v.mutable SymbolKind.Variable else SymbolKind.Constant
+      val sym = DocumentSymbol(name: v.label.name, kind: kind, range: range, selectionRange: selectionRange, children: [])
+      symbols.push(sym)
+    }
+
+    for fn in scope.functions {
+      val (range, selectionRange) = rangesFromLabel(fn.label)
+      val sym = DocumentSymbol(name: fn.label.name, kind: SymbolKind.Function, range: range, selectionRange: selectionRange, children: [])
+      symbols.push(sym)
+    }
+
+    for s in scope.structs {
+      val children: DocumentSymbol[] = []
+
+      for f in s.fields {
+        val (range, selectionRange) = rangesFromLabel(f.name)
+        val sym = DocumentSymbol(name: f.name.name, kind: SymbolKind.Field, range: range, selectionRange: selectionRange, children: [])
+        children.push(sym)
+      }
+
+      for fn in s.instanceMethods {
+        if fn.isGenerated continue
+
+        val (range, selectionRange) = rangesFromLabel(fn.label)
+        val sym = DocumentSymbol(name: fn.label.name, kind: SymbolKind.Method, range: range, selectionRange: selectionRange, children: [])
+        children.push(sym)
+      }
+
+      for fn in s.staticMethods {
+        if fn.isGenerated continue
+
+        val (range, selectionRange) = rangesFromLabel(fn.label)
+        val sym = DocumentSymbol(name: fn.label.name, kind: SymbolKind.Method, range: range, selectionRange: selectionRange, children: [])
+        children.push(sym)
+      }
+
+      val (range, selectionRange) = rangesFromLabel(s.label)
+      val sym = DocumentSymbol(name: s.label.name, kind: SymbolKind.Class, range: range, selectionRange: selectionRange, children: children)
+      symbols.push(sym)
+    }
+
+    for e in scope.enums {
+      val children: DocumentSymbol[] = []
+
+      for v in e.variants {
+        val (range, selectionRange) = rangesFromLabel(v.label)
+        val sym = DocumentSymbol(name: v.label.name, kind: SymbolKind.EnumMember, range: range, selectionRange: selectionRange, children: [])
+        children.push(sym)
+      }
+
+      for fn in e.instanceMethods {
+        if fn.isGenerated continue
+
+        val (range, selectionRange) = rangesFromLabel(fn.label)
+        val sym = DocumentSymbol(name: fn.label.name, kind: SymbolKind.Method, range: range, selectionRange: selectionRange, children: [])
+        children.push(sym)
+      }
+
+      for fn in e.staticMethods {
+        if fn.isGenerated continue
+
+        val (range, selectionRange) = rangesFromLabel(fn.label)
+        val sym = DocumentSymbol(name: fn.label.name, kind: SymbolKind.Method, range: range, selectionRange: selectionRange, children: [])
+        children.push(sym)
+      }
+
+      val (range, selectionRange) = rangesFromLabel(e.label)
+      val sym = DocumentSymbol(name: e.label.name, kind: SymbolKind.Enum, range: range, selectionRange: selectionRange, children: children)
+      symbols.push(sym)
+    }
+
+    val result = ResponseResult.Symbols(symbols)
+    val s  = result.toString()
+    ResponseMessage.Success(id: id, result: Some(result))
+  }
+
   // Notification handlers
 
   func _textDocumentDidOpen(self, textDocument: TextDocumentItem) {
     // textDocument/didOpen events are currently not sent by the client (see self._initialize)
-    val diagnostics = self._runTypecheckerStartingAtUri(textDocument.uri)
+    val diagnostics = self.runTypecheckerStartingAtUri(textDocument.uri)
     val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
     self.sendNotification(notif)
   }
 
   func _textDocumentDidChange(self, textDocument: VersionedTextDocumentIdentifier, contentChanges: TextDocumentContentChangeEvent[]) {
     // textDocument/didChange events are currently not sent by the client (see self._initialize)
-    if contentChanges.isEmpty() return
+    // if contentChanges.isEmpty() return
 
-    val filePath = textDocument.uri.replaceAll("file://", "")
-    for changeEvent in contentChanges {
-      match changeEvent {
-        TextDocumentContentChangeEvent.Incremental => todo("TextDocumentContentChangeEvent.Incremental")
-        TextDocumentContentChangeEvent.Full(text) => {
-          // self._virtualFileSystem[filePath] = text
-        }
-      }
-    }
-    self._moduleLoader.invalidateModule(filePath)
-    self._project.modules.remove(filePath)
+    // val filePath = textDocument.uri.replaceAll("file://", "")
+    // for changeEvent in contentChanges {
+    //   match changeEvent {
+    //     TextDocumentContentChangeEvent.Incremental => todo("TextDocumentContentChangeEvent.Incremental")
+    //     TextDocumentContentChangeEvent.Full(text) => { }
+    //   }
+    // }
 
-    val diagnostics = self._runTypecheckerStartingAtUri(textDocument.uri)
-    val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
-    self.sendNotification(notif)
+    // val diagnostics = self.invalidateAndTypecheck(textDocument.uri)
+    // val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
+    // self.sendNotification(notif)
   }
 
   func _textDocumentDidSave(self, textDocument: TextDocumentIdentifier) {
-    val filePath = textDocument.uri.replaceAll("file://", "")
-    self._moduleLoader.invalidateModule(filePath)
-    self._project.modules.remove(filePath)
-    // self._virtualFileSystem.remove(filePath)
-
-    val diagnostics = self._runTypecheckerStartingAtUri(textDocument.uri)
+    val diagnostics = self.invalidateAndTypecheck(textDocument.uri)
     val notif = NotificationMessage.TextDocumentPublishDiagnostics(uri: textDocument.uri, diagnostics: diagnostics)
     self.sendNotification(notif)
   }
 
   // Compiler bridge
 
-  func _runTypecheckerStartingAtUri(self, uri: String): Diagnostic[] {
+  func getModuleOrTypecheck(self, uri: String): TypedModule? {
+    val filePath = uri.replaceAll("file://", "")
+
+    // TODO: it's not necessarily enough to test the _presence_ of the module, but also potentially if the module was
+    // typechecked with lspMode enabled. For example, if moduleA imports moduleB and moduleA was opened first, then
+    // moduleA will be typechecked with lspMode enabled but moduleB will not be. While moduleB will be _present_ in
+    // the project's module cache, it will not have lsp information (namely idents).
+    val module = try self._project.modules[filePath] else {
+      self.invalidateAndTypecheck(uri)
+
+      return self._project.modules[filePath]
+    }
+
+    Some(module)
+  }
+
+  func invalidateAndTypecheck(self, uri: String): Diagnostic[] {
+    val filePath = uri.replaceAll("file://", "")
+    self._moduleLoader.invalidateModule(filePath)
+    self._project.modules.remove(filePath)
+
+    self.runTypecheckerStartingAtUri(uri)
+  }
+
+  func runTypecheckerStartingAtUri(self, uri: String): Diagnostic[] {
     // todo: what happens if it's not a `file://` uri?
     val filePath = uri.replaceAll("file://", "")
 
@@ -297,19 +405,22 @@ pub type AbraLanguageService {
           }
         }
 
-        val range = ((position.line - 1, position.col - 1), (position.line - 1, position.col))
+        val pos = Position(line: position.line - 1, character: position.col - 1)
         val diagnostic = Diagnostic(
-          range: range,
+          range: Range(start: pos, end: pos),
           severity: Some(DiagnosticSeverity.Error),
-          message: message.replaceAll("\n", "\\n").replaceAll("\"", "\\\""),
+          message: message
+            .replaceAll("\n", "\\n")
+            .replaceAll("\"", "\\\"")
+            .replaceAll("\t", "\\t"),
         )
         [diagnostic]
       }
     }
   }
 
-  func _findIdentAtPosition(self, filePath: String, position: Position): (Int, Int, Int, IdentifierMeta)? {
-    val module = try self._project.modules[filePath]
+  func _findIdentAtPosition(self, uri: String, position: Position): (Int, Int, Int, IdentifierMeta)? {
+    val module = try self.getModuleOrTypecheck(uri)
     val line = position.line
     val identsByLine = try module.identsByLine[line]
 
@@ -329,6 +440,7 @@ pub type AbraLanguageService {
       RequestMessage.Initialize(id, processId, rootPath) => self._initialize(id, processId, rootPath)
       RequestMessage.Hover(id, textDocument, position) => self._hover(id, textDocument, position)
       RequestMessage.Definition(id, textDocument, position) => self._goToDefinition(id, textDocument, position)
+      RequestMessage.Symbols(id, textDocument) => self._symbols(id, textDocument)
     }
   }
 

--- a/projects/lsp/src/lsp_spec.abra
+++ b/projects/lsp/src/lsp_spec.abra
@@ -5,6 +5,7 @@ pub enum RequestMessage {
   Initialize(id: Int, processId: Int?, rootPath: String?)
   Hover(id: Int, textDocument: TextDocumentIdentifier, position: Position)
   Definition(id: Int, textDocument: TextDocumentIdentifier, position: Position)
+  Symbols(id: Int, textDocument: TextDocumentIdentifier)
 
   pub func fromJson(json: JsonValue): Result<RequestMessage?, JsonError> {
     val obj = try json.asObject()
@@ -46,6 +47,13 @@ pub enum RequestMessage {
         val position = try Position.fromJson(positionObj)
 
         Ok(Some(RequestMessage.Definition(id: id, textDocument: textDocument, position: position)))
+      }
+      "textDocument/documentSymbol" => {
+        val params = try obj.getObjectRequired("params")
+        val textDocumentObj = try params.getValueRequired("textDocument")
+        val textDocument = try TextDocumentIdentifier.fromJson(textDocumentObj)
+
+        Ok(Some(RequestMessage.Symbols(id: id, textDocument: textDocument)))
       }
       else => {
         log.writeln("Error: Unimplemented RequestMessage method '$method'")
@@ -154,14 +162,15 @@ pub enum ResponseResult {
   // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_definition
   // Note: the actual response body for textDocument/definition requests is just a `Location` type, which is flattened here
   Definition(uri: String, range: Range)
+  Symbols(symbols: DocumentSymbol[])
 
   pub func toJson(self): JsonValue {
-    val obj = match self {
+    match self {
       ResponseResult.Initialize(capabilities, serverInfo) => {
-        JsonObject.of({
+        JsonValue.Object(JsonObject.of({
           "capabilities": capabilities.toJson(),
           "serverInfo": serverInfo.toJson(),
-        })
+        }))
       }
       ResponseResult.Hover(contents, range) => {
         val obj = JsonObject.of({
@@ -172,17 +181,16 @@ pub enum ResponseResult {
           obj.set("range", range.toJson())
         }
 
-        obj
+        JsonValue.Object(obj)
       }
       ResponseResult.Definition(uri, range) => {
-        JsonObject.of({
+        JsonValue.Object(JsonObject.of({
           "uri": JsonValue.String(uri),
           "range": range.toJson(),
-        })
+        }))
       }
+      ResponseResult.Symbols(symbols) => JsonValue.Array(symbols.map(s => s.toJson()))
     }
-
-    JsonValue.Object(obj)
   }
 }
 
@@ -233,6 +241,7 @@ pub type ServerCapabilities {
   pub diagnosticProvider: DiagnosticOptions? = None
   pub hoverProvider: Bool? = None
   pub definitionProvider: Bool? = None
+  pub documentSymbolProvider: Bool? = None
 
   pub func toJson(self): JsonValue {
     val obj = JsonObject()
@@ -251,6 +260,10 @@ pub type ServerCapabilities {
 
     if self.definitionProvider |dp| {
       obj.set("definitionProvider", JsonValue.Boolean(dp))
+    }
+
+    if self.documentSymbolProvider |dsp| {
+      obj.set("documentSymbolProvider", JsonValue.Boolean(dsp))
     }
 
     JsonValue.Object(obj)
@@ -430,10 +443,7 @@ pub type Range {
 }
 
 pub enum TextDocumentContentChangeEvent {
-  Incremental(
-    range: ((Int, Int), (Int, Int)), // (line: Int, character: Int), zero-based
-    text: String
-  )
+  Incremental(range: Range, text: String)
   Full(text: String)
 
   func fromJson(json: JsonValue): Result<TextDocumentContentChangeEvent, JsonError> {
@@ -449,23 +459,12 @@ pub enum TextDocumentContentChangeEvent {
 }
 
 pub type Diagnostic {
-  pub range: ((Int, Int), (Int, Int)) // (line: Int, character: Int), zero-based
+  pub range: Range
   pub severity: DiagnosticSeverity? = None
   pub message: String
 
   pub func toJson(self): JsonValue {
-    val obj = JsonObject()
-
-    obj.set("range", JsonValue.Object(JsonObject.of({
-      start: JsonValue.Object(JsonObject.of({
-        line: JsonValue.Number(Either.Left(self.range[0][0])),
-        character: JsonValue.Number(Either.Left(self.range[0][1])),
-      })),
-      end: JsonValue.Object(JsonObject.of({
-        line: JsonValue.Number(Either.Left(self.range[1][0])),
-        character: JsonValue.Number(Either.Left(self.range[1][1])),
-      }))
-    })))
+    val obj = JsonObject.of({ range: self.range.toJson() })
 
     if self.severity |severity| {
       obj.set("severity", JsonValue.Number(Either.Left(severity.intVal())))
@@ -509,4 +508,99 @@ pub type MarkupContent {
 pub enum MarkupKind {
   PlainText
   Markdown
+}
+
+pub type DocumentSymbol {
+  pub name: String
+  pub detail: String? = None
+  pub kind: SymbolKind
+
+  // The range enclosing this symbol not including leading/trailing whitespace
+  // but everything else like comments. This information is typically used to
+  // determine if the client's cursor is inside the symbol to reveal in the
+  // symbol in the UI.
+  pub range: Range
+
+  // The range that should be selected and revealed when this symbol is being
+  // picked, e.g. the name of a function. Must be contained by the `range`.
+  pub selectionRange: Range
+
+  pub children: DocumentSymbol[]
+
+  pub func toJson(self): JsonValue {
+    val obj = JsonObject.of({
+      name: JsonValue.String(self.name),
+      kind: JsonValue.Number(Either.Left(self.kind.intVal())),
+      range: self.range.toJson(),
+      selectionRange: self.selectionRange.toJson(),
+    })
+
+    if self.detail |detail| {
+      obj.set("detail", JsonValue.String(detail))
+    }
+
+    if !self.children.isEmpty() {
+      obj.set("children", JsonValue.Array(self.children.map(c => c.toJson())))
+    }
+
+    JsonValue.Object(obj)
+  }
+}
+
+pub enum SymbolKind {
+  File
+  Module
+  Namespace
+  Package
+  Class
+  Method
+  Property
+  Field
+  Constructor
+  Enum
+  Interface
+  Function
+  Variable
+  Constant
+  String
+  Number
+  Boolean
+  Array
+  Object
+  Key
+  Null
+  EnumMember
+  Struct
+  Event
+  Operator
+  TypeParameter
+
+  func intVal(self): Int = match self {
+    SymbolKind.File => 1
+    SymbolKind.Module => 2
+    SymbolKind.Namespace => 3
+    SymbolKind.Package => 4
+    SymbolKind.Class => 5
+    SymbolKind.Method => 6
+    SymbolKind.Property => 7
+    SymbolKind.Field => 8
+    SymbolKind.Constructor => 9
+    SymbolKind.Enum => 10
+    SymbolKind.Interface => 11
+    SymbolKind.Function => 12
+    SymbolKind.Variable => 13
+    SymbolKind.Constant => 14
+    SymbolKind.String => 15
+    SymbolKind.Number => 16
+    SymbolKind.Boolean => 17
+    SymbolKind.Array => 18
+    SymbolKind.Object => 19
+    SymbolKind.Key => 20
+    SymbolKind.Null => 21
+    SymbolKind.EnumMember => 22
+    SymbolKind.Struct => 23
+    SymbolKind.Event => 24
+    SymbolKind.Operator => 25
+    SymbolKind.TypeParameter => 26
+  }
 }


### PR DESCRIPTION
This change allows the LSP to provide a list of symbols for the current document, which includes a nested hierarchical view of types and their fields, enums and their variants, instance and static methods for each, as well as top-level variables and functions.

Doing this caused a few bugs and gaps to surface, which are also fixed as part of this changeset. These include:

Lexer: Consider a \t as a whitespace character when previously it wasn't.

Typechecker: When adding a TypedModule to the Project, make sure to use the normalized path name, with `/a/b/../c` resolved to `/a/c` (previously this wasn't the case).

Language service: If the TypedModule isn't currently present in the project, pre-emptively typecheck the current module rather than waiting for a save. This is helpful because it allows for more seamless go-to-definition and hover commands, but also because I think if the symbols aren't resolved correctly when the file first opens, vscode will ignore subsequent symbols provided by `textDocument/documentSymbol`. I also cleaned up residual "virtual file system" changes which had been commented out but which can now be disregarded because I don't think I'm going to be doing that any time soon.