### PR TITLE
Continuing to support <unknown> type

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,22 +1,55 @@
 import "./example2" as ex2
 
 func bar(a: Abc): Int {
-  val b = -a
-  val c = !a
-  val d = "hello $a"
-  val e = (a)
-  val f = r
+  // unary
+  val unary1 = -a
+  val unary2 = !a
 
-  val g = ex2?.bar
-  val h = ex2.bar
+  val binary1 = a + 1
+  val binary2 = a - 1
+  val binary3 = a * 1
+  val binary4 = a / 1
+  val binary5 = a % 1
+  val binary6 = a > 1
+  val binary7 = a >= 1
+  val binary8 = a < 1
+  val binary9 = a <= 1
+
+  val stringInterpolation = "hello $a"
+
+  val grouped = (a)
+
+  val identifier = r
+
+  // accessor
+  val nonOptModuleAccess = ex2?.bar
+  val modAccess = ex2.bar
   val arr = [a.abc, a.def]
-  val i = arr.size.absVal
-  val j = [1, 2, 3][0].abs
-  val k = arr.withCapacity
-  // val g = ex2.bar()
+  val fieldAccess = arr.size.absVal
+  val optFieldAccess = [1, 2, 3][0].abs
+  val staticFieldAccess = arr.withCapacity
 
-  val x = a + 1
-  return x
+  // invocation
+  val invocationModuleAccess = ex2.bar()
+  val invocationNoSuchFunction = what()
+  val invocationNoSuchInstanceMethod = arr.foo()
+  val invocationNoSuchStaticMethod = Array.foo()
+
+  val indexing1 = huh[0]
+  val indexing2 = arr.huh[0]
+
+  val try1 = try huh
+  val try2 = try arr.huh
+
+  return a + 1
 }
 
 val abc = bar(123)
+
+func baz(): Abc? {
+  val try1 = try [1, 2, 3][0]
+  val try2 = try huh
+  val try3 = try arr.huh
+}
+
+val def = baz()

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -1366,13 +1366,16 @@ type TypeError {
           InvalidTryLocationReason.NotWithinFunction => {
             lines.push("Try expressions can only be used inside of function bodies")
           }
-          InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel, tryType, returnType, isResult) => {
+          InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel, tryType, returnType, kind) => {
             lines.push("The containing function '${fnLabel.name}' has return type '${returnType.repr()}', which is incompatible with the try expression's type '${tryType.repr()}'.")
             lines.push(self._getCursorLine(fnLabel.position, contents))
-            if isResult {
-              lines.push("To be compatible, '${fnLabel.name}' must return a Result whose error type matches that of the try expression")
-            } else {
-              lines.push("To be compatible, '${fnLabel.name}' must return an Option type")
+            match kind {
+              InvalidFunctionReturnTypeKind.IsResult => {
+                lines.push("To be compatible, '${fnLabel.name}' must return a Result whose error type matches that of the try expression")
+              }
+              InvalidFunctionReturnTypeKind.IsOption => {
+                lines.push("To be compatible, '${fnLabel.name}' must return an Option type")
+              }
             }
           }
         }
@@ -1448,9 +1451,15 @@ enum InvalidDestructuringReason {
   InvalidTupleArity(expected: Int, given: Int)
 }
 
