### PR TITLE
IR: Passing float (and bool) tests

### DIFF
--- a/projects/compiler/src/ir.abra
+++ b/projects/compiler/src/ir.abra
@@ -188,6 +188,11 @@ pub enum Builtin {
   U64ToString(intVal: Value)
   F64ToString(floatVal: Value)
   BoolToString(boolVal: Value)
+  IntAsFloat(intVal: Value)
+  FloatAsInt(floatVal: Value)
+  FloatCeil(floatVal: Value)
+  FloatFloor(floatVal: Value)
+  FloatRound(floatVal: Value)
 }
 
 pub type Block {
@@ -220,10 +225,10 @@ pub enum Operation {
   Mod(left: Value, right: Value)
   Pow(left: Value, right: Value)
   BitAnd(left: Value, right: Value)
-  BoolAnd(left: Value, right: Value)
+  BoolAnd(left: Value, right: CompoundValue)
   BitOr(left: Value, right: Value)
-  BoolOr(left: Value, right: Value)
-  Xor(left: Value, right: Value)
+  BoolOr(left: Value, right: CompoundValue)
+  Xor(bitwise: Bool, left: Value, right: Value)
   Eq(primitive: Bool, negate: Bool, left: Value, right: Value)
   Lt(left: Value, right: Value)
   Lte(left: Value, right: Value)
@@ -329,10 +334,14 @@ pub enum Operation {
         sb.write(")")
       }
       Operation.BoolAnd(l, r) => {
+        for instr in r.body {
+          instr.render(sb)
+          sb.writeln()
+        }
         sb.write("and(")
         l.render(sb)
         sb.write(", ")
-        r.render(sb)
+        r.result.render(sb)
         sb.write(")")
       }
       Operation.BitOr(l, r) => {
@@ -343,13 +352,17 @@ pub enum Operation {
         sb.write(")")
       }
       Operation.BoolOr(l, r) => {
+        for instr in r.body {
+          instr.render(sb)
+          sb.writeln()
+        }
         sb.write("or(")
         l.render(sb)
         sb.write(", ")
-        r.render(sb)
+        r.result.render(sb)
         sb.write(")")
       }
-      Operation.Xor(l, r) => {
+      Operation.Xor(_, l, r) => {
         sb.write("xor(")
         l.render(sb)
         sb.write(", ")
@@ -574,6 +587,26 @@ pub enum Operation {
           Builtin.BoolToString(int) => {
             sb.write("bool_to_string, ")
             int.render(sb)
+          }
+          Builtin.IntAsFloat(float) => {
+            sb.write("int_as_float, ")
+            float.render(sb)
+          }
+          Builtin.FloatAsInt(float) => {
+            sb.write("float_as_int, ")
+            float.render(sb)
+          }
+          Builtin.FloatCeil(float) => {
+            sb.write("float_ceil, ")
+            float.render(sb)
+          }
+          Builtin.FloatFloor(float) => {
+            sb.write("float_floor, ")
+            float.render(sb)
+          }
+          Builtin.FloatRound(float) => {
+            sb.write("float_round, ")
+            float.render(sb)
           }
         }
         sb.write(")")
@@ -1189,7 +1222,7 @@ pub type Generator {
           }
         }
 
-        self.ssaValue(IrType.I64, Operation.Minus(exprVal), dst)
+        self.ssaValue(self.getValueTy(exprVal), Operation.Minus(exprVal), dst)
       }
       UnaryOp.Negate => {
         if self.valueAsCompileTime(exprVal) |exprVal| {
@@ -1375,11 +1408,11 @@ pub type Generator {
       }
       BinaryOp.And => {
         val lval = self.genExpression(left, concreteGenerics)
-        val rval = self.genExpression(right, concreteGenerics)
+        val rval = self.genCompoundValue(() => self.genExpression(right, concreteGenerics))
         val lvalTy = self.getValueTy(lval)
-        val rvalTy = self.getValueTy(rval)
+        val rvalTy = self.getValueTy(rval.result)
 
-        if self.valuesAsCompileTime(lval, rval) |(lval, rval)| {
+        if self.valuesAsCompileTime(lval, rval.result) |(lval, rval)| {
           val const = match lval {
             Const.Int(l) => match rval { Const.Int(r) => Const.Int(l && r), else => unreachable("[genBinary bit-and]: unexpected const value ($rval)") }
             Const.Bool(l) => match rval { Const.Bool(r) => Const.Bool(l && r), else => unreachable("[genBinary bool-and]: unexpected const value ($rval)") }
@@ -1390,18 +1423,18 @@ pub type Generator {
         }
 
         if lvalTy == IrType.I64 && rvalTy == IrType.I64 {
-          self.ssaValue(IrType.I64, Operation.BitAnd(lval, rval), dst)
+          self.ssaValue(IrType.I64, Operation.BitAnd(lval, rval.result), dst)
         } else {
           self.ssaValue(IrType.Bool, Operation.BoolAnd(lval, rval), dst)
         }
       }
       BinaryOp.Or => {
         val lval = self.genExpression(left, concreteGenerics)
-        val rval = self.genExpression(right, concreteGenerics)
+        val rval = self.genCompoundValue(() => self.genExpression(right, concreteGenerics))
         val lvalTy = self.getValueTy(lval)
-        val rvalTy = self.getValueTy(rval)
+        val rvalTy = self.getValueTy(rval.result)
 
-        if self.valuesAsCompileTime(lval, rval) |(lval, rval)| {
+        if self.valuesAsCompileTime(lval, rval.result) |(lval, rval)| {
           val const = match lval {
             Const.Int(l) => match rval { Const.Int(r) => Const.Int(l || r), else => unreachable("[genBinary bit-or]: unexpected const value ($rval)") }
             Const.Bool(l) => match rval { Const.Bool(r) => Const.Bool(l || r), else => unreachable("[genBinary bool-or]: unexpected const value ($rval)") }
@@ -1412,7 +1445,7 @@ pub type Generator {
         }
 
         if lvalTy == IrType.I64 && rvalTy == IrType.I64 {
-          self.ssaValue(IrType.I64, Operation.BitOr(lval, rval), dst)
+          self.ssaValue(IrType.I64, Operation.BitOr(lval, rval.result), dst)
         } else {
           self.ssaValue(IrType.Bool, Operation.BoolOr(lval, rval), dst)
         }
@@ -1423,8 +1456,9 @@ pub type Generator {
         val lvalTy = self.getValueTy(lval)
         val rvalTy = self.getValueTy(rval)
 
-        val retTy = if lvalTy == IrType.I64 && rvalTy == IrType.I64 { IrType.I64 } else { IrType.Bool }
-        self.ssaValue(retTy, Operation.Xor(lval, rval), dst)
+        val bitwise = lvalTy == IrType.I64 && rvalTy == IrType.I64
+        val retTy = if bitwise { IrType.I64 } else { IrType.Bool }
+        self.ssaValue(retTy, Operation.Xor(bitwise, lval, rval), dst)
       }
       BinaryOp.Coalesce => todo("genBinary: BinaryOp.Coalesce")
       BinaryOp.Eq => self.genEq(concreteGenerics, left, right, false, dst)
@@ -1643,6 +1677,36 @@ pub type Generator {
             "char_as_int" => {
               val arg = self.intrinsicArgs1("char_as_int", args)
               self.genExpression(arg, concreteGenerics, dst)
+            }
+            "int_as_float" => {
+              val arg = self.intrinsicArgs1("int_as_float", args)
+              val intVal = self.genExpression(arg, concreteGenerics, dst)
+
+              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.F64, builtin: Builtin.IntAsFloat(intVal)), dst)
+            }
+            "float_as_int" => {
+              val arg = self.intrinsicArgs1("float_as_int", args)
+              val floatVal = self.genExpression(arg, concreteGenerics, dst)
+
+              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.I64, builtin: Builtin.FloatAsInt(floatVal)), dst)
+            }
+            "float_ceil" => {
+              val arg = self.intrinsicArgs1("float_ceil", args)
+              val floatVal = self.genExpression(arg, concreteGenerics, dst)
+
+              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.I64, builtin: Builtin.FloatCeil(floatVal)), dst)
+            }
+            "float_floor" => {
+              val arg = self.intrinsicArgs1("float_floor", args)
+              val floatVal = self.genExpression(arg, concreteGenerics, dst)
+
+              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.I64, builtin: Builtin.FloatFloor(floatVal)), dst)
+            }
+            "float_round" => {
+              val arg = self.intrinsicArgs1("float_round", args)
+              val floatVal = self.genExpression(arg, concreteGenerics, dst)
+
+              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.I64, builtin: Builtin.FloatRound(floatVal)), dst)
             }
             "u64_to_string" => {
               val arg = self.intrinsicArgs1("u64_to_string", args)

--- a/projects/compiler/src/ir_compiler.abra
+++ b/projects/compiler/src/ir_compiler.abra
@@ -291,7 +291,10 @@ pub type Compiler {
         self.currentFn.block.buildJnz(left, labelThen, labelElse)
 
         self.currentFn.block.registerLabel(labelThen)
-        var right = self.irValueToQbeValue(r)
+        for inst in r.body {
+          self.compileInstruction(inst)
+        }
+        val right = self.irValueToQbeValue(r.result)
         val rightLabel = self.currentFn.block.currentLabel
         self.currentFn.block.buildJmp(labelCont)
 
@@ -301,7 +304,7 @@ pub type Compiler {
         self.currentFn.block.registerLabel(labelCont)
 
         val phiCases = [(rightLabel, right), (labelElse, left)]
-        try self.currentFn.block.buildPhi(phiCases) else |e| unreachable(e)
+        try self.currentFn.block.buildPhi(phiCases, dst) else |e| unreachable(e)
       }
       Operation.BitOr(l, r) => {
         var left = self.irValueToQbeValue(l)
@@ -322,16 +325,19 @@ pub type Compiler {
         self.currentFn.block.buildJmp(labelCont)
 
         self.currentFn.block.registerLabel(labelElse)
-        var right = self.irValueToQbeValue(r)
+        for inst in r.body {
+          self.compileInstruction(inst)
+        }
+        val right = self.irValueToQbeValue(r.result)
         val rightLabel = self.currentFn.block.currentLabel
         self.currentFn.block.buildJmp(labelCont)
 
         self.currentFn.block.registerLabel(labelCont)
 
         val phiCases = [(labelThen, left), (rightLabel, right)]
-        try self.currentFn.block.buildPhi(phiCases) else |e| unreachable(e)
+        try self.currentFn.block.buildPhi(phiCases, dst) else |e| unreachable(e)
       }
-      Operation.Xor(l, r) => {
+      Operation.Xor(_, l, r) => {
         var left = self.irValueToQbeValue(l)
         var right = self.irValueToQbeValue(r)
 
@@ -513,7 +519,7 @@ pub type Compiler {
             if thenPhiValue |(label, v)| phiCases.push((label, v))
             if elsePhiValue |(label, v)| phiCases.push((label, v))
 
-            try self.currentFn.block.buildPhi(phiCases, dst) else |e| unreachable(e)
+            try self.currentFn.block.buildPhi(phiCases, dst) else |e| unreachable("$e ($thenBlock)")
           }
         } else {
           if !isStmt unreachable("must be a statement at this point")
@@ -700,6 +706,34 @@ pub type Compiler {
 
             self.currentFn.block.registerLabel(labelCont)
             try self.currentFn.block.buildPhi(phiCases, dst) else |e| unreachable(e)
+          }
+          Builtin.IntAsFloat(int) => {
+            val intVal = self.irValueToQbeValue(int)
+
+            self.currentFn.block.buildLToF(intVal, true, dst)
+          }
+          Builtin.FloatAsInt(float) => {
+            val floatVal = self.irValueToQbeValue(float)
+
+            self.currentFn.block.buildFToL(floatVal, true, dst)
+          }
+          Builtin.FloatCeil(float) => {
+            val floatVal = self.irValueToQbeValue(float)
+
+            val ceilRes = try self.currentFn.block.buildCallRaw("ceil", QbeType.F64, [floatVal], Some(self.nextTemp())) else |e| unreachable(e)
+            self.currentFn.block.buildFToL(ceilRes, true, dst)
+          }
+          Builtin.FloatFloor(float) => {
+            val floatVal = self.irValueToQbeValue(float)
+
+            val floorRes = try self.currentFn.block.buildCallRaw("floor", QbeType.F64, [floatVal], Some(self.nextTemp())) else |e| unreachable(e)
+            self.currentFn.block.buildFToL(floorRes, true, dst)
+          }
+          Builtin.FloatRound(float) => {
+            val floatVal = self.irValueToQbeValue(float)
+
+            val roundRes = try self.currentFn.block.buildCallRaw("round", QbeType.F64, [floatVal], Some(self.nextTemp())) else |e| unreachable(e)
+            self.currentFn.block.buildFToL(roundRes, true, dst)
           }
         }
       }

--- a/projects/compiler/src/ir_compiler_builtins.abra
+++ b/projects/compiler/src/ir_compiler_builtins.abra
@@ -36,7 +36,7 @@ pub val u64ToString = BuiltinFunction(
 )
 
 val builtinF64ToStringCode = "\
-data \$fmt_d = { b \"%g\", b 0 }\
+data \$fmt_d = { b \"%g\", b 0 } # %g means 6 significant decimal digits\
 \
 function l \$builtin_f64_to_string(d %float, l %lenptr) {\
 @start\

--- a/projects/compiler/src/ir_compiler_js.abra
+++ b/projects/compiler/src/ir_compiler_js.abra
@@ -157,10 +157,69 @@ pub type Compiler {
       Operation.Mod(l, r) => self.genBinary(dst, "%", l, r)
       Operation.Pow(l, r) => self.genBinary(dst, "**", l, r)
       Operation.BitAnd(l, r) => self.genBinary(dst, "&", l, r)
-      Operation.BoolAnd(l, r) => self.genBinary(dst, "&&", l, r)
+      Operation.BoolAnd(l, r) => {
+        self.sb.writeln("let $dst;")
+
+        self.emitIndent()
+        val lTmp = self.nextTemp()
+        self.sb.write("const $lTmp = ")
+        self.emitIrValueToJsValue(l)
+        self.sb.writeln(";")
+
+        self.emitIndent()
+        self.sb.writeln("if (!$lTmp)")
+        self.emitIndent()
+        self.sb.writeln("  $dst = false;")
+        self.emitIndent()
+        self.sb.writeln("else {")
+        for inst in r.body {
+          self.emitIndent()
+          self.compileInstruction(inst)
+        }
+        self.sb.write("  $dst = ")
+        self.emitIrValueToJsValue(r.result)
+        self.sb.writeln(";")
+        self.emitIndent()
+        self.sb.writeln("}")
+
+      }
       Operation.BitOr(l, r) => self.genBinary(dst, "|", l, r)
-      Operation.BoolOr(l, r) => self.genBinary(dst, "||", l, r)
-      Operation.Xor(l, r) => self.genBinary(dst, "^", l, r)
+      Operation.BoolOr(l, r) => {
+        self.sb.writeln("let $dst;")
+
+        self.emitIndent()
+        val lTmp = self.nextTemp()
+        self.sb.write("const $lTmp = ")
+        self.emitIrValueToJsValue(l)
+        self.sb.writeln(";")
+
+        self.emitIndent()
+        self.sb.writeln("if ($lTmp)")
+        self.emitIndent()
+        self.sb.writeln("  $dst = true;")
+        self.emitIndent()
+        self.sb.writeln("else {")
+        for inst in r.body {
+          self.emitIndent()
+          self.compileInstruction(inst)
+        }
+        self.sb.write("  $dst = ")
+        self.emitIrValueToJsValue(r.result)
+        self.sb.writeln(";")
+        self.emitIndent()
+        self.sb.writeln("}")
+      }
+      Operation.Xor(bitwise, l, r) => {
+        if bitwise {
+          self.sb.write("const $dst = (")
+        } else {
+          self.sb.write("const $dst = !!(")
+        }
+        self.emitIrValueToJsValue(l)
+        self.sb.write(" ^ ")
+        self.emitIrValueToJsValue(r)
+        self.sb.writeln(");")
+      }
       Operation.Eq(primitive, negate, l, r) => {
         if !primitive todo("non-primitive Eq operation")
 
@@ -353,13 +412,27 @@ pub type Compiler {
           Builtin.F64ToString(float) => {
             val strInitFn = self.ir.knowns.stringInitializerFn()
 
+            val floatVal = self.irValueToJsValue(float)
+
+            self.sb.writeln("let $dst;")
+            self.emitIndent()
+            self.sb.writeln("if ($floatVal === -0) {")
+            self.emitIndent()
+            self.sb.writeln("  $dst = ${self.makeConstString("-0")};")
+            self.emitIndent()
+            self.sb.writeln("} else {")
+
+            self.indentLevel += 1
             val strTmp = self.nextTemp()
-            self.sb.write("const $strTmp = ")
-            self.emitIrValueToJsValue(float)
-            self.sb.writeln(".toFixed(5).replace(/0+$/, '').replace(/\\.$/, '').split('');")
+            self.emitIndent()
+            self.sb.writeln("const $strTmp = $floatVal.toPrecision(6).replace(/0+$/, '').replace(/\\.$/, '').split('');")
 
             self.emitIndent()
-            self.sb.writeln("const $dst = ${strInitFn.name}($strTmp.length, $strTmp);")
+            self.sb.writeln("$dst = ${strInitFn.name}($strTmp.length, $strTmp);")
+            self.indentLevel -= 1
+
+            self.emitIndent()
+            self.sb.writeln("}")
           }
           Builtin.BoolToString(bool) => {
             val strInitFn = self.ir.knowns.stringInitializerFn()
@@ -371,6 +444,31 @@ pub type Compiler {
 
             self.emitIndent()
             self.sb.writeln("const $dst = ${strInitFn.name}($strTmp.length, $strTmp);")
+          }
+          Builtin.IntAsFloat(int) => {
+            self.sb.write("const $dst = ")
+            self.emitIrValueToJsValue(int)
+            self.sb.writeln(";")
+          }
+          Builtin.FloatAsInt(float) => {
+            self.sb.write("const $dst = Math.trunc(")
+            self.emitIrValueToJsValue(float)
+            self.sb.writeln(");")
+          }
+          Builtin.FloatCeil(float) => {
+            self.sb.write("const $dst = Math.ceil(")
+            self.emitIrValueToJsValue(float)
+            self.sb.writeln(");")
+          }
+          Builtin.FloatFloor(float) => {
+            self.sb.write("const $dst = Math.floor(")
+            self.emitIrValueToJsValue(float)
+            self.sb.writeln(");")
+          }
+          Builtin.FloatRound(float) => {
+            self.sb.write("const $dst = Math.round(")
+            self.emitIrValueToJsValue(float)
+            self.sb.writeln(");")
           }
         }
       }

--- a/projects/compiler/test/compiler/floats.abra
+++ b/projects/compiler/test/compiler/floats.abra
@@ -120,6 +120,8 @@ printlnBool(17.1 >= 15.1)
 // Float#asInt
 /// Expect: 1
 stdoutWriteln((1.23).asInt().toString())
+/// Expect: 1
+stdoutWriteln((1.78).asInt().toString())
 
 // Float#abs
 /// Expect: 1.23


### PR DESCRIPTION
Add float builtins (ceil, floor, round, etc), and ensure the `test/compiler/floats.abra` test suite passes (for both native and js compilation targets).
Additionally, the `test/compiler/bools.abra` test suite passes too, but not without requiring a fix for a bug which that suite helped me find; I had not properly implemented lazy evaluation of boolean && and || operators! Xor was also wrong in the js target.