### PR TITLE
Lexer & Parser: Adding support for `decorator`

### DIFF
--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -37,6 +37,7 @@ pub enum TokenKind {
   Match
   Type
   Enum
+  Decorator
   Return(subsequentNewline: Bool)
   Readonly
   Import
@@ -111,6 +112,7 @@ pub enum TokenKind {
     TokenKind.Match => "match"
     TokenKind.Type => "type"
     TokenKind.Enum => "enum"
+    TokenKind.Decorator => "decorator"
     TokenKind.Return => "return"
     TokenKind.Readonly => "readonly"
     TokenKind.Import => "import"
@@ -664,6 +666,7 @@ pub type Lexer {
       "match" => TokenKind.Match
       "type" => TokenKind.Type
       "enum" => TokenKind.Enum
+      "decorator" => TokenKind.Decorator
       "return" => {
         val sawNewline = self._skipWhitespace()
         TokenKind.Return(sawNewline)

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -223,6 +223,7 @@ type TypeField {
 pub type TypeDeclarationNode {
   pub decorators: DecoratorNode[]
   pub pubToken: Token?
+  pub isDecorator: Bool
   pub name: Label
   pub typeParams: Label[]
   pub fields: TypeField[]
@@ -496,7 +497,7 @@ pub type Parser {
         try self._parseDecorator()
 
         val nextToken = try self._expectPeek()
-        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum, TokenKind.At, TokenKind.Pub]
+        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum, TokenKind.Decorator, TokenKind.At, TokenKind.Pub]
         if !expected.contains(nextToken.kind) {
           return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
         }
@@ -508,7 +509,7 @@ pub type Parser {
         self._advance() // consume 'pub' token
 
         val nextToken = try self._expectPeek()
-        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum]
+        val expected = [TokenKind.Val, TokenKind.Var, TokenKind.Func, TokenKind.Type, TokenKind.Enum, TokenKind.Decorator]
         if !expected.contains(nextToken.kind) {
           return Err(ParseError(position: nextToken.position, kind: ParseErrorKind.ExpectedToken(expected, nextToken.kind)))
         }
@@ -518,8 +519,9 @@ pub type Parser {
       TokenKind.Val => self._parseBindingDeclaration(mutable: false)
       TokenKind.Var => self._parseBindingDeclaration(mutable: true)
       TokenKind.Func => self._parseFunctionDeclaration()
-      TokenKind.Type => self._parseTypeDeclaration()
+      TokenKind.Type => self._parseTypeDeclaration(isDecorator: false)
       TokenKind.Enum => self._parseEnumDeclaration()
+      TokenKind.Decorator => self._parseTypeDeclaration(isDecorator: true)
       TokenKind.While => self._parseWhileLoop()
       TokenKind.For => self._parseForLoop()
       TokenKind.Break => self._parseBreak()
@@ -703,7 +705,7 @@ pub type Parser {
     Ok(AstNode(token: token, kind: AstNodeKind.FunctionDeclaration(node)))
   }
 
-  func _parseTypeDeclaration(self): Result<AstNode, ParseError> {
+  func _parseTypeDeclaration(self, isDecorator: Bool): Result<AstNode, ParseError> {
     val decorators = self._seenDecorators
     self._seenDecorators = []
 
@@ -762,6 +764,7 @@ pub type Parser {
     val node = TypeDeclarationNode(
       decorators: decorators,
       pubToken: pubToken,
+      isDecorator: isDecorator,
       name: typeName,
       typeParams: typeParams,
       fields: fields,

--- a/projects/compiler/src/test_utils.abra
+++ b/projects/compiler/src/test_utils.abra
@@ -81,6 +81,7 @@ func printTokenKindAsJson(kind: TokenKind, indentLevelStart: Int, currentIndentL
     TokenKind.Match => println("$fieldsIndent\"name\": \"Match\"")
     TokenKind.Type => println("$fieldsIndent\"name\": \"Type\"")
     TokenKind.Enum => println("$fieldsIndent\"name\": \"Enum\"")
+    TokenKind.Decorator => println("$fieldsIndent\"name\": \"Decorator\"")
     TokenKind.Return => println("$fieldsIndent\"name\": \"Return\"")
     TokenKind.Readonly => println("$fieldsIndent\"name\": \"Readonly\"")
     TokenKind.Import => println("$fieldsIndent\"name\": \"Import\"")
@@ -263,21 +264,21 @@ func printTypeIdentifierAsJson(typeIdentifier: TypeIdentifier, indentLevelStart:
   print("$endIndent}")
 }
 
-func printDecoratorNodeAsJson(decorator: DecoratorNode, indentLevelStart: Int, currentIndentLevel: Int) {
+func printDecoratorNodeAsJson(dec: DecoratorNode, indentLevelStart: Int, currentIndentLevel: Int) {
   val startIndent = "  ".repeat(indentLevelStart)
   val fieldsIndent = "  ".repeat(currentIndentLevel + 1)
   val endIndent = "  ".repeat(currentIndentLevel)
 
   print("$startIndent{\n$fieldsIndent\"name\": ")
-  printLabelAsJson(decorator.name)
+  printLabelAsJson(dec.name)
 
-  if decorator.arguments.isEmpty() {
+  if dec.arguments.isEmpty() {
     println(",\n$fieldsIndent\"arguments\": []")
   } else {
     println(",\n$fieldsIndent\"arguments\": [")
     val pathIndent = "  ".repeat(currentIndentLevel + 2)
     val pathsIndent = "  ".repeat(currentIndentLevel + 3)
-    for arg, idx in decorator.arguments {
+    for arg, idx in dec.arguments {
       print("$pathIndent{\n$pathsIndent\"label\": ")
       if arg.label |label| {
         printLabelAsJson(label)
@@ -287,7 +288,7 @@ func printDecoratorNodeAsJson(decorator: DecoratorNode, indentLevelStart: Int, c
       }
       print("$pathsIndent\"value\": ")
       printAstNodeAsJson(arg.value, 0, currentIndentLevel + 3)
-      val comma = if idx != decorator.arguments.length - 1 "," else ""
+      val comma = if idx != dec.arguments.length - 1 "," else ""
       println("\n$pathIndent}$comma")
     }
     println("$fieldsIndent]")
@@ -929,6 +930,9 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
         println(",")
       } else {
         println("$fieldsIndent\"pubToken\": null,")
+      }
+      if node.isDecorator {
+        println("$fieldsIndent\"isDecorator\": true,")
       }
       print("$fieldsIndent\"typeName\": ")
       printLabelAsJson(node.name)

--- a/projects/compiler/test/lexer/keywords.abra
+++ b/projects/compiler/test/lexer/keywords.abra
@@ -1,1 +1,1 @@
-true false val var if else func while break for in type enum self match readonly import from as try continue pub
+true false val var if else func while break for in type enum self match readonly import from as try continue pub decorator

--- a/projects/compiler/test/lexer/keywords.out.json
+++ b/projects/compiler/test/lexer/keywords.out.json
@@ -132,5 +132,11 @@
     "kind": {
       "name": "Pub"
     }
+  },
+  {
+    "position": [1, 114],
+    "kind": {
+      "name": "Decorator"
+    }
   }
 ]

--- a/projects/compiler/test/parser/decorator_error_before_expr.out
+++ b/projects/compiler/test/parser/decorator_error_before_expr.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:2:1
-Unexpected token 'identifier', expected one of 'val', 'var', 'func', 'type', 'enum', '@', 'pub':
+Unexpected token 'identifier', expected one of 'val', 'var', 'func', 'type', 'enum', 'decorator', '@', 'pub':
   |  abc()
      ^

--- a/projects/compiler/test/parser/decorator_error_before_invalid_stmt.out
+++ b/projects/compiler/test/parser/decorator_error_before_invalid_stmt.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:2:1
-Unexpected token 'while', expected one of 'val', 'var', 'func', 'type', 'enum', '@', 'pub':
+Unexpected token 'while', expected one of 'val', 'var', 'func', 'type', 'enum', 'decorator', '@', 'pub':
   |  while true { }
      ^

--- a/projects/compiler/test/parser/decoratordecl.abra
+++ b/projects/compiler/test/parser/decoratordecl.abra
@@ -1,0 +1,60 @@
+decorator Foo { }
+decorator Foo<A, B> { }
+decorator Foo<A> { a: A, b: Bool }
+decorator Foo {
+  a: Int
+  b: Bool = true
+}
+
+decorator FooBar123 {
+  func foo(self, b: String) {}
+}
+
+decorator FooBar123 {
+  a: Int
+
+  func foo(self, b: String): X<Y> = 123
+  func bar(self, b = true) { self.a + b }
+}
+
+decorator FooBar123 {
+  a: Int
+
+  func foo(self, b: String): X<Y> = 123
+
+  @Foo
+  func bar(self, b = true) { self.a + b }
+}
+
+decorator Outer {
+  a: Int
+
+  func foo(self, b: String): X<Y> { 123 }
+
+  type InnerType {
+    a: Int
+
+    func bar(self, b = true) { self.a + b }
+  }
+
+  enum InnerEnum {
+    A(a: Int)
+
+    func bar(self, b = true) { self.a + b }
+  }
+}
+
+@Bar("a")
+pub decorator Outer {
+  a: Int
+
+  @Bar("b")
+  func foo(self, b: String): X<Y> { 123 }
+
+  @Bar("c")
+  type Inner { a: Int }
+}
+
+pub decorator Outer2 {
+  pub a: Int
+}

--- a/projects/compiler/test/parser/decoratordecl.out.json
+++ b/projects/compiler/test/parser/decoratordecl.out.json
@@ -1,0 +1,1054 @@
+{
+  "imports": [],
+  "nodes": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": null,
+        "isDecorator": true,
+        "typeName": { "name": "Foo", "position": [1, 11] },
+        "typeParams": [],
+        "fields": [],
+        "methods": [],
+        "nestedTypes": [],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [2, 1],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": null,
+        "isDecorator": true,
+        "typeName": { "name": "Foo", "position": [2, 11] },
+        "typeParams": [
+          { "name": "A", "position": [2, 15] },
+          { "name": "B", "position": [2, 18] }
+        ],
+        "fields": [],
+        "methods": [],
+        "nestedTypes": [],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [3, 1],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": null,
+        "isDecorator": true,
+        "typeName": { "name": "Foo", "position": [3, 11] },
+        "typeParams": [
+          { "name": "A", "position": [3, 15] }
+        ],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [3, 20] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "A", "position": [3, 23] },
+              "typeArguments": []
+            },
+            "initializer": null
+          },
+          {
+            "label": { "name": "b", "position": [3, 26] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Bool", "position": [3, 29] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [],
+        "nestedTypes": [],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [4, 1],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": null,
+        "isDecorator": true,
+        "typeName": { "name": "Foo", "position": [4, 11] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [5, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [5, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          },
+          {
+            "label": { "name": "b", "position": [6, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Bool", "position": [6, 6] },
+              "typeArguments": []
+            },
+            "initializer": {
+              "token": {
+                "position": [6, 13],
+                "kind": {
+                  "name": "Bool",
+                  "value": true
+                }
+              },
+              "kind": {
+                "name": "literal",
+                "type": "bool",
+                "value": true
+              }
+            }
+          }
+        ],
+        "methods": [],
+        "nestedTypes": [],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [9, 1],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": null,
+        "isDecorator": true,
+        "typeName": { "name": "FooBar123", "position": [9, 11] },
+        "typeParams": [],
+        "fields": [],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [],
+            "pubToken": null,
+            "ident": { "name": "foo", "position": [10, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [10, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [10, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [10, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": []
+          }
+        ],
+        "nestedTypes": [],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [13, 1],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": null,
+        "isDecorator": true,
+        "typeName": { "name": "FooBar123", "position": [13, 11] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [14, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [14, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [],
+            "pubToken": null,
+            "ident": { "name": "foo", "position": [16, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [16, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [16, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [16, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [16, 37],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 123
+                }
+              }
+            ]
+          },
+          {
+            "name": "function",
+            "decorators": [],
+            "pubToken": null,
+            "ident": { "name": "bar", "position": [17, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [17, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [17, 18] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": {
+                  "token": {
+                    "position": [17, 22],
+                    "kind": {
+                      "name": "Bool",
+                      "value": true
+                    }
+                  },
+                  "kind": {
+                    "name": "literal",
+                    "type": "bool",
+                    "value": true
+                  }
+                }
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [17, 37],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "kind": {
+                  "name": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [17, 34],
+                      "kind": {
+                        "name": "Dot"
+                      }
+                    },
+                    "kind": {
+                      "name": "accessor",
+                      "root": {
+                        "token": {
+                          "position": [17, 30],
+                          "kind": {
+                            "name": "Self"
+                          }
+                        },
+                        "kind": {
+                          "name": "identifier",
+                          "ident": "self"
+                        }
+                      },
+                      "path": [
+                        {
+                          "dotToken": {
+                            "position": [17, 34],
+                            "kind": {
+                              "name": "Dot"
+                            }
+                          },
+                          "ident": "a",
+                          "position": [17, 35]
+                        }
+                      ]
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [17, 39],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "b"
+                      }
+                    },
+                    "kind": {
+                      "name": "identifier",
+                      "ident": "b"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "nestedTypes": [],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [20, 1],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": null,
+        "isDecorator": true,
+        "typeName": { "name": "FooBar123", "position": [20, 11] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [21, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [21, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [],
+            "pubToken": null,
+            "ident": { "name": "foo", "position": [23, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [23, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [23, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [23, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [23, 37],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 123
+                }
+              }
+            ]
+          },
+          {
+            "name": "function",
+            "decorators": [
+              {
+                "name": { "name": "Foo", "position": [25, 4] },
+                "arguments": []
+              }
+            ],
+            "pubToken": null,
+            "ident": { "name": "bar", "position": [26, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [26, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [26, 18] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": {
+                  "token": {
+                    "position": [26, 22],
+                    "kind": {
+                      "name": "Bool",
+                      "value": true
+                    }
+                  },
+                  "kind": {
+                    "name": "literal",
+                    "type": "bool",
+                    "value": true
+                  }
+                }
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [26, 37],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "kind": {
+                  "name": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [26, 34],
+                      "kind": {
+                        "name": "Dot"
+                      }
+                    },
+                    "kind": {
+                      "name": "accessor",
+                      "root": {
+                        "token": {
+                          "position": [26, 30],
+                          "kind": {
+                            "name": "Self"
+                          }
+                        },
+                        "kind": {
+                          "name": "identifier",
+                          "ident": "self"
+                        }
+                      },
+                      "path": [
+                        {
+                          "dotToken": {
+                            "position": [26, 34],
+                            "kind": {
+                              "name": "Dot"
+                            }
+                          },
+                          "ident": "a",
+                          "position": [26, 35]
+                        }
+                      ]
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [26, 39],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "b"
+                      }
+                    },
+                    "kind": {
+                      "name": "identifier",
+                      "ident": "b"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "nestedTypes": [],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [29, 1],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": null,
+        "isDecorator": true,
+        "typeName": { "name": "Outer", "position": [29, 11] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [30, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [30, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [],
+            "pubToken": null,
+            "ident": { "name": "foo", "position": [32, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [32, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [32, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [32, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [32, 37],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 123
+                }
+              }
+            ]
+          }
+        ],
+        "nestedTypes": [
+          {
+            "name": "typeDeclaration",
+            "decorators": [],
+            "pubToken": null,
+            "typeName": { "name": "InnerType", "position": [34, 8] },
+            "typeParams": [],
+            "fields": [
+              {
+                "label": { "name": "a", "position": [35, 5] },
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "Int", "position": [35, 8] },
+                  "typeArguments": []
+                },
+                "initializer": null
+              }
+            ],
+            "methods": [
+              {
+                "name": "function",
+                "decorators": [],
+                "pubToken": null,
+                "ident": { "name": "bar", "position": [37, 10] },
+                "typeParams": [],
+                "params": [
+                  {
+                    "label": { "name": "self", "position": [37, 14] },
+                    "isVariadic": false,
+                    "typeAnnotation": null,
+                    "defaultValue": null
+                  },
+                  {
+                    "label": { "name": "b", "position": [37, 20] },
+                    "isVariadic": false,
+                    "typeAnnotation": null,
+                    "defaultValue": {
+                      "token": {
+                        "position": [37, 24],
+                        "kind": {
+                          "name": "Bool",
+                          "value": true
+                        }
+                      },
+                      "kind": {
+                        "name": "literal",
+                        "type": "bool",
+                        "value": true
+                      }
+                    }
+                  }
+                ],
+                "body": [
+                  {
+                    "token": {
+                      "position": [37, 39],
+                      "kind": {
+                        "name": "Plus"
+                      }
+                    },
+                    "kind": {
+                      "name": "binary",
+                      "op": "BinaryOp.Add",
+                      "left": {
+                        "token": {
+                          "position": [37, 36],
+                          "kind": {
+                            "name": "Dot"
+                          }
+                        },
+                        "kind": {
+                          "name": "accessor",
+                          "root": {
+                            "token": {
+                              "position": [37, 32],
+                              "kind": {
+                                "name": "Self"
+                              }
+                            },
+                            "kind": {
+                              "name": "identifier",
+                              "ident": "self"
+                            }
+                          },
+                          "path": [
+                            {
+                              "dotToken": {
+                                "position": [37, 36],
+                                "kind": {
+                                  "name": "Dot"
+                                }
+                              },
+                              "ident": "a",
+                              "position": [37, 37]
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [37, 41],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "b"
+                          }
+                        },
+                        "kind": {
+                          "name": "identifier",
+                          "ident": "b"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "nestedTypes": [],
+            "nestedEnums": []
+          }
+        ],
+        "nestedEnums": [
+          {
+            "name": "enumDeclaration",
+            "decorators": [],
+            "pubToken": null,
+            "typeName": { "name": "InnerEnum", "position": [40, 8] },
+            "typeParams": [],
+            "variants": [
+              {
+                "kind": "container",
+                "name": { "name": "A", "position": [41, 5] },
+                "fields": [
+                  {
+                    "label": { "name": "a", "position": [41, 7] },
+                    "typeAnnotation": {
+                      "kind": "normal",
+                      "label": { "name": "Int", "position": [41, 10] },
+                      "typeArguments": []
+                    },
+                    "initializer": null
+                  }
+                ]
+              }
+            ],
+            "methods": [
+              {
+                "name": "function",
+                "decorators": [],
+                "pubToken": null,
+                "ident": { "name": "bar", "position": [43, 10] },
+                "typeParams": [],
+                "params": [
+                  {
+                    "label": { "name": "self", "position": [43, 14] },
+                    "isVariadic": false,
+                    "typeAnnotation": null,
+                    "defaultValue": null
+                  },
+                  {
+                    "label": { "name": "b", "position": [43, 20] },
+                    "isVariadic": false,
+                    "typeAnnotation": null,
+                    "defaultValue": {
+                      "token": {
+                        "position": [43, 24],
+                        "kind": {
+                          "name": "Bool",
+                          "value": true
+                        }
+                      },
+                      "kind": {
+                        "name": "literal",
+                        "type": "bool",
+                        "value": true
+                      }
+                    }
+                  }
+                ],
+                "body": [
+                  {
+                    "token": {
+                      "position": [43, 39],
+                      "kind": {
+                        "name": "Plus"
+                      }
+                    },
+                    "kind": {
+                      "name": "binary",
+                      "op": "BinaryOp.Add",
+                      "left": {
+                        "token": {
+                          "position": [43, 36],
+                          "kind": {
+                            "name": "Dot"
+                          }
+                        },
+                        "kind": {
+                          "name": "accessor",
+                          "root": {
+                            "token": {
+                              "position": [43, 32],
+                              "kind": {
+                                "name": "Self"
+                              }
+                            },
+                            "kind": {
+                              "name": "identifier",
+                              "ident": "self"
+                            }
+                          },
+                          "path": [
+                            {
+                              "dotToken": {
+                                "position": [43, 36],
+                                "kind": {
+                                  "name": "Dot"
+                                }
+                              },
+                              "ident": "a",
+                              "position": [43, 37]
+                            }
+                          ]
+                        }
+                      },
+                      "right": {
+                        "token": {
+                          "position": [43, 41],
+                          "kind": {
+                            "name": "Ident",
+                            "value": "b"
+                          }
+                        },
+                        "kind": {
+                          "name": "identifier",
+                          "ident": "b"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "nestedTypes": [],
+            "nestedEnums": []
+          }
+        ]
+      }
+    },
+    {
+      "token": {
+        "position": [48, 5],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [
+          {
+            "name": { "name": "Bar", "position": [47, 2] },
+            "arguments": [
+              {
+                "label": null,
+                "value": {
+                  "token": {
+                    "position": [47, 6],
+                    "kind": {
+                      "name": "String",
+                      "value": "a"
+                    }
+                  },
+                  "kind": {
+                    "name": "literal",
+                    "type": "string",
+                    "value": "a"
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "pubToken": {
+          "position": [48, 1],
+          "kind": {
+            "name": "Pub"
+          }
+        },
+        "isDecorator": true,
+        "typeName": { "name": "Outer", "position": [48, 15] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [49, 3] },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [49, 6] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [
+          {
+            "name": "function",
+            "decorators": [
+              {
+                "name": { "name": "Bar", "position": [51, 4] },
+                "arguments": [
+                  {
+                    "label": null,
+                    "value": {
+                      "token": {
+                        "position": [51, 8],
+                        "kind": {
+                          "name": "String",
+                          "value": "b"
+                        }
+                      },
+                      "kind": {
+                        "name": "literal",
+                        "type": "string",
+                        "value": "b"
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "pubToken": null,
+            "ident": { "name": "foo", "position": [52, 8] },
+            "typeParams": [],
+            "params": [
+              {
+                "label": { "name": "self", "position": [52, 12] },
+                "isVariadic": false,
+                "typeAnnotation": null,
+                "defaultValue": null
+              },
+              {
+                "label": { "name": "b", "position": [52, 18] },
+                "isVariadic": false,
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "String", "position": [52, 21] },
+                  "typeArguments": []
+                },
+                "defaultValue": null
+              }
+            ],
+            "body": [
+              {
+                "token": {
+                  "position": [52, 37],
+                  "kind": {
+                    "name": "Int",
+                    "value": 123
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 123
+                }
+              }
+            ]
+          }
+        ],
+        "nestedTypes": [
+          {
+            "name": "typeDeclaration",
+            "decorators": [
+              {
+                "name": { "name": "Bar", "position": [54, 4] },
+                "arguments": [
+                  {
+                    "label": null,
+                    "value": {
+                      "token": {
+                        "position": [54, 8],
+                        "kind": {
+                          "name": "String",
+                          "value": "c"
+                        }
+                      },
+                      "kind": {
+                        "name": "literal",
+                        "type": "string",
+                        "value": "c"
+                      }
+                    }
+                  }
+                ]
+              }
+            ],
+            "pubToken": null,
+            "typeName": { "name": "Inner", "position": [55, 8] },
+            "typeParams": [],
+            "fields": [
+              {
+                "label": { "name": "a", "position": [55, 16] },
+                "typeAnnotation": {
+                  "kind": "normal",
+                  "label": { "name": "Int", "position": [55, 19] },
+                  "typeArguments": []
+                },
+                "initializer": null
+              }
+            ],
+            "methods": [],
+            "nestedTypes": [],
+            "nestedEnums": []
+          }
+        ],
+        "nestedEnums": []
+      }
+    },
+    {
+      "token": {
+        "position": [58, 5],
+        "kind": {
+          "name": "Decorator"
+        }
+      },
+      "kind": {
+        "name": "typeDeclaration",
+        "decorators": [],
+        "pubToken": {
+          "position": [58, 1],
+          "kind": {
+            "name": "Pub"
+          }
+        },
+        "isDecorator": true,
+        "typeName": { "name": "Outer2", "position": [58, 15] },
+        "typeParams": [],
+        "fields": [
+          {
+            "label": { "name": "a", "position": [59, 7] },
+            "pubToken": {
+              "position": [59, 3],
+              "kind": {
+                "name": "Pub"
+              }
+            },
+            "typeAnnotation": {
+              "kind": "normal",
+              "label": { "name": "Int", "position": [59, 10] },
+              "typeArguments": []
+            },
+            "initializer": null
+          }
+        ],
+        "methods": [],
+        "nestedTypes": [],
+        "nestedEnums": []
+      }
+    }
+  ]
+}

--- a/projects/compiler/test/parser/export_error_before_expr.out
+++ b/projects/compiler/test/parser/export_error_before_expr.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:1:5
-Unexpected token 'identifier', expected one of 'val', 'var', 'func', 'type', 'enum':
+Unexpected token 'identifier', expected one of 'val', 'var', 'func', 'type', 'enum', 'decorator':
   |  pub a + 1
          ^

--- a/projects/compiler/test/parser/export_error_before_invalid_statement.out
+++ b/projects/compiler/test/parser/export_error_before_invalid_statement.out
@@ -1,4 +1,4 @@
 Error at %FILE_NAME%:1:5
-Unexpected token 'while', expected one of 'val', 'var', 'func', 'type', 'enum':
+Unexpected token 'while', expected one of 'val', 'var', 'func', 'type', 'enum', 'decorator':
   |  pub while true {}
          ^


### PR DESCRIPTION
This is take 2 of this change, as I was unhappy with the way I did it the first time around. Basically, this time I decided to implement decorators as just being syntactic wrapper on top of existing `type` declarations. They'll have all the same semantics when it comes to typechecking, and implementing them in terms of existing type declarations saves from having a lot of duplicate logic.