+enum InvalidFunctionReturnTypeKind {
+  IsResult
+  IsOption
+  IsNotTryable
+}
+
 enum InvalidTryLocationReason {
   NotWithinFunction
-  InvalidFunctionReturnType(fnLabel: Label, tryType: Type, returnType: Type, isResult: Bool)
+  InvalidFunctionReturnType(fnLabel: Label, tryType: Type, returnType: Type, kind: InvalidFunctionReturnTypeKind)
 }
 
 enum TypeErrorKind {
@@ -2404,7 +2413,10 @@ pub type Typechecker {
     }
 
     val returnType = if node.returnTypeAnnotation |typeAnn| {
-      try self.resolveTypeIdentifier(typeAnn)
+      try self.resolveTypeIdentifier(typeAnn) else |err| {
+        self.currentModule.addTypeError(err)
+        Type(kind: TypeKind.CouldNotDetermine)
+      }
     } else {
       Type(kind: TypeKind.PrimitiveUnit)
     }
@@ -2585,7 +2597,7 @@ pub type Typechecker {
     val prevFn = self.currentFunction
     self.currentFunction = Some(fn)
 
-    val hasReturnValue = fn.returnType.kind != TypeKind.PrimitiveUnit
+    val hasReturnValue = fn.returnType.kind != TypeKind.PrimitiveUnit && fn.returnType.kind != TypeKind.CouldNotDetermine
     if hasReturnValue && body.isEmpty() {
       if !fn.decorators.find(dec => dec.label.name == "Stub" || dec.label.name == "Intrinsic" || dec.label.name == "CBinding")
         return Err(TypeError(position: fn.label.position, kind: TypeErrorKind.ReturnTypeMismatch(Some(fn.label.name), fn.returnType, None)))
@@ -3420,10 +3432,10 @@ pub type Typechecker {
         return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: TypedAstNodeKind.Assignment(mode, op, typedExpr)))
       }
       AssignmentMode.Indexing(targetExpr, indexExpr) => {
-        val typedLhs = try self._typecheckIndexing(token, targetExpr, IndexingMode.Single(indexExpr), None)
+        val typedLhs = try self.typecheckIndexing(token, targetExpr, IndexingMode.Single(indexExpr), None)
         val typedIndexingNode = match typedLhs.kind {
           TypedAstNodeKind.Indexing(node) => node
-          _ => unreachable("_typecheckIndexing returned unexpected TypedAstNodeKind")
+          _ => unreachable("typecheckIndexing returned unexpected TypedAstNodeKind")
         }
         val assignmentTy = self._typeIsOption(typedLhs.ty) ?: typedLhs.ty
 
@@ -4068,16 +4080,16 @@ pub type Typechecker {
       }
       AstNodeKind.Identifier(kind) => self.typecheckIdentifier(token, kind, typeHint)
       AstNodeKind.Accessor(node) => self.typecheckAccessor(token, node, typeHint)
-      AstNodeKind.Invocation(node) => self._typecheckInvocation(token, node, typeHint)
-      AstNodeKind.Array(items) => self._typecheckArray(token, items, typeHint)
-      AstNodeKind.Set(items) => self._typecheckSet(token, items, typeHint)
-      AstNodeKind.Map(items) => self._typecheckMap(token, items, typeHint)
-      AstNodeKind.Tuple(items) => self._typecheckTuple(token, items, typeHint)
-      AstNodeKind.Indexing(expr, index) => self._typecheckIndexing(token, expr, index, typeHint)
+      AstNodeKind.Invocation(node) => self.typecheckInvocation(token, node, typeHint)
+      AstNodeKind.Array(items) => self.typecheckArray(token, items, typeHint)
+      AstNodeKind.Set(items) => self.typecheckSet(token, items, typeHint)
+      AstNodeKind.Map(items) => self.typecheckMap(token, items, typeHint)
+      AstNodeKind.Tuple(items) => self.typecheckTuple(token, items, typeHint)
+      AstNodeKind.Indexing(expr, index) => self.typecheckIndexing(token, expr, index, typeHint)
       AstNodeKind.Lambda(value) => self._typecheckLambda(token, value, typeHint)
       AstNodeKind.If(condition, conditionBinding, ifBlock, elseBlock) => self._typecheckIf(token, condition, conditionBinding, ifBlock, elseBlock, typeHint)
       AstNodeKind.Match(subject, cases) => self._typecheckMatch(token, subject, cases, typeHint)
-      AstNodeKind.Try(expr, elseClause) => self._typecheckTry(token, expr, elseClause, typeHint)
+      AstNodeKind.Try(expr, elseClause) => self.typecheckTry(token, expr, elseClause, typeHint)
       _ => unreachable("all other node types should have already been handled")
     }
 
@@ -4547,6 +4559,8 @@ pub type Typechecker {
 
     val path: AccessorPathSegment[] = []
     var ty = typedRoot.ty
+    if ty.kind == TypeKind.CouldNotDetermine return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.CouldNotDetermine), kind: TypedAstNodeKind.Placeholder))
+
     var seenOptSafeDot = false
     for (token, label), idx in accessorPath {
       val isOptSafe = token.kind == TokenKind.QuestionDot
@@ -4670,12 +4684,14 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Accessor(typedRoot, path, finalField)))
   }
 
-  func _typecheckInvocation(self, token: Token, node: InvocationAstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
+  func typecheckInvocation(self, token: Token, node: InvocationAstNode, typeHint: Type?): Result<TypedAstNode, TypeError> {
     self.isStructOrEnumValueAllowed = true
     self.isEnumContainerValueAllowed = true
     val invokee = try self._typecheckExpression(node.invokee, None)
     self.isEnumContainerValueAllowed = false
     self.isStructOrEnumValueAllowed = false
+
+    if invokee.ty.kind == TypeKind.CouldNotDetermine return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.CouldNotDetermine), kind: TypedAstNodeKind.Placeholder))
 
     match invokee.kind {
       TypedAstNodeKind.Identifier(name, variable, _, _) => {
@@ -4998,7 +5014,7 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Invocation(typedInvokee, typedArguments, resolvedGenerics)))
   }
 
-  func _typecheckArray(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
+  func typecheckArray(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
     var innerType: Type? = None
     if typeHint |hint| {
       if self._typeAsInstance1(hint, self.project.preludeArrayStruct) |inner| {
@@ -5038,7 +5054,7 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Array(typedItems)))
   }
 
-  func _typecheckSet(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
+  func typecheckSet(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
     var innerType: Type? = None
     if typeHint |hint| {
       if self._typeAsInstance1(hint, self.project.preludeSetStruct) |inner| {
@@ -5078,7 +5094,7 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Set(typedItems)))
   }
 
-  func _typecheckMap(self, token: Token, items: (AstNode, AstNode)[], typeHint: Type?): Result<TypedAstNode, TypeError> {
+  func typecheckMap(self, token: Token, items: (AstNode, AstNode)[], typeHint: Type?): Result<TypedAstNode, TypeError> {
     var keyTy: Type? = None
     var valTy: Type? = None
     if typeHint |hint| {
@@ -5138,7 +5154,7 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Map(typedItems)))
   }
 
-  func _typecheckTuple(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
+  func typecheckTuple(self, token: Token, items: AstNode[], typeHint: Type?): Result<TypedAstNode, TypeError> {
     var typeHints: Type[]? = None
     if typeHint |hint| {
       match hint.kind {
@@ -5169,8 +5185,10 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Tuple(typedItems)))
   }
 
-  func _typecheckIndexing(self, token: Token, expr: AstNode, indexMode: IndexingMode<AstNode>, typeHint: Type?): Result<TypedAstNode, TypeError> {
+  func typecheckIndexing(self, token: Token, expr: AstNode, indexMode: IndexingMode<AstNode>, typeHint: Type?): Result<TypedAstNode, TypeError> {
     val typedExpr = try self._typecheckExpression(expr, None)
+    if typedExpr.ty.kind == TypeKind.CouldNotDetermine return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.CouldNotDetermine), kind: TypedAstNodeKind.Placeholder))
+
     if self._typeIsOption(typedExpr.ty) {
       return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: false)))
     }
@@ -5325,7 +5343,7 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: lambdaTy, kind: TypedAstNodeKind.Lambda(fn, typeHint)))
   }
 
