### PR TITLE
IR: Adding to test runner

### DIFF
--- a/projects/compiler/src/ir_compiler.test.abra
+++ b/projects/compiler/src/ir_compiler.test.abra
@@ -79,7 +79,7 @@ func main() {
     // to it. Instead, we should create the directory and file if we need to.
     val cwd = fs.getCurrentWorkingDirectory()
     val ssaOutFileName = args[2] ?: "_main"
-    val ssaOutPath = "$cwd/._abra/$ssaOutFileName.v2.ssa"
+    val ssaOutPath = "$cwd/._abra/$ssaOutFileName.ssa"
     val ssaOutFile = match fs.openFile(ssaOutPath, fs.AccessMode.WriteOnly) {
       Ok(v) => v
       Err(e) => {

--- a/projects/compiler/test/compiler/process_callstack.abra
+++ b/projects/compiler/test/compiler/process_callstack.abra
@@ -26,7 +26,7 @@ val arr = [1].map((i, _) => {
 /// Expect:   at baz (%TEST_DIR%/compiler/process_callstack.abra:10)
 /// Expect:   at bar (%TEST_DIR%/compiler/process_callstack.abra:5)
 /// Expect:   at foo (%TEST_DIR%/compiler/process_callstack.abra:19)
-/// Expect:   at <expression> (%STD_DIR%/prelude.abra:773)
+/// Expect:   at <expression> (%STD_DIR%/prelude.abra:781)
 /// Expect:   at Array.map (%TEST_DIR%/compiler/process_callstack.abra:18)
 
 type OneTwoThreeIterator {

--- a/projects/compiler/test/run-tests.js
+++ b/projects/compiler/test/run-tests.js
@@ -830,8 +830,32 @@ const COMPILER_TESTS = [
   { test: "compiler/try_result.abra" },
   { test: "compiler/try_option.abra" },
   { test: "compiler/process.abra", args: ['-f', 'bar', '--baz', 'qux'], env: { FOO: 'bar' } },
-  // { test: "compiler/process_callstack.abra" },
+  { test: "compiler/process_callstack.abra" },
   { test: "compiler/json.abra" },
+]
+
+const IR_COMPILER_TESTS = [
+  { test: "compiler/ints.abra" },
+  { test: "compiler/floats.abra" },
+  { test: "compiler/bools.abra" },
+  // { test: "compiler/chars.abra" },
+  // { test: "compiler/strings.abra" },
+  // { test: "compiler/arrays.abra" },
+  // { test: "compiler/functions.abra" },
+  // { test: "compiler/optionals.abra" },
+  // { test: "compiler/ifs.abra" },
+  // { test: "compiler/loops.abra" },
+  // { test: "compiler/types.abra" },
+  // { test: "compiler/enums.abra" },
+  // { test: "compiler/tuples.abra" },
+  // { test: "compiler/maps.abra" },
+  // { test: "compiler/sets.abra" },
+  // { test: "compiler/match.abra" },
+  // { test: "compiler/try_result.abra" },
+  // { test: "compiler/try_option.abra" },
+  // { test: "compiler/process.abra", args: ['-f', 'bar', '--baz', 'qux'], env: { FOO: 'bar' } },
+  // { test: "compiler/process_callstack.abra" },
+  // { test: "compiler/json.abra" },
 ]
 
 async function main() {
@@ -840,27 +864,30 @@ async function main() {
   let numErr = 0
   let numTests = 0
 
-  const lexerPath = `${__dirname}/../src/lexer.test.abra`
-  const parserPath = `${__dirname}/../src/parser.test.abra`
-  const typecheckerPath = `${__dirname}/../src/typechecker.test.abra`
-  const compilerPath = `${__dirname}/../src/compiler.test.abra`
-
   const runners = [
     {
-      runner: new TestRunner('lexer_test', lexerPath),
+      runner: new TestRunner('lexer_test', `${__dirname}/../src/lexer.test.abra`),
       tests: LEXER_TESTS,
     },
     {
-      runner: new TestRunner('parser_test', parserPath),
+      runner: new TestRunner('parser_test', `${__dirname}/../src/parser.test.abra`),
       tests: PARSER_TESTS,
     },
     {
-      runner: new TestRunner('typechecker_test', typecheckerPath),
+      runner: new TestRunner('typechecker_test', `${__dirname}/../src/typechecker.test.abra`),
       tests: TYPECHECKER_TESTS,
     },
     {
-      runner: new TestRunner('compiler_test', compilerPath),
+      runner: new TestRunner('compiler_test', `${__dirname}/../src/compiler.test.abra`),
       tests: COMPILER_TESTS,
+    },
+    {
+      runner: new TestRunner('native_ir_compiler_test', `${__dirname}/../src/ir_compiler.test.abra`),
+      tests: IR_COMPILER_TESTS,
+    },
+    {
+      runner: new TestRunner('js_ir_compiler_test', `${__dirname}/../src/ir_compiler_js.test.abra`, true),
+      tests: IR_COMPILER_TESTS,
     },
   ]
 

--- a/projects/compiler/test/test-runner.js
+++ b/projects/compiler/test/test-runner.js
@@ -2,9 +2,10 @@ const childProcess = require('child_process')
 const fs = require('fs/promises')
 
 class TestRunner {
-  constructor(runnerName, harnessPath) {
+  constructor(runnerName, harnessPath, isJsTarget = false) {
     this.runnerName = runnerName
     this.harnessPath = harnessPath
+    this.isJsTarget = isJsTarget
   }
 
   async runTests(tests) {
@@ -62,9 +63,27 @@ class TestRunner {
   async _runCompilerTest(bin, testFile, args = [], env = {}) {
     const testFilePath = `${__dirname}/${testFile}`
 
+    async function buildAndRunTestBin(testFilePath, compilerBin, args, env, isJsTarget) {
+      const testPathSegs = testFilePath.split('/')
+      const testName = testPathSegs[testPathSegs.length - 1].replace('.abra', '')
+
+      if (isJsTarget) {
+        await fs.writeFile(`${process.cwd()}/._abra/${testName}.mjs`, '', { encoding: 'utf-8' })
+        let jsHarness = await fs.readFile(`${process.cwd()}/example.mjs`).then(buf => buf.toString())
+        jsHarness = jsHarness.replace('._abra/_main.mjs', `${testName}.mjs`)
+        await fs.writeFile(`${process.cwd()}/._abra/${testName}_harness.mjs`, jsHarness, { encoding: 'utf-8' })
+
+        await runCommand(compilerBin, [testFilePath, testName])
+        return runCommand('node', [`${process.cwd()}/._abra/${testName}_harness.mjs`, ...args], env)
+      } else {
+        await runCommand('abra', ['build', '-o', testName, testFilePath], { COMPILER_BIN: compilerBin })
+        return runCommand(`${process.cwd()}/._abra/${testName}`, args, env)
+      }
+    }
+
     try {
       const [actual, expectedOutput] = await Promise.all([
-        runCommand('abra', [testFilePath, ...args], { COMPILER_BIN: bin, ...env }),
+        buildAndRunTestBin(testFilePath, bin, args, env, this.isJsTarget),
         fs.readFile(testFilePath, { encoding: 'utf8' }),
       ])
 
@@ -112,10 +131,10 @@ class TestRunner {
         case 'fail': {
           numFail += 1
           console.log(magenta(`  [FAIL] ${result.testFile}`))
-          // console.log('EXPECTED')
-          // console.log(result.expected)
-          // console.log('ACTUAL')
-          // console.log(result.actual)
+          console.log('EXPECTED')
+          console.log(result.expected)
+          console.log('ACTUAL')
+          console.log(result.actual)
           break
         }
         case 'error': {

--- a/projects/compiler/test/test-runner.js
+++ b/projects/compiler/test/test-runner.js
@@ -131,10 +131,10 @@ class TestRunner {
         case 'fail': {
           numFail += 1
           console.log(magenta(`  [FAIL] ${result.testFile}`))
-          console.log('EXPECTED')
-          console.log(result.expected)
-          console.log('ACTUAL')
-          console.log(result.actual)
+          // console.log('EXPECTED')
+          // console.log(result.expected)
+          // console.log('ACTUAL')
+          // console.log(result.actual)
           break
         }
         case 'error': {


### PR DESCRIPTION
Right now, IR compilation for both targets (native and js) supports a few of the existing compiler test suites. Let's add them to the test runner to track progress and catch regressions.