### PR TITLE
IR: simplify array literal generation

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,78 +1,10 @@
-// pub val a = 123
-// pub var b = a + 123
+// val i1 = 1
+// val f1 = 1.1
+// val f2 = f1 + 1
+// val f3 = f1 + 1.1
+// val f4 = i1 + 1
+// // stdoutWriteln("${(f1, f2, f3, f4)}")
+// stdoutWriteln("$f1 $f2 $f3 $f4")
 
-// func add(x: Int, b: Int): Int = x + b
-
-// stdoutWriteln(add(1 + b, 2 + 3).toString())
-
-// pub var a = 15
-// pub var b = 31
-
-// if t() {
-//   stdoutWriteln("hello")
-// }
-
-// func t(): Bool = true
-// func foo() {
-//   val b = 1
-//   val x = if t() {
-//     val b = a + 1
-//     b
-//   } else {
-//     val b = 30
-//     b + 1
-//   }
-//   stdoutWriteln(x.toString())
-// }
-// foo()
-
-// if 1 == 1 {
-//   stdoutWriteln("true")
-// } else {
-//   stdoutWriteln("false")
-// }
-
-// if 1 != 1 {
-//   stdoutWriteln("true")
-// } else {
-//   stdoutWriteln("false")
-// }
-
-// func n(b: Bool): Bool {
-//   val x = !b
-//   x
-// }
-
-// stdoutWriteln(""+n(true))
-// stdoutWriteln(""+n(false))
-
-var arr = [1, 2, 3]
-stdoutWriteln("" + arr.length)
+val arr = [1, 2, 3]
 stdoutWriteln("" + arr)
-// stdoutWriteln(arr.length.toString())
-// stdoutWriteln(arr.toString())
-
-arr.push(4)
-arr.push(5)
-arr.push(6)
-stdoutWriteln("" + arr.length)
-stdoutWriteln("" + arr)
-// stdoutWriteln(arr.length.toString())
-// stdoutWriteln(arr.toString())
-
-func f() {
-  val s = "a" + "b"
-  val b = 1 < 3
-  if 1 < 3 {
-    stdoutWriteln("h")
-  }
-  stdoutWriteln(s.toString())
-}
-f()
-
-val i1 = 1
-val f1 = 1.1
-val f2 = f1 + 1
-val f3 = f1 + 1.1
-val f4 = i1 + 1
-stdoutWriteln([""+f1,""+ f2,""+ f3,""+ f4].toString())

--- a/projects/compiler/src/ir.abra
+++ b/projects/compiler/src/ir.abra
@@ -1951,30 +1951,43 @@ pub type Generator {
 
   func genArray(self, pos: Position, concreteGenerics: Map<String, ConcreteType>, dst: String?, arrayTy: tc.Type, items: tc.TypedAstNode[]): Value {
     val arrayConcreteType = self.getConcreteTypeFromType(arrayTy, concreteGenerics)
+    val arrayItemConcreteType = try arrayConcreteType.typeArgs[0] else unreachable("ConcreteType for array must have 1 type argument")
 
-    val arrConcreteGenerics = {"T": ConcreteType(instanceKind: InstanceKind.Struct(self.project.preludeIntStruct))}
+    val arrayItemIrTy = self.getIrTypeForConcreteType(arrayItemConcreteType)
+    val values = items.map(item => self.genExpression(item, concreteGenerics))
+
+    self.generateArrayWithItems(pos, arrayItemConcreteType, dst, values)
+  }
+
+  // codegen helpers
+
+  func generateArrayWithItems(self, pos: Position, arrayItemConcreteType: ConcreteType, dst: String?, values: Value[]): Value {
+    val arrayConcreteType = ConcreteType(instanceKind: InstanceKind.Struct(self.project.preludeArrayStruct), typeArgs: [arrayItemConcreteType])
+    val arrConcreteGenerics = { "T": arrayItemConcreteType } // `T` is the known generic of `Array.withCapacity`
     val arrayWithCapacityFn = self.getMethodByName(InstanceKind.Struct(self.project.preludeArrayStruct), "withCapacity", staticMethod: true)
     val arrayWithCapacityFnName = self.fnName(None, arrayWithCapacityFn, arrConcreteGenerics, [])
     self.enqueueFunction(arrayWithCapacityFn, arrayWithCapacityFnName, [], None, arrConcreteGenerics)
 
-    val sizeVal = Value.Const(Const.Int(items.length.nextPowerOf2()))
+    val sizeVal = Value.Const(Const.Int(values.length.nextPowerOf2()))
     val arrayIrTy = self.getIrTypeForConcreteType(arrayConcreteType)
     val op = Operation.Call(ret: arrayIrTy, fnName: arrayWithCapacityFnName, args: [sizeVal])
     val arrVal = self.ssaValue(arrayIrTy, op, dst)
 
-    val arrayPushFn = self.getMethodByName(InstanceKind.Struct(self.project.preludeArrayStruct), "push", staticMethod: false)
-    val arrayPushFnName = self.fnName(Some(arrayConcreteType), arrayPushFn, arrConcreteGenerics, [])
-    self.enqueueFunction(arrayPushFn, arrayPushFnName, [], Some(arrayConcreteType), arrConcreteGenerics)
+    val (_, lengthFieldIdx) = try self.project.preludeArrayStruct.fields.findIndex(f => f.name.name == "length") else unreachable("no such field 'length'")
+    self.emit(Instruction(op: Operation.StoreField(ty: IrType.I64, value: Value.Const(Const.Int(values.length)), mem: arrVal, name: "length", offset: lengthFieldIdx * 8)))
 
-    for item in items {
-      val itemVal = self.genExpression(item, arrConcreteGenerics)
-      self.emit(Instruction(op: Operation.Call(ret: IrType.Unit, fnName: arrayPushFnName, args: [arrVal, itemVal])))
+    val (_, bufferFieldIdx) = try self.project.preludeArrayStruct.fields.findIndex(f => f.name.name == "_buffer") else unreachable("no such field '_buffer'")
+    val bufferVal = Ident(ty: IrType.Ptr, kind: IdentKind.Anon(self.nextAnonLocal()))
+    self.emit(Instruction(assignee: Some(bufferVal), op: Operation.LoadField(ty: IrType.Ptr, mem: arrVal, name: "_buffer", offset: bufferFieldIdx * 8)))
+
+    val arrayItemIrTy = self.getIrTypeForConcreteType(arrayItemConcreteType)
+    for value, idx in values {
+      val builtin = Builtin.Store(ptr: Value.Ident(bufferVal), value: value, offset: Value.Const(Const.Int(idx)), itemTy: arrayItemIrTy)
+      self.emit(Instruction(op: Operation.Builtin(ret: IrType.Unit, builtin: builtin)))
     }
 
     arrVal
   }
-
-  // codegen helpers
 
   func ssaValueComptime(self, const: Const, name: String?): Value {
     if name |name| {


### PR DESCRIPTION
Rather than requiring code generation for the array's `#push` method, we can insert the items directly into the internal buffer and set the length to be the known length value. This works for array literals since all of that information is known at compile-time, and any subsequent calls to `#push` will still work as expected. But it saves time during compilation since we don't generate code for the `#push` method unless it's explicitly called in code (not to mention that inserting directly into the buffer is more efficient than calling the `#push` method). We see codegen gains as well as resulting binary size improvements with this approach because `Array#push` is generic so potential specialized version are no longer being generated.