-  func _typecheckTry(self, token: Token, expr: AstNode, elseClause: (Token, BindingPattern?, AstNode[])?, typeHint: Type?): Result<TypedAstNode, TypeError> {
+  func typecheckTry(self, token: Token, expr: AstNode, elseClause: (Token, BindingPattern?, AstNode[])?, typeHint: Type?): Result<TypedAstNode, TypeError> {
     // TODO: support top-level try (the error case would just exit the program)
     val currentFn = try self.currentFunction else return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.NotWithinFunction)))
 
@@ -5342,11 +5360,18 @@ pub type Typechecker {
     } else if elseClause {
       val typedExpr = try self._typecheckExpression(expr, None)
       (typedExpr, None)
+    } else if currentFn.returnType.kind == TypeKind.CouldNotDetermine {
+      return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.CouldNotDetermine), kind: TypedAstNodeKind.Placeholder))
     } else {
       val typedExpr = try self._typecheckExpression(expr, None)
-      val isResult = !!self._typeIsResult(typedExpr.ty)
-      return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel: currentFn.label, tryType: typedExpr.ty, returnType: currentFn.returnType, isResult: isResult))))
+
+      if typedExpr.ty.kind == TypeKind.CouldNotDetermine return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.CouldNotDetermine), kind: TypedAstNodeKind.Placeholder))
+
+      val kind = if self._typeIsResult(typedExpr.ty) InvalidFunctionReturnTypeKind.IsResult else InvalidFunctionReturnTypeKind.IsOption
+      return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel: currentFn.label, tryType: typedExpr.ty, returnType: currentFn.returnType, kind: kind))))
     }
+
+    if typedExpr.ty.kind == TypeKind.CouldNotDetermine return Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.CouldNotDetermine), kind: TypedAstNodeKind.Placeholder))
 
     val (tryValType, typedElseClause) = if elseClause |(elseToken, bindingPattern, elseBlock)| {
       val isStatement = if typeHint |hint| hint.kind == TypeKind.PrimitiveUnit else false
@@ -5413,11 +5438,11 @@ pub type Typechecker {
             exprOkType
           }
         } else {
-          return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel: currentFn.label, tryType: typedExpr.ty, returnType: currentFn.returnType, isResult: true))))
+          return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel: currentFn.label, tryType: typedExpr.ty, returnType: currentFn.returnType, kind: InvalidFunctionReturnTypeKind.IsResult))))
         }
       } else if self._typeIsOption(typedExpr.ty) |inner| {
         if returnTypeResultErr {
-          return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel: currentFn.label, tryType: typedExpr.ty, returnType: currentFn.returnType, isResult: false))))
+          return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.InvalidFunctionReturnType(fnLabel: currentFn.label, tryType: typedExpr.ty, returnType: currentFn.returnType, kind: InvalidFunctionReturnTypeKind.IsOption))))
         } else {
           inner
         }

--- a/projects/compiler/test/typechecker/import/error_alias_unknown_import.out
+++ b/projects/compiler/test/typechecker/import/error_alias_unknown_import.out
@@ -5,9 +5,3 @@ Unknown member 'bogus'
 There's no exported value named 'bogus' in module aliased as 'a' at:
   |  import "./_exports" as a
                             ^
-
-Error at %TEST_DIR%/typechecker/import/error_alias_unknown_import.abra:3:2
-Cannot invoke target as function
-  |  a.bogus()
-      ^
-Type '<unknown>' is not callable

--- a/projects/compiler/test/typechecker/multi_error_reporting/could_not_resolve_types.abra
+++ b/projects/compiler/test/typechecker/multi_error_reporting/could_not_resolve_types.abra
@@ -1,22 +1,55 @@
 import "./_exports" as ex
 
 func bar(a: Abc): Int {
-  val b = -a
-  val c = !a
-  val d = "hello $a"
-  val e = (a)
-  val f = r
+  // unary
+  val unary1 = -a
+  val unary2 = !a
 
-  val g = ex?.bar
-  val h = ex.bar
+  val binary1 = a + 1
+  val binary2 = a - 1
+  val binary3 = a * 1
+  val binary4 = a / 1
+  val binary5 = a % 1
+  val binary6 = a > 1
+  val binary7 = a >= 1
+  val binary8 = a < 1
+  val binary9 = a <= 1
+
+  val stringInterpolation = "hello $a"
+
+  val grouped = (a)
+
+  val identifier = r
+
+  // accessor
+  val nonOptModuleAccess = ex?.bar
+  val modAccess = ex.bar
   val arr = [a.abc, a.def]
-  val i = arr.size.absVal
-  val j = [1, 2, 3][0].abs
-  val k = arr.withCapacity
-  // val g = ex2.bar()
+  val fieldAccess = arr.size.absVal
+  val optFieldAccess = [1, 2, 3][0].abs
+  val staticFieldAccess = arr.withCapacity
 
-  val x = a + 1
-  return x
+  // invocation
+  val invocationModuleAccess = ex.bar()
+  val invocationNoSuchFunction = what()
+  val invocationNoSuchInstanceMethod = arr.foo()
+  val invocationNoSuchStaticMethod = Array.foo()
+
+  val indexing1 = huh[0]
+  val indexing2 = arr.huh[0]
+
+  val try1 = try huh
+  val try2 = try arr.huh
+
+  return a + 1
 }
 
 val abc = bar(123)
+
+func baz(): Abc? {
+  val try1 = try [1, 2, 3][0]
+  val try2 = try huh
+  val try3 = try arr.huh
+}
+
+val def = baz()

