### PR TITLE
Removing `Any` type

### DIFF
--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -1050,8 +1050,7 @@ pub type Compiler {
               val targetParamTypes = if fnAliasTypeHint |hint| {
                 val paramTypes = match hint.kind {
                   TypeKind.Func(paramTypes, _) => Some(paramTypes)
-                  // If the function value is being treated as a Any or a Hole, then no param type info needs to be known later anyway
-                  TypeKind.Any => None
+                  // If the function value is being treated as a Hole, then no param type info needs to be known later anyway
                   TypeKind.Hole => None
                   _ => unreachable("fnAliasTypeKind must be TypeKind.Func")
                 }
@@ -1524,7 +1523,8 @@ pub type Compiler {
         val targetParamTypes = if typeHint |hint| {
           val paramTypes = match hint.kind {
             TypeKind.Func(paramTypes, _) => Some(paramTypes)
-            TypeKind.Any => None // if the function value is being treated as an Any, then no param type info needs to be known later anyway
+            // If the function value is being treated as a Hole, then no param type info needs to be known later anyway
+            TypeKind.Hole => None
             _ => unreachable("typeKind must be TypeKind.Func")
           }
           paramTypes
@@ -2261,7 +2261,6 @@ pub type Compiler {
       TypeKind.PrimitiveChar => Ok(Some(QbeType.U64))
       TypeKind.PrimitiveString => Ok(Some(QbeType.Pointer))
       TypeKind.Never => Ok(None)
-      TypeKind.Any => todo("TypeKind.Any")
       TypeKind.Generic(name) => {
         if self._resolvedGenerics.resolveGeneric(name) |ty| self._getQbeTypeForType(ty) else unreachable("unexpected generic '$name' at this point")
       }
@@ -2358,8 +2357,7 @@ pub type Compiler {
           val targetParamTypes = if fnAliasTypeHint |hint| {
             val paramTypes = match hint.kind {
               TypeKind.Func(paramTypes, _) => Some(paramTypes)
-              // If the function value is being treated as a Any or a Hole, then no param type info needs to be known later anyway
-              TypeKind.Any => None
+              // If the function value is being treated as a Hole, then no param type info needs to be known later anyway
               TypeKind.Hole => None
               _ => unreachable("fnAliasTypeKind must be TypeKind.Func")
             }
@@ -4205,7 +4203,6 @@ pub type Compiler {
   func _getInstanceTypeForType(self, ty: Type): Result<(InstanceKind, Type[]), CompileError> {
     match ty.kind {
       TypeKind.CouldNotDetermine => unreachable("used for surfacing partial results; no module with this type should make it to the compilation phase")
-      TypeKind.Any => unreachable("getInstanceTypeForType: Any")
       TypeKind.PrimitiveUnit => unreachable("getInstanceTypeForType: Unit")
       TypeKind.PrimitiveInt => Ok((InstanceKind.Struct(self._project.preludeIntStruct), []))
       TypeKind.PrimitiveFloat => Ok((InstanceKind.Struct(self._project.preludeFloatStruct), []))

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -433,7 +433,6 @@ pub type Type {
   pub func repr(self, shorthand = true): String {
     match self.kind {
       TypeKind.CouldNotDetermine => "<unknown>"
-      TypeKind.Any => "Any"
       TypeKind.PrimitiveUnit => "Unit"
       TypeKind.PrimitiveInt => "Int"
       TypeKind.PrimitiveFloat => "Float"
@@ -486,7 +485,6 @@ pub type Type {
 
   func hasUnfilledHoles(self): Bool = match self.kind {
     TypeKind.CouldNotDetermine => false
-    TypeKind.Any => false
     TypeKind.PrimitiveUnit => false
     TypeKind.PrimitiveInt => false
     TypeKind.PrimitiveFloat => false
@@ -661,7 +659,6 @@ pub enum TypeKind {
   PrimitiveChar
   PrimitiveString
   Never
-  Any
   Generic(name: String)
   Instance(instanceKind: InstanceKind, generics: Type[])
   Func(paramTypes: (Type, Bool)[], returnType: Type)
@@ -1736,7 +1733,6 @@ pub type Typechecker {
 
   func findTypeByNameInScope(self, name: String, startingScope = self.currentScope): (Type, TypedModule?)? {
     match name {
-      "Any" => Some((Type(kind: TypeKind.Any), None))
       "Unit" => Some((Type(kind: TypeKind.PrimitiveUnit), None))
       "Int" => Some((Type(kind: TypeKind.PrimitiveInt), None))
       "Float" => Some((Type(kind: TypeKind.PrimitiveFloat), None))
@@ -2034,7 +2030,6 @@ pub type Typechecker {
     if required.kind == TypeKind.CouldNotDetermine || ty.kind == TypeKind.CouldNotDetermine return true
     if required.kind == TypeKind.Hole return true
     if required.kind == TypeKind.Never || ty.kind == TypeKind.Never return true
-    if required.kind == TypeKind.Any return true
 
     match required.kind {
       TypeKind.PrimitiveInt => match ty.kind {
@@ -4472,29 +4467,9 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: variable.ty, kind: TypedAstNodeKind.Identifier(name, variable, fnTypeHint, varImportMod)))
   }
 
-  func resolveAccessorPathSegmentAny(self, label: Label, optSafe: Bool, typeHint: Type?): AccessorPathSegment? {
-    val scope = self.project.preludeScope.makeChild("Any", ScopeKind.Type)
-    val method: Function? = if label.name == "toString" {
-      Some(Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(None, true)))
-    } else if label.name == "hash" {
-      Some(Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(None, true)))
-    } else if label.name == "eq" {
-      Some(Function.generated(scope, "eq", [("other", Type(kind: TypeKind.Any))], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(None, true)))
-    } else {
-      None
-    }
-
-    if method |method| {
-      Some(AccessorPathSegment.Method(label, method, optSafe, typeHint))
-    } else {
-      None
-    }
-  }
-
   func resolveAccessorPathSegment(self, ty: Type, label: Label, typeHint: Type?, optSafe = false): Result<AccessorPathSegment?, TypeError> {
     val foundSegment = match ty.kind {
       TypeKind.CouldNotDetermine => None
-      TypeKind.Any => self.resolveAccessorPathSegmentAny(label, optSafe, typeHint)
       TypeKind.PrimitiveUnit => None
       TypeKind.PrimitiveInt => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeIntStruct), [])), label, None, optSafe)
       TypeKind.PrimitiveFloat => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeFloatStruct), [])), label, None, optSafe)
@@ -4502,7 +4477,24 @@ pub type Typechecker {
       TypeKind.PrimitiveChar => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeCharStruct), [])), label, None, optSafe)
       TypeKind.PrimitiveString => return self.resolveAccessorPathSegment(Type(kind: TypeKind.Instance(InstanceKind.Struct(self.project.preludeStringStruct), [])), label, None, optSafe)
       TypeKind.Never => None
-      TypeKind.Generic => self.resolveAccessorPathSegmentAny(label, optSafe, typeHint)
+      TypeKind.Generic => {
+        val scope = self.project.preludeScope.makeChild("T", ScopeKind.Type)
+        val method = if label.name == "toString" {
+          Some(Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(None, true)))
+        } else if label.name == "hash" {
+          Some(Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(None, true)))
+        } else if label.name == "eq" {
+          Some(Function.generated(scope, "eq", [("other", ty)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(None, true)))
+        } else {
+          None
+        }
+
+        if method |method| {
+          Some(AccessorPathSegment.Method(label, method, optSafe, typeHint))
+        } else {
+          None
+        }
+      }
       TypeKind.Instance(instanceKind, generics) => {
         val (instanceMethods, typeParams, instanceTypeModuleId) = match instanceKind {
           InstanceKind.Struct(struct) => {

--- a/projects/compiler/src/typechecker_test_utils.abra
+++ b/projects/compiler/src/typechecker_test_utils.abra
@@ -96,10 +96,6 @@ pub type Jsonifier {
       TypeKind.CouldNotDetermine => {
         self.println("\"kind\": \"could not determine\"")
       }
-      TypeKind.Any => {
-        self.println("\"kind\": \"primitive\",")
-        self.println("\"primitive\": \"Any\"")
-      }
       TypeKind.PrimitiveUnit => {
         self.println("\"kind\": \"primitive\",")
         self.println("\"primitive\": \"Unit\"")

--- a/projects/compiler/test/compiler/arrays.abra
+++ b/projects/compiler/test/compiler/arrays.abra
@@ -334,7 +334,7 @@ func doSum(acc: Int, i: Int): Int = acc + i
 
   // TODO: I shouldn't need r1/r2 below, but otherwise I get a typechecker error:
   //   Type mismatch for parameter 'initialValue'
-  //     |    stdoutWriteln(arr.reduce(0, doSum))
+  //     |    println(arr.reduce(0, doSum))
   //                             ^
   //   Expected: Any
   //   but instead found: Int

--- a/projects/compiler/test/compiler/process_callstack.abra
+++ b/projects/compiler/test/compiler/process_callstack.abra
@@ -26,7 +26,7 @@ val arr = [1].map((i, _) => {
 /// Expect:   at baz (%TEST_DIR%/compiler/process_callstack.abra:10)
 /// Expect:   at bar (%TEST_DIR%/compiler/process_callstack.abra:5)
 /// Expect:   at foo (%TEST_DIR%/compiler/process_callstack.abra:19)
-/// Expect:   at <expression> (%STD_DIR%/prelude.abra:789)
+/// Expect:   at <expression> (%STD_DIR%/prelude.abra:771)
 /// Expect:   at Array.map (%TEST_DIR%/compiler/process_callstack.abra:18)
 
 type OneTwoThreeIterator {

--- a/projects/compiler/test/compiler/strings.abra
+++ b/projects/compiler/test/compiler/strings.abra
@@ -256,22 +256,6 @@ stdoutWriteln("hello")
   stdoutWriteln("hello".endsWith("hhello").toString())
 })()
 
-// // String#concat
-// (() => {
-//   /// Expect: helloworld
-//   stdoutWriteln("hello".concat("world"))
-//   /// Expect: hello12
-//   stdoutWriteln("hello".concat(12))
-//   /// Expect: hello1.23
-//   stdoutWriteln("hello".concat(1.23))
-//   /// Expect: hellotrue
-//   stdoutWriteln("hello".concat(true))
-//   /// Expect: hello[1, 2, 3]
-//   stdoutWriteln("hello".concat([1, 2, 3]))
-//   /// Expect: hello12.3true[1, 2, 3]
-//   stdoutWriteln("hello".concat(1, 2.3, true, [1, 2, 3]))
-// })()
-
 // String#repeat
 (() => {
   /// Expect: ||

--- a/projects/lsp/src/log.abra
+++ b/projects/lsp/src/log.abra
@@ -7,7 +7,7 @@ val logFilePath = "$cwd/log.txt"
 pub val log = match fs.createFile(logFilePath, fs.AccessMode.WriteOnly) {
   Ok(v) => v
   Err(e) => {
-    stdoutWriteln(e)
+    stdoutWriteln(e.toString())
     process.exit(1)
   }
 }

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -11,21 +11,21 @@ func stdoutWriteln(str = "") {
   stdoutWrite("\n")
 }
 
-func print(*items: Any[]) {
-  for i in range(0, items.length) {
-    val item = items._buffer.offset(i).load()
-    stdoutWrite(item.toString())
-
-    if i != items.length - 1 {
-      stdoutWrite(" ")
-    }
-  }
-}
-
-func println(*items: Any[]) {
-  print(items: items)
-  stdoutWrite("\n")
-}
+//func print(*items: Any[]) {
+//  for i in range(0, items.length) {
+//    val item = items._buffer.offset(i).load()
+//    stdoutWrite(item.toString())
+//
+//    if i != items.length - 1 {
+//      stdoutWrite(" ")
+//    }
+//  }
+//}
+//
+//func println(*items: Any[]) {
+//  print(items: items)
+//  stdoutWrite("\n")
+//}
 
 pub enum Option<V> {
   Some(value: V)
@@ -533,24 +533,6 @@ type String {
     }
 
     true
-  }
-
-  pub func concat<T>(self, suffix: T, *others: Any[]): String {
-    val suffixStr = suffix.toString()
-    val othersRepr = others.join()
-    var newLength = self.length + suffixStr.length + othersRepr.length
-
-    val newString = String.withLength(newLength)
-    newString._buffer.copyFrom(self._buffer, self.length)
-    newString._buffer
-      .offset(self.length)
-      .copyFrom(suffixStr._buffer, suffixStr.length)
-    if !others.isEmpty() {
-      newString._buffer
-        .offset(self.length + suffixStr.length)
-        .copyFrom(othersRepr._buffer, othersRepr.length)
-    }
-    newString
   }
 
   pub func replaceAll(self, pattern: String, replacement: String): String {


### PR DESCRIPTION
The time has come. I've decided to not have a dedicated notion of "traits" or interfaces in the language, instead on just using types and passing required functions as values. In the future, perhaps this can be simplified with compiletime functions, but for now I think that (plus generics) provide enough of a surface area that traits/interfaces will not be required.
As such, it's time to remove the primordial trait/interface which has been a part of the language since the beginning: `Any`. There is now no such thing as `Any`. The notion of "a type for which the only information we have is that it has toString/hash/eq" is effectively equivalent to a generic `T`; in fact `println` can (non-variadically) be implemented as just:
```
func println<T>(item: T) = stdoutWriteln(item.toString())
```
In the future, some notion of variadic generics may be added which would allow for something like this:
```
func println<*T>(*items: T[]) {
  for item in items {
    stdoutWrite(item.toString())
    stdoutWrite(" ")
  }
  stdoutWrite("\n")
}
```
However, that syntax doesn't exist yet (and may not ever, who knows?). But for now, let's get rid of the last vestiges of `Any` and do some minor cleanup.