### PR TITLE
IR: Working `Array#toString`

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -40,10 +40,10 @@
 
 var arr = [1, 2, 3]
 stdoutWriteln(arr.length.toString())
+stdoutWriteln(arr.toString())
 
 arr.push(4)
 arr.push(5)
 arr.push(6)
 stdoutWriteln(arr.length.toString())
-
-// stdoutWriteln(arr.toString())
+stdoutWriteln(arr.toString())

--- a/projects/compiler/example.html
+++ b/projects/compiler/example.html
@@ -14,15 +14,16 @@
       // When outputting to the console, make sure to disregard newlines and empty strings, since
       // `console` methods always append the newline.
       function write(fd, buf, _count) {
-        stdout.innerHTML += buf
+        let str = buf.join('')
+        stdout.innerHTML += str
 
-        if (buf.endsWith('\n')) { buf = buf.substring(0, buf.length - 1); }
-        if (!buf.length) return;
+        if (str.endsWith('\n')) { str = str.substring(0, str.length - 1); }
+        if (!str.length) return;
 
         if (fd === 1) {
-          console.log(buf);
+          console.log(str);
         } else if (fd === 2) {
-          console.err(buf);
+          console.err(str);
         }
       }
 

--- a/projects/compiler/example.mjs
+++ b/projects/compiler/example.mjs
@@ -1,10 +1,11 @@
 import main from './._abra/_main.mjs';
 