--- a/projects/compiler/test/typechecker/multi_error_reporting/could_not_resolve_types.out
+++ b/projects/compiler/test/typechecker/multi_error_reporting/could_not_resolve_types.out
@@ -1,65 +1,109 @@
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:49:13
+Unknown type 'Abc'
+  |  func baz(): Abc? {
+                 ^
+No type with that name is visible in current scope
+
 Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:3:13
 Unknown type 'Abc'
   |  func bar(a: Abc): Int {
                  ^
 No type with that name is visible in current scope
 
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:8:11
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:22:20
 Unknown variable 'r'
-  |    val f = r
-               ^
+  |    val identifier = r
+                        ^
 No variable with that name is visible in current scope
 
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:10:13
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:25:30
 Unnecessary use of '?.' operator
-  |    val g = ex?.bar
-                 ^
+  |    val nonOptModuleAccess = ex?.bar
+                                  ^
 (The lhs value's type here is known to be a non-Option type)
 
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:10:15
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:25:32
 Unknown member 'bar'
-  |    val g = ex?.bar
-                   ^
+  |    val nonOptModuleAccess = ex?.bar
+                                    ^
 There's no exported value named 'bar' in module aliased as 'ex' at:
   |  import "./_exports" as ex
                             ^
 
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:11:14
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:26:22
 Unknown member 'bar'
-  |    val h = ex.bar
-                  ^
+  |    val modAccess = ex.bar
+                          ^
 There's no exported value named 'bar' in module aliased as 'ex' at:
   |  import "./_exports" as ex
                             ^
 
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:12:16
-Unknown field 'abc'
-  |    val arr = [a.abc, a.def]
-                    ^
-No field 'abc' found on type <unknown>
-
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:12:23
-Unknown field 'def'
-  |    val arr = [a.abc, a.def]
-                           ^
-No field 'def' found on type <unknown>
-
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:13:15
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:28:25
 Unknown field 'size'
-  |    val i = arr.size.absVal
-                   ^
+  |    val fieldAccess = arr.size.absVal
+                             ^
 No field 'size' found on type <unknown>[]
 
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:14:24
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:29:37
 Unknown field 'abs'
-  |    val j = [1, 2, 3][0].abs
-                            ^
+  |    val optFieldAccess = [1, 2, 3][0].abs
+                                         ^
 Type 'Int' has field 'abs', but lhs is of type 'Int?'
 (You can use the '?.' operator instead of '.')
 
-Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:15:15
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:30:31
 Unknown field 'withCapacity'
-  |    val k = arr.withCapacity
-                   ^
+  |    val staticFieldAccess = arr.withCapacity
+                                   ^
 No field 'withCapacity' found on instance of type <unknown>[]
 'withCapacity' is a static member of <unknown>[], did you mean to write <unknown>[].withCapacity?
+
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:33:35
+Unknown member 'bar'
+  |    val invocationModuleAccess = ex.bar()
+                                       ^
+There's no exported value named 'bar' in module aliased as 'ex' at:
+  |  import "./_exports" as ex
+                            ^
+
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:34:34
+Unknown variable 'what'
+  |    val invocationNoSuchFunction = what()
+                                      ^
+No variable with that name is visible in current scope
+
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:35:44
+Unknown field 'foo'
+  |    val invocationNoSuchInstanceMethod = arr.foo()
+                                                ^
+No field 'foo' found on type <unknown>[]
+
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:36:44
+Unknown field 'foo'
+  |    val invocationNoSuchStaticMethod = Array.foo()
+                                                ^
+No field 'foo' found on type <#type Array>
+
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:38:19
+Unknown variable 'huh'
+  |    val indexing1 = huh[0]
+                       ^
+No variable with that name is visible in current scope
+
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:39:23
+Unknown field 'huh'
+  |    val indexing2 = arr.huh[0]
+                           ^
+No field 'huh' found on type <unknown>[]
+
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:41:18
+Unknown variable 'huh'
+  |    val try1 = try huh
+                      ^
+No variable with that name is visible in current scope
+
+Error at %TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra:42:22
+Unknown field 'huh'
+  |    val try2 = try arr.huh
+                          ^
+No field 'huh' found on type <unknown>[]

--- a/projects/compiler/test/typechecker/multi_error_reporting/could_not_resolve_types.out.json
+++ b/projects/compiler/test/typechecker/multi_error_reporting/could_not_resolve_types.out.json
@@ -229,21 +229,84 @@
                   }
                 },
                 {
-                  "label": { "name": "b", "position": [4, 7] },
+                  "label": { "name": "unary1", "position": [5, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "c", "position": [5, 7] },
+                  "label": { "name": "unary2", "position": [6, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "d", "position": [6, 7] },
+                  "label": { "name": "binary1", "position": [8, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "binary2", "position": [9, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "binary3", "position": [10, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "binary4", "position": [11, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "binary5", "position": [12, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "binary6", "position": [13, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "binary7", "position": [14, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "binary8", "position": [15, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "binary9", "position": [16, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "stringInterpolation", "position": [18, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "primitive",
@@ -251,35 +314,35 @@
                   }
                 },
                 {
-                  "label": { "name": "e", "position": [7, 7] },
+                  "label": { "name": "grouped", "position": [20, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "f", "position": [8, 7] },
+                  "label": { "name": "identifier", "position": [22, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "g", "position": [10, 7] },
+                  "label": { "name": "nonOptModuleAccess", "position": [25, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "h", "position": [11, 7] },
+                  "label": { "name": "modAccess", "position": [26, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "arr", "position": [12, 7] },
+                  "label": { "name": "arr", "position": [27, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "instance",
@@ -292,28 +355,77 @@
                   }
                 },
                 {
-                  "label": { "name": "i", "position": [13, 7] },
+                  "label": { "name": "fieldAccess", "position": [28, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "j", "position": [14, 7] },
+                  "label": { "name": "optFieldAccess", "position": [29, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "k", "position": [15, 7] },
+                  "label": { "name": "staticFieldAccess", "position": [30, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
                   }
                 },
                 {
-                  "label": { "name": "x", "position": [18, 7] },
+                  "label": { "name": "invocationModuleAccess", "position": [33, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "invocationNoSuchFunction", "position": [34, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "invocationNoSuchInstanceMethod", "position": [35, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "invocationNoSuchStaticMethod", "position": [36, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "indexing1", "position": [38, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "indexing2", "position": [39, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "try1", "position": [41, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "try2", "position": [42, 7] },
                   "mutable": false,
                   "type": {
                     "kind": "could not determine"
@@ -342,65 +454,6 @@
             "body": [
               {
                 "token": {
-                  "position": [4, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "b", "position": [4, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "b", "position": [4, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "could not determine"
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [4, 11],
-                      "kind": {
-                        "name": "Minus"
-                      }
-                    },
-                    "type": {
-                      "kind": "could not determine"
-                    },
-                    "node": {
-                      "kind": "unary",
-                      "op": "UnaryOp.Minus",
-                      "expr": {
-                        "token": {
-                          "position": [4, 12],
-                          "kind": {
-                            "name": "Ident",
-                            "value": "a"
-                          }
-                        },
-                        "type": {
-                          "kind": "could not determine"
-                        },
-                        "node": {
-                          "kind": "identifier",
-                          "name": "a"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
                   "position": [5, 3],
                   "kind": {
                     "name": "Val"
@@ -414,11 +467,11 @@
                   "kind": "bindingDeclaration",
                   "pattern": {
                     "kind": "variable",
-                    "label": { "name": "c", "position": [5, 7] }
+                    "label": { "name": "unary1", "position": [5, 7] }
                   },
                   "variables": [
                     {
-                      "label": { "name": "c", "position": [5, 7] },
+                      "label": { "name": "unary1", "position": [5, 7] },
                       "mutable": false,
                       "type": {
                         "kind": "could not determine"
@@ -427,9 +480,9 @@
                   ],
                   "expr": {
                     "token": {
-                      "position": [5, 11],
+                      "position": [5, 16],
                       "kind": {
-                        "name": "Bang"
+                        "name": "Minus"
                       }
                     },
                     "type": {
@@ -437,10 +490,10 @@
                     },
                     "node": {
                       "kind": "unary",
-                      "op": "UnaryOp.Negate",
+                      "op": "UnaryOp.Minus",
                       "expr": {
                         "token": {
-                          "position": [5, 12],
+                          "position": [5, 17],
                           "kind": {
                             "name": "Ident",
                             "value": "a"
@@ -473,115 +526,11 @@
                   "kind": "bindingDeclaration",
                   "pattern": {
                     "kind": "variable",
-                    "label": { "name": "d", "position": [6, 7] }
+                    "label": { "name": "unary2", "position": [6, 7] }
                   },
                   "variables": [
                     {
-                      "label": { "name": "d", "position": [6, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "primitive",
-                        "primitive": "String"
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [6, 11],
-                      "kind": {
-                        "name": "StringInterpolation",
-                        "chunks": [
-                          {
-                            "position": [6, 11],
-                            "kind": {
-                              "name": "String",
-                              "value": "hello "
-                            }
-                          },
-                          [
-                            {
-                              "position": [6, 19],
-                              "kind": {
-                                "name": "Ident",
-                                "value": "a"
-                              }
-                            }
-                          ],
-                          {
-                            "position": [6, 20],
-                            "kind": {
-                              "name": "String",
-                              "value": ""
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "type": {
-                      "kind": "primitive",
-                      "primitive": "String"
-                    },
-                    "node": {
-                      "kind": "stringInterpolation",
-                      "exprs": [
-                        {
-                          "token": {
-                            "position": [6, 11],
-                            "kind": {
-                              "name": "String",
-                              "value": "hello "
-                            }
-                          },
-                          "type": {
-                            "kind": "primitive",
-                            "primitive": "String"
-                          },
-                          "node": {
-                            "kind": "literal",
-                            "value": "hello "
-                          }
-                        },
-                        {
-                          "token": {
-                            "position": [6, 19],
-                            "kind": {
-                              "name": "Ident",
-                              "value": "a"
-                            }
-                          },
-                          "type": {
-                            "kind": "could not determine"
-                          },
-                          "node": {
-                            "kind": "identifier",
-                            "name": "a"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
-                  "position": [7, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "e", "position": [7, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "e", "position": [7, 7] },
+                      "label": { "name": "unary2", "position": [6, 7] },
                       "mutable": false,
                       "type": {
                         "kind": "could not determine"
@@ -590,19 +539,20 @@
                   ],
                   "expr": {
                     "token": {
-                      "position": [7, 11],
+                      "position": [6, 16],
                       "kind": {
-                        "name": "LParen"
+                        "name": "Bang"
                       }
                     },
                     "type": {
                       "kind": "could not determine"
                     },
                     "node": {
-                      "kind": "grouped",
+                      "kind": "unary",
+                      "op": "UnaryOp.Negate",
                       "expr": {
                         "token": {
-                          "position": [7, 12],
+                          "position": [6, 17],
                           "kind": {
                             "name": "Ident",
                             "value": "a"
@@ -635,11 +585,11 @@
                   "kind": "bindingDeclaration",
                   "pattern": {
                     "kind": "variable",
-                    "label": { "name": "f", "position": [8, 7] }
+                    "label": { "name": "binary1", "position": [8, 7] }
                   },
                   "variables": [
                     {
-                      "label": { "name": "f", "position": [8, 7] },
+                      "label": { "name": "binary1", "position": [8, 7] },
                       "mutable": false,
                       "type": {
                         "kind": "could not determine"
@@ -648,345 +598,7 @@
                   ],
                   "expr": {
                     "token": {
-                      "position": [8, 11],
-                      "kind": {
-                        "name": "Ident",
-                        "value": "r"
-                      }
-                    },
-                    "type": {
-                      "kind": "could not determine"
-                    },
-                    "node": {
-                      "kind": "identifier",
-                      "name": "r"
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
-                  "position": [10, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "g", "position": [10, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "g", "position": [10, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "could not determine"
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [10, 13],
-                      "kind": {
-                        "name": "QuestionDot"
-                      }
-                    },
-                    "type": {
-                      "kind": "could not determine"
-                    },
-                    "node": {
-                      "kind": "placeholder"
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
-                  "position": [11, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "h", "position": [11, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "h", "position": [11, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "could not determine"
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [11, 13],
-                      "kind": {
-                        "name": "Dot"
-                      }
-                    },
-                    "type": {
-                      "kind": "could not determine"
-                    },
-                    "node": {
-                      "kind": "placeholder"
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
-                  "position": [12, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "arr", "position": [12, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "arr", "position": [12, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "instance",
-                        "struct": { "moduleId": 2, "name": "Array" },
-                        "typeParams": [
-                          {
-                            "kind": "could not determine"
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [12, 13],
-                      "kind": {
-                        "name": "LBrack"
-                      }
-                    },
-                    "type": {
-                      "kind": "instance",
-                      "struct": { "moduleId": 2, "name": "Array" },
-                      "typeParams": [
-                        {
-                          "kind": "could not determine"
-                        }
-                      ]
-                    },
-                    "node": {
-                      "kind": "array",
-                      "items": [
-                        {
-                          "token": {
-                            "position": [12, 15],
-                            "kind": {
-                              "name": "Dot"
-                            }
-                          },
-                          "type": {
-                            "kind": "could not determine"
-                          },
-                          "node": {
-                            "kind": "placeholder"
-                          }
-                        },
-                        {
-                          "token": {
-                            "position": [12, 22],
-                            "kind": {
-                              "name": "Dot"
-                            }
-                          },
-                          "type": {
-                            "kind": "could not determine"
-                          },
-                          "node": {
-                            "kind": "placeholder"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
-                  "position": [13, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "i", "position": [13, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "i", "position": [13, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "could not determine"
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [13, 14],
-                      "kind": {
-                        "name": "Dot"
-                      }
-                    },
-                    "type": {
-                      "kind": "could not determine"
-                    },
-                    "node": {
-                      "kind": "placeholder"
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
-                  "position": [14, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "j", "position": [14, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "j", "position": [14, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "could not determine"
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [14, 23],
-                      "kind": {
-                        "name": "Dot"
-                      }
-                    },
-                    "type": {
-                      "kind": "could not determine"
-                    },
-                    "node": {
-                      "kind": "placeholder"
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
-                  "position": [15, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "k", "position": [15, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "k", "position": [15, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "could not determine"
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [15, 14],
-                      "kind": {
-                        "name": "Dot"
-                      }
-                    },
-                    "type": {
-                      "kind": "could not determine"
-                    },
-                    "node": {
-                      "kind": "placeholder"
-                    }
-                  }
-                }
-              },
-              {
-                "token": {
-                  "position": [18, 3],
-                  "kind": {
-                    "name": "Val"
-                  }
-                },
-                "type": {
-                  "kind": "primitive",
-                  "primitive": "Unit"
-                },
-                "node": {
-                  "kind": "bindingDeclaration",
-                  "pattern": {
-                    "kind": "variable",
-                    "label": { "name": "x", "position": [18, 7] }
-                  },
-                  "variables": [
-                    {
-                      "label": { "name": "x", "position": [18, 7] },
-                      "mutable": false,
-                      "type": {
-                        "kind": "could not determine"
-                      }
-                    }
-                  ],
-                  "expr": {
-                    "token": {
-                      "position": [18, 13],
+                      "position": [8, 19],
                       "kind": {
                         "name": "Plus"
                       }
@@ -999,7 +611,7 @@
                       "op": "BinaryOp.Add",
                       "left": {
                         "token": {
-                          "position": [18, 11],
+                          "position": [8, 17],
                           "kind": {
                             "name": "Ident",
                             "value": "a"
@@ -1015,7 +627,7 @@
                       },
                       "right": {
                         "token": {
-                          "position": [18, 15],
+                          "position": [8, 21],
                           "kind": {
                             "name": "Int",
                             "value": 1
@@ -1036,7 +648,1451 @@
               },
               {
                 "token": {
-                  "position": [19, 3],
+                  "position": [9, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "binary2", "position": [9, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "binary2", "position": [9, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [9, 19],
+                      "kind": {
+                        "name": "Minus"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.Sub",
+                      "left": {
+                        "token": {
+                          "position": [9, 17],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [9, 21],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [10, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "binary3", "position": [10, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "binary3", "position": [10, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [10, 19],
+                      "kind": {
+                        "name": "Star"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.Mul",
+                      "left": {
+                        "token": {
+                          "position": [10, 17],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [10, 21],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [11, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "binary4", "position": [11, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "binary4", "position": [11, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [11, 19],
+                      "kind": {
+                        "name": "Slash"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.Div",
+                      "left": {
+                        "token": {
+                          "position": [11, 17],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [11, 21],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [12, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "binary5", "position": [12, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "binary5", "position": [12, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [12, 19],
+                      "kind": {
+                        "name": "Percent"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.Mod",
+                      "left": {
+                        "token": {
+                          "position": [12, 17],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [12, 21],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [13, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "binary6", "position": [13, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "binary6", "position": [13, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [13, 19],
+                      "kind": {
+                        "name": "GT"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.GT",
+                      "left": {
+                        "token": {
+                          "position": [13, 17],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [13, 21],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [14, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "binary7", "position": [14, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "binary7", "position": [14, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [14, 19],
+                      "kind": {
+                        "name": "GTE"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.GTE",
+                      "left": {
+                        "token": {
+                          "position": [14, 17],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [14, 22],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [15, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "binary8", "position": [15, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "binary8", "position": [15, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [15, 19],
+                      "kind": {
+                        "name": "LT"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.LT",
+                      "left": {
+                        "token": {
+                          "position": [15, 17],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [15, 21],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [16, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "binary9", "position": [16, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "binary9", "position": [16, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [16, 19],
+                      "kind": {
+                        "name": "LTE"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "binary",
+                      "op": "BinaryOp.LTE",
+                      "left": {
+                        "token": {
+                          "position": [16, 17],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [16, 22],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [18, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "stringInterpolation", "position": [18, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "stringInterpolation", "position": [18, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "primitive",
+                        "primitive": "String"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [18, 29],
+                      "kind": {
+                        "name": "StringInterpolation",
+                        "chunks": [
+                          {
+                            "position": [18, 29],
+                            "kind": {
+                              "name": "String",
+                              "value": "hello "
+                            }
+                          },
+                          [
+                            {
+                              "position": [18, 37],
+                              "kind": {
+                                "name": "Ident",
+                                "value": "a"
+                              }
+                            }
+                          ],
+                          {
+                            "position": [18, 38],
+                            "kind": {
+                              "name": "String",
+                              "value": ""
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "String"
+                    },
+                    "node": {
+                      "kind": "stringInterpolation",
+                      "exprs": [
+                        {
+                          "token": {
+                            "position": [18, 29],
+                            "kind": {
+                              "name": "String",
+                              "value": "hello "
+                            }
+                          },
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "String"
+                          },
+                          "node": {
+                            "kind": "literal",
+                            "value": "hello "
+                          }
+                        },
+                        {
+                          "token": {
+                            "position": [18, 37],
+                            "kind": {
+                              "name": "Ident",
+                              "value": "a"
+                            }
+                          },
+                          "type": {
+                            "kind": "could not determine"
+                          },
+                          "node": {
+                            "kind": "identifier",
+                            "name": "a"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [20, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "grouped", "position": [20, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "grouped", "position": [20, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [20, 17],
+                      "kind": {
+                        "name": "LParen"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "grouped",
+                      "expr": {
+                        "token": {
+                          "position": [20, 18],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [22, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "identifier", "position": [22, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "identifier", "position": [22, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [22, 20],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "r"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "r"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [25, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "nonOptModuleAccess", "position": [25, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "nonOptModuleAccess", "position": [25, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [25, 30],
+                      "kind": {
+                        "name": "QuestionDot"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [26, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "modAccess", "position": [26, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "modAccess", "position": [26, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [26, 21],
+                      "kind": {
+                        "name": "Dot"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [27, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "arr", "position": [27, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "arr", "position": [27, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "instance",
+                        "struct": { "moduleId": 2, "name": "Array" },
+                        "typeParams": [
+                          {
+                            "kind": "could not determine"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [27, 13],
+                      "kind": {
+                        "name": "LBrack"
+                      }
+                    },
+                    "type": {
+                      "kind": "instance",
+                      "struct": { "moduleId": 2, "name": "Array" },
+                      "typeParams": [
+                        {
+                          "kind": "could not determine"
+                        }
+                      ]
+                    },
+                    "node": {
+                      "kind": "array",
+                      "items": [
+                        {
+                          "token": {
+                            "position": [27, 15],
+                            "kind": {
+                              "name": "Dot"
+                            }
+                          },
+                          "type": {
+                            "kind": "could not determine"
+                          },
+                          "node": {
+                            "kind": "placeholder"
+                          }
+                        },
+                        {
+                          "token": {
+                            "position": [27, 22],
+                            "kind": {
+                              "name": "Dot"
+                            }
+                          },
+                          "type": {
+                            "kind": "could not determine"
+                          },
+                          "node": {
+                            "kind": "placeholder"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [28, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "fieldAccess", "position": [28, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "fieldAccess", "position": [28, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [28, 24],
+                      "kind": {
+                        "name": "Dot"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [29, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "optFieldAccess", "position": [29, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "optFieldAccess", "position": [29, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [29, 36],
+                      "kind": {
+                        "name": "Dot"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [30, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "staticFieldAccess", "position": [30, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "staticFieldAccess", "position": [30, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [30, 30],
+                      "kind": {
+                        "name": "Dot"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [33, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "invocationModuleAccess", "position": [33, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "invocationModuleAccess", "position": [33, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [33, 38],
+                      "kind": {
+                        "name": "LParen"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [34, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "invocationNoSuchFunction", "position": [34, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "invocationNoSuchFunction", "position": [34, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [34, 38],
+                      "kind": {
+                        "name": "LParen"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [35, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "invocationNoSuchInstanceMethod", "position": [35, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "invocationNoSuchInstanceMethod", "position": [35, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [35, 47],
+                      "kind": {
+                        "name": "LParen"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [36, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "invocationNoSuchStaticMethod", "position": [36, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "invocationNoSuchStaticMethod", "position": [36, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [36, 47],
+                      "kind": {
+                        "name": "LParen"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [38, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "indexing1", "position": [38, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "indexing1", "position": [38, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [38, 22],
+                      "kind": {
+                        "name": "LBrack"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [39, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "indexing2", "position": [39, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "indexing2", "position": [39, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [39, 26],
+                      "kind": {
+                        "name": "LBrack"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [41, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "try1", "position": [41, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "try1", "position": [41, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [41, 14],
+                      "kind": {
+                        "name": "Try"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [42, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "try2", "position": [42, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "try2", "position": [42, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [42, 14],
+                      "kind": {
+                        "name": "Try"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [44, 3],
                   "kind": {
                     "name": "Return"
                   }
@@ -1048,18 +2104,50 @@
                   "kind": "return",
                   "expr": {
                     "token": {
-                      "position": [19, 10],
+                      "position": [44, 12],
                       "kind": {
-                        "name": "Ident",
-                        "value": "x"
+                        "name": "Plus"
                       }
                     },
                     "type": {
                       "kind": "could not determine"
                     },
                     "node": {
-                      "kind": "identifier",
-                      "name": "x"
+                      "kind": "binary",
+                      "op": "BinaryOp.Add",
+                      "left": {
+                        "token": {
+                          "position": [44, 10],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "a"
+                          }
+                        },
+                        "type": {
+                          "kind": "could not determine"
+                        },
+                        "node": {
+                          "kind": "identifier",
+                          "name": "a"
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [44, 14],
+                          "kind": {
+                            "name": "Int",
+                            "value": 1
+                          }
+                        },
+                        "type": {
+                          "kind": "primitive",
+                          "primitive": "Int"
+                        },
+                        "node": {
+                          "kind": "literal",
+                          "value": 1
+                        }
+                      }
                     }
                   }
                 }
@@ -1070,7 +2158,7 @@
       },
       {
         "token": {
-          "position": [22, 1],
+          "position": [47, 1],
           "kind": {
             "name": "Val"
           }
@@ -1083,11 +2171,11 @@
           "kind": "bindingDeclaration",
           "pattern": {
             "kind": "variable",
-            "label": { "name": "abc", "position": [22, 5] }
+            "label": { "name": "abc", "position": [47, 5] }
           },
           "variables": [
             {
-              "label": { "name": "abc", "position": [22, 5] },
+              "label": { "name": "abc", "position": [47, 5] },
               "mutable": false,
               "type": {
                 "kind": "primitive",
@@ -1097,7 +2185,7 @@
           ],
           "expr": {
             "token": {
-              "position": [22, 14],
+              "position": [47, 14],
               "kind": {
                 "name": "LParen"
               }
@@ -1129,7 +2217,7 @@
               "arguments": [
                 {
                   "token": {
-                    "position": [22, 15],
+                    "position": [47, 15],
                     "kind": {
                       "name": "Int",
                       "value": 123
@@ -1145,6 +2233,239 @@
                   }
                 }
               ]
+            }
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [49, 1],
+          "kind": {
+            "name": "Func"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "functionDeclaration",
+          "function": {
+            "label": { "name": "baz", "position": [49, 6] },
+            "scope": {
+              "name": "$root::module_4::baz",
+              "variables": [
+                {
+                  "label": { "name": "try1", "position": [50, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "try2", "position": [51, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                },
+                {
+                  "label": { "name": "try3", "position": [52, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "could not determine"
+                  }
+                }
+              ],
+              "functions": [],
+              "types": []
+            },
+            "kind": "FunctionKind.Standalone",
+            "typeParameters": [],
+            "parameters": [],
+            "returnType": {
+              "kind": "could not determine"
+            },
+            "body": [
+              {
+                "token": {
+                  "position": [50, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "try1", "position": [50, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "try1", "position": [50, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [50, 14],
+                      "kind": {
+                        "name": "Try"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [51, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "try2", "position": [51, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "try2", "position": [51, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [51, 14],
+                      "kind": {
+                        "name": "Try"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              },
+              {
+                "token": {
+                  "position": [52, 3],
+                  "kind": {
+                    "name": "Val"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Unit"
+                },
+                "node": {
+                  "kind": "bindingDeclaration",
+                  "pattern": {
+                    "kind": "variable",
+                    "label": { "name": "try3", "position": [52, 7] }
+                  },
+                  "variables": [
+                    {
+                      "label": { "name": "try3", "position": [52, 7] },
+                      "mutable": false,
+                      "type": {
+                        "kind": "could not determine"
+                      }
+                    }
+                  ],
+                  "expr": {
+                    "token": {
+                      "position": [52, 14],
+                      "kind": {
+                        "name": "Try"
+                      }
+                    },
+                    "type": {
+                      "kind": "could not determine"
+                    },
+                    "node": {
+                      "kind": "placeholder"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "token": {
+          "position": [55, 1],
+          "kind": {
+            "name": "Val"
+          }
+        },
+        "type": {
+          "kind": "primitive",
+          "primitive": "Unit"
+        },
+        "node": {
+          "kind": "bindingDeclaration",
+          "pattern": {
+            "kind": "variable",
+            "label": { "name": "def", "position": [55, 5] }
+          },
+          "variables": [
+            {
+              "label": { "name": "def", "position": [55, 5] },
+              "mutable": false,
+              "type": {
+                "kind": "could not determine"
+              }
+            }
+          ],
+          "expr": {
+            "token": {
+              "position": [55, 14],
+              "kind": {
+                "name": "LParen"
+              }
+            },
+            "type": {
+              "kind": "could not determine"
+            },
+            "node": {
+              "kind": "invocation",
+              "invokee": {
+                "function": "baz",
+                "type": {
+                  "kind": "function",
+                  "parameters": [],
+                  "returnType": {
+                    "kind": "could not determine"
+                  }
+                }
+              },
+              "arguments": []
             }
           }
         }

--- a/projects/compiler/test/typechecker/try/error_bad_return_type_option.out
+++ b/projects/compiler/test/typechecker/try/error_bad_return_type_option.out
@@ -1,4 +1,4 @@
-Error at %FILE_NAME%:4:11
+Error at %TEST_DIR%/typechecker/try/error_bad_return_type_option.abra:4:11
 Invalid location for try expression
   |    val x = try foo()
                ^

--- a/projects/compiler/test/typechecker/try/error_bad_return_type_result.out
+++ b/projects/compiler/test/typechecker/try/error_bad_return_type_result.out
@@ -1,4 +1,4 @@
-Error at %FILE_NAME%:4:11
+Error at %TEST_DIR%/typechecker/try/error_bad_return_type_result.abra:4:11
 Invalid location for try expression
   |    val x = try foo()
                ^


### PR DESCRIPTION
Adding support to the remaining (I think, at least) expression handlers. I'm sure I missed some places, but now an unrecognized or invalid value should result in a type of CouldNotDetermine being threaded properly throughout the expression.