### PR TITLE
Cleanup: rename StructOrEnum

### DIFF
--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -2,7 +2,7 @@ import "fs" as fs
 import "process" as process
 import Position from "./lexer"
 import LiteralAstNode, UnaryOp, BinaryOp, AssignOp, BindingPattern, IndexingMode from "./parser"
-import Project, TypedModule, Scope, ScopeKind, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, StructOrEnum, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind, BuiltinModule, Variable, Terminator from "./typechecker"
+import Project, TypedModule, Scope, ScopeKind, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, InstanceKind, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind, BuiltinModule, Variable, Terminator from "./typechecker"
 import ModuleBuilder, Block, QbeType, Dest, QbeFunction, Value, Label, Callable, QbeData, QbeDataKind, Var from "./qbe"
 
 type CompilationError {
@@ -107,12 +107,12 @@ type ResolvedGenerics {
           Err("layer: could not resolve generic '$genericName'")
         }
       }
-      TypeKind.Instance(structOrEnum, typeArgs) => {
+      TypeKind.Instance(instanceKind, typeArgs) => {
         val resolvedGenerics: Type[] = []
         for typeArg in typeArgs {
           resolvedGenerics.push(try self._resolveType(typeArg))
         }
-        Ok(Type(kind: TypeKind.Instance(structOrEnum, resolvedGenerics)))
+        Ok(Type(kind: TypeKind.Instance(instanceKind, resolvedGenerics)))
       }
       TypeKind.Tuple(typeArgs) => {
         val resolvedGenerics: Type[] = []
@@ -387,7 +387,7 @@ pub type Compiler {
         val (instTy, typeArgs) = try self._getInstanceTypeForType(typedIterator.ty)
 
         val (iterVal, iterTy, nextFn, popAdditionalResolvedGenericsLayer) = match instTy {
-          StructOrEnum.Struct(s) => {
+          InstanceKind.Struct(s) => {
             if s == self._project.preludeArrayStruct {
               val innerTy = try typeArgs[0] else unreachable("Array has 1 required type argument")
               match self._resolvedGenerics.addLayer("array literal", { "T": innerTy }) { Ok => {}, Err(e) => return Err(CompileError(position: node.token.position, kind: CompileErrorKind.ResolvedGenericsError(context: "array literal", message: e))) }
@@ -403,10 +403,10 @@ pub type Compiler {
               val frameCtx = CallframeContext(position: typedIterator.token.position, callee: Some(fnName))
               val iter = try self._buildCall(Some(frameCtx), Callable.Function(iteratorFnVal), [arrayVal])
 
-              val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
-              val nextFn = self._getMethodFunctionByName(structOrEnum, "next")
+              val (instanceKind, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
+              val nextFn = self._getMethodFunctionByName(instanceKind, "next")
 
-              val iterTy = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
+              val iterTy = Type(kind: TypeKind.Instance(instanceKind, typeArgs))
               (iter, iterTy, nextFn, true)
             } else if s == self._project.preludeSetStruct {
               val innerTy = try typeArgs[0] else unreachable("Set has 1 required type argument")
@@ -423,10 +423,10 @@ pub type Compiler {
               val frameCtx = CallframeContext(position: typedIterator.token.position, callee: Some(fnName))
               val iter = try self._buildCall(Some(frameCtx), Callable.Function(iteratorFnVal), [mapVal])
 
-              val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
-              val nextFn = self._getMethodFunctionByName(structOrEnum, "next")
+              val (instanceKind, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
+              val nextFn = self._getMethodFunctionByName(instanceKind, "next")
 
-              val iterTy = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
+              val iterTy = Type(kind: TypeKind.Instance(instanceKind, typeArgs))
               (iter, iterTy, nextFn, true)
             } else if s == self._project.preludeMapStruct {
               val keyTy = try typeArgs[0] else unreachable("Map has 2 required type arguments")
@@ -444,10 +444,10 @@ pub type Compiler {
               val frameCtx = CallframeContext(position: typedIterator.token.position, callee: Some(fnName))
               val iter = try self._buildCall(Some(frameCtx), Callable.Function(iteratorFnVal), [mapVal])
 
-              val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
-              val nextFn = self._getMethodFunctionByName(structOrEnum, "next")
+              val (instanceKind, typeArgs) = try self._getInstanceTypeForType(iteratorFn.returnType)
+              val nextFn = self._getMethodFunctionByName(instanceKind, "next")
 
-              val iterTy = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
+              val iterTy = Type(kind: TypeKind.Instance(instanceKind, typeArgs))
               (iter, iterTy, nextFn, true)
             } else {
               self._currentFn.block.addComment("for-loop (${node.token.position.line}, ${node.token.position.col}) iterator")
@@ -457,7 +457,7 @@ pub type Compiler {
               (iter, typedIterator.ty, nextFn, false)
             }
           }
-          StructOrEnum.Enum(_enum) => todo("enum as for-loop target")
+          InstanceKind.Enum(_enum) => todo("enum as for-loop target")
         }
 
         val nextItemTy = try self._typeIsOption(nextFn.returnType) else unreachable("a 'next' method must return an Option type")
@@ -620,13 +620,13 @@ pub type Compiler {
                     val idxExprVal = try self._compileExpression(idxExpr)
 
                     val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "set", expr.token.position)
-                    val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
-                    match structOrEnum {
-                      StructOrEnum.Struct(struct) => if struct != self._project.preludeArrayStruct unreachable("index-assignment only implemented for arrays")
-                      StructOrEnum.Enum => unreachable("index-assignment only implemented for arrays")
+                    val (instanceKind, _) = try self._getInstanceTypeForType(expr.ty)
+                    match instanceKind {
+                      InstanceKind.Struct(struct) => if struct != self._project.preludeArrayStruct unreachable("index-assignment only implemented for arrays")
+                      InstanceKind.Enum => unreachable("index-assignment only implemented for arrays")
                     }
 
-                    val setFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeArrayStruct), "set")
+                    val setFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeArrayStruct), "set")
                     val setFnVal = try self._getOrCompileMethod(instType, setFn)
                     self._resolvedGenerics.popLayer()
 
@@ -641,13 +641,13 @@ pub type Compiler {
                 val idxExprVal = try self._compileExpression(idxExpr)
 
                 val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "set", expr.token.position)
-                val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
-                match structOrEnum {
-                  StructOrEnum.Struct(struct) => if struct != self._project.preludeMapStruct unreachable("index-assignment only implemented for map")
-                  StructOrEnum.Enum => unreachable("index-assignment only implemented for maps")
+                val (instanceKind, _) = try self._getInstanceTypeForType(expr.ty)
+                match instanceKind {
+                  InstanceKind.Struct(struct) => if struct != self._project.preludeMapStruct unreachable("index-assignment only implemented for map")
+                  InstanceKind.Enum => unreachable("index-assignment only implemented for maps")
                 }
 
-                val insertFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeMapStruct), "insert")
+                val insertFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeMapStruct), "insert")
                 val insertFnVal = try self._getOrCompileMethod(instType, insertFn)
                 self._resolvedGenerics.popLayer()
 
@@ -710,8 +710,8 @@ pub type Compiler {
           lenVal = try self._currentFn.block.buildAdd(lenVal, stringLength) else |e| return qbeError(e)
         }
 
-        val stringWithLengthFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeStringStruct), "withLength", staticMethod: true)
-        val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
+        val stringWithLengthFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeStringStruct), "withLength", staticMethod: true)
+        val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(InstanceKind.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
         // Do not track String.withLength in callframes
         val newString = try self._buildCall(None, Callable.Function(stringWithLengthFnVal), [lenVal])
         var newBuffer = self._currentFn.block.buildLoadL(try self._currentFn.block.buildAdd(Value.Int(8), newString) else |e| return qbeError(e))
@@ -783,8 +783,8 @@ pub type Compiler {
                 rightVal = try self._buildCall(Some(frameCtx), Callable.Function(rightToStringFnVal), [rightVal])
               }
 
-              val stringWithLengthFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeStringStruct), "withLength", staticMethod: true)
-              val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
+              val stringWithLengthFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeStringStruct), "withLength", staticMethod: true)
+              val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(InstanceKind.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
               val leftLength = self._currentFn.block.buildLoadL(leftVal)
               val rightLength = self._currentFn.block.buildLoadL(rightVal)
               val totalLength = try self._currentFn.block.buildAdd(leftLength, rightLength) else |e| return qbeError(e)
@@ -1315,7 +1315,7 @@ pub type Compiler {
           _ => unreachable("we know it's an array instance here")
         }
 
-        val arrayWithCapacityFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeArrayStruct), "withCapacity", staticMethod: true)
+        val arrayWithCapacityFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeArrayStruct), "withCapacity", staticMethod: true)
         val arrayWithCapacityFnVal = try self._getOrCompileMethod(node.ty, arrayWithCapacityFn)
 
         val sizeVal = Value.Int(items.length.nextPowerOf2())
@@ -1323,7 +1323,7 @@ pub type Compiler {
         val arrayInstance = try self._buildCall(None, Callable.Function(arrayWithCapacityFnVal), [sizeVal], resultLocalName)
         self._currentFn.block.addCommentBefore("${arrayInstance.repr()}: ${node.ty.repr()}")
 
-        val arrayPushFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeArrayStruct), "push")
+        val arrayPushFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeArrayStruct), "push")
         val arrayPushFnVal = try self._getOrCompileMethod(node.ty, arrayPushFn)
 
         for item in items {
@@ -1345,14 +1345,14 @@ pub type Compiler {
           _ => unreachable("we know it's a set instance here")
         }
 
-        val setNewFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeSetStruct), "new", staticMethod: true)
+        val setNewFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeSetStruct), "new", staticMethod: true)
         val setNewFnVal = try self._getOrCompileMethod(node.ty, setNewFn, [true])
 
         // Do not track Set.new in callframes
         val setInstance = try self._buildCall(None, Callable.Function(setNewFnVal), [], resultLocalName)
         self._currentFn.block.addCommentBefore("${setInstance.repr()}: ${node.ty.repr()}")
 
-        val setInsertFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeSetStruct), "insert")
+        val setInsertFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeSetStruct), "insert")
         val setInsertFnVal = try self._getOrCompileMethod(node.ty, setInsertFn)
 
         for item in items {
@@ -1375,7 +1375,7 @@ pub type Compiler {
           _ => unreachable("we know it's a map instance here")
         }
 
-        val mapNewFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeMapStruct), "new", staticMethod: true)
+        val mapNewFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeMapStruct), "new", staticMethod: true)
         val mapNewFnVal = try self._getOrCompileMethod(node.ty, mapNewFn, [true])
 
         val fnName = self._functionName(mapNewFn.label.name, mapNewFn.kind)
@@ -1383,7 +1383,7 @@ pub type Compiler {
         val mapInstance = try self._buildCall(None, Callable.Function(mapNewFnVal), [], resultLocalName)
         self._currentFn.block.addCommentBefore("${mapInstance.repr()}: ${node.ty.repr()}")
 
-        val mapInsertFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeMapStruct), "insert")
+        val mapInsertFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeMapStruct), "insert")
         val mapInsertFnVal = try self._getOrCompileMethod(node.ty, mapInsertFn)
 
         for (keyExpr, valExpr) in items {
@@ -1399,10 +1399,10 @@ pub type Compiler {
       }
       TypedAstNodeKind.Tuple(items) => {
         val tupleStruct = self._tupleStruct(items.length)
-        val selfType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(tupleStruct), items.map(node => node.ty)))
+        val selfType = Type(kind: TypeKind.Instance(InstanceKind.Struct(tupleStruct), items.map(node => node.ty)))
 
         val resolvedGenerics: Map<String, Type> = {}
