### PR TITLE
Improved pointer intrinsic methods (part 1)

### DIFF
--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -2680,6 +2680,25 @@ pub type Compiler {
     (arg0, arg1, arg2)
   }
 
+  func _intrinsicArgs5(self, name: String, arguments: TypedAstNode?[]): (TypedAstNode, TypedAstNode, TypedAstNode, TypedAstNode, TypedAstNode) {
+    val _arg0 = try arguments[0] else unreachable("'$name' has 5 required arguments")
+    val arg0 = try _arg0 else unreachable("'$name' has 5 required arguments")
+
+    val _arg1 = try arguments[1] else unreachable("'$name' has 5 required arguments")
+    val arg1 = try _arg1 else unreachable("'$name' has 5 required arguments")
+
+    val _arg2 = try arguments[2] else unreachable("'$name' has 5 required arguments")
+    val arg2 = try _arg2 else unreachable("'$name' has 5 required arguments")
+
+    val _arg3 = try arguments[3] else unreachable("'$name' has 5 required arguments")
+    val arg3 = try _arg3 else unreachable("'$name' has 5 required arguments")
+
+    val _arg4 = try arguments[4] else unreachable("'$name' has 5 required arguments")
+    val arg4 = try _arg4 else unreachable("'$name' has 5 required arguments")
+
+    (arg0, arg1, arg2, arg3, arg4)
+  }
+
   func invokeIntrinsicFn(self, dec: Decorator, fn: Function, arguments: TypedAstNode?[]): Result<Value, CompileError> {
     val intrinsicFnName = match dec.arguments[0] {
       LiteralAstNode.String(value) => value
@@ -2753,6 +2772,27 @@ pub type Compiler {
 
         bogusValue
       }
+      "pointer_store_at" => {
+        val (ptr, value, offset) = self._intrinsicArgs3(intrinsicFnName, arguments)
+        val ptrVal = try self._compileExpression(ptr)
+        val valueVal = try self._compileExpression(value)
+        val offsetVal = try self._compileExpression(offset)
+
+        val innerTy = try self._resolvedGenerics.resolveGeneric("T") else unreachable("(pointer_store) could not resolve T for Pointer<T>")
+        val innerTySize = try self._pointerSize(innerTy)
+
+        val sizeVal = try self._currentFn.block.buildMul(Value.Int(innerTySize), offsetVal) else |e| return qbeError(e)
+        val mem = try self._currentFn.block.buildAdd(sizeVal, ptrVal) else |e| return qbeError(e)
+
+        if innerTySize == 1 {
+          self._currentFn.block.buildStoreB(valueVal, mem)
+        } else {
+          val innerQbeType = try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+          self._currentFn.block.buildStore(innerQbeType, valueVal, mem)
+        }
+
+        bogusValue
+      }
       "pointer_offset" => {
         val (ptr, offset) = self._intrinsicArgs2(intrinsicFnName, arguments)
         val ptrVal = try self._compileExpression(ptr)
@@ -2775,6 +2815,21 @@ pub type Compiler {
 
         self._currentFn.block.buildLoad(innerQbeType, ptrVal)
       }
+      "pointer_load_at" => {
+        val (ptr, offset) = self._intrinsicArgs2(intrinsicFnName, arguments)
+        val ptrVal = try self._compileExpression(ptr)
+        val offsetVal = try self._compileExpression(offset)
+
+        val innerTy = try self._resolvedGenerics.resolveGeneric("T") else unreachable("(pointer_load) could not resolve T for Pointer<T>")
+
+        val innerTySize = try self._pointerSize(innerTy)
+        val innerQbeType = if innerTySize == 1 QbeType.U8 else try self._getQbeTypeForTypeExpect(innerTy, "unacceptable type", None)
+
+        val sizeVal = try self._currentFn.block.buildMul(Value.Int(innerTySize), offsetVal) else |e| return qbeError(e)
+        val mem = try self._currentFn.block.buildAdd(sizeVal, ptrVal) else |e| return qbeError(e)
+
+        self._currentFn.block.buildLoad(innerQbeType, mem)
+      }
       "pointer_copy_from" => {
         val (ptr, other, size) = self._intrinsicArgs3(intrinsicFnName, arguments)
         val ptrVal = try self._compileExpression(ptr)
@@ -2786,6 +2841,31 @@ pub type Compiler {
         val sizeVal = try self._currentFn.block.buildMul(Value.Int(innerTySize), sizeArg) else |e| return qbeError(e)
 
         self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [ptrVal, otherVal, sizeVal])
+
+        bogusValue
+      }
+      "pointer_copy_from_2" => {
+        val (ptr, dstOffset, other, srcOffset, size) = self._intrinsicArgs5(intrinsicFnName, arguments)
+        val ptrVal = try self._compileExpression(ptr)
+        val dstOffsetVal = try self._compileExpression(dstOffset)
+        val otherVal = try self._compileExpression(other)
+        val srcOffsetVal = try self._compileExpression(srcOffset)
+        val sizeArg = try self._compileExpression(size)
+
+        val innerTy = try self._resolvedGenerics.resolveGeneric("T") else unreachable("(pointer_copy_from) could not resolve T for Pointer<T>")
+        val innerTySize = try self._pointerSize(innerTy)
+        val sizeVal = try self._currentFn.block.buildMul(Value.Int(innerTySize), sizeArg) else |e| return qbeError(e)
+
+        val dstMem = try self._currentFn.block.buildAdd(
+          try self._currentFn.block.buildMul(Value.Int(innerTySize), dstOffsetVal) else |e| return qbeError(e),
+          ptrVal
+        ) else |e| return qbeError(e)
+        val srcMem = try self._currentFn.block.buildAdd(
+          try self._currentFn.block.buildMul(Value.Int(innerTySize), srcOffsetVal) else |e| return qbeError(e),
+          otherVal
+        ) else |e| return qbeError(e)
+
+        self._currentFn.block.buildVoidCall(Callable.Function(self._memcpy), [dstMem, srcMem, sizeVal])
 
         bogusValue
       }

--- a/projects/std/src/_intrinsics.abra
+++ b/projects/std/src/_intrinsics.abra
@@ -72,12 +72,21 @@ pub type Pointer<T> {
   @intrinsic("pointer_store")
   pub func store(self, value: T)
 
+  @intrinsic("pointer_store_at")
+  pub func storeAt(self, value: T, offset: Int)
+
   @intrinsic("pointer_load")
   pub func load(self): T
+
+  @intrinsic("pointer_load_at")
+  pub func loadAt(self, offset: Int): T
 
   @intrinsic("pointer_offset")
   pub func offset(self, offset: Int): Pointer<T>
 
   @intrinsic("pointer_copy_from")
   pub func copyFrom(self, other: Pointer<T>, size: Int)
+
+  @intrinsic("pointer_copy_from_2")
+  pub func copyFrom2(self, toStart: Int, other: Pointer<T>, fromStart: Int, size: Int)
 }


### PR DESCRIPTION
While working on IR compilation for the js target, I realized that the existing Pointer intrinsics for store/load weren't sufficient because the potential offset is calculated ahead of time. While there may have been a way to successfully convert the IR into javascript code, it's also true that the existing way of interacting with these low-level Pointer methods is sort of clunky.