-export function write(fd, buf, _count) {
+function write(fd, buf, _count) {
+  const str = buf.join('')
   if (fd === 1) {
-    process.stdout.write(buf);
+    process.stdout.write(str);
   } else if (fd === 2) {
-    process.stderr.write(buf);
+    process.stderr.write(str);
   }
 }
 

--- a/projects/compiler/src/ir.abra
+++ b/projects/compiler/src/ir.abra
@@ -317,7 +317,7 @@ pub enum Operation {
           sb.writeln()
         }
         sb.write("while(")
-        cond.result?.render(sb)
+        (try cond.result else unreachable()).render(sb)
         sb.writeln(", .${body.name})")
 
         sb.writeln(".${body.name}:")
@@ -769,7 +769,13 @@ pub type Generator {
       }
       TypedAstNodeKind.Match => todo("TypedAstNodeKind.Match (${node.token.position})")
       TypedAstNodeKind.While(condNode, condBinding, block, terminator) => {
+        // It may be strange to think of the loop condition as a "block", a single expression node could result in many
+        // instructions. All of the condition's instructions will need to be rerun for each iteration of the loop in
+        // order to determine whether the loop should continue, so it's necessary to keep track of those in a manner
+        // separate from the rest of the instructions in the current function (in order to properly set up jump labels
+        // if necessary when compiling the IR to its target).
         val cond = self.withinBlock("while_loop_cond", false, () => Some(self.genExpression(condNode, concreteGenerics)))
+
         if self.project.typeIsOption(condNode.ty) todo("optional while-conditions")
         if condBinding todo("while-expr condition binding")
 

--- a/projects/compiler/src/ir.abra
+++ b/projects/compiler/src/ir.abra
@@ -177,6 +177,11 @@ pub type Block {
   pub terminates: Bool
 }
 
+pub type CompoundValue {
+  pub body: Instruction[]
+  pub result: Value
+}
+
 pub enum Operation {
   NewLocal(ty: IrType, initialValue: Value? = None)
   ConstInt(int: Int)
@@ -193,7 +198,7 @@ pub enum Operation {
   StoreField(ty: IrType, value: Value, mem: Value, name: String, offset: Int)
 
   If(ty: IrType, cond: Value, thenBlock: Block, elseBlock: Block)
-  While(ty: IrType, cond: Block, body: Block)
+  While(ty: IrType, cond: CompoundValue, body: Block)
 
   Call(ret: IrType, fnName: String, args: Value[])
 
@@ -317,7 +322,7 @@ pub enum Operation {
           sb.writeln()
         }
         sb.write("while(")
-        (try cond.result else unreachable()).render(sb)
+        cond.result.render(sb)
         sb.writeln(", .${body.name})")
 
         sb.writeln(".${body.name}:")
@@ -769,17 +774,16 @@ pub type Generator {
       }
       TypedAstNodeKind.Match => todo("TypedAstNodeKind.Match (${node.token.position})")
       TypedAstNodeKind.While(condNode, condBinding, block, terminator) => {
-        // It may be strange to think of the loop condition as a "block", a single expression node could result in many
-        // instructions. All of the condition's instructions will need to be rerun for each iteration of the loop in
-        // order to determine whether the loop should continue, so it's necessary to keep track of those in a manner
-        // separate from the rest of the instructions in the current function (in order to properly set up jump labels
-        // if necessary when compiling the IR to its target).
-        val cond = self.withinBlock("while_loop_cond", false, () => Some(self.genExpression(condNode, concreteGenerics)))
+        // A single expression node could result in many instructions. All of the condition's instructions will need
+        // to be rerun for each iteration of the loop in order to determine whether the loop should continue, so it's
+        // necessary to keep track of those in a manner separate from the rest of the instructions in the current
+        // function (in order to properly set up jump labels if necessary when compiling the IR to its target).
+        val cond = self.genCompoundValue(() => self.genExpression(condNode, concreteGenerics))
 
         if self.project.typeIsOption(condNode.ty) todo("optional while-conditions")
         if condBinding todo("while-expr condition binding")
 
-        if self.valueAsCompileTime(try cond.result else unreachable("while-conditions always result in a value")) |cond| {
+        if self.valueAsCompileTime(cond.result) |cond| {
           val condVal = match cond { Value.ConstBool(b) => b, else => todo("non-boolean while-conditions") }
           if !condVal return
         }
@@ -1456,6 +1460,17 @@ pub type Generator {
     self.curCtx.block = prevBlock
 
     Block(name: name, body: instrs, result: finalVal, terminates: terminates)
+  }
+
+  func genCompoundValue(self, fn: () => Value): CompoundValue {
+    val prevBlock = self.curCtx.block
+
+    val instrs: Instruction[] = []
+    self.curCtx.block = ("_compoundvalue", instrs)
+    val finalVal = fn()
+    self.curCtx.block = prevBlock
+
+    CompoundValue(body: instrs, result: finalVal)
   }
 
   func enqueueFunction(self, fn: tc.Function, fnName: String, paramsNeedingDefaultValue: Bool[], methodInstanceType: ConcreteType?, concreteGenerics: Map<String, ConcreteType>) {

--- a/projects/compiler/src/ir.abra
+++ b/projects/compiler/src/ir.abra
@@ -125,7 +125,9 @@ pub type Ident {
 pub enum Value {
   Unit
   ConstInt(value: Int)
+  // ConstFloat(value: Float)
   ConstBool(value: Bool)
+  ConstChar(value: Int) // 64-bit repr of char
   ConstString(value: String)
   Ident(ident: Ident)
   Global(global: GlobalVariable)
@@ -140,6 +142,10 @@ pub enum Value {
       Value.ConstBool(b) => {
         IrType.Bool.render(sb)
         sb.write(" $b")
+      }
+      Value.ConstChar(intVal) => {
+        IrType.I64.render(sb)
+        sb.write(" ${Char.fromInt(intVal)}")
       }
       Value.ConstString(s) => {
         sb.write("\"")
@@ -159,7 +165,16 @@ pub enum Builtin {
   Malloc(count: Value, itemTy: IrType? = None)
   Realloc(ptr: Value, count: Value, itemTy: IrType? = None)
   Store(ptr: Value, value: Value, offset: Value, itemTy: IrType)
+  Load(ptr: Value, offset: Value, itemTy: IrType)
+  CopyFrom(dst: Value, dstOffset: Value, src: Value, srcOffset: Value, size: Value, itemTy: IrType)
   I64ToString(intVal: Value)
+}
+
+pub type Block {
+  pub name: String
+  pub body: Instruction[]
+  pub result: Value?
+  pub terminates: Bool
 }
 
 pub enum Operation {
@@ -167,15 +182,18 @@ pub enum Operation {
   ConstInt(int: Int)
 
   Add(left: Value, right: Value)
+  Sub(left: Value, right: Value)
   Mul(left: Value, right: Value)
   Eq(primitive: Bool, negate: Bool, left: Value, right: Value)
+  Lt(left: Value, right: Value)
 
   Load(ty: IrType, mem: Value)
   LoadField(ty: IrType, mem: Value, name: String, offset: Int)
   Store(ty: IrType, value: Value, mem: Value)
   StoreField(ty: IrType, value: Value, mem: Value, name: String, offset: Int)
 
-  If(ty: IrType, cond: Value, thenBlock: (String, Instruction[], Value?), elseBlock: (String, Instruction[], Value?))
+  If(ty: IrType, cond: Value, thenBlock: Block, elseBlock: Block)
+  While(ty: IrType, cond: Block, body: Block)
 
   Call(ret: IrType, fnName: String, args: Value[])
 
@@ -219,6 +237,13 @@ pub enum Operation {
         right.render(sb)
         sb.write(")")
       }
+      Operation.Lt(left, right) => {
+        sb.write("lt(")
+        left.render(sb)
+        sb.write(", ")
+        right.render(sb)
+        sb.write(")")
+      }
       Operation.Load(ty, mem) => {
         sb.write("load(")
         ty.render(sb)
@@ -254,34 +279,54 @@ pub enum Operation {
       Operation.If(ty, cond, thenBlock, elseBlock) => {
         sb.write("if(")
         cond.render(sb)
-        val (thenLabel, thenInstrs, thenVal) = thenBlock
-        sb.write(", .$thenLabel")
-        if thenVal |v| {
+        sb.write(", .${thenBlock.name}")
+        if thenBlock.result |v| {
           sb.write(" (")
           v.render(sb)
           sb.write(")")
         }
-        val (elseLabel, elseInstrs, elseVal) = elseBlock
-        sb.write(", .$elseLabel")
-        if elseVal |v| {
-          sb.write(" (")
-          v.render(sb)
-          sb.write(")")
+        if !elseBlock.body.isEmpty() {
+          sb.write(", .${elseBlock.name}")
+          if elseBlock.result |v| {
+            sb.write(" (")
+            v.render(sb)
+            sb.write(")")
+          }
         }
         sb.writeln(")")
-        sb.writeln(".$thenLabel:")
-        for instr in thenInstrs {
+
+        sb.writeln(".${thenBlock.name}:")
+        for instr in thenBlock.body {
           sb.write("  ")
           instr.render(sb)
           sb.writeln()
         }
-        sb.writeln(".$elseLabel:")
-        for instr in elseInstrs {
-          sb.write("  ")
-          instr.render(sb)
-          sb.writeln()
+        if !elseBlock.body.isEmpty() {
+          sb.writeln(".${elseBlock.name}:")
+          for instr in elseBlock.body {
+            sb.write("  ")
+            instr.render(sb)
+            sb.writeln()
+          }
         }
         sb.write("# endif")
+      }
+      Operation.While(ty, cond, body) => {
+        for instr in cond.body {
+          instr.render(sb)
+          sb.writeln()
+        }
+        sb.write("while(")
+        cond.result?.render(sb)
+        sb.writeln(", .${body.name})")
+
+        sb.writeln(".${body.name}:")
+        for instr in body.body {
+          sb.write("  ")
+          instr.render(sb)
+          sb.writeln()
+        }
+        sb.write("# endwhile")
       }
       Operation.Call(ret, fnName, args) => {
         sb.write("call(")
@@ -331,6 +376,28 @@ pub enum Operation {
             sb.write(", ")
             itemTy.render(sb)
           }
+          Builtin.Load(ptr, offset, itemTy) => {
+            sb.write("ptr_load, ")
+            ptr.render(sb)
+            sb.write(", ")
+            offset.render(sb)
+            sb.write(", ")
+            itemTy.render(sb)
+          }
+          Builtin.CopyFrom(dst, dstOffset, src, srcOffset, size, itemTy) => {
+            sb.write("copy_from, ")
+            dst.render(sb)
+            sb.write(", ")
+            dstOffset.render(sb)
+            sb.write(", ")
+            src.render(sb)
+            sb.write(", ")
+            srcOffset.render(sb)
+            sb.write(", ")
+            size.render(sb)
+            sb.write(", ")
+            itemTy.render(sb)
+          }
           Builtin.I64ToString(int) => {
             sb.write("i64_to_string, ")
             int.render(sb)
@@ -346,6 +413,7 @@ pub enum IrType {
   Unit
   I64
   Bool
+  Byte
   Composite(name: String)
   Ptr
 
@@ -354,6 +422,7 @@ pub enum IrType {
       IrType.Unit => sb.write("unit")
       IrType.I64 => sb.write("i64")
       IrType.Bool => sb.write("bool")
+      IrType.Byte => sb.write("byte")
       IrType.Composite(name) => sb.write(name)
       IrType.Ptr => sb.write("ptr")
     }
@@ -536,15 +605,14 @@ pub type Generator {
     val prevCtx = self.enterFunction(irFunc)
 
     match fn.kind {
-      FunctionKind.InstanceMethod(instanceKind, _) => {
+      FunctionKind.InstanceMethod => {
         val selfConcreteType = try ctx.methodInstanceType else unreachable("Instance method without instance type")
         val selfTy = self.getIrTypeForConcreteType(selfConcreteType)
         val selfParamIdent = Ident(ty: selfTy, kind: IdentKind.Named("self"))
         irFunc.params.push(selfParamIdent)
 
         if fn.label.name == "toString" && fn.isGenerated {
-          val inst = try instanceKind else unreachable("generic receiver of toString method")
-          self.genToStringMethodBody(Value.Ident(selfParamIdent), inst)
+          self.genToStringMethodBody(Value.Ident(selfParamIdent), selfConcreteType)
           self.curCtx = prevCtx
           return
         }
@@ -646,8 +714,8 @@ pub type Generator {
     irFunc
   }
 
-  func genToStringMethodBody(self, selfVal: Value, instanceKind: tc.InstanceKind) {
-    match instanceKind {
+  func genToStringMethodBody(self, selfVal: Value, concreteType: ConcreteType) {
+    match concreteType.instanceKind {
       InstanceKind.Struct(s) => {
         if s == self.project.preludeIntStruct {
           val strTy = self.getIrTypeForConcreteType(ConcreteType(instanceKind: InstanceKind.Struct(self.project.preludeStringStruct), typeArgs: []))
@@ -660,51 +728,66 @@ pub type Generator {
     }
   }
 
-
   func genStatement(self, node: tc.TypedAstNode, concreteGenerics: Map<String, ConcreteType>) {
     match node.kind {
       TypedAstNodeKind.If(isStatement, condNode, condBinding, ifBlock, ifBlockTerminator, elseBlock, elseBlockTerminator) => {
-        if isStatement {
-          val cond = self.genExpression(condNode, concreteGenerics)
-          if self.project.typeIsOption(condNode.ty) todo("optional if-conditions")
-          if condBinding todo("if-expr condition binding")
+        if !isStatement {
+          self.genExpression(node, concreteGenerics)
+          return
+        }
 
-          if ifBlockTerminator todo("if-expr if block terminator")
-          if elseBlockTerminator todo("if-expr else block terminator")
+        val cond = self.genExpression(condNode, concreteGenerics)
+        if self.project.typeIsOption(condNode.ty) todo("optional if-conditions")
+        if condBinding todo("if-expr condition binding")
 
-          if self.valueAsCompileTime(cond) |cond| {
-            val condVal = match cond { Value.ConstBool(b) => b, else => todo("non-boolean if-conditions") }
-            val block = if condVal ifBlock else elseBlock
-            for node, idx in block {
-              // TODO: handle block terminator
-              self.genStatement(node, concreteGenerics)
-            }
-
-            return
+        if self.valueAsCompileTime(cond) |cond| {
+          val condVal = match cond { Value.ConstBool(b) => b, else => todo("non-boolean if-conditions") }
+          val block = if condVal ifBlock else elseBlock
+          for node, idx in block {
+            self.genStatement(node, concreteGenerics)
           }
 
-          val ifBody = self.withinBlock("then", () => {
-            for node, idx in ifBlock {
-              self.genStatement(node, concreteGenerics)
-            }
-
-            None
-          })
-          val elseBody = self.withinBlock("else", () => {
-            for node, idx in elseBlock {
-              self.genStatement(node, concreteGenerics)
-            }
-
-            None
-          })
-
-          self.emit(Instruction(op: Operation.If(IrType.Unit, cond, ifBody, elseBody)))
-        } else {
-          self.genExpression(node, concreteGenerics)
+          return
         }
+
+        val ifBody = self.withinBlock("then", !!ifBlockTerminator, () => {
+          for node, idx in ifBlock {
+            self.genStatement(node, concreteGenerics)
+          }
+
+          None
+        })
+        val elseBody = self.withinBlock("else", !!elseBlockTerminator, () => {
+          for node, idx in elseBlock {
+            self.genStatement(node, concreteGenerics)
+          }
+
+          None
+        })
+
+        self.emit(Instruction(op: Operation.If(IrType.Unit, cond, ifBody, elseBody)))
       }
       TypedAstNodeKind.Match => todo("TypedAstNodeKind.Match (${node.token.position})")
-      TypedAstNodeKind.While => todo("TypedAstNodeKind.While (${node.token.position})")
+      TypedAstNodeKind.While(condNode, condBinding, block, terminator) => {
+        val cond = self.withinBlock("while_loop_cond", false, () => Some(self.genExpression(condNode, concreteGenerics)))
+        if self.project.typeIsOption(condNode.ty) todo("optional while-conditions")
+        if condBinding todo("while-expr condition binding")
+
+        if self.valueAsCompileTime(try cond.result else unreachable("while-conditions always result in a value")) |cond| {
+          val condVal = match cond { Value.ConstBool(b) => b, else => todo("non-boolean while-conditions") }
+          if !condVal return
+        }
+
+        val body = self.withinBlock("while_loop", !!terminator, () => {
+          for node, idx in block {
+            self.genStatement(node, concreteGenerics)
+          }
+
+          None
+        })
+
+        self.emit(Instruction(op: Operation.While(IrType.Unit, cond, body)))
+      }
       TypedAstNodeKind.For => todo("TypedAstNodeKind.For (${node.token.position})")
       TypedAstNodeKind.BindingDeclaration(node) => self.genBindingDeclaration(node, concreteGenerics)
       TypedAstNodeKind.FunctionDeclaration => { /* todo: TypedAstNodeKind.FunctionDeclaration */ }
@@ -712,7 +795,15 @@ pub type Generator {
       TypedAstNodeKind.EnumDeclaration => { /* todo: TypedAstNodeKind.EnumDeclaration */ }
       TypedAstNodeKind.Break => todo("TypedAstNodeKind.Break (${node.token.position})")
       TypedAstNodeKind.Continue => todo("TypedAstNodeKind.Continue (${node.token.position})")
-      TypedAstNodeKind.Return => todo("TypedAstNodeKind.Return (${node.token.position})")
+      TypedAstNodeKind.Return(retValExpr) => {
+        val retVal = if retValExpr |expr| {
+          Some(self.genExpression(expr, concreteGenerics))
+        } else {
+          None
+        }
+
+        self.emit(Instruction(op: Operation.Return(retVal)))
+      }
       TypedAstNodeKind.Placeholder => unreachable("Placeholder nodes should not be emitted from the typechecker")
       TypedAstNodeKind.Assignment(mode, op, expr) => self.genAssignment(concreteGenerics, mode, op, expr)
       else => self.genExpression(node, concreteGenerics)
@@ -750,19 +841,11 @@ pub type Generator {
     val varIrTy = self.getIrTypeForConcreteType(varTy)
     val ident = Ident(ty: varIrTy, kind: IdentKind.Named(varName))
     if valueNode |node| {
-      val value = self.genExpression(node, concreteGenerics, if variable.mutable None else Some(varName))
-      match value {
-        Value.Unit => unreachable("values cannot be of type Unit")
-        Value.ConstInt(i) => self.emit(Instruction(assignee: Some(ident), op: Operation.ConstInt(i)))
-        Value.ConstString => self.emit(Instruction(assignee: Some(ident), op: Operation.NewLocal(ty: varIrTy, initialValue: Some(value))))
-        Value.Ident(id) => {
-          if id.kind != ident.kind {
-            self.emit(Instruction(assignee: Some(ident), op: Operation.NewLocal(ty: varIrTy, initialValue: Some(value))))
-          }
-        }
-        Value.Global => {
-          self.emit(Instruction(assignee: Some(ident), op: Operation.NewLocal(ty: varIrTy, initialValue: Some(value))))
-        }
+      if variable.mutable {
+        val value = self.genExpression(node, concreteGenerics, None)
+        self.emit(Instruction(assignee: Some(ident), op: Operation.NewLocal(ty: varIrTy, initialValue: Some(value))))
+      } else {
+        self.genExpression(node, concreteGenerics, Some(varName))
       }
     } else {
       self.emit(Instruction(assignee: Some(ident), op: Operation.NewLocal(ty: varIrTy, initialValue: None)))
@@ -773,7 +856,13 @@ pub type Generator {
     val res = self.genExpression(expr, concreteGenerics)
 
     match mode {
-      TypedAssignmentMode.Variable => todo("genAssignment: Variable")
+      TypedAssignmentMode.Variable(v) => {
+        val varName = if v.scope.idxInFn |idx| "_${v.label.name}_${idx}" else v.label.name
+        val varTy = self.getConcreteTypeFromType(v.ty, concreteGenerics)
+        val varIrTy = self.getIrTypeForConcreteType(varTy)
+        val ident = Ident(ty: varIrTy, kind: IdentKind.Named(varName))
+        self.emit(Instruction(op: Operation.Store(ty: varIrTy, value: res, mem: Value.Ident(ident))))
+      }
       TypedAssignmentMode.Indexing => todo("genAssignment: Indexing")
       TypedAssignmentMode.Accessor(head, middle, tail) => {
         val (ty, mem, fieldName, offset) = self.followAccessorPath(head, middle, tail, concreteGenerics)
@@ -814,15 +903,11 @@ pub type Generator {
         if self.project.typeIsOption(condNode.ty) todo("optional if-conditions")
         if condBinding todo("if-expr condition binding")
 
-        if ifBlockTerminator todo("if-expr if block terminator")
-        if elseBlockTerminator todo("if-expr else block terminator")
-
         if self.valueAsCompileTime(cond) |cond| {
           val condVal = match cond { Value.ConstBool(b) => b, else => todo("non-boolean if-conditions") }
           val block = if condVal ifBlock else elseBlock
           for node, idx in block {
-            // TODO: handle block terminator
-            if idx == block.length - 1 {
+            if idx == block.length - 1 && !ifBlockTerminator {
               return self.genExpression(node, concreteGenerics, dst)
             } else {
               self.genStatement(node, concreteGenerics)
@@ -831,10 +916,9 @@ pub type Generator {
           unreachable("should have returned above")
         }
 
-        val ifBody = self.withinBlock("then", () => {
+        val ifBody = self.withinBlock("then", !!ifBlockTerminator, () => {
           for node, idx in ifBlock {
-            // TODO: handle if-block terminator
-            if idx == ifBlock.length - 1 {
+            if idx == ifBlock.length - 1 && !ifBlockTerminator {
               return Some(self.genExpression(node, concreteGenerics))
             } else {
               self.genStatement(node, concreteGenerics)
@@ -843,10 +927,9 @@ pub type Generator {
 
           None
         })
-        val elseBody = self.withinBlock("else", () => {
+        val elseBody = self.withinBlock("else", !!elseBlockTerminator, () => {
           for node, idx in elseBlock {
-            // TODO: handle else-block terminator
-            if idx == elseBlock.length - 1 {
+            if idx == elseBlock.length - 1 && !elseBlockTerminator {
               return Some(self.genExpression(node, concreteGenerics))
             } else {
               self.genStatement(node, concreteGenerics)
@@ -870,7 +953,9 @@ pub type Generator {
   func genLiteral(self, pos: Position, lit: LiteralAstNode): Value {
     match lit {
       LiteralAstNode.Int(i) => Value.ConstInt(i)
+      LiteralAstNode.Float => todo("genLiteral: LiteralAstNode.Float")
       LiteralAstNode.Bool(b) => Value.ConstBool(b)
+      LiteralAstNode.Char(c) => Value.ConstChar(c)
       LiteralAstNode.String(s) => {
         val strConcreteTy = ConcreteType(instanceKind: InstanceKind.Struct(self.project.preludeStringStruct))
         // Ensure the composite type and struct initializer functions are known, even though they're not used when constructing a string literal
@@ -879,7 +964,6 @@ pub type Generator {
 
         Value.ConstString(s)
       }
-      else => todo("Other literal kinds ($pos)")
     }
   }
 
@@ -904,7 +988,25 @@ pub type Generator {
 
         Value.Ident(ident: ident)
       }
-      BinaryOp.Sub => todo("genBinary: BinaryOp.Sub")
+      BinaryOp.Sub => {
+        val lval = self.genExpression(left, concreteGenerics)
+        val rval = self.genExpression(right, concreteGenerics)
+
+        if self.valueAsCompileTime(lval) |lval| {
+          if self.valueAsCompileTime(rval) |rval| {
+            val l = match lval { Value.ConstInt(l) => l, else => todo("genBinary: constant-folding other value types (sub)") }
+            val r = match rval { Value.ConstInt(r) => r, else => todo("genBinary: constant-folding other value types (sub)") }
+
+            return Value.ConstInt(l - r)
+          }
+        }
+
+        val identKind = if dst |dst| IdentKind.Named(dst) else IdentKind.Anon(self.nextAnonLocal())
+        val ident = Ident(ty: IrType.I64, kind: identKind)
+        self.emit(Instruction(assignee: Some(ident), op: Operation.Sub(lval, rval)))
+
+        Value.Ident(ident: ident)
+      }
       BinaryOp.Mul => {
         val lval = self.genExpression(left, concreteGenerics)
         val rval = self.genExpression(right, concreteGenerics)
@@ -927,13 +1029,36 @@ pub type Generator {
       BinaryOp.Div => todo("genBinary: BinaryOp.Div")
       BinaryOp.Mod => todo("genBinary: BinaryOp.Mod")
       BinaryOp.Pow => todo("genBinary: BinaryOp.Pow")
-      BinaryOp.And => todo("genBinary: BinaryOp.And")
+      BinaryOp.And => todo("genBinary: BinaryOp.And ($pos)")
       BinaryOp.Or => todo("genBinary: BinaryOp.Or")
       BinaryOp.Xor => todo("genBinary: BinaryOp.Xor")
       BinaryOp.Coalesce => todo("genBinary: BinaryOp.Coalesce")
       BinaryOp.Eq => self.genEq(concreteGenerics, left, right, false, dst)
       BinaryOp.Neq => self.genEq(concreteGenerics, left, right, true, dst)
-      else => todo("Other binary operators ($pos)")
+      BinaryOp.LT => {
+        val lval = self.genExpression(left, concreteGenerics)
+        val rval = self.genExpression(right, concreteGenerics)
+
+        if self.valueAsCompileTime(lval) |lval| {
+          if self.valueAsCompileTime(rval) |rval| {
+            val l = match lval { Value.ConstInt(l) => l, else => todo("genBinary: constant-folding other value types (lt)") }
+            val r = match rval { Value.ConstInt(r) => r, else => todo("genBinary: constant-folding other value types (lt)") }
+
+            return Value.ConstBool(l < r)
+          }
+        }
+
+        val identKind = if dst |dst| IdentKind.Named(dst) else IdentKind.Anon(self.nextAnonLocal())
+        val ident = Ident(ty: IrType.I64, kind: identKind)
+        self.emit(Instruction(assignee: Some(ident), op: Operation.Lt(lval, rval)))
+
+        Value.Ident(ident: ident)
+      }
+      BinaryOp.LTE => todo("genBinary: BinaryOp.LTE")
+      BinaryOp.Shl => todo("genBinary: BinaryOp.Shl")
+      BinaryOp.GT => todo("genBinary: BinaryOp.GT")
+      BinaryOp.GTE => todo("genBinary: BinaryOp.GTE")
+      BinaryOp.Shr => todo("genBinary: BinaryOp.Shr")
     }
   }
 
@@ -983,6 +1108,22 @@ pub type Generator {
     (arg0, arg1)
   }
 
+  func intrinsicArgs4(self, name: String, arguments: tc.TypedAstNode?[]): (tc.TypedAstNode, tc.TypedAstNode, tc.TypedAstNode, tc.TypedAstNode) {
+    val _arg0 = try arguments[0] else unreachable("'$name' has 4 required arguments")
+    val arg0 = try _arg0 else unreachable("'$name' has 4 required arguments")
+
+    val _arg1 = try arguments[1] else unreachable("'$name' has 4 required arguments")
+    val arg1 = try _arg1 else unreachable("'$name' has 4 required arguments")
+
+    val _arg2 = try arguments[2] else unreachable("'$name' has 4 required arguments")
+    val arg2 = try _arg2 else unreachable("'$name' has 4 required arguments")
+
+    val _arg3 = try arguments[3] else unreachable("'$name' has 4 required arguments")
+    val arg3 = try _arg3 else unreachable("'$name' has 4 required arguments")
+
+    (arg0, arg1, arg2, arg3)
+  }
+
   func genCall(self, pos: Position, concreteGenerics: Map<String, ConcreteType>, dst: String?, returnType: tc.Type, invokee: tc.TypedInvokee, args: tc.TypedAstNode?[]): Value {
     val argValues: Value[] = []
 
@@ -1002,6 +1143,14 @@ pub type Generator {
               val builtin = Builtin.Malloc(count: count, itemTy: Some(itemTy))
               self.emit(Instruction(assignee: Some(ident), op: Operation.Builtin(ret: IrType.Ptr, builtin: builtin)))
               Value.Ident(ident: ident)
+            }
+            "byte_from_int" => {
+              val arg = self.intrinsicArgs1("byte_from_int", args)
+              self.genExpression(arg, concreteGenerics)
+            }
+            "char_as_int" => {
+              val arg = self.intrinsicArgs1("char_as_int", args)
+              self.genExpression(arg, concreteGenerics)
             }
             else => todo("Unimplemented static/standalone intrinsic '$intrinsicName'")
           }
@@ -1030,10 +1179,10 @@ pub type Generator {
         } else if self.getIntrinsicDecName(fn) |intrinsicName| {
           return match intrinsicName {
             "pointer_realloc" => {
+              val ptrVal = self.genExpression(selfVal, concreteGenerics)
               val count = self.intrinsicArgs1("pointer_realloc", args)
 
               val itemTy = self.getIrTypeForConcreteType(try concreteGenerics["T"] else unreachable("(pointer_realloc) could not resolve T for Pointer<T>"))
-              val ptrVal = self.genExpression(selfVal, concreteGenerics)
               val countVal = self.genExpression(count, concreteGenerics)
 
               val identKind = if dst |dst| IdentKind.Named(dst) else IdentKind.Anon(self.nextAnonLocal())
@@ -1043,14 +1192,41 @@ pub type Generator {
               Value.Ident(ident: ident)
             }
             "pointer_store_at" => {
+              val ptrVal = self.genExpression(selfVal, concreteGenerics)
               val (value, offset) = self.intrinsicArgs2("pointer_store_at", args)
 
               val itemTy = self.getIrTypeForConcreteType(try concreteGenerics["T"] else unreachable("(pointer_store) could not resolve T for Pointer<T>"))
-              val ptrVal = self.genExpression(selfVal, concreteGenerics)
               val valueVal = self.genExpression(value, concreteGenerics)
               val offsetVal = self.genExpression(offset, concreteGenerics)
 
               self.emit(Instruction(op: Operation.Builtin(ret: IrType.Unit, builtin: Builtin.Store(ptr: ptrVal, value: valueVal, offset: offsetVal, itemTy: itemTy))))
+              Value.Unit
+            }
+            "pointer_load_at" => {
+              val ptrVal = self.genExpression(selfVal, concreteGenerics)
+              val offset = self.intrinsicArgs1("pointer_load_at", args)
+
+              val itemTy = self.getIrTypeForConcreteType(try concreteGenerics["T"] else unreachable("(pointer_load) could not resolve T for Pointer<T>"))
+              val offsetVal = self.genExpression(offset, concreteGenerics)
+
+              val identKind = if dst |dst| IdentKind.Named(dst) else IdentKind.Anon(self.nextAnonLocal())
+              val ident = Ident(ty: itemTy, kind: identKind)
+              self.emit(Instruction(assignee: Some(ident), op: Operation.Builtin(ret: itemTy, builtin: Builtin.Load(ptr: ptrVal, offset: offsetVal, itemTy: itemTy))))
+              Value.Ident(ident: ident)
+            }
+            "pointer_copy_from" => {
+              val ptrVal = self.genExpression(selfVal, concreteGenerics)
+              val (dstOffset, src, srcOffset, size) = self.intrinsicArgs4("pointer_copy_from", args)
+
+              val dstOffsetVal = self.genExpression(dstOffset, concreteGenerics)
+              val srcVal = self.genExpression(src, concreteGenerics)
+              val srcOffsetVal = self.genExpression(srcOffset, concreteGenerics)
+              val sizeVal = self.genExpression(size, concreteGenerics)
+
+              val itemTy = self.getIrTypeForConcreteType(try concreteGenerics["T"] else unreachable("(pointer_copy_from) could not resolve T for Pointer<T>"))
+
+              val builtin = Builtin.CopyFrom(dst: ptrVal, dstOffset: dstOffsetVal, src: srcVal, srcOffset: srcOffsetVal, size: sizeVal, itemTy: itemTy)
+              self.emit(Instruction(op: Operation.Builtin(ret: IrType.Unit, builtin: builtin)))
               Value.Unit
             }
             else => todo("Unimplemented method intrinsic '$intrinsicName'")
@@ -1265,7 +1441,7 @@ pub type Generator {
     prevCtx
   }
 
-  func withinBlock(self, name: String, fn: () => Value?): (String, Instruction[], Value?) {
+  func withinBlock(self, name: String, terminates: Bool, fn: () => Value?): Block {
     val prevBlock = self.curCtx.block
 
     val instrs: Instruction[] = []
@@ -1273,7 +1449,7 @@ pub type Generator {
     val finalVal = fn()
     self.curCtx.block = prevBlock
 
-    (name, instrs, finalVal)
+    Block(name: name, body: instrs, result: finalVal, terminates: terminates)
   }
 
   func enqueueFunction(self, fn: tc.Function, fnName: String, paramsNeedingDefaultValue: Bool[], methodInstanceType: ConcreteType?, concreteGenerics: Map<String, ConcreteType>) {
@@ -1398,6 +1574,10 @@ pub type Generator {
       InstanceKind.Struct(s) => {
         if s == self.project.preludeIntStruct return IrType.I64
 
+        if s.builtin == Some(tc.BuiltinModule.Intrinsics) {
+          if s.label.name == "Byte" return IrType.Byte
+        }
+
         val t = self.getOrAddCompositeType(ty)
         IrType.Composite(name: t.name)
       }
@@ -1458,6 +1638,7 @@ pub type Generator {
       Value.Unit => None // should be unreachable, but it's ok to return None here
       Value.ConstInt => Some(value)
       Value.ConstBool => Some(value)
+      Value.ConstChar => Some(value)
       Value.ConstString => Some(value)
       Value.Ident => None
       Value.Global(global) => if global.mutable None else global.initialValue

--- a/projects/compiler/src/ir_compiler.abra
+++ b/projects/compiler/src/ir_compiler.abra
@@ -280,7 +280,7 @@ pub type Compiler {
         for inst in cond.body {
           self.compileInstruction(inst)
         }
-        val condVal = self.irValueToQbeValue(try cond.result else unreachable())
+        val condVal = self.irValueToQbeValue(cond.result)
         self.currentFn.block.buildJnz(condVal, labelBody, labelCont)
 
         self.currentFn.block.registerLabel(labelBody)

--- a/projects/compiler/src/ir_compiler.abra
+++ b/projects/compiler/src/ir_compiler.abra
@@ -25,6 +25,7 @@ pub type Compiler {
   builtinI64ToStringUsed: Bool = false
   mallocFn: qbe.QbeFunction = qbe.QbeFunction.spec(name: "GC_malloc", returnType: Some(QbeType.Pointer))
   reallocFn: qbe.QbeFunction = qbe.QbeFunction.spec(name: "GC_realloc", returnType: Some(QbeType.Pointer))
+  memcpyFn: qbe.QbeFunction = qbe.QbeFunction.spec(name: "memcpy", returnType: None)
 
   pub func compile(ir: IR): CompilationResult {
     val builder = ModuleBuilder()
@@ -135,6 +136,14 @@ pub type Compiler {
 
         self.currentFn.block.buildAdd(left, right, dst)
       }
+      Operation.Sub(l, r) => {
+        val left = self.irValueToQbeValue(l)
+        val right = self.irValueToQbeValue(r)
+
+        if left.ty() != right.ty() unreachable("Operation.Sub: left.ty (${left.ty}) != right.ty (${right.ty})")
+
+        self.currentFn.block.buildSub(left, right, dst)
+      }
       Operation.Mul(l, r) => {
         val left = self.irValueToQbeValue(l)
         val right = self.irValueToQbeValue(r)
@@ -155,6 +164,14 @@ pub type Compiler {
           try self.currentFn.block.buildCompareEq(left, right, Some(self.nextTemp())) else |e| unreachable(e)
         }
         self.currentFn.block.buildExt(res, false, dst)
+      }
+      Operation.Lt(l, r) => {
+        val left = self.irValueToQbeValue(l)
+        val right = self.irValueToQbeValue(r)
+
+        if left.ty() != right.ty() unreachable("Operation.Lt: left.ty (${left.ty}) != right.ty (${right.ty})")
+
+        self.currentFn.block.buildCompareLt(left, right, dst)
       }
       Operation.Load(ty, mem) => {
         val ptr = self.irValueToQbeValue(mem)
@@ -187,23 +204,24 @@ pub type Compiler {
       }
       Operation.If(ty, cond, thenBlock, elseBlock) => {
         val isStmt = ty == IrType.Unit
-        val (thenLabel, thenBody, thenVal) = thenBlock
-        val (elseLabel, elseBody, elseVal) = elseBlock
         val condVal = self.irValueToQbeValue(cond)
 
-        val labelThen = self.currentFn.block.addLabel(thenLabel)
+        val labelThen = self.currentFn.block.addLabel(thenBlock.name)
         val labelCont = self.currentFn.block.addLabel("cont")
 
-        if !elseBody.isEmpty() || !!elseVal {
-          val labelElse = self.currentFn.block.addLabel(elseLabel)
+        if !elseBlock.body.isEmpty() || !!elseBlock.result {
+          val labelElse = self.currentFn.block.addLabel(elseBlock.name)
 
           self.currentFn.block.buildJnz(condVal, labelThen, labelElse)
           self.currentFn.block.registerLabel(labelThen)
-          for inst in thenBody {
+          for inst in thenBlock.body {
             self.compileInstruction(inst)
           }
-          val thenPhiValue = if thenVal |v| {
+          if !thenBlock.terminates {
             self.currentFn.block.buildJmp(labelCont)
+          }
+
+          val thenPhiValue = if thenBlock.result |v| {
             val label = self.currentFn.block.currentLabel
             val thenVal = self.irValueToQbeValue(v)
             Some((label, thenVal))
@@ -212,11 +230,13 @@ pub type Compiler {
           }
 
           self.currentFn.block.registerLabel(labelElse)
-          for inst in elseBody {
+          for inst in elseBlock.body {
             self.compileInstruction(inst)
           }
-          val elsePhiValue = if elseVal |v| {
+          if !elseBlock.terminates {
             self.currentFn.block.buildJmp(labelCont)
+          }
+          val elsePhiValue = if elseBlock.result |v| {
             val label = self.currentFn.block.currentLabel
             val elseVal = self.irValueToQbeValue(v)
             Some((label, elseVal))
@@ -226,7 +246,7 @@ pub type Compiler {
 
           self.currentFn.block.registerLabel(labelCont)
 
-          if !thenVal && !elseVal {
+          if !thenBlock.result && !elseBlock.result {
             // in if-exprs that are missing both then- and else-values, emit unreachable
             if !isStmt self.currentFn.block.buildHalt()
           } else {
@@ -241,11 +261,37 @@ pub type Compiler {
 
           self.currentFn.block.buildJnz(condVal, labelThen, labelCont)
           self.currentFn.block.registerLabel(labelThen)
-          for inst in thenBody {
+          for inst in thenBlock.body {
             self.compileInstruction(inst)
           }
+          if !thenBlock.terminates {
+            self.currentFn.block.buildJmp(labelCont)
+          }
+
           self.currentFn.block.registerLabel(labelCont)
         }
+      }
+      Operation.While(_, cond, body) => {
+        val labelCond = self.currentFn.block.addLabel("${body.name}_cond")
+        val labelBody = self.currentFn.block.addLabel("${body.name}_body")
+        val labelCont = self.currentFn.block.addLabel("${body.name}_cont")
+
+        self.currentFn.block.registerLabel(labelCond)
+        for inst in cond.body {
+          self.compileInstruction(inst)
+        }
+        val condVal = self.irValueToQbeValue(try cond.result else unreachable())
+        self.currentFn.block.buildJnz(condVal, labelBody, labelCont)
+
+        self.currentFn.block.registerLabel(labelBody)
+        for inst in body.body {
+          self.compileInstruction(inst)
+        }
+        if !body.terminates {
+          self.currentFn.block.buildJmp(labelCond)
+        }
+
+        self.currentFn.block.registerLabel(labelCont)
       }
       Operation.Call(ret, fnName, args) => {
         val argVals = args.map(a => self.irValueToQbeValue(a))
@@ -263,11 +309,22 @@ pub type Compiler {
         }
       }
       Operation.Builtin(ret, builtin) => {
+        val sizeOfType = (irType: IrType) => {
+          match irType {
+            IrType.Unit => unreachable("values cannot be of type unit")
+            IrType.I64 => (8, QbeType.U64)
+            IrType.Bool => (8, QbeType.U64)
+            IrType.Byte => (1, QbeType.U8)
+            IrType.Composite => (8, QbeType.U64)
+            IrType.Ptr => (8, QbeType.U64)
+          }
+        }
+
         match builtin {
           Builtin.Malloc(count, itemTy) => {
             val countVal = self.irValueToQbeValue(count)
             val sizeVal = if itemTy |itemTy| {
-              val (size, _) = self.sizeOfType(itemTy)
+              val (size, _) = sizeOfType(itemTy)
               try self.currentFn.block.buildMul(qbe.Value.Int(size), countVal, Some(self.nextTemp())) else |e| unreachable(e)
             } else {
               countVal
@@ -279,7 +336,7 @@ pub type Compiler {
             val ptrVal = self.irValueToQbeValue(ptr)
             val countVal = self.irValueToQbeValue(count)
             val sizeVal = if itemTy |itemTy| {
-              val (size, _) = self.sizeOfType(itemTy)
+              val (size, _) = sizeOfType(itemTy)
               try self.currentFn.block.buildMul(qbe.Value.Int(size), countVal, Some(self.nextTemp())) else |e| unreachable(e)
             } else {
               countVal
@@ -292,15 +349,51 @@ pub type Compiler {
             val valueVal = self.irValueToQbeValue(value)
             val offsetVal = self.irValueToQbeValue(offset)
 
-            val (size, qbeTy) = self.sizeOfType(itemTy)
+            val (size, qbeTy) = sizeOfType(itemTy)
             val sizeVal = try self.currentFn.block.buildMul(qbe.Value.Int(size), offsetVal, Some(self.nextTemp())) else |e| unreachable(e)
-            val mem = try self.currentFn.block.buildAdd(sizeVal, ptrVal, dst) else |e| unreachable(e)
+            val mem = try self.currentFn.block.buildAdd(sizeVal, ptrVal, Some(self.nextTemp())) else |e| unreachable(e)
 
             if size == 1 {
               self.currentFn.block.buildStoreB(valueVal, mem)
             } else {
               self.currentFn.block.buildStore(qbeTy, valueVal, mem)
             }
+          }
+          Builtin.Load(ptr, offset, itemTy) => {
+            val ptrVal = self.irValueToQbeValue(ptr)
+            val offsetVal = self.irValueToQbeValue(offset)
+
+            val (size, qbeTy) = sizeOfType(itemTy)
+            val sizeVal = try self.currentFn.block.buildMul(qbe.Value.Int(size), offsetVal, Some(self.nextTemp())) else |e| unreachable(e)
+            val mem = try self.currentFn.block.buildAdd(sizeVal, ptrVal, Some(self.nextTemp())) else |e| unreachable(e)
+
+            if size == 1 {
+              todo("Builtin.Load Byte")
+            } else {
+              self.currentFn.block.buildLoad(qbeTy, mem, dst)
+            }
+          }
+          Builtin.CopyFrom(dst, dstOffset, src, srcOffset, count, itemTy) => {
+            val dstVal = self.irValueToQbeValue(dst)
+            val dstOffsetVal = self.irValueToQbeValue(dstOffset)
+            val srcVal = self.irValueToQbeValue(src)
+            val srcOffsetVal = self.irValueToQbeValue(srcOffset)
+            val countVal = self.irValueToQbeValue(count)
+
+            val (size, qbeTy) = sizeOfType(itemTy)
+
+            val dstMem = try self.currentFn.block.buildAdd(
+              try self.currentFn.block.buildMul(qbe.Value.Int(size), dstOffsetVal, Some(self.nextTemp())) else |e| unreachable(e),
+              dstVal,
+              Some(self.nextTemp()),
+            ) else |e| unreachable(e)
+            val srcMem = try self.currentFn.block.buildAdd(
+              try self.currentFn.block.buildMul(qbe.Value.Int(size), srcOffsetVal, Some(self.nextTemp())) else |e| unreachable(e),
+              srcVal,
+              Some(self.nextTemp()),
+            ) else |e| unreachable(e)
+
+            self.currentFn.block.buildVoidCall(qbe.Callable.Function(self.memcpyFn), [dstMem, srcMem, countVal])
           }
           Builtin.I64ToString(int) => {
             self.builtinI64ToStringUsed = true
@@ -322,21 +415,6 @@ pub type Compiler {
     name
   }
 
-  func sizeOfType(self, irType: IrType): (Int, qbe.QbeType) {
-    val qbeTy = self.irTypeToQbeType(irType)
-    val size = match qbeTy {
-      QbeType.U8 => 1      // 'b'
-      QbeType.U16 => 2     // 'h' (should be unreachable)
-      QbeType.U32 => 4     // 'w' (should be unreachable)
-      QbeType.U64 => 8     // 'l'
-      QbeType.Pointer => 8 // 'l'
-      QbeType.F32 => 4     // 's' (should be unreachable)
-      QbeType.F64 => 8     // 'd'
-    }
-
-    (size, qbeTy)
-  }
-
   func irTypeToQbeType(self, irType: IrType): qbe.QbeType {
     match irType {
       IrType.I64 => QbeType.U64
@@ -344,6 +422,7 @@ pub type Compiler {
       IrType.Composite => QbeType.U64 // pointer to GC'd object
       IrType.Ptr => QbeType.U64 // raw pointer
       IrType.Unit => unreachable("values cannot be of type Unit")
+      IrType.Byte => QbeType.U64 // treat bytes as longs when they're ordinary values; but use `loadb`/`storeb`
     }
   }
 
@@ -354,6 +433,7 @@ pub type Compiler {
       Value.Unit => unreachable("values cannot be of type unit")
       Value.ConstInt(i) => qbe.Value.Int(i)
       Value.ConstBool(b) => qbe.Value.Int(if b 1 else 0)
+      Value.ConstChar(c) => qbe.Value.Int(c)
       Value.ConstString(s) => {
         val str = s.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n").replaceAll("\r", "\\r")
         val (dataPtr, data) = self.builder.buildGlobalString(str)

--- a/projects/compiler/src/ir_compiler_builtins.abra
+++ b/projects/compiler/src/ir_compiler_builtins.abra
@@ -4,14 +4,14 @@ pub type BuiltinFunction {
 }
 
 val builtinI64ToStringCode = "\
-data $_5 = { b \"%lld\", b 0 }\
+data \$fmt_lld = { b \"%lld\", b 0 }\
 \
 function l \$builtin_i64_to_string(l %int, l %lenptr) {\
 @start\
-  %_t0 =l call \$snprintf(l 0, l 0, l $_5, ..., l %int)\
+  %_t0 =l call \$snprintf(l 0, l 0, l \$fmt_lld, ..., l %int)\
   %_t1 =l add 1, %_t0\
   %_t2 =l call \$GC_malloc(l %_t1)\
-  %_t3 =l call \$snprintf(l %_t2, l %_t1, l $_5, ..., l %int)\
+  %_t3 =l call \$snprintf(l %_t2, l %_t1, l \$fmt_lld, ..., l %int)\
   storel %_t0, %lenptr\
   ret %_t2\
 }\

--- a/projects/compiler/src/ir_compiler_js.abra
+++ b/projects/compiler/src/ir_compiler_js.abra
@@ -136,6 +136,14 @@ pub type Compiler {
         self.emitIrValueToJsValue(r)
         self.sb.writeln(";")
       }
+      Operation.Sub(l, r) => {
+        self.emitIndent()
+        self.sb.write("const $dst = ")
+        self.emitIrValueToJsValue(l)
+        self.sb.write(" - ")
+        self.emitIrValueToJsValue(r)
+        self.sb.writeln(";")
+      }
       Operation.Mul(l, r) => {
         self.emitIndent()
         self.sb.write("const $dst = ")
@@ -155,6 +163,14 @@ pub type Compiler {
         } else {
           self.sb.write(" === ")
         }
+        self.emitIrValueToJsValue(r)
+        self.sb.writeln(";")
+      }
+      Operation.Lt(l, r) => {
+        self.emitIndent()
+        self.sb.write("const $dst = ")
+        self.emitIrValueToJsValue(l)
+        self.sb.write(" < ")
         self.emitIrValueToJsValue(r)
         self.sb.writeln(";")
       }
@@ -186,8 +202,6 @@ pub type Compiler {
       }
       Operation.If(ty, cond, thenBlock, elseBlock) => {
         val isStmt = ty == IrType.Unit
-        val (thenLabel, thenBody, thenVal) = thenBlock
-        val (elseLabel, elseBody, elseVal) = elseBlock
 
         if !isStmt {
           self.emitIndent()
@@ -198,10 +212,10 @@ pub type Compiler {
         val condVal = self.irValueToJsValue(cond)
         self.sb.writeln("if ($condVal) {")
         self.indentLevel += 1
-        for inst, idx in thenBody {
+        for inst, idx in thenBlock.body {
           self.compileInstruction(inst)
         }
-        if thenVal |v| {
+        if thenBlock.result |v| {
           self.emitIndent()
           self.sb.write("$dst = ")
           self.emitIrValueToJsValue(v)
@@ -209,15 +223,15 @@ pub type Compiler {
         }
         self.indentLevel -= 1
 
-        if !elseBody.isEmpty() || !!elseVal {
+        if !elseBlock.body.isEmpty() || !!elseBlock.result {
           self.emitIndent()
           self.sb.writeln("} else {")
 
           self.indentLevel += 1
-          for inst, idx in elseBody {
+          for inst, idx in elseBlock.body {
             self.compileInstruction(inst)
           }
-          if elseVal |v| {
+          if elseBlock.result |v| {
             self.emitIndent()
             self.sb.write("$dst = ")
             self.emitIrValueToJsValue(v)
@@ -225,6 +239,26 @@ pub type Compiler {
           }
           self.indentLevel -= 1
         }
+
+        self.emitIndent()
+        self.sb.writeln("}")
+      }
+      Operation.While(_, cond, body) => {
+        self.emitIndent()
+        self.sb.writeln("while (true) {")
+        self.indentLevel += 1
+        for inst in cond.body {
+          self.compileInstruction(inst)
+        }
+        self.emitIndent()
+        self.sb.write("if (!")
+        self.emitIrValueToJsValue(try cond.result else unreachable())
+        self.sb.writeln(") break;")
+
+        for inst in body.body {
+          self.compileInstruction(inst)
+        }
+        self.indentLevel -= 1
 
         self.emitIndent()
         self.sb.writeln("}")
@@ -266,13 +300,13 @@ pub type Compiler {
               self.sb.writeln("[]; // builtin(malloc)")
             }
           }
-          Builtin.Realloc(ptr, count, itemTy) => {
+          Builtin.Realloc(ptr, count, _) => {
             self.emitIndent()
             self.sb.write("const $dst = ")
             self.emitIrValueToJsValue(ptr)
             self.sb.writeln("; // realloc (no-op)")
           }
-          Builtin.Store(ptr, value, offset, itemTy) => {
+          Builtin.Store(ptr, value, offset, _) => {
             self.emitIndent()
             self.emitIrValueToJsValue(ptr)
             self.sb.write("[")
@@ -281,6 +315,34 @@ pub type Compiler {
             self.emitIrValueToJsValue(value)
             self.sb.writeln("; // builtin(ptr_store)")
           }
+          Builtin.Load(ptr, offset, _) => {
+            self.emitIndent()
+            self.sb.write("const $dst = ")
+            self.emitIrValueToJsValue(ptr)
+            self.sb.write("[")
+            self.emitIrValueToJsValue(offset)
+            self.sb.writeln("]; // builtin(ptr_load)")
+          }
+          Builtin.CopyFrom(dst, dstOffset, src, srcOffset, count, _) => {
+            self.emitIndent()
+            val countVal = self.irValueToJsValue(count)
+            self.sb.writeln("for (let i = 0; i < $countVal; i++) {")
+            self.indentLevel += 1
+
+            self.emitIndent()
+            self.emitIrValueToJsValue(dst)
+            self.sb.write("[")
+            self.emitIrValueToJsValue(dstOffset)
+            self.sb.write(" + i] = ")
+            self.emitIrValueToJsValue(src)
+            self.sb.write("[")
+            self.emitIrValueToJsValue(srcOffset)
+            self.sb.writeln(" + i]; // builtin(copy_from)")
+
+            self.indentLevel -= 1
+            self.emitIndent()
+            self.sb.writeln("}")
+          }
           Builtin.I64ToString(int) => {
             val strInitFn = self.ir.knowns.stringInitializerFn()
 
@@ -288,7 +350,7 @@ pub type Compiler {
             self.emitIndent()
             self.sb.write("const $strTmp = ")
             self.emitIrValueToJsValue(int)
-            self.sb.writeln(".toString();")
+            self.sb.writeln(".toString().split('');")
 
             self.emitIndent()
             self.sb.writeln("const $dst = ${strInitFn.name}($strTmp.length, $strTmp);")
@@ -317,9 +379,10 @@ pub type Compiler {
       Value.Unit => unreachable("values cannot be of type unit")
       Value.ConstInt(i) => i.toString()
       Value.ConstBool(b) => b.toString()
+      Value.ConstChar(c) => "'${Char.fromInt(c).toString()}'"
       Value.ConstString(s) => {
         val str = s.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n").replaceAll("\r", "\\r")
-        "{ length: ${str.length}, _buffer: \"$str\" }"
+        "{ length: ${s.length}, _buffer: \"$str\".split('') }"
       }
       Value.Ident(i) => {
         match i.kind {

--- a/projects/compiler/src/ir_compiler_js.abra
+++ b/projects/compiler/src/ir_compiler_js.abra
@@ -252,7 +252,7 @@ pub type Compiler {
         }
         self.emitIndent()
         self.sb.write("if (!")
-        self.emitIrValueToJsValue(try cond.result else unreachable())
+        self.emitIrValueToJsValue(cond.result)
         self.sb.writeln(") break;")
 
         for inst in body.body {

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -4984,17 +4984,21 @@ pub type Typechecker {
         else => unreachable("if selfVal passed, then FunctionKind must be InstanceMethod")
       }
 
-      if instanceKind |instanceKind| {
+      // When instanceKind is not present on FunctionKind.InstanceMethod, that means that the method's selfVal is a generic.
+      // In that case, the template from which to extract generics should just be self's type.
+      val template = if instanceKind |instanceKind| {
         val typeParams = match instanceKind { InstanceKind.Struct(s) => s.typeParams, InstanceKind.Enum(e) => e.typeParams }
-        val template = Type(kind: TypeKind.Instance(instanceKind, typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
-        val extractedGenerics = selfNode.ty.extractGenerics(template: template)
-        for (name, ty) in extractedGenerics {
-          if resolvedGenerics[name] |original| {
-            if original != ty unreachable("original != ty") // is this check necessary? i don't think so
-            continue
-          }
-          resolvedGenerics[name] = ty
+        Type(kind: TypeKind.Instance(instanceKind, typeParams.map(name => Type(kind: TypeKind.Generic(name)))))
+      } else {
+        selfNode.ty
+      }
+      val extractedGenerics = selfNode.ty.extractGenerics(template: template)
+      for (name, ty) in extractedGenerics {
+        if resolvedGenerics[name] |original| {
+          if original != ty unreachable("original != ty") // is this check necessary? i don't think so
+          continue
         }
+        resolvedGenerics[name] = ty
       }
     }
 


### PR DESCRIPTION
The motivating example for this change was getting the `Array#toString()` method to correctly generate IR, as well as correctly compiling that IR to both current targets (native and javascript). This involved implementation of while-loops, loading from memory, and more. I was also able to fix a bug in the typechecker, related to extracting generics out of method invocations' `selfVal`.