-        val template = Type(kind: TypeKind.Instance(StructOrEnum.Struct(tupleStruct), tupleStruct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+        val template = Type(kind: TypeKind.Instance(InstanceKind.Struct(tupleStruct), tupleStruct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
         for (name, ty) in selfType.extractGenerics(template) {
           resolvedGenerics[name] = ty
         }
@@ -1430,10 +1430,10 @@ pub type Compiler {
                 val idxExprVal = try self._compileExpression(idxExpr)
 
                 val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "get", expr.token.position)
-                val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
-                val getFn = match structOrEnum {
-                  StructOrEnum.Struct => self._getMethodFunctionByName(structOrEnum, "get")
-                  StructOrEnum.Enum => unreachable("array-like indexing never applies to enum instances")
+                val (instanceKind, _) = try self._getInstanceTypeForType(expr.ty)
+                val getFn = match instanceKind {
+                  InstanceKind.Struct => self._getMethodFunctionByName(instanceKind, "get")
+                  InstanceKind.Enum => unreachable("array-like indexing never applies to enum instances")
                 }
                 val getFnVal = try self._getOrCompileMethod(instType, getFn)
                 self._resolvedGenerics.popLayer()
@@ -1458,10 +1458,10 @@ pub type Compiler {
                 }
 
                 val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "getRange", expr.token.position)
-                val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
-                val getRangeFn = match structOrEnum {
-                  StructOrEnum.Struct => self._getMethodFunctionByName(structOrEnum, "getRange")
-                  StructOrEnum.Enum => unreachable("array-like indexing never applies to enum instances")
+                val (instanceKind, _) = try self._getInstanceTypeForType(expr.ty)
+                val getRangeFn = match instanceKind {
+                  InstanceKind.Struct => self._getMethodFunctionByName(instanceKind, "getRange")
+                  InstanceKind.Enum => unreachable("array-like indexing never applies to enum instances")
                 }
                 val getRangeFnVal = try self._getOrCompileMethod(instType, getRangeFn, paramsNeedingDefaultValue)
                 self._resolvedGenerics.popLayer()
@@ -1476,13 +1476,13 @@ pub type Compiler {
             val idxExprVal = try self._compileExpression(idxExpr)
 
             val instType = try self._addResolvedGenericsLayerForInstanceMethod(expr.ty, "get", expr.token.position)
-            val (structOrEnum, _) = try self._getInstanceTypeForType(expr.ty)
-            match structOrEnum {
-              StructOrEnum.Struct(struct) => if struct != self._project.preludeMapStruct unreachable("map indexing only implemented for map")
-              StructOrEnum.Enum => unreachable("map indexing never applies to enum instances")
+            val (instanceKind, _) = try self._getInstanceTypeForType(expr.ty)
+            match instanceKind {
+              InstanceKind.Struct(struct) => if struct != self._project.preludeMapStruct unreachable("map indexing only implemented for map")
+              InstanceKind.Enum => unreachable("map indexing never applies to enum instances")
             }
 
-            val getFn = self._getMethodFunctionByName(structOrEnum, "get")
+            val getFn = self._getMethodFunctionByName(instanceKind, "get")
             val getFnVal = try self._getOrCompileMethod(instType, getFn)
             self._resolvedGenerics.popLayer()
 
@@ -1492,16 +1492,16 @@ pub type Compiler {
           TypedIndexingNode.Tuple(tupleExpr, idx) => {
             val exprVal = try self._compileExpression(tupleExpr)
 
-            val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(tupleExpr.ty)
-            val struct = match structOrEnum {
-              StructOrEnum.Struct(struct) => struct
-              StructOrEnum.Enum => unreachable("tuples are represented as structs")
+            val (instanceKind, typeArgs) = try self._getInstanceTypeForType(tupleExpr.ty)
+            val struct = match instanceKind {
+              InstanceKind.Struct(struct) => struct
+              InstanceKind.Enum => unreachable("tuples are represented as structs")
             }
 
-            val selfType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
+            val selfType = Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), typeArgs))
 
             val resolvedGenerics: Map<String, Type> = {}
-            val template = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+            val template = Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
             for (name, ty) in selfType.extractGenerics(template) {
               resolvedGenerics[name] = ty
             }
@@ -2057,19 +2057,19 @@ pub type Compiler {
     } else {
       // If the closure is being called in the same scope in which it was declared, then the `*.captures` value is visible as a stack local.
       val prefix = match fn.kind {
-        FunctionKind.InstanceMethod(structOrEnum, _) => {
-          if structOrEnum |structOrEnum| {
-            val typeName = match structOrEnum {
-              StructOrEnum.Struct(struct) => struct.label.name
-              StructOrEnum.Enum(enum_) => enum_.label.name
+        FunctionKind.InstanceMethod(instanceKind, _) => {
+          if instanceKind |instanceKind| {
+            val typeName = match instanceKind {
+              InstanceKind.Struct(struct) => struct.label.name
+              InstanceKind.Enum(enum_) => enum_.label.name
             }
             "$typeName.."
-          } else unreachable("an instance method should have a structOrEnum")
+          } else unreachable("an instance method should have a instanceKind")
         }
-        FunctionKind.StaticMethod(structOrEnum, _) => {
-          val typeName = match structOrEnum {
-            StructOrEnum.Struct(struct) => struct.label.name
-            StructOrEnum.Enum(enum_) => enum_.label.name
+        FunctionKind.StaticMethod(instanceKind, _) => {
+          val typeName = match instanceKind {
+            InstanceKind.Struct(struct) => struct.label.name
+            InstanceKind.Enum(enum_) => enum_.label.name
           }
           "$typeName."
         }
@@ -2231,10 +2231,10 @@ pub type Compiler {
     val hasReturn = fn.returnType.kind != TypeKind.PrimitiveUnit
     val (struct, _) = self._functionStruct(targetArity, hasReturn)
     val typeArgs = (if hasReturn { [fn.returnType] } else []).concat(fnValParamTypes)
-    val fnStructSelfType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
+    val fnStructSelfType = Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), typeArgs))
 
     val resolvedGenerics: Map<String, Type> = {}
-    val template = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+    val template = Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
     for (name, ty) in fnStructSelfType.extractGenerics(template) {
       resolvedGenerics[name] = ty
     }
@@ -2269,9 +2269,9 @@ pub type Compiler {
       TypeKind.Generic(name) => {
         if self._resolvedGenerics.resolveGeneric(name) |ty| self._getQbeTypeForType(ty) else unreachable("unexpected generic '$name' at this point")
       }
-      TypeKind.Instance(structOrEnum, generics) => {
-        match structOrEnum {
-          StructOrEnum.Struct(struct) => {
+      TypeKind.Instance(instanceKind, generics) => {
+        match instanceKind {
+          InstanceKind.Struct(struct) => {
             if struct == self._project.preludeIntStruct return Ok(Some(QbeType.U64))
             if struct == self._project.preludeFloatStruct return Ok(Some(QbeType.F64))
 
@@ -2299,8 +2299,8 @@ pub type Compiler {
 
   func _followAccessorPath(self, head: TypedAstNode, middle: AccessorPathSegment[], tail: AccessorPathSegment, loadFinal: Bool, localName: String? = None): Result<Value, CompileError> {
     val segs = middle.concat([tail])
-    var instTy = StructOrEnum.Struct(self._project.preludeBoolStruct)
-    var instType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self._project.preludeBoolStruct), []))
+    var instTy = InstanceKind.Struct(self._project.preludeBoolStruct)
+    var instType = Type(kind: TypeKind.Instance(InstanceKind.Struct(self._project.preludeBoolStruct), []))
     var curVal = Value.Ident("bogus", QbeType.F32)
     match segs[0] {
       AccessorPathSegment.Field => {
@@ -2339,7 +2339,7 @@ pub type Compiler {
 
           curVal = try self._getOrCompileEnumVariantConst(enum_, variant)
 
-          instTy = StructOrEnum.Enum(enum_)
+          instTy = InstanceKind.Enum(enum_)
         }
         AccessorPathSegment.Method(label, fn, isOptSafe, fnAliasTypeHint) => {
           if isOptSafe todo("opt-safe method accessor")
@@ -2413,7 +2413,7 @@ pub type Compiler {
           }
 
           match instTy {
-            StructOrEnum.Struct(struct) => {
+            InstanceKind.Struct(struct) => {
               var offset = 0
               var fieldTyQbe = QbeType.F32 // placeholder sentinel value
               for f in struct.fields {
@@ -2442,7 +2442,7 @@ pub type Compiler {
                 curVal = nextVal
               }
             }
-            StructOrEnum.Enum(_enum) => todo("enum field accessor")
+            InstanceKind.Enum(_enum) => todo("enum field accessor")
           }
 
           if optSafeCtx |(labelIsNone, noneRes, someVariantFn, labelCont)| {
@@ -2691,9 +2691,9 @@ pub type Compiler {
   func _pointerSize(self, ty: Type): Result<Int, CompileError> {
     val isByte = match ty.kind {
       TypeKind.Generic(name) => unreachable("unresolved generic '$name'")
-      TypeKind.Instance(structOrEnum, generics) => {
-        match structOrEnum {
-          StructOrEnum.Struct(struct) => struct.builtin == Some(BuiltinModule.Intrinsics) && struct.label.name == "Byte"
+      TypeKind.Instance(instanceKind, generics) => {
+        match instanceKind {
+          InstanceKind.Struct(struct) => struct.builtin == Some(BuiltinModule.Intrinsics) && struct.label.name == "Byte"
           _ => false
         }
       }
@@ -3136,8 +3136,8 @@ pub type Compiler {
   func _getOrCompileFunctionCallMethod(self, selfType: Type): Result<QbeFunction, CompileError> {
     val (selfTy, typeArgs) = try self._getInstanceTypeForType(selfType)
     val (fnStruct, fnCallMethodFn) = match selfTy {
-      StructOrEnum.Struct(struct) => try self._isFunctionStruct(struct) else unreachable("type of fn expr must be a Function struct")
-      StructOrEnum.Enum => unreachable()
+      InstanceKind.Struct(struct) => try self._isFunctionStruct(struct) else unreachable("type of fn expr must be a Function struct")
+      InstanceKind.Enum => unreachable()
     }
 
     var methodName = try self._structMethodFnName(fnStruct, fnCallMethodFn)
@@ -3298,7 +3298,7 @@ pub type Compiler {
   func _getOrCompileToStringMethod(self, ty: Type): Result<QbeFunction, CompileError> {
     val (selfTy, typeArgs) = try self._getInstanceTypeForType(ty)
     val (methodName, fn) = match selfTy {
-      StructOrEnum.Struct(struct) => {
+      InstanceKind.Struct(struct) => {
         if struct == self._project.preludeIntStruct return self._getOrCompileIntToStringMethod()
         if struct == self._project.preludeFloatStruct return self._getOrCompileFloatToStringMethod()
         if struct == self._project.preludeStringStruct return self._getOrCompileStringToStringMethod()
@@ -3308,7 +3308,7 @@ pub type Compiler {
 
         (try self._structMethodFnName(struct, fn), fn)
       }
-      StructOrEnum.Enum(enum_) => {
+      InstanceKind.Enum(enum_) => {
         val fn = self._getMethodFunctionByName(selfTy, "toString")
 
         (try self._enumMethodFnName(enum_, fn), fn)
@@ -3339,7 +3339,7 @@ pub type Compiler {
     val selfParamVal = fnVal.addParameter("self", selfTyQbe)
 
     match selfTy {
-      StructOrEnum.Struct(struct) => {
+      InstanceKind.Struct(struct) => {
         val data: (String, Position, Type)[] = []
 
         if self._isFunctionStruct(struct) {
@@ -3359,7 +3359,7 @@ pub type Compiler {
           self._currentFn.block.buildReturn(Some(res))
         }
       }
-      StructOrEnum.Enum(enum_) => {
+      InstanceKind.Enum(enum_) => {
         val variantIdxVal = self._emitGetEnumVariantIdx(selfParamVal)
 
         var labelElse = self._currentFn.block.addLabel("__initial")
@@ -3453,8 +3453,8 @@ pub type Compiler {
     }
 
     val totalLengthVal = try self._currentFn.block.buildAdd(Value.Int(len), lenVal) else |e| return qbeError(e)
-    val stringWithLengthFn = self._getMethodFunctionByName(StructOrEnum.Struct(self._project.preludeStringStruct), "withLength", staticMethod: true)
-    val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(StructOrEnum.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
+    val stringWithLengthFn = self._getMethodFunctionByName(InstanceKind.Struct(self._project.preludeStringStruct), "withLength", staticMethod: true)
+    val stringWithLengthFnVal = try self._getOrCompileMethod(Type(kind: TypeKind.Type(InstanceKind.Struct(self._project.preludeStringStruct))), stringWithLengthFn)
     // Do not track String.withLength in callframes
     val newStr = try self._buildCall(None, Callable.Function(stringWithLengthFnVal), [totalLengthVal])
 
@@ -3636,7 +3636,7 @@ pub type Compiler {
   func _getOrCompileEqMethod(self, ty: Type): Result<QbeFunction, CompileError> {
     val (selfTy, _) = try self._getInstanceTypeForType(ty)
     val (methodName, fn) = match selfTy {
-      StructOrEnum.Struct(struct) => {
+      InstanceKind.Struct(struct) => {
         val boolTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveBool), "bool qbe type should exist")
 
         // TODO: surely there's a cleaner way to represent these built-in eq methods
@@ -3731,7 +3731,7 @@ pub type Compiler {
 
         (try self._structMethodFnName(struct, fn), fn)
       }
-      StructOrEnum.Enum(enum_) => {
+      InstanceKind.Enum(enum_) => {
         val fn = self._getMethodFunctionByName(selfTy, "eq")
 
         (try self._enumMethodFnName(enum_, fn), fn)
@@ -3763,7 +3763,7 @@ pub type Compiler {
     val otherParamVal = fnVal.addParameter("other", selfTyQbe)
 
     match selfTy {
-      StructOrEnum.Struct(struct) => {
+      InstanceKind.Struct(struct) => {
         val data: (String, Position, Type)[] = []
 
         val isTuple = self._isTupleStruct(struct)
@@ -3774,7 +3774,7 @@ pub type Compiler {
 
         try self._emitEqLogicForStructuredData(selfParamVal, otherParamVal, data)
       }
-      StructOrEnum.Enum(enum_) => {
+      InstanceKind.Enum(enum_) => {
         val selfVariantIdxVal = self._emitGetEnumVariantIdx(selfParamVal)
         val otherVariantIdxVal = self._emitGetEnumVariantIdx(otherParamVal)
 
@@ -3875,7 +3875,7 @@ pub type Compiler {
   func _getOrCompileHashMethod(self, ty: Type): Result<QbeFunction, CompileError> {
     val (selfTy, _) = try self._getInstanceTypeForType(ty)
     val (methodName, fn) = match selfTy {
-      StructOrEnum.Struct(struct) => {
+      InstanceKind.Struct(struct) => {
         val intTypeQbe = try self._getQbeTypeForTypeExpect(Type(kind: TypeKind.PrimitiveInt), "int qbe type should exist")
 
         // TODO: surely there's a cleaner way to represent these built-in hash methods
@@ -3964,7 +3964,7 @@ pub type Compiler {
 
         (try self._structMethodFnName(struct, fn), fn)
       }
-      StructOrEnum.Enum(enum_) => {
+      InstanceKind.Enum(enum_) => {
         val fn = self._getMethodFunctionByName(selfTy, "hash")
 
         (try self._enumMethodFnName(enum_, fn), fn)
@@ -3995,7 +3995,7 @@ pub type Compiler {
     val selfParamVal = fnVal.addParameter("self", selfTyQbe)
 
     match selfTy {
-      StructOrEnum.Struct(struct) => {
+      InstanceKind.Struct(struct) => {
         val data: (String, Position, Type)[] = []
         val isTuple = self._isTupleStruct(struct)
         for field in struct.fields {
@@ -4005,7 +4005,7 @@ pub type Compiler {
 
         try self._emitHashLogicForStructuredData(selfParamVal, data)
       }
-      StructOrEnum.Enum(enum_) => {
+      InstanceKind.Enum(enum_) => {
         val variantIdxVal = self._emitGetEnumVariantIdx(selfParamVal)
 
         var labelElse = self._currentFn.block.addLabel("__initial")
@@ -4156,17 +4156,17 @@ pub type Compiler {
   }
 
   func _addResolvedGenericsLayerForInstanceMethod(self, ty: Type, methodName: String, position: Position, resolvedGenerics: Map<String, Type> = {}): Result<Type, CompileError> {
-    val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(ty)
-    val (template, selfInstanceType) = match structOrEnum {
-      StructOrEnum.Struct(struct) => {
-        val template = Type(kind: TypeKind.Instance(structOrEnum, struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
-        val inst = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
+    val (instanceKind, typeArgs) = try self._getInstanceTypeForType(ty)
+    val (template, selfInstanceType) = match instanceKind {
+      InstanceKind.Struct(struct) => {
+        val template = Type(kind: TypeKind.Instance(instanceKind, struct.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+        val inst = Type(kind: TypeKind.Instance(instanceKind, typeArgs))
 
         (template, inst)
       }
-      StructOrEnum.Enum(enum_) => {
-        val template = Type(kind: TypeKind.Instance(structOrEnum, enum_.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
-        val inst = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
+      InstanceKind.Enum(enum_) => {
+        val template = Type(kind: TypeKind.Instance(instanceKind, enum_.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+        val inst = Type(kind: TypeKind.Instance(instanceKind, typeArgs))
 
         (template, inst)
       }
@@ -4174,9 +4174,9 @@ pub type Compiler {
     for (name, ty) in selfInstanceType.extractGenerics(template) {
       resolvedGenerics[name] = ty
     }
-    val layerName = match structOrEnum {
-      StructOrEnum.Struct(struct) => "${struct.label.name}.$methodName"
-      StructOrEnum.Enum(enum_) => "${enum_.label.name}.$methodName"
+    val layerName = match instanceKind {
+      InstanceKind.Struct(struct) => "${struct.label.name}.$methodName"
+      InstanceKind.Enum(enum_) => "${enum_.label.name}.$methodName"
     }
     match self._resolvedGenerics.addLayer(layerName, resolvedGenerics) { Ok => {}, Err(e) => return Err(CompileError(position: position, kind: CompileErrorKind.ResolvedGenericsError(context: layerName, message: e))) }
 
@@ -4184,12 +4184,12 @@ pub type Compiler {
   }
 
   func _addResolvedGenericsLayerForEnumVariant(self, ty: Type, variantName: String, position: Position, resolvedGenerics: Map<String, Type> = {}): Result<Type, CompileError> {
-    val (structOrEnum, typeArgs) = try self._getInstanceTypeForType(ty)
-    match structOrEnum {
-      StructOrEnum.Struct => unreachable("type should always be an enum here")
-      StructOrEnum.Enum(enum_) => {
-        val template = Type(kind: TypeKind.Instance(structOrEnum, enum_.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
-        val selfInstanceType = Type(kind: TypeKind.Instance(structOrEnum, typeArgs))
+    val (instanceKind, typeArgs) = try self._getInstanceTypeForType(ty)
+    match instanceKind {
+      InstanceKind.Struct => unreachable("type should always be an enum here")
+      InstanceKind.Enum(enum_) => {
+        val template = Type(kind: TypeKind.Instance(instanceKind, enum_.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+        val selfInstanceType = Type(kind: TypeKind.Instance(instanceKind, typeArgs))
 
         for (name, ty) in selfInstanceType.extractGenerics(template) {
           resolvedGenerics[name] = ty
@@ -4225,7 +4225,7 @@ pub type Compiler {
         name: "call",
         params: params,
         returnType: returnType,
-        kind: FunctionKind.InstanceMethod(Some(StructOrEnum.Struct(struct)), false),
+        kind: FunctionKind.InstanceMethod(Some(InstanceKind.Struct(struct)), false),
       )
 
       (struct, callMethod)
@@ -4252,33 +4252,33 @@ pub type Compiler {
 
   func _isTupleStruct(self, struct: Struct): Bool = if self._tupleStructs[struct.label.name] |s| s == struct else false
 
-  func _getInstanceTypeForType(self, ty: Type): Result<(StructOrEnum, Type[]), CompileError> {
+  func _getInstanceTypeForType(self, ty: Type): Result<(InstanceKind, Type[]), CompileError> {
     match ty.kind {
       TypeKind.CouldNotDetermine => unreachable("used for surfacing partial results; no module with this type should make it to the compilation phase")
       TypeKind.Any => unreachable("getInstanceTypeForType: Any")
       TypeKind.PrimitiveUnit => unreachable("getInstanceTypeForType: Unit")
-      TypeKind.PrimitiveInt => Ok((StructOrEnum.Struct(self._project.preludeIntStruct), []))
-      TypeKind.PrimitiveFloat => Ok((StructOrEnum.Struct(self._project.preludeFloatStruct), []))
-      TypeKind.PrimitiveBool => Ok((StructOrEnum.Struct(self._project.preludeBoolStruct), []))
-      TypeKind.PrimitiveChar => Ok((StructOrEnum.Struct(self._project.preludeCharStruct), []))
-      TypeKind.PrimitiveString => Ok((StructOrEnum.Struct(self._project.preludeStringStruct), []))
+      TypeKind.PrimitiveInt => Ok((InstanceKind.Struct(self._project.preludeIntStruct), []))
+      TypeKind.PrimitiveFloat => Ok((InstanceKind.Struct(self._project.preludeFloatStruct), []))
+      TypeKind.PrimitiveBool => Ok((InstanceKind.Struct(self._project.preludeBoolStruct), []))
+      TypeKind.PrimitiveChar => Ok((InstanceKind.Struct(self._project.preludeCharStruct), []))
+      TypeKind.PrimitiveString => Ok((InstanceKind.Struct(self._project.preludeStringStruct), []))
       TypeKind.Never => unreachable("getInstanceTypeForType: Never")
       TypeKind.Generic(name) => {
         if self._resolvedGenerics.resolveGeneric(name) |ty| self._getInstanceTypeForType(ty) else unreachable("failed to resolve generic: '$name'")
       }
-      TypeKind.Instance(structOrEnum, typeParams) => Ok((structOrEnum, typeParams))
+      TypeKind.Instance(instanceKind, typeParams) => Ok((instanceKind, typeParams))
       TypeKind.Tuple(types) => {
         val struct = self._tupleStruct(types.length)
-        Ok((StructOrEnum.Struct(struct), types))
+        Ok((InstanceKind.Struct(struct), types))
       }
       TypeKind.Func(paramTypes, returnType) => {
         val hasReturn = returnType.kind != TypeKind.PrimitiveUnit
         val (struct, _) = self._functionStruct(paramTypes.length, hasReturn)
 
         val typeArgs = (if hasReturn { [returnType] } else []).concat(paramTypes.map(_p => _p[0]))
-        Ok((StructOrEnum.Struct(struct), typeArgs))
+        Ok((InstanceKind.Struct(struct), typeArgs))
       }
-      TypeKind.Type(structOrEnum) => Ok((structOrEnum, []))
+      TypeKind.Type(instanceKind) => Ok((instanceKind, []))
       TypeKind.Hole => unreachable("getInstanceTypeForType: Hole")
     }
   }
@@ -4288,10 +4288,10 @@ pub type Compiler {
       TypeKind.Generic(name) => {
         if self._resolvedGenerics.resolveGeneric(name) |ty| self._getReprForType(ty) else unreachable("failed to resolve generic repr: '$name'")
       }
-      TypeKind.Instance(structOrEnum, typeParams) => {
-        val n = match structOrEnum {
-          StructOrEnum.Struct(struct) => struct.label.name
-          StructOrEnum.Enum(_enum) => _enum.label.name
+      TypeKind.Instance(instanceKind, typeParams) => {
+        val n = match instanceKind {
+          InstanceKind.Struct(struct) => struct.label.name
+          InstanceKind.Enum(_enum) => _enum.label.name
         }
         if !typeParams.isEmpty() {
           val params: String[] = []
@@ -4306,14 +4306,14 @@ pub type Compiler {
       }
       TypeKind.Tuple(types) => {
         val struct = self._tupleStruct(types.length)
-        self._getReprForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), types)))
+        self._getReprForType(Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), types)))
       }
       TypeKind.Func(paramTypes, returnType) => {
         val hasReturn = returnType.kind != TypeKind.PrimitiveUnit
         val (struct, _) = self._functionStruct(paramTypes.length, hasReturn)
 
         val typeArgs = (if hasReturn { [returnType] } else []).concat(paramTypes.map(_p => _p[0]))
-        self._getReprForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs)))
+        self._getReprForType(Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), typeArgs)))
       }
       _ => Ok(ty.repr())
     }
@@ -4324,10 +4324,10 @@ pub type Compiler {
       TypeKind.Generic(name) => {
         if self._resolvedGenerics.resolveGeneric(name) |ty| self._getNameForType(ty) else unreachable("failed to resolve generic repr: '$name'")
       }
-      TypeKind.Instance(structOrEnum, typeParams) => {
-        val n = match structOrEnum {
-          StructOrEnum.Struct(struct) => struct.label.name
-          StructOrEnum.Enum(_enum) => _enum.label.name
+      TypeKind.Instance(instanceKind, typeParams) => {
+        val n = match instanceKind {
+          InstanceKind.Struct(struct) => struct.label.name
+          InstanceKind.Enum(_enum) => _enum.label.name
         }
         if !typeParams.isEmpty() {
           val params: String[] = []
@@ -4342,14 +4342,14 @@ pub type Compiler {
       }
       TypeKind.Tuple(types) => {
         val struct = self._tupleStruct(types.length)
-        self._getNameForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), types)))
+        self._getNameForType(Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), types)))
       }
       TypeKind.Func(paramTypes, returnType) => {
         val hasReturn = returnType.kind != TypeKind.PrimitiveUnit
         val (struct, _) = self._functionStruct(paramTypes.length, hasReturn)
 
         val typeArgs = (if hasReturn { [returnType] } else []).concat(paramTypes.map(_p => _p[0]))
-        self._getNameForType(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs)))
+        self._getNameForType(Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), typeArgs)))
       }
       _ => Ok(ty.repr())
     }
@@ -4366,13 +4366,13 @@ pub type Compiler {
     match kind {
       FunctionKind.Standalone => name
       FunctionKind.InstanceMethod(structOrEnumOpt, _) => match structOrEnumOpt {
-        StructOrEnum.Struct(s) => "${s.label.name}.$name"
-        StructOrEnum.Enum(e) => "${e.label.name}.$name"
+        InstanceKind.Struct(s) => "${s.label.name}.$name"
+        InstanceKind.Enum(e) => "${e.label.name}.$name"
         _ => name
       }
-      FunctionKind.StaticMethod(structOrEnum, _) => match structOrEnum {
-        StructOrEnum.Struct(s) => "${s.label.name}#$name"
-        StructOrEnum.Enum(e) => "${e.label.name}#$name"
+      FunctionKind.StaticMethod(instanceKind, _) => match instanceKind {
+        InstanceKind.Struct(s) => "${s.label.name}#$name"
+        InstanceKind.Enum(e) => "${e.label.name}#$name"
       }
     }
   }
@@ -4462,17 +4462,17 @@ pub type Compiler {
     Ok("${typeName}${sep}${fn.label.name}")
   }
 
-  func _methodFnName(self, structOrEnum: StructOrEnum, fn: Function): Result<String, CompileError> {
-    match structOrEnum {
-      StructOrEnum.Struct(struct) => self._structMethodFnName(struct, fn)
-      StructOrEnum.Enum(enum_) => self._enumMethodFnName(enum_, fn)
+  func _methodFnName(self, instanceKind: InstanceKind, fn: Function): Result<String, CompileError> {
+    match instanceKind {
+      InstanceKind.Struct(struct) => self._structMethodFnName(struct, fn)
+      InstanceKind.Enum(enum_) => self._enumMethodFnName(enum_, fn)
     }
   }
 
-  func _fnSignature(self, structOrEnum: StructOrEnum?, fn: Function, paramsNeedingDefaultValue: Bool[] = []): Result<String, CompileError> {
+  func _fnSignature(self, instanceKind: InstanceKind?, fn: Function, paramsNeedingDefaultValue: Bool[] = []): Result<String, CompileError> {
     val parts: String[] = []
-    match structOrEnum {
-      StructOrEnum.Struct(struct) => {
+    match instanceKind {
+      InstanceKind.Struct(struct) => {
         parts.push(struct.label.name)
         if !struct.typeParams.isEmpty() {
           parts.push("<")
@@ -4486,7 +4486,7 @@ pub type Compiler {
         }
         parts.push(match fn.kind { FunctionKind.InstanceMethod => "#", _ => "." })
       }
-      StructOrEnum.Enum(enum_) => {
+      InstanceKind.Enum(enum_) => {
         parts.push(enum_.label.name)
         if !enum_.typeParams.isEmpty() {
           parts.push("<")
@@ -4583,10 +4583,10 @@ pub type Compiler {
     Ok(parts.join())
   }
 
-  func _getMethodFunctionByName(self, parent: StructOrEnum, name: String, staticMethod = false): Function {
+  func _getMethodFunctionByName(self, parent: InstanceKind, name: String, staticMethod = false): Function {
     val (parentName, methods) = match parent {
-      StructOrEnum.Struct(s) => (s.label.name, if staticMethod s.staticMethods else s.instanceMethods)
-      StructOrEnum.Enum(e) => (e.label.name, if staticMethod e.staticMethods else e.instanceMethods)
+      InstanceKind.Struct(s) => (s.label.name, if staticMethod s.staticMethods else s.instanceMethods)
+      InstanceKind.Enum(e) => (e.label.name, if staticMethod e.staticMethods else e.instanceMethods)
     }
 
     try methods.find(m => m.label.name == name) else {
@@ -4599,18 +4599,18 @@ pub type Compiler {
     try enum_.variants.findIndex(v => v.label.name == name) else unreachable("${enum_.label.name}.$name must exist")
   }
 
-  func _typeIsInt(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveInt || ty.kind == TypeKind.Instance(StructOrEnum.Struct(self._project.preludeIntStruct), [])
-  func _typeIsFloat(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveFloat || ty.kind == TypeKind.Instance(StructOrEnum.Struct(self._project.preludeFloatStruct), [])
-  func _typeIsBool(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveBool || ty.kind == TypeKind.Instance(StructOrEnum.Struct(self._project.preludeBoolStruct), [])
-  func _typeIsChar(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveChar || ty.kind == TypeKind.Instance(StructOrEnum.Struct(self._project.preludeCharStruct), [])
-  func _typeIsString(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveString || ty.kind == TypeKind.Instance(StructOrEnum.Struct(self._project.preludeStringStruct), [])
+  func _typeIsInt(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveInt || ty.kind == TypeKind.Instance(InstanceKind.Struct(self._project.preludeIntStruct), [])
+  func _typeIsFloat(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveFloat || ty.kind == TypeKind.Instance(InstanceKind.Struct(self._project.preludeFloatStruct), [])
+  func _typeIsBool(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveBool || ty.kind == TypeKind.Instance(InstanceKind.Struct(self._project.preludeBoolStruct), [])
+  func _typeIsChar(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveChar || ty.kind == TypeKind.Instance(InstanceKind.Struct(self._project.preludeCharStruct), [])
+  func _typeIsString(self, ty: Type): Bool = ty.kind == TypeKind.PrimitiveString || ty.kind == TypeKind.Instance(InstanceKind.Struct(self._project.preludeStringStruct), [])
 
   // TODO: this is copied from Typechecker
   func _typeIsOption(self, ty: Type): Type? {
     match ty.kind {
-      TypeKind.Instance(structOrEnum, generics) => {
-        match structOrEnum {
-          StructOrEnum.Enum(enum_) => {
+      TypeKind.Instance(instanceKind, generics) => {
+        match instanceKind {
+          InstanceKind.Enum(enum_) => {
             if enum_ != self._project.preludeOptionEnum return None
             if generics[0] |innerTy| {
               Some(innerTy)

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -69,7 +69,7 @@ pub type ModuleLoader {
 pub enum Export {
   Variable(variable: Variable)
   Function(aliasVar: Variable)
-  Type(structOrEnum: StructOrEnum, aliasVar: Variable)
+  Type(instanceKind: InstanceKind, aliasVar: Variable)
 }
 
 pub type Import {
@@ -80,7 +80,7 @@ pub type Import {
 enum TypedImportKind {
   Variable(variable: Variable)
   Function(aliasVar: Variable)
-  Type(structOrEnum: StructOrEnum, aliasVar: Variable)
+  Type(instanceKind: InstanceKind, aliasVar: Variable)
 }
 
 type ImportedModule {
@@ -258,12 +258,12 @@ pub type Struct {
       staticMethods: [],
     )
 
-    val structOrEnum = StructOrEnum.Struct(struct)
+    val instanceKind = InstanceKind.Struct(struct)
     val selfInstanceType = struct.asInstanceType()
 
-    struct.instanceMethods.push(Function.generated(bogusScope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(Some(structOrEnum), true)))
-    struct.instanceMethods.push(Function.generated(bogusScope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(Some(structOrEnum), true)))
-    struct.instanceMethods.push(Function.generated(bogusScope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(structOrEnum), true)))
+    struct.instanceMethods.push(Function.generated(bogusScope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(Some(instanceKind), true)))
+    struct.instanceMethods.push(Function.generated(bogusScope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(Some(instanceKind), true)))
+    struct.instanceMethods.push(Function.generated(bogusScope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(instanceKind), true)))
 
     struct
   }
@@ -279,7 +279,7 @@ pub type Struct {
 
   func asInstanceType(self): Type {
     val typeArgs = self.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
-    Type(kind: TypeKind.Instance(StructOrEnum.Struct(self), typeArgs))
+    Type(kind: TypeKind.Instance(InstanceKind.Struct(self), typeArgs))
   }
 }
 
@@ -314,15 +314,15 @@ pub type Enum {
 
   func asInstanceType(self): Type {
     val typeArgs = self.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
-    Type(kind: TypeKind.Instance(StructOrEnum.Enum(self), typeArgs))
+    Type(kind: TypeKind.Instance(InstanceKind.Enum(self), typeArgs))
   }
 }
 
+// TODO: is type type necessary? can't it just basically be InstanceKind
 enum Instantiatable {
   Struct(struct: Struct)
   EnumContainerVariant(enum_: Enum, variant: TypedEnumVariant, fields: Field[])
 }
-
 
 pub type Project {
   pub modules: Map<String, TypedModule> = {}
@@ -350,27 +350,27 @@ pub type Project {
       }
       TypeKind.PrimitiveInt => match other.kind {
         TypeKind.PrimitiveInt => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.preludeIntStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.preludeIntStruct)
         _ => false
       }
       TypeKind.PrimitiveFloat => match other.kind {
         TypeKind.PrimitiveFloat => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.preludeFloatStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.preludeFloatStruct)
         _ => false
       }
       TypeKind.PrimitiveBool => match other.kind {
         TypeKind.PrimitiveBool => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.preludeBoolStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.preludeBoolStruct)
         _ => false
       }
       TypeKind.PrimitiveChar => match other.kind {
         TypeKind.PrimitiveChar => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.preludeCharStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.preludeCharStruct)
         _ => false
       }
       TypeKind.PrimitiveString => match other.kind {
         TypeKind.PrimitiveString => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.preludeStringStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.preludeStringStruct)
         _ => false
       }
       TypeKind.Func(reqParamTypes, reqRetType) => match ty.kind {
@@ -393,8 +393,8 @@ pub type Project {
         _ => false
       }
       TypeKind.Instance(reqStructOrEnum, reqTypeArgs) => match ty.kind {
-        TypeKind.Instance(structOrEnum, typeArgs) => {
-          if reqStructOrEnum != structOrEnum return false
+        TypeKind.Instance(instanceKind, typeArgs) => {
+          if reqStructOrEnum != instanceKind return false
           if reqTypeArgs.length != typeArgs.length return false
           for reqTypeArg, i in reqTypeArgs {
             val typeArg = try typeArgs[i] else return true
@@ -403,11 +403,11 @@ pub type Project {
 
           true
         }
-        TypeKind.PrimitiveInt => reqStructOrEnum == StructOrEnum.Struct(self.preludeIntStruct)
-        TypeKind.PrimitiveFloat => reqStructOrEnum == StructOrEnum.Struct(self.preludeFloatStruct)
-        TypeKind.PrimitiveBool => reqStructOrEnum == StructOrEnum.Struct(self.preludeBoolStruct)
-        TypeKind.PrimitiveChar => reqStructOrEnum == StructOrEnum.Struct(self.preludeCharStruct)
-        TypeKind.PrimitiveString => reqStructOrEnum == StructOrEnum.Struct(self.preludeStringStruct)
+        TypeKind.PrimitiveInt => reqStructOrEnum == InstanceKind.Struct(self.preludeIntStruct)
+        TypeKind.PrimitiveFloat => reqStructOrEnum == InstanceKind.Struct(self.preludeFloatStruct)
+        TypeKind.PrimitiveBool => reqStructOrEnum == InstanceKind.Struct(self.preludeBoolStruct)
+        TypeKind.PrimitiveChar => reqStructOrEnum == InstanceKind.Struct(self.preludeCharStruct)
+        TypeKind.PrimitiveString => reqStructOrEnum == InstanceKind.Struct(self.preludeStringStruct)
         _ => false
       }
       TypeKind.Tuple(reqTypes) => match ty.kind {
@@ -442,9 +442,9 @@ pub type Type {
       TypeKind.PrimitiveString => "String"
       TypeKind.Never => "Never"
       TypeKind.Generic(name) => name
-      TypeKind.Instance(structOrEnum, typeParams) => {
-        match structOrEnum {
-          StructOrEnum.Struct(struct) => {
+      TypeKind.Instance(instanceKind, typeParams) => {
+        match instanceKind {
+          InstanceKind.Struct(struct) => {
             if shorthand && struct.builtin == Some(BuiltinModule.Prelude) && struct.label.name == "Array" {
               val innerRepr = typeParams[0]?.repr() ?: "<unknown>"
               "$innerRepr[]"
@@ -456,7 +456,7 @@ pub type Type {
               "${struct.label.name}$genericsRepr"
             }
           }
-          StructOrEnum.Enum(enum_) => {
+          InstanceKind.Enum(enum_) => {
             if shorthand && enum_.builtin == Some(BuiltinModule.Prelude) && enum_.label.name == "Option" {
               val innerRepr = typeParams[0]?.repr() ?: "<unknown>"
               "$innerRepr?"
@@ -476,9 +476,9 @@ pub type Type {
         val returnTypeRepr = returnType.repr()
         "($paramsRepr) => $returnTypeRepr"
       }
-      TypeKind.Type(structOrEnum) => match structOrEnum {
-        StructOrEnum.Struct(struct) => "<#type ${struct.label.name}>"
-        StructOrEnum.Enum(enum_) => "<#enum ${enum_.label.name}>"
+      TypeKind.Type(instanceKind) => match instanceKind {
+        InstanceKind.Struct(struct) => "<#type ${struct.label.name}>"
+        InstanceKind.Enum(enum_) => "<#enum ${enum_.label.name}>"
       }
       TypeKind.Hole => "<unknown>"
     }
@@ -548,9 +548,9 @@ pub type Type {
           Type(kind: TypeKind.Hole)
         }
       }
-      TypeKind.Instance(structOrEnum, typeArgs) => {
+      TypeKind.Instance(instanceKind, typeArgs) => {
         val substTypeArgs = typeArgs.map(ty => ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown, genericsInScope))
-        Type(kind: TypeKind.Instance(structOrEnum, substTypeArgs))
+        Type(kind: TypeKind.Instance(instanceKind, substTypeArgs))
       }
       TypeKind.Tuple(typeArgs) => {
         val substTypeArgs = typeArgs.map(ty => ty.withSubstitutedGenerics(resolvedGenerics, retainUnknown, genericsInScope))
@@ -640,14 +640,14 @@ pub type Type {
   }
 }
 
-pub enum StructOrEnum {
+pub enum InstanceKind {
   Struct(struct: Struct)
   Enum(enum_: Enum)
 
   func asInstanceType(self): Type {
     match self {
-      StructOrEnum.Struct(s) => s.asInstanceType()
-      StructOrEnum.Enum(e) => e.asInstanceType()
+      InstanceKind.Struct(s) => s.asInstanceType()
+      InstanceKind.Enum(e) => e.asInstanceType()
     }
   }
 }
@@ -663,9 +663,9 @@ pub enum TypeKind {
   Never
   Any
   Generic(name: String)
-  Instance(structOrEnum: StructOrEnum, generics: Type[])
+  Instance(instanceKind: InstanceKind, generics: Type[])
   Func(paramTypes: (Type, Bool)[], returnType: Type)
-  Type(type_: StructOrEnum)
+  Type(type_: InstanceKind)
   Tuple(types: Type[])
   Hole
 }
@@ -697,8 +697,8 @@ type TypedFunctionParam {
 
 pub enum FunctionKind {
   Standalone
-  InstanceMethod(structOrEnum: StructOrEnum?, isPublic: Bool)
-  StaticMethod(structOrEnum: StructOrEnum, isPublic: Bool)
+  InstanceMethod(instanceKind: InstanceKind?, isPublic: Bool)
+  StaticMethod(instanceKind: InstanceKind, isPublic: Bool)
 }
 
 pub type Function {
@@ -741,7 +741,7 @@ pub type Function {
     val structTypeParams = struct.typeParams.map(t => (Type(kind: TypeKind.Generic(t)), Label(name: t, position: bogusPosition)))
     val params = struct.fields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer, variable: Variable.bogus()))
     val typeArgs = struct.typeParams.map(t => Type(kind: TypeKind.Generic(t)))
-    val returnType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), typeArgs))
+    val returnType = Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), typeArgs))
 
     Function(label: struct.label, scope: fnScope, kind: FunctionKind.Standalone, typeParams: structTypeParams, params: params, returnType: returnType, body: [], isGenerated: true)
   }
@@ -758,7 +758,7 @@ pub type Function {
     val typeParams = enum_.typeParams.map(t => (Type(kind: TypeKind.Generic(t)), Label(name: t, position: bogusPosition)))
     val params = variantFields.map(f => TypedFunctionParam(label: Label(name: f.name.name, position: bogusPosition), ty: f.ty, defaultValue: f.initializer, variable: Variable.bogus()))
     val typeArgs = enum_.typeParams.map(t => Type(kind: TypeKind.Generic(t)))
-    val returnType = Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
+    val returnType = Type(kind: TypeKind.Instance(InstanceKind.Enum(enum_), typeArgs))
 
     Function(label: variantLabel, scope: fnScope, kind: FunctionKind.Standalone, typeParams: typeParams, params: params, returnType: returnType, body: [], isGenerated: true)
   }
@@ -900,8 +900,8 @@ type TypeError {
   // comparison here is roughly the same as `Enum#eq`.
   func _typeIsOption(self, ty: Type): Type? {
     match ty.kind {
-      TypeKind.Instance(structOrEnum, generics) => match structOrEnum {
-        StructOrEnum.Enum(enum_) => if enum_.builtin == Some(BuiltinModule.Prelude) && enum_.label.name == "Option" {
+      TypeKind.Instance(instanceKind, generics) => match instanceKind {
+        InstanceKind.Enum(enum_) => if enum_.builtin == Some(BuiltinModule.Prelude) && enum_.label.name == "Option" {
           generics[0]
         } else {
           None
@@ -1189,9 +1189,9 @@ type TypeError {
         lines.push("Cannot invoke target as function")
         lines.push(self._getCursorLine(self.position, contents))
         match ty.kind {
-          TypeKind.Instance(structOrEnum, _) => {
-            match structOrEnum {
-              StructOrEnum.Enum => lines.push("This is a constant enum variant, and it accepts no arguments")
+          TypeKind.Instance(instanceKind, _) => {
+            match instanceKind {
+              InstanceKind.Enum => lines.push("This is a constant enum variant, and it accepts no arguments")
               _ => unreachable()
             }
           }
@@ -1550,7 +1550,7 @@ pub type Typechecker {
   pub project: Project
   currentModule: TypedModule = TypedModule.bogus()
   currentScope: Scope = Scope(name: "\$root")
-  currentTypeDecl: StructOrEnum? = None
+  currentTypeDecl: InstanceKind? = None
   currentFunction: Function? = None
   paramDefaultValueContext: ParamDefaultValueContext? = None
   isStructOrEnumValueAllowed: Bool = false
@@ -1652,7 +1652,7 @@ pub type Typechecker {
   }
 
   func addStructToScope(self, struct: Struct, isExported: Bool, scope = self.currentScope): Result<Int, TypeError> {
-    val structTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Struct(struct)))
+    val structTy = Type(kind: TypeKind.Type(type_: InstanceKind.Struct(struct)))
     self.currentScope.types.push(structTy)
 
     val variable = Variable(label: struct.label, scope: scope, mutable: false, ty: structTy, alias: Some(VariableAlias.Struct(struct)))
@@ -1662,14 +1662,14 @@ pub type Typechecker {
 
     if isExported {
       variable.isExported = true
-      self.currentModule.exports[struct.label.name] = Export.Type(StructOrEnum.Struct(struct), variable)
+      self.currentModule.exports[struct.label.name] = Export.Type(InstanceKind.Struct(struct), variable)
     }
 
     Ok(0) // <- unnecessary 0
   }
 
   func addEnumToScope(self, enum_: Enum, isExported: Bool, scope = self.currentScope): Result<Int, TypeError> {
-    val enumTy = Type(kind: TypeKind.Type(type_: StructOrEnum.Enum(enum_)))
+    val enumTy = Type(kind: TypeKind.Type(type_: InstanceKind.Enum(enum_)))
     self.currentScope.types.push(enumTy)
 
     val variable = Variable(label: enum_.label, scope: scope, mutable: false, ty: enumTy, alias: Some(VariableAlias.Enum(enum_)))
@@ -1679,7 +1679,7 @@ pub type Typechecker {
 
     if isExported {
       variable.isExported = true
-      self.currentModule.exports[enum_.label.name] = Export.Type(StructOrEnum.Enum(enum_), variable)
+      self.currentModule.exports[enum_.label.name] = Export.Type(InstanceKind.Enum(enum_), variable)
     }
 
     Ok(0) // <- unnecessary 0
@@ -1711,23 +1711,23 @@ pub type Typechecker {
     Ok(types)
   }
 
-  func _resolveInstanceTypeIdentifier(self, importMod: TypedModule?, structOrEnum: StructOrEnum, label: Label, typeArguments: TypeIdentifier[]): Result<Type?, TypeError> {
-    match structOrEnum {
-      StructOrEnum.Struct(struct) => {
+  func _resolveInstanceTypeIdentifier(self, importMod: TypedModule?, instanceKind: InstanceKind, label: Label, typeArguments: TypeIdentifier[]): Result<Type?, TypeError> {
+    match instanceKind {
+      InstanceKind.Struct(struct) => {
         if self.lspMode {
           self._addLSPIdentForStruct(label.position, struct, importMod)
         }
 
         val instanceTypeArgs = try self._verifyNumTypeArgs(label.position, typeArguments, struct.typeParams.length)
-        return Ok(Some(Type(kind: TypeKind.Instance(StructOrEnum.Struct(struct), instanceTypeArgs))))
+        return Ok(Some(Type(kind: TypeKind.Instance(InstanceKind.Struct(struct), instanceTypeArgs))))
       }
-      StructOrEnum.Enum(enum_) => {
+      InstanceKind.Enum(enum_) => {
         if self.lspMode {
           self._addLSPIdentForEnum(label.position, enum_, importMod)
         }
 
         val instanceTypeArgs = try self._verifyNumTypeArgs(label.position, typeArguments, enum_.typeParams.length)
-        return Ok(Some(Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), instanceTypeArgs))))
+        return Ok(Some(Type(kind: TypeKind.Instance(InstanceKind.Enum(enum_), instanceTypeArgs))))
       }
     }
 
@@ -1743,18 +1743,18 @@ pub type Typechecker {
       "Bool" => Some((Type(kind: TypeKind.PrimitiveBool), None))
       "Char" => Some((Type(kind: TypeKind.PrimitiveChar), None))
       "String" => Some((Type(kind: TypeKind.PrimitiveString), None))
-      "Map" => Some((Type(kind: TypeKind.Type(StructOrEnum.Struct(self.project.preludeMapStruct))), None))
-      "Set" => Some((Type(kind: TypeKind.Type(StructOrEnum.Struct(self.project.preludeSetStruct))), None))
+      "Map" => Some((Type(kind: TypeKind.Type(InstanceKind.Struct(self.project.preludeMapStruct))), None))
+      "Set" => Some((Type(kind: TypeKind.Type(InstanceKind.Struct(self.project.preludeSetStruct))), None))
       _ => {
         var scope = Some(self.currentScope)
         while scope |sc| {
           for ty in sc.types {
             match ty.kind {
               TypeKind.Generic(genericName) => if name == genericName return Some((ty, None))
-              TypeKind.Type(structOrEnum) => {
-                match structOrEnum {
-                  StructOrEnum.Struct(struct) => if name == struct.label.name return Some((ty, None))
-                  StructOrEnum.Enum(enum_) => if name == enum_.label.name return Some((ty, None))
+              TypeKind.Type(instanceKind) => {
+                match instanceKind {
+                  InstanceKind.Struct(struct) => if name == struct.label.name return Some((ty, None))
+                  InstanceKind.Enum(enum_) => if name == enum_.label.name return Some((ty, None))
                 }
               }
               _ => continue
@@ -1766,10 +1766,10 @@ pub type Typechecker {
         for ty in self.project.preludeScope.types {
           match ty.kind {
             TypeKind.Generic(genericName) => if name == genericName return Some((ty, None))
-            TypeKind.Type(structOrEnum) => {
-              match structOrEnum {
-                StructOrEnum.Struct(struct) => if name == struct.label.name return Some((ty, None))
-                StructOrEnum.Enum(enum_) => if name == enum_.label.name return Some((ty, None))
+            TypeKind.Type(instanceKind) => {
+              match instanceKind {
+                InstanceKind.Struct(struct) => if name == struct.label.name return Some((ty, None))
+                InstanceKind.Enum(enum_) => if name == enum_.label.name return Some((ty, None))
               }
             }
             _ => continue
@@ -1780,13 +1780,13 @@ pub type Typechecker {
           for (importName, imp) in importedModule.imports {
             if importName == name {
               match imp.kind {
-                TypedImportKind.Type(structOrEnum, _) => {
-                  val ty = Type(kind: TypeKind.Type(structOrEnum))
+                TypedImportKind.Type(instanceKind, _) => {
+                  val ty = Type(kind: TypeKind.Type(instanceKind))
 
                   val importMod = self.project.modules[moduleName]
-                  match structOrEnum {
-                    StructOrEnum.Struct(struct) => if name == struct.label.name return Some((ty, importMod))
-                    StructOrEnum.Enum(enum_) => if name == enum_.label.name return Some((ty, importMod))
+                  match instanceKind {
+                    InstanceKind.Struct(struct) => if name == struct.label.name return Some((ty, importMod))
+                    InstanceKind.Enum(enum_) => if name == enum_.label.name return Some((ty, importMod))
                   }
                 }
                 _ => continue
@@ -1821,8 +1821,8 @@ pub type Typechecker {
 
           val foundTy = match mod.exports[label.name] {
             None => return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownImportForAlias(label.name, aliasLabel)))
-            Export.Type(structOrEnum, _) => {
-              try self._resolveInstanceTypeIdentifier(Some(mod), structOrEnum, label, typeArguments)
+            Export.Type(instanceKind, _) => {
+              try self._resolveInstanceTypeIdentifier(Some(mod), instanceKind, label, typeArguments)
             }
             _ => None
           }
@@ -1834,8 +1834,8 @@ pub type Typechecker {
           return Err(TypeError(position: label.position, kind: TypeErrorKind.UnknownName(label.name, "type")))
         }
         match ty.kind {
-          TypeKind.Type(structOrEnum) => {
-            val ty = try self._resolveInstanceTypeIdentifier(importMod, structOrEnum, label, typeArguments)
+          TypeKind.Type(instanceKind) => {
+            val ty = try self._resolveInstanceTypeIdentifier(importMod, instanceKind, label, typeArguments)
             try ty else unreachable()
           }
           TypeKind.PrimitiveInt => {
@@ -1871,11 +1871,11 @@ pub type Typechecker {
       }
       TypeIdentifier.Array(inner) => {
         val innerTy = try self.resolveTypeIdentifier(inner)
-        Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [innerTy]))
+        Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeArrayStruct), [innerTy]))
       }
       TypeIdentifier.Option(inner) => {
         val innerTy = try self.resolveTypeIdentifier(inner)
-        Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [innerTy]))
+        Type(kind: TypeKind.Instance(InstanceKind.Enum(self.project.preludeOptionEnum), [innerTy]))
       }
       TypeIdentifier.Tuple(typeIdents) => {
         val types: Type[] = []
@@ -1911,15 +1911,15 @@ pub type Typechecker {
           return Err(TypeError(position: last.position, kind: TypeErrorKind.UnknownName(last.name, "type")))
         }
         val t = match ty.kind {
-          TypeKind.Type(structOrEnum) => Type(kind: TypeKind.Instance(structOrEnum, []))
+          TypeKind.Type(instanceKind) => Type(kind: TypeKind.Instance(instanceKind, []))
           _ => ty
         }
 
         if self.lspMode {
-          if self._getLSPTypeData(t) |(definitionModule, structOrEnum)| {
-            match structOrEnum {
-              StructOrEnum.Struct(struct) => self._addLSPIdentForStruct(last.position, struct, importMod)
-              StructOrEnum.Enum(enum_) => self._addLSPIdentForEnum(last.position, enum_, importMod)
+          if self._getLSPTypeData(t) |(definitionModule, instanceKind)| {
+            match instanceKind {
+              InstanceKind.Struct(struct) => self._addLSPIdentForStruct(last.position, struct, importMod)
+              InstanceKind.Enum(enum_) => self._addLSPIdentForEnum(last.position, enum_, importMod)
             }
           }
         }
@@ -1939,9 +1939,9 @@ pub type Typechecker {
             }
 
             match ty.kind {
-              TypeKind.Type(structOrEnum) => {
-                match structOrEnum {
-                  StructOrEnum.Enum(enum_) => {
+              TypeKind.Type(instanceKind) => {
+                match instanceKind {
+                  InstanceKind.Enum(enum_) => {
                     if enum_.variants.findIndex(v => v.label.name == label.name) |(variant, variantIdx)| {
                       if self.lspMode {
                         self._addLSPIdentForEnum(first.position, enum_, importMod)
@@ -2039,27 +2039,27 @@ pub type Typechecker {
     match required.kind {
       TypeKind.PrimitiveInt => match ty.kind {
         TypeKind.PrimitiveInt => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.project.preludeIntStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.project.preludeIntStruct)
         _ => false
       }
       TypeKind.PrimitiveFloat => match ty.kind {
         TypeKind.PrimitiveFloat => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.project.preludeFloatStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.project.preludeFloatStruct)
         _ => false
       }
       TypeKind.PrimitiveBool => match ty.kind {
         TypeKind.PrimitiveBool => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.project.preludeBoolStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.project.preludeBoolStruct)
         _ => false
       }
       TypeKind.PrimitiveChar => match ty.kind {
         TypeKind.PrimitiveChar => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.project.preludeCharStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.project.preludeCharStruct)
         _ => false
       }
       TypeKind.PrimitiveString => match ty.kind {
         TypeKind.PrimitiveString => true
-        TypeKind.Instance(structOrEnum, _) => structOrEnum == StructOrEnum.Struct(self.project.preludeStringStruct)
+        TypeKind.Instance(instanceKind, _) => instanceKind == InstanceKind.Struct(self.project.preludeStringStruct)
         _ => false
       }
       TypeKind.Func(reqParamTypes, reqRetType) => match ty.kind {
@@ -2082,8 +2082,8 @@ pub type Typechecker {
         _ => false
       }
       TypeKind.Instance(reqStructOrEnum, reqTypeArgs) => match ty.kind {
-        TypeKind.Instance(structOrEnum, typeArgs) => {
-          if reqStructOrEnum != structOrEnum return false
+        TypeKind.Instance(instanceKind, typeArgs) => {
+          if reqStructOrEnum != instanceKind return false
 
           if reqTypeArgs.length != typeArgs.length return false
           for reqTypeArg, i in reqTypeArgs {
@@ -2093,11 +2093,11 @@ pub type Typechecker {
 
           true
         }
-        TypeKind.PrimitiveInt => reqStructOrEnum == StructOrEnum.Struct(self.project.preludeIntStruct)
-        TypeKind.PrimitiveFloat => reqStructOrEnum == StructOrEnum.Struct(self.project.preludeFloatStruct)
-        TypeKind.PrimitiveBool => reqStructOrEnum == StructOrEnum.Struct(self.project.preludeBoolStruct)
-        TypeKind.PrimitiveChar => reqStructOrEnum == StructOrEnum.Struct(self.project.preludeCharStruct)
-        TypeKind.PrimitiveString => reqStructOrEnum == StructOrEnum.Struct(self.project.preludeStringStruct)
+        TypeKind.PrimitiveInt => reqStructOrEnum == InstanceKind.Struct(self.project.preludeIntStruct)
+        TypeKind.PrimitiveFloat => reqStructOrEnum == InstanceKind.Struct(self.project.preludeFloatStruct)
+        TypeKind.PrimitiveBool => reqStructOrEnum == InstanceKind.Struct(self.project.preludeBoolStruct)
+        TypeKind.PrimitiveChar => reqStructOrEnum == InstanceKind.Struct(self.project.preludeCharStruct)
+        TypeKind.PrimitiveString => reqStructOrEnum == InstanceKind.Struct(self.project.preludeStringStruct)
         _ => false
       }
       TypeKind.Tuple(reqTypes) => match ty.kind {
@@ -2131,8 +2131,8 @@ pub type Typechecker {
       match fn.kind {
         FunctionKind.InstanceMethod(typeDecl, _) => {
           val genericNames = match typeDecl {
-            StructOrEnum.Struct(struct) => struct.typeParams,
-            StructOrEnum.Enum(enum_) => enum_.typeParams,
+            InstanceKind.Struct(struct) => struct.typeParams,
+            InstanceKind.Enum(enum_) => enum_.typeParams,
             None => []
           }
           for name in genericNames {
@@ -2148,14 +2148,14 @@ pub type Typechecker {
 
   func _typeAsInstance1(self, ty: Type, struct: Struct): Type? {
     match ty.kind {
-      TypeKind.Instance(s, generics) => if s == StructOrEnum.Struct(struct) { generics[0] } else None
+      TypeKind.Instance(s, generics) => if s == InstanceKind.Struct(struct) { generics[0] } else None
       _ => None
     }
   }
 
   func _typeAsInstance2(self, ty: Type, struct: Struct): (Type, Type)? {
     match ty.kind {
-      TypeKind.Instance(s, generics) => if s == StructOrEnum.Struct(struct) {
+      TypeKind.Instance(s, generics) => if s == InstanceKind.Struct(struct) {
         if generics[0] |g1| (if generics[1] |g2| Some((g1, g2)) else None) else None
       } else None
       _ => None
@@ -2255,21 +2255,21 @@ pub type Typechecker {
     }
   }
 
-  func _getLSPTypeData(self, ty: Type): (IdentifierMetaModule, StructOrEnum)? {
-    val structOrEnum = match ty.kind {
-      TypeKind.PrimitiveInt => StructOrEnum.Struct(self.project.preludeIntStruct)
-      TypeKind.PrimitiveFloat => StructOrEnum.Struct(self.project.preludeFloatStruct)
-      TypeKind.PrimitiveBool => StructOrEnum.Struct(self.project.preludeBoolStruct)
-      TypeKind.PrimitiveChar => StructOrEnum.Struct(self.project.preludeCharStruct)
-      TypeKind.PrimitiveString => StructOrEnum.Struct(self.project.preludeStringStruct)
+  func _getLSPTypeData(self, ty: Type): (IdentifierMetaModule, InstanceKind)? {
+    val instanceKind = match ty.kind {
+      TypeKind.PrimitiveInt => InstanceKind.Struct(self.project.preludeIntStruct)
+      TypeKind.PrimitiveFloat => InstanceKind.Struct(self.project.preludeFloatStruct)
+      TypeKind.PrimitiveBool => InstanceKind.Struct(self.project.preludeBoolStruct)
+      TypeKind.PrimitiveChar => InstanceKind.Struct(self.project.preludeCharStruct)
+      TypeKind.PrimitiveString => InstanceKind.Struct(self.project.preludeStringStruct)
       TypeKind.Type(type_) => type_
-      TypeKind.Instance(structOrEnum, _) => structOrEnum
+      TypeKind.Instance(instanceKind, _) => instanceKind
       else => return None
     }
 
-    val scope = match structOrEnum {
-      StructOrEnum.Struct(struct) => struct.scope
-      StructOrEnum.Enum(enum_) => enum_.scope
+    val scope = match instanceKind {
+      InstanceKind.Struct(struct) => struct.scope
+      InstanceKind.Enum(enum_) => enum_.scope
     }
 
     val mod = if scope.parent == Some(self.project.preludeScope) {
@@ -2281,7 +2281,7 @@ pub type Typechecker {
       }
     }
 
-    Some((mod, structOrEnum))
+    Some((mod, instanceKind))
   }
 
   // End LSP helpers
@@ -2404,9 +2404,9 @@ pub type Typechecker {
       return Err(TypeError(position: dec.name.position, kind: TypeErrorKind.UnknownName(decName, "decorator")))
     }
     val struct_ = match foundTy.kind {
-      TypeKind.Type(structOrEnum) => match structOrEnum {
-        StructOrEnum.Struct(s) => if !s.isDecoratorType None else Some(s)
-        StructOrEnum.Enum => None
+      TypeKind.Type(instanceKind) => match instanceKind {
+        InstanceKind.Struct(s) => if !s.isDecoratorType None else Some(s)
+        InstanceKind.Enum => None
       }
       else => None
     }
@@ -2495,8 +2495,8 @@ pub type Typechecker {
     if param.label.name == "self" {
       if !allowSelf return Err(TypeError(position: param.label.position, kind: TypeErrorKind.InvalidParamPosition(purpose: "self")))
 
-      if self.currentTypeDecl |structOrEnum| {
-        val ty = structOrEnum.asInstanceType()
+      if self.currentTypeDecl |instanceKind| {
+        val ty = instanceKind.asInstanceType()
 
         val variable = Variable(label: param.label, scope: self.currentScope, mutable: false, ty: ty, isParameter: true)
         try self.addVariableToScope(variable)
@@ -2760,7 +2760,7 @@ pub type Typechecker {
     val prevScope = self.currentScope
     self.currentScope = struct.scope
     val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = Some(StructOrEnum.Struct(struct))
+    self.currentTypeDecl = Some(InstanceKind.Struct(struct))
 
     val seenFields: Map<String, Label> = {}
     for field in node.fields {
@@ -2791,17 +2791,17 @@ pub type Typechecker {
     Ok(0)
   }
 
-  func _typecheckMethodsPass2(self, structOrEnum: StructOrEnum, funcDeclNodes: FunctionDeclarationNode[]): Result<Map<Label, Int[]>, TypeError> {
+  func _typecheckMethodsPass2(self, instanceKind: InstanceKind, funcDeclNodes: FunctionDeclarationNode[]): Result<Map<Label, Int[]>, TypeError> {
     val allParamsNeedingRevisit: Map<Label, Int[]> = {}
 
-    val (scope, instanceMethods, staticMethods) = match structOrEnum {
-      StructOrEnum.Struct(struct) => (struct.scope, struct.instanceMethods, struct.staticMethods)
-      StructOrEnum.Enum(enum_) => (enum_.scope, enum_.instanceMethods, enum_.staticMethods)
+    val (scope, instanceMethods, staticMethods) = match instanceKind {
+      InstanceKind.Struct(struct) => (struct.scope, struct.instanceMethods, struct.staticMethods)
+      InstanceKind.Enum(enum_) => (enum_.scope, enum_.instanceMethods, enum_.staticMethods)
     }
 
-    val selfInstanceType = match structOrEnum {
-      StructOrEnum.Struct(struct) => struct.asInstanceType()
-      StructOrEnum.Enum(enum_) => Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), []))
+    val selfInstanceType = match instanceKind {
+      InstanceKind.Struct(struct) => struct.asInstanceType()
+      InstanceKind.Enum(enum_) => Type(kind: TypeKind.Instance(InstanceKind.Enum(enum_), []))
     }
 
     val instanceMethodsByName = instanceMethods.keyBy(f => f.label)
@@ -2851,18 +2851,18 @@ pub type Typechecker {
 
     // Ensure toString/hash/eq methods exist (include generated stubs if not), and sure the proper order
     val reorderedInstanceMethods = [
-      toStringFn ?: Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(Some(structOrEnum), true)),
-      hashFn ?: Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(Some(structOrEnum), true)),
-      eqFn ?: Function.generated(scope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(structOrEnum), true)),
+      toStringFn ?: Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(Some(instanceKind), true)),
+      hashFn ?: Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(Some(instanceKind), true)),
+      eqFn ?: Function.generated(scope, "eq", [("other", selfInstanceType)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(Some(instanceKind), true)),
     ]
     for m in instanceMethods {
       if m.label.name == "toString" || m.label.name == "hash" || m.label.name == "eq" continue
       reorderedInstanceMethods.push(m)
     }
 
-    match structOrEnum {
-      StructOrEnum.Struct(struct) => struct.instanceMethods = reorderedInstanceMethods
-      StructOrEnum.Enum(enum_) => enum_.instanceMethods = reorderedInstanceMethods
+    match instanceKind {
+      InstanceKind.Struct(struct) => struct.instanceMethods = reorderedInstanceMethods
+      InstanceKind.Enum(enum_) => enum_.instanceMethods = reorderedInstanceMethods
     }
 
     Ok(allParamsNeedingRevisit)
@@ -2872,9 +2872,9 @@ pub type Typechecker {
     val prevScope = self.currentScope
     self.currentScope = struct.scope
     val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = Some(StructOrEnum.Struct(struct))
+    self.currentTypeDecl = Some(InstanceKind.Struct(struct))
 
-    val allParamsNeedingRevisit = try self._typecheckMethodsPass2(StructOrEnum.Struct(struct), node.methods)
+    val allParamsNeedingRevisit = try self._typecheckMethodsPass2(InstanceKind.Struct(struct), node.methods)
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
@@ -2886,7 +2886,7 @@ pub type Typechecker {
     val prevScope = self.currentScope
     self.currentScope = struct.scope
     val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = Some(StructOrEnum.Struct(struct))
+    self.currentTypeDecl = Some(InstanceKind.Struct(struct))
 
     for field, idx in node.fields {
       val initializer = try field.initializer else continue
@@ -2964,7 +2964,7 @@ pub type Typechecker {
     val prevScope = self.currentScope
     self.currentScope = enum_.scope
     val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = Some(StructOrEnum.Enum(enum_))
+    self.currentTypeDecl = Some(InstanceKind.Enum(enum_))
 
     var allVariantsConstant = true
     val seenVariants: Map<String, Label> = {}
@@ -3019,7 +3019,7 @@ pub type Typechecker {
     val prevScope = self.currentScope
     self.currentScope = enum_.scope
     val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = Some(StructOrEnum.Enum(enum_))
+    self.currentTypeDecl = Some(InstanceKind.Enum(enum_))
 
     for typedVariant, idx in enum_.variants {
       match typedVariant.kind {
@@ -3047,7 +3047,7 @@ pub type Typechecker {
       }
     }
 
-    val allParamsNeedingRevisit = try self._typecheckMethodsPass2(StructOrEnum.Enum(enum_), node.methods)
+    val allParamsNeedingRevisit = try self._typecheckMethodsPass2(InstanceKind.Enum(enum_), node.methods)
 
     self.currentTypeDecl = prevTypeDecl
     self.currentScope = prevScope
@@ -3059,7 +3059,7 @@ pub type Typechecker {
     val prevScope = self.currentScope
     self.currentScope = enum_.scope
     val prevTypeDecl = self.currentTypeDecl
-    self.currentTypeDecl = Some(StructOrEnum.Enum(enum_))
+    self.currentTypeDecl = Some(InstanceKind.Enum(enum_))
 
     val instanceMethods = enum_.instanceMethods.keyBy(f => f.label)
     val staticMethods = enum_.staticMethods.keyBy(f => f.label)
@@ -3101,7 +3101,7 @@ pub type Typechecker {
           val typedImportKind = match mod.exports[imp.name] {
             Export.Variable(v) => TypedImportKind.Variable(v)
             Export.Function(v) => TypedImportKind.Function(v)
-            Export.Type(structOrEnum, v) => TypedImportKind.Type(structOrEnum, v)
+            Export.Type(instanceKind, v) => TypedImportKind.Type(instanceKind, v)
             None => {
               // If the imported module could not be read, then let's not emit UnknownImport. Likewise for when the current module
               // has been flagged as having started a cycle. In both cases, these errors aren't very actionable and are just noisy.
@@ -3628,9 +3628,9 @@ pub type Typechecker {
 
   func _typeIsOption(self, ty: Type): Type? {
     match ty.kind {
-      TypeKind.Instance(structOrEnum, generics) => {
-        match structOrEnum {
-          StructOrEnum.Enum(enum_) => {
+      TypeKind.Instance(instanceKind, generics) => {
+        match instanceKind {
+          InstanceKind.Enum(enum_) => {
             if enum_ != self.project.preludeOptionEnum return None
             if generics[0] |innerTy| {
               Some(innerTy)
@@ -3647,9 +3647,9 @@ pub type Typechecker {
 
   func _typeIsResult(self, ty: Type): (Type, Type)? {
     match ty.kind {
-      TypeKind.Instance(structOrEnum, generics) => {
-        match structOrEnum {
-          StructOrEnum.Enum(enum_) => {
+      TypeKind.Instance(instanceKind, generics) => {
+        match instanceKind {
+          InstanceKind.Enum(enum_) => {
             if enum_ != self.project.preludeResultEnum return None
             if generics[0] |valTy| {
               if generics[1] |errTy| {
@@ -3670,9 +3670,9 @@ pub type Typechecker {
 
   func _typeIsIterable(self, ty: Type): Type? {
     match ty.kind {
-      TypeKind.Instance(structOrEnum, generics) => {
-        val instanceMethods = match structOrEnum {
-          StructOrEnum.Struct(struct) => {
+      TypeKind.Instance(instanceKind, generics) => {
+        val instanceMethods = match instanceKind {
+          InstanceKind.Struct(struct) => {
             if struct == self.project.preludeArrayStruct return generics[0]
             if struct == self.project.preludeSetStruct return generics[0]
             if struct == self.project.preludeMapStruct {
@@ -3683,7 +3683,7 @@ pub type Typechecker {
 
             struct.instanceMethods
           }
-          StructOrEnum.Enum(enum_) => enum_.instanceMethods
+          InstanceKind.Enum(enum_) => enum_.instanceMethods
         }
         for m in instanceMethods {
           if m.label.name == "next" {
@@ -3996,7 +3996,7 @@ pub type Typechecker {
               }
 
               val subjectTy = self._typeIsOption(subjectTy) ?: subjectTy
-              val template = Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), enum_.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+              val template = Type(kind: TypeKind.Instance(InstanceKind.Enum(enum_), enum_.typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
               val extractedGenerics = subjectTy.extractGenerics(template)
               val resolvedGenerics: Map<String, Type> = {}
               for (name, ty) in extractedGenerics {
@@ -4496,16 +4496,16 @@ pub type Typechecker {
       TypeKind.CouldNotDetermine => None
       TypeKind.Any => self.resolveAccessorPathSegmentAny(label, optSafe, typeHint)
       TypeKind.PrimitiveUnit => None
-      TypeKind.PrimitiveInt => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeIntStruct), [])), label, None, optSafe)
-      TypeKind.PrimitiveFloat => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeFloatStruct), [])), label, None, optSafe)
-      TypeKind.PrimitiveBool => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeBoolStruct), [])), label, None, optSafe)
-      TypeKind.PrimitiveChar => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeCharStruct), [])), label, None, optSafe)
-      TypeKind.PrimitiveString => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeStringStruct), [])), label, None, optSafe)
+      TypeKind.PrimitiveInt => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeIntStruct), [])), label, None, optSafe)
+      TypeKind.PrimitiveFloat => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeFloatStruct), [])), label, None, optSafe)
+      TypeKind.PrimitiveBool => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeBoolStruct), [])), label, None, optSafe)
+      TypeKind.PrimitiveChar => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeCharStruct), [])), label, None, optSafe)
+      TypeKind.PrimitiveString => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeStringStruct), [])), label, None, optSafe)
       TypeKind.Never => None
       TypeKind.Generic => self.resolveAccessorPathSegmentAny(label, optSafe, typeHint)
-      TypeKind.Instance(structOrEnum, generics) => {
-        val (instanceMethods, typeParams, instanceTypeModuleId) = match structOrEnum {
-          StructOrEnum.Struct(struct) => {
+      TypeKind.Instance(instanceKind, generics) => {
+        val (instanceMethods, typeParams, instanceTypeModuleId) = match instanceKind {
+          InstanceKind.Struct(struct) => {
             for field in struct.fields {
               if field.name.name == label.name {
                 if !field.isPublic && self._isIllegalAccessForMember(struct.moduleId) {
@@ -4518,7 +4518,7 @@ pub type Typechecker {
                 }
                 var ty = field.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
                 if optSafe {
-                  ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [ty]))
+                  ty = Type(kind: TypeKind.Instance(InstanceKind.Enum(self.project.preludeOptionEnum), [ty]))
                 }
                 return Ok(Some(AccessorPathSegment.Field(label, ty, field, optSafe)))
               }
@@ -4526,7 +4526,7 @@ pub type Typechecker {
 
             (struct.instanceMethods, struct.typeParams, struct.moduleId)
           }
-          StructOrEnum.Enum(enum_) => (enum_.instanceMethods, enum_.typeParams, enum_.moduleId)
+          InstanceKind.Enum(enum_) => (enum_.instanceMethods, enum_.typeParams, enum_.moduleId)
         }
 
         for fn in instanceMethods {
@@ -4552,17 +4552,17 @@ pub type Typechecker {
       }
       TypeKind.Tuple => None
       TypeKind.Func => None
-      TypeKind.Type(structOrEnum) => {
+      TypeKind.Type(instanceKind) => {
         // TODO: static fields
 
-        val (staticMethods, typeModuleId) = match structOrEnum {
-          StructOrEnum.Struct(struct) => (struct.staticMethods, struct.moduleId)
-          StructOrEnum.Enum(enum_) => {
+        val (staticMethods, typeModuleId) = match instanceKind {
+          InstanceKind.Struct(struct) => (struct.staticMethods, struct.moduleId)
+          InstanceKind.Enum(enum_) => {
             for variant in enum_.variants {
               if variant.label.name == label.name {
                 val typeArgs = enum_.typeParams.map(p => Type(kind: TypeKind.Generic(p)))
                 val ty = if typeHint |hint| {
-                  val template = Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
+                  val template = Type(kind: TypeKind.Instance(InstanceKind.Enum(enum_), typeArgs))
                   val extractedGenerics = hint.extractGenerics(template)
                   val resolvedGenerics: Map<String, Type> = {}
                   for (name, ty) in extractedGenerics {
@@ -4572,8 +4572,8 @@ pub type Typechecker {
                   template.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: #{})
                 } else {
                   match variant.kind {
-                    EnumVariantKind.Container => Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), typeArgs))
-                    EnumVariantKind.Constant => Type(kind: TypeKind.Instance(StructOrEnum.Enum(enum_), enum_.typeParams.map(() => Type(kind: TypeKind.Hole))))
+                    EnumVariantKind.Container => Type(kind: TypeKind.Instance(InstanceKind.Enum(enum_), typeArgs))
+                    EnumVariantKind.Constant => Type(kind: TypeKind.Instance(InstanceKind.Enum(enum_), enum_.typeParams.map(() => Type(kind: TypeKind.Hole))))
                   }
                 }
 
@@ -4759,7 +4759,7 @@ pub type Typechecker {
         ty = if isOptSafe {
           match seg {
             AccessorPathSegment.Field => nextTy // type is already wrapped in Option in resolveAccessorPathSegment for fields if opt-safe
-            _ => Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [nextTy]))
+            _ => Type(kind: TypeKind.Instance(InstanceKind.Enum(self.project.preludeOptionEnum), [nextTy]))
           }
         } else {
           nextTy
@@ -4774,8 +4774,8 @@ pub type Typechecker {
           }
         } else {
           match ty.kind {
-            TypeKind.Instance(structOrEnum, _) => {
-              val seg = try self.resolveAccessorPathSegment(Type(kind: TypeKind.Type(structOrEnum)), label, typeHint)
+            TypeKind.Instance(instanceKind, _) => {
+              val seg = try self.resolveAccessorPathSegment(Type(kind: TypeKind.Type(instanceKind)), label, typeHint)
 
               if seg {
                 Some(UnknownFieldSpecialCase.StaticFieldReferencedAsInstance)
@@ -4814,7 +4814,7 @@ pub type Typechecker {
             val initializerFn = Function.initializer(self.currentScope, struct)
             self.typecheckInvocationOfFunction(token, invokee.token.position, initializerFn, node.typeArguments, node.arguments, typeHint, None, Some(Instantiatable.Struct(struct)))
           }
-          VariableAlias.Enum(enum_) => return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Type(StructOrEnum.Enum(enum_))))))
+          VariableAlias.Enum(enum_) => return Err(TypeError(position: invokee.token.position, kind: TypeErrorKind.IllegalCallableType(Type(kind: TypeKind.Type(InstanceKind.Enum(enum_))))))
           None => self._typecheckInvocationOfExpression(token, invokee, invokee.token.position, node)
         }
       }
@@ -4841,7 +4841,7 @@ pub type Typechecker {
 
                 if optSafe {
                   val typedNode = try self.typecheckInvocationOfFunction(token, invokee.token.position, fn, node.typeArguments, node.arguments, typeHint, Some((selfVal, true)))
-                  typedNode.ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [typedNode.ty]))
+                  typedNode.ty = Type(kind: TypeKind.Instance(InstanceKind.Enum(self.project.preludeOptionEnum), [typedNode.ty]))
                   Ok(typedNode)
                 } else {
                   self.typecheckInvocationOfFunction(token, invokee.token.position, fn, node.typeArguments, node.arguments, typeHint, Some((selfVal, false)))
@@ -4995,7 +4995,7 @@ pub type Typechecker {
           mostRecentLabeledOptionalParam = Some(label)
         }
         if param.isVariadic {
-          paramTy = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [paramTy]))
+          paramTy = Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeArrayStruct), [paramTy]))
         }
       } else if instantiationOf |instantiatable| {
         match instantiatable {
@@ -5064,7 +5064,7 @@ pub type Typechecker {
 
     if variadicParam |(param, _)| {
       var innerType = param.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: genericsInScope)
-      val paramType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [innerType]))
+      val paramType = Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeArrayStruct), [innerType]))
       typedArgumentsByName[param.label.name] = TypedAstNode(token: token, ty: paramType, kind: TypedAstNodeKind.Array(variadicArgs))
     }
 
@@ -5076,7 +5076,7 @@ pub type Typechecker {
         typedArguments.push(None)
       } else if param.isVariadic {
         var innerType = param.ty.withSubstitutedGenerics(resolvedGenerics: resolvedGenerics, retainUnknown: false, genericsInScope: genericsInScope)
-        val paramType = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [innerType]))
+        val paramType = Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeArrayStruct), [innerType]))
         typedArguments.push(Some(TypedAstNode(token: token, ty: paramType, kind: TypedAstNodeKind.Array([]))))
       } else {
         val errorKind = if instantiationOf |i| {
@@ -5158,7 +5158,7 @@ pub type Typechecker {
     }
 
     val inner = innerType ?: Type(kind: TypeKind.Hole)
-    val ty = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeArrayStruct), [inner]))
+    val ty = Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeArrayStruct), [inner]))
     val innerHasUnfilledHoles = inner.hasUnfilledHoles()
 
     for item in typedItems {
@@ -5198,7 +5198,7 @@ pub type Typechecker {
     }
 
     val inner = innerType ?: Type(kind: TypeKind.Hole)
-    val ty = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeSetStruct), [inner]))
+    val ty = Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeSetStruct), [inner]))
     val innerHasUnfilledHoles = inner.hasUnfilledHoles()
 
     for item in typedItems {
@@ -5261,7 +5261,7 @@ pub type Typechecker {
 
     val kTy = keyTy ?: Type(kind: TypeKind.Hole)
     val vTy = valTy ?: Type(kind: TypeKind.Hole)
-    val ty = Type(kind: TypeKind.Instance(StructOrEnum.Struct(self.project.preludeMapStruct), [kTy, vTy]))
+    val ty = Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeMapStruct), [kTy, vTy]))
     val keyTyHasUnfilledHoles = kTy.hasUnfilledHoles()
     val valTyHasUnfilledHoles = vTy.hasUnfilledHoles()
 
@@ -5320,7 +5320,7 @@ pub type Typechecker {
       TypeKind.Tuple(types) => self._typecheckIndexingTuple(token, types, typedExpr, indexMode)
       TypeKind.Instance(struct, typeArgs) => {
         if self._typeAsInstance1(typedExpr.ty, self.project.preludeArrayStruct) |inner| {
-          val innerAsOpt = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [inner]))
+          val innerAsOpt = Type(kind: TypeKind.Instance(InstanceKind.Enum(self.project.preludeOptionEnum), [inner]))
           self._typecheckIndexingArraylike(token: token, typedExpr: typedExpr, indexMode: indexMode, singleModeType: innerAsOpt, rangeModeType: typedExpr.ty)
         } else if self._typeAsInstance2(typedExpr.ty, self.project.preludeMapStruct) |(keyTy, valTy)| {
           match indexMode {
@@ -5330,7 +5330,7 @@ pub type Typechecker {
                 return Err(TypeError(position: typedIdxExpr.token.position, kind: TypeErrorKind.TypeMismatch([keyTy], typedIdxExpr.ty)))
               }
 
-              val ty = Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [Type(kind: valTy.kind, )]))
+              val ty = Type(kind: TypeKind.Instance(InstanceKind.Enum(self.project.preludeOptionEnum), [Type(kind: valTy.kind, )]))
               Ok(TypedAstNode(token: token, ty: ty, kind: TypedAstNodeKind.Indexing(TypedIndexingNode.Map(typedExpr, typedIdxExpr))))
             }
             IndexingMode.Range => return Err(TypeError(position: typedExpr.token.position, kind: TypeErrorKind.IllegalIndexableType(ty: typedExpr.ty, isRange: true)))
@@ -5467,12 +5467,12 @@ pub type Typechecker {
     val currentFn = try self.currentFunction else return Err(TypeError(position: token.position, kind: TypeErrorKind.InvalidTryLocation(InvalidTryLocationReason.NotWithinFunction)))
 
     val (typedExpr, returnTypeResultErr) = if self._typeIsResult(currentFn.returnType) |(_, retErrType)| {
-      val hint = if typeHint |typeHint| { Some(Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeResultEnum), [typeHint, retErrType]))) } else None
+      val hint = if typeHint |typeHint| { Some(Type(kind: TypeKind.Instance(InstanceKind.Enum(self.project.preludeResultEnum), [typeHint, retErrType]))) } else None
       val typedExpr = try self._typecheckExpression(expr, hint)
 
       (typedExpr, Some(retErrType))
     } else if self._typeIsOption(currentFn.returnType) |inner| {
-      val hint = if typeHint |typeHint| { Some(Type(kind: TypeKind.Instance(StructOrEnum.Enum(self.project.preludeOptionEnum), [typeHint]))) } else None
+      val hint = if typeHint |typeHint| { Some(Type(kind: TypeKind.Instance(InstanceKind.Enum(self.project.preludeOptionEnum), [typeHint]))) } else None
       val typedExpr = try self._typecheckExpression(expr, hint)
 
       (typedExpr, None)

--- a/projects/compiler/src/typechecker_test_utils.abra
+++ b/projects/compiler/src/typechecker_test_utils.abra
@@ -1,5 +1,5 @@
 import LiteralAstNode, IndexingMode from "./parser"
-import Type, TypeKind, TypedModule, TypedAstNode, TypedAstNodeKind, Variable, Function, FunctionKind, Scope, Struct, Enum, StructOrEnum, AccessorPathSegment, TypedInvokee, TypedIndexingNode, TypedAssignmentMode, Field, EnumVariantKind, Export, TypedMatchCaseKind from "./typechecker"
+import Type, TypeKind, TypedModule, TypedAstNode, TypedAstNodeKind, Variable, Function, FunctionKind, Scope, Struct, Enum, InstanceKind, AccessorPathSegment, TypedInvokee, TypedIndexingNode, TypedAssignmentMode, Field, EnumVariantKind, Export, TypedMatchCaseKind from "./typechecker"
 import printTokenAsJson, printLabelAsJson, printBindingPatternAsJson from "./test_utils"
 
 pub type Jsonifier {
@@ -127,13 +127,13 @@ pub type Jsonifier {
         self.println("\"kind\": \"generic\",")
         self.println("\"name\": \"$name\"")
       }
-      TypeKind.Instance(structOrEnum, generics) => {
-        match structOrEnum {
-          StructOrEnum.Struct(struct) => {
+      TypeKind.Instance(instanceKind, generics) => {
+        match instanceKind {
+          InstanceKind.Struct(struct) => {
             self.println("\"kind\": \"instance\",")
             self.println("\"struct\": { \"moduleId\": ${struct.moduleId}, \"name\": \"${struct.label.name}\" },")
           }
-          StructOrEnum.Enum(enum_) => {
+          InstanceKind.Enum(enum_) => {
             self.println("\"kind\": \"enumInstance\",")
             self.println("\"enum\": { \"moduleId\": ${enum_.moduleId}, \"name\": \"${enum_.label.name}\" },")
           }
@@ -169,14 +169,14 @@ pub type Jsonifier {
         self.printType(ret)
         println()
       }
-      TypeKind.Type(structOrEnum) => {
-        match structOrEnum {
-          StructOrEnum.Struct(struct) => {
+      TypeKind.Type(instanceKind) => {
+        match instanceKind {
+          InstanceKind.Struct(struct) => {
             self.println("\"kind\": \"struct\",")
             self.print("\"struct\": ")
             self.printStruct(struct: struct, abridged: true)
           }
-          StructOrEnum.Enum(enum_) => {
+          InstanceKind.Enum(enum_) => {
             self.println("\"kind\": \"enum\",")
             self.print("\"enum\": ")
             self.printEnum(enum_: enum_, abridged: true)


### PR DESCRIPTION
Previously the `StructOrEnum` type represented the backing type (either a struct (`type`) or an `enum`, aptly) for an instance. However, once Traits are introduced, a third option for an instance's backing type is possible. So, prior to introducing traits, let's rename this to `InstanceKind`.