### PR TITLE
Officially adding syntax for decorators

### DIFF
--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -1113,16 +1113,16 @@ pub type Compiler {
               return res
             }
 
-            val intrinsicDec = fn.decorators.find(dec => dec.label.name == "Intrinsic")
+            val intrinsicDec = fn.decorators.find(dec => dec.label.name == "Intrinsic" || dec.label.name == "intrinsic")
             if intrinsicDec |dec| {
-              val res = self._invokeIntrinsicFn(dec, fn, arguments)
+              val res = self.invokeIntrinsicFn(dec, fn, arguments)
               self._resolvedGenerics.popLayer()
               return res
             }
 
-            val cBindingDec = fn.decorators.find(dec => dec.label.name == "CBinding")
-            if cBindingDec |dec| {
-              val res = self._invokeCBindingFn(dec, fn, arguments)
+            val externalDec = fn.decorators.find(dec => dec.label.name == "CBinding" || dec.label.name == "external")
+            if externalDec |dec| {
+              val res = self.invokeExternalFn(dec, fn, arguments)
               self._resolvedGenerics.popLayer()
               return res
             }
@@ -1150,10 +1150,10 @@ pub type Compiler {
           TypedInvokee.Method(fn, selfExpr, isOptSafe) => {
             var selfInstanceType = try self._addResolvedGenericsLayerForInstanceMethod(selfExpr.ty, fn.label.name, node.token.position, resolvedGenerics)
 
-            val intrinsicDec = fn.decorators.find(dec => dec.label.name == "Intrinsic")
+            val intrinsicDec = fn.decorators.find(dec => dec.label.name == "Intrinsic" || dec.label.name == "intrinsic")
             if intrinsicDec |dec| {
               if isOptSafe unreachable("cannot have opt-safe intrinsic method calls")
-              val res = self._invokeIntrinsicFn(dec, fn, [Some(selfExpr)].concat(arguments))
+              val res = self.invokeIntrinsicFn(dec, fn, [Some(selfExpr)].concat(arguments))
               self._resolvedGenerics.popLayer()
               return res
             }
@@ -2661,10 +2661,10 @@ pub type Compiler {
     Ok(Value.Ident("bogus", QbeType.F32))
   }
 
-  func _invokeCBindingFn(self, dec: Decorator, fn: Function, arguments: TypedAstNode?[]): Result<Value, CompileError> {
+  func invokeExternalFn(self, dec: Decorator, fn: Function, arguments: TypedAstNode?[]): Result<Value, CompileError> {
     val cFnName = match dec.arguments[0] {
       LiteralAstNode.String(value) => value
-      _ => unreachable("@CBinding decorator requires 1 string argument for the name")
+      _ => unreachable("@external decorator requires 1 string argument for the name")
     }
 
     val args: Value[] = []
@@ -2673,7 +2673,7 @@ pub type Compiler {
         val arg = try self._compileExpression(node)
         args.push(arg)
       } else {
-        unreachable("functions with @CBinding decorator cannot have optional parameters")
+        unreachable("functions with @external decorator cannot have optional parameters")
       }
     }
 
@@ -2732,10 +2732,10 @@ pub type Compiler {
     (arg0, arg1, arg2)
   }
 
-  func _invokeIntrinsicFn(self, dec: Decorator, fn: Function, arguments: TypedAstNode?[]): Result<Value, CompileError> {
+  func invokeIntrinsicFn(self, dec: Decorator, fn: Function, arguments: TypedAstNode?[]): Result<Value, CompileError> {
     val intrinsicFnName = match dec.arguments[0] {
       LiteralAstNode.String(value) => value
-      _ => unreachable("@Intrinsic decorator requires 1 string argument for the name")
+      _ => unreachable("@intrinsic decorator requires 1 string argument for the name")
     }
 
     self._currentFn.block.addComment("begin $intrinsicFnName...")

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -675,7 +675,7 @@ pub type Parser {
 
     val isStub = decorators.find(dec => {
       val decName = dec.name.name
-      decName == "Stub" || decName == "Intrinsic" || decName == "CBinding"
+      decName == "Intrinsic" || decName == "CBinding" || decName == "intrinsic" || decName == "external"
     })
 
     val body = if isStub {

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -2602,7 +2602,7 @@ pub type Typechecker {
 
     val hasReturnValue = fn.returnType.kind != TypeKind.PrimitiveUnit && fn.returnType.kind != TypeKind.CouldNotDetermine
     if hasReturnValue && body.isEmpty() {
-      if !fn.decorators.find(dec => dec.label.name == "Stub" || dec.label.name == "Intrinsic" || dec.label.name == "CBinding")
+      if !fn.decorators.find(dec => dec.label.name == "Intrinsic" || dec.label.name == "CBinding" || dec.label.name == "intrinsic" || dec.label.name == "external")
         return Err(TypeError(position: fn.label.position, kind: TypeErrorKind.ReturnTypeMismatch(Some(fn.label.name), fn.returnType, None)))
     }
 

--- a/projects/compiler/test/parser/functiondecl.abra
+++ b/projects/compiler/test/parser/functiondecl.abra
@@ -9,11 +9,8 @@ func foo(a: Int, b: Bool = true, c = "abc") {
 func foo<A, B>() {}
 func foo(*items: A[]) {}
 
-@Stub
+@intrinsic("foo_bar")
 func stubbedFunc(): String
 
-@Intrinsic("foo_bar")
-func stubbedFunc(): String
-
-@CBinding("strlen")
+@external("strlen")
 func stubbedFunc(): String

--- a/projects/compiler/test/parser/functiondecl.out.json
+++ b/projects/compiler/test/parser/functiondecl.out.json
@@ -341,8 +341,26 @@
         "name": "function",
         "decorators": [
           {
-            "name": { "name": "Stub", "position": [12, 2] },
-            "arguments": []
+            "name": { "name": "intrinsic", "position": [12, 2] },
+            "arguments": [
+              {
+                "label": null,
+                "value": {
+                  "token": {
+                    "position": [12, 12],
+                    "kind": {
+                      "name": "String",
+                      "value": "foo_bar"
+                    }
+                  },
+                  "kind": {
+                    "name": "literal",
+                    "type": "string",
+                    "value": "foo_bar"
+                  }
+                }
+              }
+            ]
           }
         ],
         "pubToken": null,
@@ -363,53 +381,13 @@
         "name": "function",
         "decorators": [
           {
-            "name": { "name": "Intrinsic", "position": [15, 2] },
+            "name": { "name": "external", "position": [15, 2] },
             "arguments": [
               {
                 "label": null,
                 "value": {
                   "token": {
-                    "position": [15, 12],
-                    "kind": {
-                      "name": "String",
-                      "value": "foo_bar"
-                    }
-                  },
-                  "kind": {
-                    "name": "literal",
-                    "type": "string",
-                    "value": "foo_bar"
-                  }
-                }
-              }
-            ]
-          }
-        ],
-        "pubToken": null,
-        "ident": { "name": "stubbedFunc", "position": [16, 6] },
-        "typeParams": [],
-        "params": [],
-        "body": []
-      }
-    },
-    {
-      "token": {
-        "position": [19, 1],
-        "kind": {
-          "name": "Func"
-        }
-      },
-      "kind": {
-        "name": "function",
-        "decorators": [
-          {
-            "name": { "name": "CBinding", "position": [18, 2] },
-            "arguments": [
-              {
-                "label": null,
-                "value": {
-                  "token": {
-                    "position": [18, 11],
+                    "position": [15, 11],
                     "kind": {
                       "name": "String",
                       "value": "strlen"
@@ -426,7 +404,7 @@
           }
         ],
         "pubToken": null,
-        "ident": { "name": "stubbedFunc", "position": [19, 6] },
+        "ident": { "name": "stubbedFunc", "position": [16, 6] },
         "typeParams": [],
         "params": [],
         "body": []

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -401,7 +401,7 @@ type String {
     (48 <= ch && ch <= 57) || (65 <= ch && ch <= 90) || (97 <= ch && ch <= 122)
   }
 
-  @Stub func padLeft(self, totalSize: Int, padding = " "): String
+  pub func padLeft(self, totalSize: Int, padding = " "): String = todo("String#padLeft")
 
   pub func trim(self): String {
     var i = 0
@@ -427,8 +427,8 @@ type String {
     self.getRange(i, j + 1)
   }
 
-  @Stub func trimStart(self, pattern: String = ""): String
-  @Stub func trimEnd(self, pattern: String = ""): String
+  pub func trimStart(self, pattern = ""): String = todo("String#trimStart")
+  pub func trimEnd(self, pattern = ""): String = todo("String#trimEnd")
 
   pub func split(self, by = ""): String[] {
     if by.isEmpty() {
@@ -479,7 +479,7 @@ type String {
     arr
   }
 
-  @Stub func splitAt(self, index: Int): (String, String)
+  pub func splitAt(self, index: Int): (String, String) = todo("String#splitAt")
 
   pub func lines(self): String[] = self.split(by: "\n")
 
@@ -497,7 +497,7 @@ type String {
     Some(num)
   }
 
-  @Stub func parseFloat(self): Float?
+  pub func parseFloat(self): Float? = todo("String#parseFloat")
 
   pub func startsWith(self, prefix: String): Bool {
     if self.length < prefix.length return false
@@ -764,8 +764,8 @@ type Array<T> {
     }
   }
 
-  @Stub func popFront(self): T?
-  @Stub func splitAt(self, index: Int): (T[], T[])
+  pub func popFront(self): T? = todo("Array#popFront")
+  pub func splitAt(self, index: Int): (T[], T[]) = todo("Array#splitAt")
 
   pub func concat(self, other: T[]): T[] {
     val newArray: T[] = Array.withCapacity(self.length + other.length)
@@ -903,7 +903,7 @@ type Array<T> {
     true
   }
 
-  @Stub func none(self, fn: (T) => Bool): Bool
+  func none(self, fn: (T) => Bool): Bool = todo("Array#none")
 
   // Implementation of quicksort using dual-pivot (Hoare) partitioning. The items are an array of tuples, the first elem
   // of which represents the integer value which will be used as the sort-value; the second elem is the original value
@@ -965,11 +965,11 @@ type Array<T> {
     res
   }
 
-  @Stub func dedupe(self): T[]
-  @Stub func dedupeBy<U>(self, fn: (T) => U): T[]
-  @Stub func partition<U>(self, fn: (T) => U): Map<U, T[]>
-  @Stub func tally(self): Map<T, Int>
-  @Stub func tallyBy<U>(self, fn: (T) => U): Map<U, Int>
+  pub func dedupe(self): T[] = todo("Array#dedupe")
+  pub func dedupeBy<U>(self, fn: (T) => U): T[] = todo("Array#dedupeBy")
+  pub func partition<U>(self, fn: (T) => U): Map<U, T[]> = todo("Array#partition")
+  pub func tally(self): Map<T, Int> = todo("Array#tally")
+  pub func tallyBy<U>(self, fn: (T) => U): Map<U, Int> = todo("Array#tallyBy")
 
   pub func keyBy<U>(self, fn: (T) => U): Map<U, T> {
     val map: Map<U, T> = Map.new()
@@ -1019,8 +1019,8 @@ type Array<T> {
     }
   }
 
-  @Stub func getOr(self, index: Int, default: T): T
-  @Stub func getOrElse(self, index: Int, getDefault: () => T): T
+  pub func getOr(self, index: Int, default: T): T = todo("Array#getOr")
+  pub func getOrElse(self, index: Int, getDefault: () => T): T = todo("Array#getOrElse")
 
   pub func getRange(self, startIndex = 0, endIndex = self.length): T[] {
     val start = if startIndex < 0 startIndex + self.length else startIndex
@@ -1049,8 +1049,8 @@ type Array<T> {
     }
   }
 
-  @Stub func update(self, index: Int, updater: (T) => T)
-  @Stub func reversed(self): T[]
+  pub func update(self, index: Int, updater: (T) => T) = todo("Array#update")
+  pub func reversed(self): T[] = todo("Array#reversed")
 }
 
 @noreturn
@@ -1120,7 +1120,7 @@ type Set<T> {
     self._map.forEach(key => fn(key))
   }
 
-  @Stub func remove(self, item: T): T?
+  func remove(self, item: T): T? = todo("Set#remove")
 
   pub func map<U>(self, fn: (T) => U): U[] {
     val arr: U[] = Array.withCapacity(self.size)
@@ -1140,7 +1140,7 @@ type Set<T> {
     newSet
   }
 
-  @Stub func reduce<U>(self, initialValue: U, fn: (U, T) => U): U
+  pub func reduce<U>(self, initialValue: U, fn: (U, T) => U): U = todo("Set#reduce")
 
   pub func asArray(self): T[] {
     val arr: T[] = Array.withCapacity(self.size)


### PR DESCRIPTION
Step 0 is a cleanup of existing decorators. Currently there's `@Intrinsic`, `@CBinding`, and `@Stub` which are used throughout the compiler and standard library. These can be consolidated and reformatted to fit the eventual future design ideas. For one, `@Stub` does not need to exist now that `todo` exists. Additionally since `@Intrinsic` and `@CBinding` really are more like language-level keywords, they should be lowercased (and `@CBinding` is being renamed to something more self-explanatory - `@external`).

The first step is to ensure that the compiler can support both. Then I can update the standard library and the compiler itself, and then remove instances of the old values.