### PR TITLE
Succeeding with typeerrors

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,4 +1,9 @@
-import QbeData, QbeDataKind from "./src/qbe"
+import QbeData, QbeDataKind from "./src/qb"
+import QbeData, QbeDataKind, Foo, Bar from "./src/qbe"
+import "./src/qbe" as q
+import "./src/qbe" as q
+import "./src/qbe" as QbeData
+import "./src/qbe" as QbeDataKind
 
 val d = QbeData(name: "__argc", kind: QbeDataKind.Constants([]))
 println(d)

--- a/projects/compiler/src/compiler.test.abra
+++ b/projects/compiler/src/compiler.test.abra
@@ -33,12 +33,42 @@ func main() {
     val project = Project()
     val typechecker = Typechecker(moduleLoader: moduleLoader, project: project)
 
-    match typechecker.typecheckEntrypoint(filePathAbs) {
-      Err(e) => {
-        println(e.getMessage())
-        process.exit(1)
+    typechecker.typecheckEntrypoint(filePathAbs)
+
+    val readFileErrors: String[] = []
+    val errorMessages: String[] = []
+    for mod in project.modules.values().sortBy(m => -m.id) {
+      if mod.readFileError {
+        readFileErrors.push(mod.name)
+        continue
       }
-      Ok(_) => {}
+
+      val contents = try moduleLoader.loadFileContents(mod.name) else {
+        // Any unreadable modules should have had the `readFileError` field set, which is checked above
+        unreachable("Could not read file '${mod.name}'")
+      }
+
+      for err in mod.lexParseErrors {
+        errorMessages.push(err.getMessage(mod.name, contents))
+      }
+
+      for err in mod.typeErrors {
+        errorMessages.push(err.getMessage(mod.name, contents))
+      }
+    }
+
+    if !errorMessages.isEmpty() {
+      for msg, idx in errorMessages {
+        println(msg)
+        if idx != errorMessages.length - 1 println() // spacer
+      }
+      process.exit(1)
+    } else if !readFileErrors.isEmpty() {
+      for path, idx in readFileErrors {
+        println("Could not read file '$path'")
+        if idx != readFileErrors.length - 1 println() // spacer
+      }
+      process.exit(1)
     }
 
     val builder = match Compiler.compile(project) {

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -32,7 +32,7 @@ pub type ModuleLoader {
     self.parsedModules.remove(modulePathAbs)
   }
 
-  func _loadFileContents(self, modulePathAbs: String): String? {
+  pub func loadFileContents(self, modulePathAbs: String): String? {
     if self._virtualFileSystem |vfs| {
       val inMemContents = vfs[modulePathAbs]
       if inMemContents return inMemContents
@@ -47,7 +47,7 @@ pub type ModuleLoader {
   func tokenizeAndParse(self, modulePath: String): Result<ParsedModule, TokenizeAndParseError> {
     if self.parsedModules[modulePath] |m| return Ok(m)
 
-    val parsedModule = if self._loadFileContents(modulePath) |contents| {
+    val parsedModule = if self.loadFileContents(modulePath) |contents| {
       match Lexer.tokenize(contents) {
         Ok(tokens) => {
           match Parser.parse(tokens) {
@@ -117,8 +117,16 @@ pub type TypedModule {
   imports: Map<String, ImportedModule> = {}
   pub exports: Map<String, Export> = {}
   pub identsByLine: Map<Int, (Int, Int, IdentifierMeta)[]> = {}
+  pub readFileError: Bool = false
+  pub startsCircDep: Bool = false
+  pub lexParseErrors: LexerOrParseError[] = []
+  pub typeErrors: TypeError[] = []
 
   func bogus(): TypedModule = TypedModule(id: -1, name: "bogus", code: [], rootScope: Scope.bogus())
+
+  func addTypeError(self, err: TypeError) {
+    self.typeErrors.push(err)
+  }
 }
 
 pub enum VariableAlias {
@@ -859,31 +867,17 @@ type TypecheckerError {
   pub modulePath: String
   pub kind: TypecheckerErrorKind
 
-  pub func getMessage(self): String {
-    match self.kind {
-      // TODO: Better error message, once imports are a thing
-      TypecheckerErrorKind.ReadFileError(path) => "Could not read file '$path'"
-      TypecheckerErrorKind.LexerError(inner) => {
-        val contents = match fs.readFile(self.modulePath) {
-          Ok(v) => v
-          Err => return "Could not read file '${self.modulePath}'"
-        }
-        inner.getMessage(self.modulePath, contents)
-      }
-      TypecheckerErrorKind.ParseError(inner) => {
-        val contents = match fs.readFile(self.modulePath) {
-          Ok(v) => v
-          Err => return "Could not read file '${self.modulePath}'"
-        }
-        inner.getMessage(self.modulePath, contents)
-      }
-      TypecheckerErrorKind.TypeError(inner) => {
-        val contents = match fs.readFile(self.modulePath) {
-          Ok(v) => v
-          Err => return "Could not read file '${self.modulePath}'"
-        }
-        inner.getMessage(self.modulePath, contents)
-      }
+  pub func getMessage(self): String = self.kind.getMessage(self.modulePath)
+}
+
+pub enum LexerOrParseError {
+  LexerError(inner: LexerError)
+  ParseError(inner: ParseError)
+
+  pub func getMessage(self, modulePath: String, contents: String): String {
+    match self {
+      LexerOrParseError.LexerError(inner) => inner.getMessage(modulePath, contents)
+      LexerOrParseError.ParseError(inner) => inner.getMessage(modulePath, contents)
     }
   }
 }
@@ -893,6 +887,34 @@ pub enum TypecheckerErrorKind {
   LexerError(inner: LexerError)
   ParseError(inner: ParseError)
   TypeError(inner: TypeError)
+
+  pub func getMessage(self, modulePath: String): String {
+    match self {
+      // TODO: Better error message, once imports are a thing
+      TypecheckerErrorKind.ReadFileError(path) => "Could not read file '$path'"
+      TypecheckerErrorKind.LexerError(inner) => {
+        val contents = match fs.readFile(modulePath) {
+          Ok(v) => v
+          Err => return "Could not read file '$modulePath'"
+        }
+        inner.getMessage(modulePath, contents)
+      }
+      TypecheckerErrorKind.ParseError(inner) => {
+        val contents = match fs.readFile(modulePath) {
+          Ok(v) => v
+          Err => return "Could not read file '$modulePath'"
+        }
+        inner.getMessage(modulePath, contents)
+      }
+      TypecheckerErrorKind.TypeError(inner) => {
+        val contents = match fs.readFile(modulePath) {
+          Ok(v) => v
+          Err => return "Could not read file '$modulePath'"
+        }
+        inner.getMessage(modulePath, contents)
+      }
+    }
+  }
 }
 
 type TypeError {
@@ -1281,7 +1303,7 @@ type TypeError {
       TypeErrorKind.CircularDependency => {
         lines.push("Could not import module due to circular dependency")
         lines.push(self._getCursorLine(self.position, contents))
-        lines.push("The current module is imported by the imported module (or one of its imports), resulting in a cycle")
+        lines.push("The current module is itself imported by this module (or one of its imports), resulting in a cycle")
       }
       TypeErrorKind.IllegalExportScope => {
         lines.push("Invalid visibility modifier")
@@ -1542,14 +1564,14 @@ pub type Typechecker {
   pub lspMode: Bool = false
   identsByLine: Map<Int, (Int, Int, IdentifierMeta)[]> = {}
 
-  pub func typecheckEntrypoint(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
+  pub func typecheckEntrypoint(self, modulePathAbs: String): TypedModule {
     val preludeModulePathSegs = getAbsolutePath(self.moduleLoader.stdRoot + "/prelude.abra")
     val preludeModulePathAbs = "/" + preludeModulePathSegs.join("/")
 
     if !self.project.modules[preludeModulePathAbs] {
       val lspMode = self.lspMode
       self.lspMode = false
-      try self._typecheckModule(preludeModulePathAbs)
+      self._typecheckModule(preludeModulePathAbs)
       self.lspMode = lspMode
 
       val preludeStructs = [
@@ -1576,21 +1598,6 @@ pub type Typechecker {
     }
 
     self._typecheckModule(modulePathAbs)
-  }
-
-  func _tokenizeAndParse(self, modulePathAbs: String): Result<ParsedModule, TypecheckerError> {
-    match self.moduleLoader.tokenizeAndParse(modulePathAbs) {
-      Ok(mod) => Ok(mod)
-      Err(e) => {
-        val kind = match e {
-          TokenizeAndParseError.ReadFileError(path) => TypecheckerErrorKind.ReadFileError(path)
-          TokenizeAndParseError.LexerError(inner) => TypecheckerErrorKind.LexerError(inner)
-          TokenizeAndParseError.ParseError(inner) => TypecheckerErrorKind.ParseError(inner)
-        }
-
-        return Err(TypecheckerError(modulePath: modulePathAbs, kind: kind))
-      }
-    }
   }
 
   func _verifyNameUniqueInScope(self, label: Label, scope: Scope): TypeError? {
@@ -2286,8 +2293,8 @@ pub type Typechecker {
 
   // End LSP helpers
 
-  func _typecheckModule(self, modulePathAbs: String): Result<TypedModule, TypecheckerError> {
-    if self.project.modules[modulePathAbs] |mod| return Ok(mod)
+  func _typecheckModule(self, modulePathAbs: String): TypedModule {
+    if self.project.modules[modulePathAbs] |mod| return mod
 
     self.typecheckingBuiltin = if modulePathAbs == self.moduleLoader.stdRoot + "/prelude.abra" {
       self.project.preludeScope = self.currentScope.makeChild("module_prelude", ScopeKind.Module(id: -1, name: modulePathAbs))
@@ -2305,7 +2312,22 @@ pub type Typechecker {
     self.currentModule = mod
     self.project.modules[modulePathAbs] = mod
 
-    val parsedModule = try self._tokenizeAndParse(modulePathAbs)
+    val parsedModule = try self.moduleLoader.tokenizeAndParse(modulePathAbs) else |e| {
+      match e {
+        TokenizeAndParseError.ReadFileError => {
+          // Mark the module as having an reading error, and also as complete since it's gone as far as it can go
+          mod.readFileError = true
+          mod.complete = true
+        }
+        TokenizeAndParseError.LexerError(inner) => mod.lexParseErrors.push(LexerOrParseError.LexerError(inner))
+        TokenizeAndParseError.ParseError(inner) => mod.lexParseErrors.push(LexerOrParseError.ParseError(inner))
+      }
+
+      // TODO: recover from this error?
+      // Maybe, for ParseErrors perhaps if we emit garbage. That may be a good way to implement intellisense in LSP
+      return mod
+    }
+
     val imports: (TypedModule, ImportNode)[] = []
     for importNode in parsedModule.imports {
       var importNodePath = importNode.moduleName.name
@@ -2320,35 +2342,30 @@ pub type Typechecker {
 
       val typedImportModule = if self.project.modules[importPathAbs] |m| {
         if !m.complete {
-          val err = TypeError(position: importNode.moduleName.position, kind: TypeErrorKind.CircularDependency)
-          return Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(err)))
+          // If a module attempts to import a module that is not yet complete, then we've found a circular dependency.
+          // Flag that imported module since it's the module whose imports began the cycle.
+          m.startsCircDep = true
+          return mod // TODO: recover from this error? i'm not sure we can
         }
 
         m
       } else {
         val childTypechecker = Typechecker(moduleLoader: self.moduleLoader, project: self.project)
-        val typedImportModule = match childTypechecker._typecheckModule(importPathAbs) {
-          Ok(m) => m
-          Err(e) => {
-            val err = match e.kind {
-              TypecheckerErrorKind.ReadFileError => {
-                val kind = if isRelativeImport {
-                  TypeErrorKind.UnknownModule(importPathAbs, true)
-                } else {
-                  TypeErrorKind.UnknownModule(importNode.moduleName.name, false)
-                }
+        childTypechecker._typecheckModule(importPathAbs)
+      }
 
-                val err = TypeError(position: importNode.moduleName.position, kind: kind)
-                TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(err))
-              }
-              _ => e
-            }
-
-            return Err(err)
-          }
+      if typedImportModule.readFileError {
+        val kind = if isRelativeImport {
+          TypeErrorKind.UnknownModule(importPathAbs, true)
+        } else {
+          TypeErrorKind.UnknownModule(importNode.moduleName.name, false)
         }
 
-        typedImportModule
+        mod.addTypeError(TypeError(position: importNode.moduleName.position, kind: kind))
+      } else if mod.startsCircDep {
+        // If the imported module can be read but the current module has been flagged as having started a circular
+        // dependency, we need to add that error to the current module so it can be surfaced.
+        mod.addTypeError(TypeError(position: importNode.moduleName.position, kind: TypeErrorKind.CircularDependency))
       }
 
       imports.push((typedImportModule, importNode))
@@ -2367,15 +2384,16 @@ pub type Typechecker {
     mod.rootScope = moduleScope
 
     for (typedImportModule, importNode) in imports {
-      match self._typecheckImport(typedImportModule, importNode) {
-        Ok(v) => v
-        Err(e) => return Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(e)))
+      val errors = self._typecheckImport(typedImportModule, importNode)
+      for err in errors {
+        mod.addTypeError(err)
       }
     }
 
-    mod.code = match self._typecheckBlock(parsedModule.nodes) {
-      Ok(v) => v
-      Err(e) => return Err(TypecheckerError(modulePath: modulePathAbs, kind: TypecheckerErrorKind.TypeError(e)))
+    // TODO: to be continued...
+    match self._typecheckBlock(parsedModule.nodes) {
+      Ok(v) => mod.code = v
+      Err(e) => mod.addTypeError(e)
     }
 
     self.currentScope = prevScope
@@ -2388,7 +2406,7 @@ pub type Typechecker {
       self.typecheckingBuiltin = None
     }
 
-    Ok(mod)
+    mod
   }
 
   func _typecheckDecoratorNode(self, dec: DecoratorNode): Result<Decorator, TypeError> {
@@ -3020,16 +3038,17 @@ pub type Typechecker {
     Ok(0)
   }
 
-  func _typecheckImport(self, mod: TypedModule, node: ImportNode): Result<Int, TypeError> {
+  func _typecheckImport(self, mod: TypedModule, node: ImportNode): TypeError[] {
     val importedModule = self.currentModule.imports.getOrInsert(mod.name, () => ImportedModule())
 
+    val errors: TypeError[] = []
     match node.kind {
       ImportKind.List(importNames) => {
         for imp in importNames {
           for (_, importedModule) in self.currentModule.imports {
             for (importedName, importedValue) in importedModule.imports {
               if importedName == imp.name {
-                return Err(TypeError(position: imp.position, kind: TypeErrorKind.DuplicateName(original: importedValue.label)))
+                errors.push(TypeError(position: imp.position, kind: TypeErrorKind.DuplicateName(original: importedValue.label)))
               }
             }
           }
@@ -3038,20 +3057,29 @@ pub type Typechecker {
             Export.Variable(v) => TypedImportKind.Variable(v)
             Export.Function(v) => TypedImportKind.Function(v)
             Export.Type(structOrEnum, v) => TypedImportKind.Type(structOrEnum, v)
-            None => return Err(TypeError(position: imp.position, kind: TypeErrorKind.UnknownImport(moduleName: node.moduleName.name, importName: imp.name)))
+            None => {
+              // If the imported module could not be read, then let's not emit UnknownImport. Likewise for when the current module
+              // has been flagged as having started a cycle. In both cases, these errors aren't very actionable and are just noisy.
+              if !mod.readFileError && !self.currentModule.startsCircDep {
+                errors.push(TypeError(position: imp.position, kind: TypeErrorKind.UnknownImport(moduleName: node.moduleName.name, importName: imp.name)))
+              }
+              continue
+            }
           }
 
           importedModule.imports[imp.name] = Import(label: imp, kind: typedImportKind)
         }
       }
       ImportKind.Alias(alias) => {
-        if self._verifyNameUniqueInScope(alias, self.currentScope) |e| return Err(e)
-
-        importedModule.aliases.push(alias)
+        if self._verifyNameUniqueInScope(alias, self.currentScope) |e| {
+          errors.push(e)
+        } else {
+          importedModule.aliases.push(alias)
+        }
       }
     }
 
-    Ok(0)
+    errors
   }
 
   func _typecheckBlock(self, nodes: AstNode[]): Result<TypedAstNode[], TypeError> {

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -863,13 +863,6 @@ pub enum AccessorPathSegment {
   }
 }
 
-type TypecheckerError {
-  pub modulePath: String
-  pub kind: TypecheckerErrorKind
-
-  pub func getMessage(self): String = self.kind.getMessage(self.modulePath)
-}
-
 pub enum LexerOrParseError {
   LexerError(inner: LexerError)
   ParseError(inner: ParseError)
@@ -878,41 +871,6 @@ pub enum LexerOrParseError {
     match self {
       LexerOrParseError.LexerError(inner) => inner.getMessage(modulePath, contents)
       LexerOrParseError.ParseError(inner) => inner.getMessage(modulePath, contents)
-    }
-  }
-}
-
-pub enum TypecheckerErrorKind {
-  ReadFileError(path: String)
-  LexerError(inner: LexerError)
-  ParseError(inner: ParseError)
-  TypeError(inner: TypeError)
-
-  pub func getMessage(self, modulePath: String): String {
-    match self {
-      // TODO: Better error message, once imports are a thing
-      TypecheckerErrorKind.ReadFileError(path) => "Could not read file '$path'"
-      TypecheckerErrorKind.LexerError(inner) => {
-        val contents = match fs.readFile(modulePath) {
-          Ok(v) => v
-          Err => return "Could not read file '$modulePath'"
-        }
-        inner.getMessage(modulePath, contents)
-      }
-      TypecheckerErrorKind.ParseError(inner) => {
-        val contents = match fs.readFile(modulePath) {
-          Ok(v) => v
-          Err => return "Could not read file '$modulePath'"
-        }
-        inner.getMessage(modulePath, contents)
-      }
-      TypecheckerErrorKind.TypeError(inner) => {
-        val contents = match fs.readFile(modulePath) {
-          Ok(v) => v
-          Err => return "Could not read file '$modulePath'"
-        }
-        inner.getMessage(modulePath, contents)
-      }
     }
   }
 }

--- a/projects/compiler/src/typechecker.test.abra
+++ b/projects/compiler/src/typechecker.test.abra
@@ -38,21 +38,52 @@ func main() {
     val moduleLoader = ModuleLoader(stdRoot: abraStdRoot)
     val project = Project()
     val typechecker = Typechecker(moduleLoader: moduleLoader, project: project)
+    typechecker.typecheckEntrypoint(filePathAbs)
 
-    match typechecker.typecheckEntrypoint(filePathAbs) {
-      Ok => {
-        val allModules = project.modules.values().sortBy(m => m.id)
-
-        if !verifyStdModule(allModules, 0, "_intrinsics") return
-        if !verifyStdModule(allModules, 1, "libc") return
-        if !verifyStdModule(allModules, 2, "prelude") return
-
-        val userModules = allModules[3:]
-        val json = Jsonifier()
-        json.printModules(userModules)
+    val readFileErrors: String[] = []
+    val errorMessages: String[] = []
+    for mod in project.modules.values().sortBy(m => -m.id) {
+      if mod.readFileError {
+        readFileErrors.push(mod.name)
+        continue
       }
-      Err(e) => println(e.getMessage())
+
+      val contents = try moduleLoader.loadFileContents(mod.name) else {
+        // Any unreadable modules should have had the `readFileError` field set, which is checked above
+        unreachable("Could not read file '${mod.name}'")
+      }
+
+      for err in mod.lexParseErrors {
+        errorMessages.push(err.getMessage(mod.name, contents))
+      }
+
+      for err in mod.typeErrors {
+        errorMessages.push(err.getMessage(mod.name, contents))
+      }
     }
+
+    if !errorMessages.isEmpty() {
+      for msg, idx in errorMessages {
+        println(msg)
+        if idx != errorMessages.length - 1 println() // spacer
+      }
+      return
+    } else if !readFileErrors.isEmpty() {
+      for path, idx in readFileErrors {
+        println("Could not read file '$path'")
+        if idx != readFileErrors.length - 1 println() // spacer
+      }
+      return
+    }
+
+    val allModules = project.modules.values().sortBy(m => m.id)
+
+    if !verifyStdModule(allModules, 0, "_intrinsics") return
+    if !verifyStdModule(allModules, 1, "libc") return
+    if !verifyStdModule(allModules, 2, "prelude") return
+
+    Jsonifier()
+      .printModules(allModules[3:])
   } else {
     println("Missing required argument <file-name>")
   }

--- a/projects/compiler/test/run-tests.js
+++ b/projects/compiler/test/run-tests.js
@@ -756,7 +756,6 @@ const TYPECHECKER_TESTS = [
   { test: "typechecker/import/import.2.abra", assertions: "typechecker/import/import.2.out.json" },
   { test: "typechecker/import/error_assignment_to_aliased_imported_variable.abra", assertions: "typechecker/import/error_assignment_to_aliased_imported_variable.out" },
   { test: "typechecker/import/error_assignment_to_imported_variable.abra", assertions: "typechecker/import/error_assignment_to_imported_variable.out" },
-
   { test: "typechecker/import/error_no_file_exists.abra", assertions: "typechecker/import/error_no_file_exists.out" },
   { test: "typechecker/import/error_nonrelative_not_found.abra", assertions: "typechecker/import/error_nonrelative_not_found.out" },
   { test: "typechecker/import/error_circular_dependency.1/mod.1.abra", assertions: "typechecker/import/error_circular_dependency.1/mod.1.out" },
@@ -789,6 +788,9 @@ const TYPECHECKER_TESTS = [
   { test: "typechecker/import/error_alias_duplicate_name.abra", assertions: "typechecker/import/error_alias_duplicate_name.out" },
   { test: "typechecker/import/error_alias_questiondot_access.abra", assertions: "typechecker/import/error_alias_questiondot_access.out" },
   { test: "typechecker/import/error_alias_unknown_import.abra", assertions: "typechecker/import/error_alias_unknown_import.out" },
+
+  // Testing error reporting
+  { test: "typechecker/error_reporting/multiple_errors_imports.abra", assertions: "typechecker/error_reporting/multiple_errors_imports.out" },
 ]
 
 const COMPILER_TESTS = [

--- a/projects/compiler/test/typechecker/error_reporting/_exports.abra
+++ b/projects/compiler/test/typechecker/error_reporting/_exports.abra
@@ -1,0 +1,2 @@
+pub type Foo {}
+pub enum Bar {}

--- a/projects/compiler/test/typechecker/error_reporting/multiple_errors_imports.abra
+++ b/projects/compiler/test/typechecker/error_reporting/multiple_errors_imports.abra
@@ -1,0 +1,7 @@
+import Foo from "./_exportsss"
+import Foo, Bazzzz from "./_exportsss"
+import Foo, Bar, Baz from "./_exports"
+import "./_exports" as e
+import "./_exports" as e
+import "./_exports" as Foo
+import "./_exports" as Bar

--- a/projects/compiler/test/typechecker/error_reporting/multiple_errors_imports.out
+++ b/projects/compiler/test/typechecker/error_reporting/multiple_errors_imports.out
@@ -1,0 +1,41 @@
+Error at %TEST_DIR%/typechecker/error_reporting/multiple_errors_imports.abra:1:17
+Could not import module
+  |  import Foo from "./_exportsss"
+                     ^
+No file exists at path '%TEST_DIR%/typechecker/error_reporting/_exportsss.abra'
+
+Error at %TEST_DIR%/typechecker/error_reporting/multiple_errors_imports.abra:2:25
+Could not import module
+  |  import Foo, Bazzzz from "./_exportsss"
+                             ^
+No file exists at path '%TEST_DIR%/typechecker/error_reporting/_exportsss.abra'
+
+Error at %TEST_DIR%/typechecker/error_reporting/multiple_errors_imports.abra:3:18
+Invalid import
+  |  import Foo, Bar, Baz from "./_exports"
+                      ^
+There's no exported value named 'Baz' in module './_exports'
+
+Error at %TEST_DIR%/typechecker/error_reporting/multiple_errors_imports.abra:5:24
+Duplicate name 'e'
+  |  import "./_exports" as e
+                            ^
+This name is also declared at (4:24)
+  |  import "./_exports" as e
+                            ^
+
+Error at %TEST_DIR%/typechecker/error_reporting/multiple_errors_imports.abra:6:24
+Duplicate name 'Foo'
+  |  import "./_exports" as Foo
+                            ^
+This name is also declared at (3:8)
+  |  import Foo, Bar, Baz from "./_exports"
+            ^
+
+Error at %TEST_DIR%/typechecker/error_reporting/multiple_errors_imports.abra:7:24
+Duplicate name 'Bar'
+  |  import "./_exports" as Bar
+                            ^
+This name is also declared at (3:13)
+  |  import Foo, Bar, Baz from "./_exports"
+                 ^

--- a/projects/compiler/test/typechecker/import/error_circular_dependency.1/mod.1.out
+++ b/projects/compiler/test/typechecker/import/error_circular_dependency.1/mod.1.out
@@ -1,5 +1,5 @@
-Error at %TEST_DIR%/typechecker/import/error_circular_dependency.1/mod.2.abra:1:15
+Error at %TEST_DIR%/typechecker/import/error_circular_dependency.1/mod.1.abra:1:15
 Could not import module due to circular dependency
-  |  import a from "./mod.1"
+  |  import a from "./mod.2"
                    ^
-The current module is imported by the imported module (or one of its imports), resulting in a cycle
+The current module is itself imported by this module (or one of its imports), resulting in a cycle

--- a/projects/compiler/test/typechecker/import/error_circular_dependency.2/mod.1.out
+++ b/projects/compiler/test/typechecker/import/error_circular_dependency.2/mod.1.out
@@ -1,5 +1,11 @@
-Error at %TEST_DIR%/typechecker/import/error_circular_dependency.2/mod.3.abra:1:15
+Error at %TEST_DIR%/typechecker/import/error_circular_dependency.2/mod.1.abra:1:15
 Could not import module due to circular dependency
-  |  import a from "./mod.1"
+  |  import a from "./mod.2"
                    ^
-The current module is imported by the imported module (or one of its imports), resulting in a cycle
+The current module is itself imported by this module (or one of its imports), resulting in a cycle
+
+Error at %TEST_DIR%/typechecker/import/error_circular_dependency.2/mod.2.abra:1:8
+Invalid import
+  |  import a from "./mod.3"
+            ^
+There's no exported value named 'a' in module './mod.3'

--- a/projects/lsp/src/language_service.abra
+++ b/projects/lsp/src/language_service.abra
@@ -2,7 +2,7 @@ import "fs" as fs
 import JsonValue from "json"
 import log from "./log"
 import Label from "../../compiler/src/parser"
-import TypedModule, ModuleLoader, Project, Typechecker, TypecheckerErrorKind, IdentifierMeta, IdentifierKindMeta, IdentifierMetaModule from "../../compiler/src/typechecker"
+import TypedModule, ModuleLoader, Project, Typechecker, TypecheckerErrorKind, IdentifierMeta, IdentifierKindMeta, IdentifierMetaModule, LexerOrParseError from "../../compiler/src/typechecker"
 import RequestMessage, NotificationMessage, ResponseMessage, ResponseResult, ResponseError, ResponseErrorCode, ServerCapabilities, TextDocumentSyncOptions, TextDocumentSyncKind, SaveOptions, ServerInfo, TextDocumentItem, TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity, Position, Range, MarkupContent, MarkupKind, DocumentSymbol, SymbolKind from "./lsp_spec"
 
 pub val contentLengthHeader = "Content-Length: "
@@ -368,55 +368,47 @@ pub type AbraLanguageService {
     // todo: what happens if it's not a `file://` uri?
     val filePath = uri.replaceAll("file://", "")
 
-    val typechecker = Typechecker(
-      moduleLoader: self._moduleLoader,
-      project: self._project,
-      lspMode: true,
-    )
+    val typechecker = Typechecker(moduleLoader: self._moduleLoader, project: self._project, lspMode: true)
+    typechecker.typecheckEntrypoint(filePath)
 
-    match typechecker.typecheckEntrypoint(filePath) {
-      Ok => []
-      Err(e) => {
-        val (position, message) = match e.kind {
-          TypecheckerErrorKind.ReadFileError => unreachable("could not read file '$filePath'")
-          TypecheckerErrorKind.LexerError(inner) => {
-            val contents = match fs.readFile(e.modulePath) {
-              Ok(v) => v
-              Err => unreachable("Could not read file '${e.modulePath}'")
-            }
-            val msg = inner.getMessage(e.modulePath, contents)
-            (inner.position, msg)
-          }
-          TypecheckerErrorKind.ParseError(inner) => {
-            val contents = match fs.readFile(e.modulePath) {
-              Ok(v) => v
-              Err => unreachable("Could not read file '${e.modulePath}'")
-            }
-            val msg = inner.getMessage(e.modulePath, contents)
-            (inner.position, msg)
-          }
-          TypecheckerErrorKind.TypeError(inner) => {
-            val contents = match fs.readFile(e.modulePath) {
-              Ok(v) => v
-              Err => unreachable("Could not read file '${e.modulePath}'")
-            }
-            val msg = inner.getMessage(e.modulePath, contents)
-            (inner.position, msg)
-          }
-        }
+    val mod = try self._project.modules[filePath] else return []
+    if mod.readFileError return [] // Skip unreadable modules; can't show Diagnostics for them anyway
+    val contents = try self._moduleLoader.loadFileContents(mod.name) else return [] // Skip unreadable modules; can't show Diagnostics for them anyway
 
-        val pos = Position(line: position.line - 1, character: position.col - 1)
-        val diagnostic = Diagnostic(
-          range: Range(start: pos, end: pos),
-          severity: Some(DiagnosticSeverity.Error),
-          message: message
-            .replaceAll("\n", "\\n")
-            .replaceAll("\"", "\\\"")
-            .replaceAll("\t", "\\t"),
-        )
-        [diagnostic]
+    val diagnostics: Diagnostic[] = []
+
+    for err in mod.lexParseErrors {
+      val (position, message) = match err {
+        LexerOrParseError.LexerError(inner) => (inner.position, inner.getMessage(mod.name, contents))
+        LexerOrParseError.ParseError(inner) => (inner.position, inner.getMessage(mod.name, contents))
       }
+
+      val pos = Position(line: position.line - 1, character: position.col - 1)
+      diagnostics.push(Diagnostic(
+        range: Range(start: pos, end: pos),
+        severity: Some(DiagnosticSeverity.Error),
+        message: message
+          .replaceAll("\n", "\\n")
+          .replaceAll("\"", "\\\"")
+          .replaceAll("\t", "\\t"),
+      ))
     }
+
+    for err in mod.typeErrors {
+      val position = err.position
+      val message = err.getMessage(mod.name, contents)
+      val pos = Position(line: position.line - 1, character: position.col - 1)
+      diagnostics.push(Diagnostic(
+        range: Range(start: pos, end: pos),
+        severity: Some(DiagnosticSeverity.Error),
+        message: message
+          .replaceAll("\n", "\\n")
+          .replaceAll("\"", "\\\"")
+          .replaceAll("\t", "\\t"),
+      ))
+    }
+
+    diagnostics
   }
 
   func _findIdentAtPosition(self, uri: String, position: Position): (Int, Int, Int, IdentifierMeta)? {

--- a/projects/lsp/src/language_service.abra
+++ b/projects/lsp/src/language_service.abra
@@ -2,7 +2,7 @@ import "fs" as fs
 import JsonValue from "json"
 import log from "./log"
 import Label from "../../compiler/src/parser"
-import TypedModule, ModuleLoader, Project, Typechecker, TypecheckerErrorKind, IdentifierMeta, IdentifierKindMeta, IdentifierMetaModule, LexerOrParseError from "../../compiler/src/typechecker"
+import TypedModule, ModuleLoader, Project, Typechecker, LexerOrParseError, IdentifierMeta, IdentifierKindMeta, IdentifierMetaModule from "../../compiler/src/typechecker"
 import RequestMessage, NotificationMessage, ResponseMessage, ResponseResult, ResponseError, ResponseErrorCode, ServerCapabilities, TextDocumentSyncOptions, TextDocumentSyncKind, SaveOptions, ServerInfo, TextDocumentItem, TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity, Position, Range, MarkupContent, MarkupKind, DocumentSymbol, SymbolKind from "./lsp_spec"
 
 pub val contentLengthHeader = "Content-Length: "


### PR DESCRIPTION
Previously, if typechecking encountered a type error (or an error reading, lexing, or parsing the file, which it packaged up as a typechecker error), it exited the program and surfaced the error. This works great, however it only allows one error to be surfaced at a time, and it also halts typechecking for the rest of the file and prevents any other meaningful type information to be gathered. This notably includes data for the LSP, so if typechecking failed there would be no go-to-definition/hover support and no symbol support, until all of the type errors were addressed (which could be cumbersome, if there are more than one and they're only revealed one at a time).

Taking this approach, wherein typechecking is allowed to recover from errors rather than bailing early (and keeping track of those errors to be surfaced later), allows the module to be at least partially typed. This, in turn, allows the LSP to still provide functionality.

I think this image is a pretty awesome representation of what this change unlocks:
<img width="289" alt="Image" src="https://github.com/user-attachments/assets/3dc95adb-387d-4985-931e-4617d7fd7065" />
In this picture, there are several type errors being surfaced due to invalid imports and name conflicts, _but_ we're still able to get hover information for the variable. Previously this wouldn't have been available.