### PR TITLE
Special for-loop form

### DIFF
--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -2,7 +2,7 @@ import "fs" as fs
 import "process" as process
 import Position from "./lexer"
 import LiteralAstNode, UnaryOp, BinaryOp, AssignOp, BindingPattern, IndexingMode from "./parser"
-import Project, TypedModule, Scope, ScopeKind, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, InstanceKind, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind, BuiltinModule, Variable, Terminator from "./typechecker"
+import Project, TypedModule, Scope, ScopeKind, TypedAstNode, TypedAstNodeKind, Type, TypeKind, Field, Struct, InstanceKind, TypedInvokee, Function, FunctionKind, Decorator, AccessorPathSegment, TypedAssignmentMode, Enum, TypedEnumVariant, EnumVariantKind, TypedIndexingNode, VariableAlias, TypedMatchCase, TypedMatchCaseKind, BuiltinModule, Variable, Terminator, TypedForIterKind from "./typechecker"
 import ModuleBuilder, Block, QbeType, Dest, QbeFunction, Value, Label, Callable, QbeData, QbeDataKind, Var from "./qbe"
 
 type CompilationError {
@@ -158,6 +158,11 @@ type CallframeContext {
   callee: String? // callee is None when the callee is an expression
 }
 
+type LoopBounds {
+  continueLabel: Label
+  breakLabel: Label
+}
+
 pub type Compiler {
   _project: Project
   _builder: ModuleBuilder
@@ -172,7 +177,7 @@ pub type Compiler {
   _functionNames: Map<String, Int> = {}
   _fnNamesPtr: Value
   _resolvedGenerics: ResolvedGenerics = ResolvedGenerics()
-  _loopStack: (/* loopStart: */ Label, /* loopEnd: */ Label)[] = []
+  _loopStack: LoopBounds[] = []
   // cached things
   _printf: QbeFunction = QbeFunction.spec(name: "printf", returnType: None, parameters: [], variadicIdx: Some(1))
   _snprintf: QbeFunction = QbeFunction.spec(name: "snprintf", returnType: Some(QbeType.U64), parameters: [], variadicIdx: Some(3))
@@ -344,7 +349,7 @@ pub type Compiler {
         val loopBodyLabel = self._currentFn.block.addLabel("while_loop_body")
         val loopEndLabel = self._currentFn.block.addLabel("while_loop_end")
 
-        self._loopStack.push((loopStartLabel, loopEndLabel))
+        self._loopStack.push(LoopBounds(continueLabel: loopStartLabel, breakLabel: loopEndLabel))
 
         self._currentFn.block.registerLabel(loopStartLabel)
         val condVal = try self._compileExpression(cond)
@@ -383,7 +388,62 @@ pub type Compiler {
 
         Ok(None)
       }
-      TypedAstNodeKind.For(typedIterator, itemBindingPattern, indexBinding, block) => {
+      TypedAstNodeKind.For(typedForIterKind, itemBindingPattern, indexBinding, block) => {
+        val (iterateePattern, iterateeBindingVars) = itemBindingPattern
+
+        val forLabelPrefix = "for_${node.token.position.line}_${node.token.position.col}"
+        val loopStartLabel = self._currentFn.block.addLabel("${forLabelPrefix}_loop_start")
+        val loopBodyLabel = self._currentFn.block.addLabel("${forLabelPrefix}_loop_body")
+        val loopTailLabel = self._currentFn.block.addLabel("${forLabelPrefix}_loop_tail")
+        val loopEndLabel = self._currentFn.block.addLabel("${forLabelPrefix}_loop_end")
+
+        self._loopStack.push(LoopBounds(continueLabel: loopTailLabel, breakLabel: loopEndLabel))
+
+        val indexBindingSlot = if indexBinding |bindingVar| {
+          val slotName = self._currentFn.block.addVar(variableToVar(bindingVar))
+          val slot = self._buildStackAllocForQbeType(QbeType.U64, Some(slotName))
+          self._currentFn.block.buildStoreL(Value.Int(0), slot)
+          Some(slot)
+        } else {
+          None
+        }
+
+        val typedIterator = match typedForIterKind {
+          TypedForIterKind.Expr(typedIterator) => typedIterator
+          TypedForIterKind.Range(start, end) => {
+            val iterateeVar = try iterateeBindingVars[0] else unreachable("There should always be an iteratee binding variable")
+            val iterateeBindingSlot = self._buildStackAllocForQbeType(QbeType.U64, Some(self._currentFn.block.addVar(variableToVar(iterateeVar))))
+            val rangeStartVal = try self._compileExpression(start)
+            self._currentFn.block.buildStoreL(rangeStartVal, iterateeBindingSlot)
+
+            self._currentFn.block.registerLabel(loopStartLabel)
+            val rangeEndVal = try self._compileExpression(end)
+            val iterateeVal = self._currentFn.block.buildLoadL(iterateeBindingSlot)
+            val cond = try self._currentFn.block.buildCompareLt(iterateeVal, rangeEndVal) else |e| return qbeError(e)
+            self._currentFn.block.buildJnz(cond, loopBodyLabel, loopEndLabel)
+
+            self._currentFn.block.registerLabel(loopBodyLabel)
+
+            for node in block {
+              try self._compileStatement(node)
+            }
+
+            self._currentFn.block.registerLabel(loopTailLabel)
+            val iterateeIncVal = try self._currentFn.block.buildAdd(Value.Int(1), iterateeVal) else |e| return qbeError(e)
+            self._currentFn.block.buildStoreL(iterateeIncVal, iterateeBindingSlot)
+            if indexBindingSlot |idxSlot| {
+              val idxVal = self._currentFn.block.buildLoadL(idxSlot)
+              val idxIncrVal = try self._currentFn.block.buildAdd(Value.Int(1), idxVal) else |e| return qbeError(e)
+              self._currentFn.block.buildStoreL(idxIncrVal, idxSlot)
+            }
+            self._currentFn.block.buildJmp(loopStartLabel)
+
+            self._currentFn.block.registerLabel(loopEndLabel)
+            self._loopStack.pop()
+            return Ok(None)
+          }
+        }
+
         val (instTy, typeArgs) = try self._getInstanceTypeForType(typedIterator.ty)
 
         val (iterVal, iterTy, nextFn, popAdditionalResolvedGenericsLayer) = match instTy {
@@ -468,24 +528,7 @@ pub type Compiler {
         self._resolvedGenerics.popLayer()
         if popAdditionalResolvedGenericsLayer self._resolvedGenerics.popLayer()
 
-        val forLabelPrefix = "for_${node.token.position.line}_${node.token.position.col}"
-        val loopStartLabel = self._currentFn.block.addLabel("${forLabelPrefix}_loop_start")
-        val loopBodyLabel = self._currentFn.block.addLabel("${forLabelPrefix}_loop_body")
-        val loopEndLabel = self._currentFn.block.addLabel("${forLabelPrefix}_loop_end")
-
-        self._loopStack.push((loopStartLabel, loopEndLabel))
-
-        val indexBindingSlot = if indexBinding |bindingVar| {
-          val slotName = self._currentFn.block.addVar(variableToVar(bindingVar))
-          val slot = self._buildStackAllocForQbeType(QbeType.U64, Some(slotName))
-          self._currentFn.block.buildStoreL(Value.Int(-1), slot)
-          Some(slot)
-        } else {
-          None
-        }
-
         self._currentFn.block.registerLabel(loopStartLabel)
-        val (iterateePattern, iterateeBindingVars) = itemBindingPattern
         val iterateeBindingVariables = iterateeBindingVars.keyBy(v => v.label.name)
         self._currentFn.block.addComment("for-loop (${node.token.position.line}, ${node.token.position.col}) next() ret value")
         val fnName = self._functionName(nextFn.label.name, nextFn.kind)
@@ -498,21 +541,20 @@ pub type Compiler {
         self._currentFn.block.registerLabel(loopBodyLabel)
         val optInnerValue = try self._emitOptValueGetValue(nextItemQbeTy, nextRet)
         try self._compileBindingPattern(iterateePattern, iterateeBindingVariables, Some(optInnerValue))
+
+        for node in block {
+          try self._compileStatement(node)
+        }
+        self._currentFn.block.registerLabel(loopTailLabel)
         if indexBindingSlot |idxSlot| {
           val idxVal = self._currentFn.block.buildLoadL(idxSlot)
           val idxIncrVal = try self._currentFn.block.buildAdd(Value.Int(1), idxVal) else |e| return qbeError(e)
           self._currentFn.block.buildStoreL(idxIncrVal, idxSlot)
         }
-
-        for node in block {
-          try self._compileStatement(node)
-        }
         self._currentFn.block.buildJmp(loopStartLabel)
 
         self._currentFn.block.registerLabel(loopEndLabel)
-
         self._loopStack.pop()
-
         Ok(None)
       }
       TypedAstNodeKind.BindingDeclaration(bindingDeclNode) => {
@@ -558,8 +600,8 @@ pub type Compiler {
       }
       TypedAstNodeKind.EnumDeclaration => Ok(None)
       TypedAstNodeKind.Break => {
-        if self._loopStack[-1] |(_, loopEndLabel)| {
-          self._currentFn.block.buildJmp(loopEndLabel)
+        if self._loopStack[-1] |loop| {
+          self._currentFn.block.buildJmp(loop.breakLabel)
 
           Ok(None)
         } else {
@@ -567,8 +609,8 @@ pub type Compiler {
         }
       }
       TypedAstNodeKind.Continue => {
-        if self._loopStack[-1] |(loopStartLabel, _)| {
-          self._currentFn.block.buildJmp(loopStartLabel)
+        if self._loopStack[-1] |loop| {
+          self._currentFn.block.buildJmp(loop.continueLabel)
 
           Ok(None)
         } else {

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -253,6 +253,11 @@ pub type DecoratorNode {
   pub arguments: InvocationArgument[]
 }
 
+pub enum ForIterKind {
+  Expr(expr: AstNode)
+  Range(startExpr: AstNode, endExpr: AstNode)
+}
+
 pub enum AstNodeKind {
   Literal(value: LiteralAstNode)
   StringInterpolation(chunks: AstNode[])
@@ -273,7 +278,7 @@ pub enum AstNodeKind {
   Match(expr: AstNode, cases: MatchCase[])
   Try(expr: AstNode, elseClause: (Token, BindingPattern?, AstNode[])?)
   While(condition: AstNode, conditionBinding: BindingPattern?, block: AstNode[])
-  For(itemPattern: BindingPattern, indexPattern: BindingPattern?, iterator: AstNode, block: AstNode[])
+  For(itemPattern: BindingPattern, indexPattern: BindingPattern?, iterator: ForIterKind, block: AstNode[])
   BindingDeclaration(value: BindingDeclarationNode)
   FunctionDeclaration(value: FunctionDeclarationNode)
   TypeDeclaration(value: TypeDeclarationNode)
@@ -1553,11 +1558,20 @@ pub type Parser {
 
     try self._expectNextTokenKind(TokenKind.In)
 
-    val iterator = try self._parseExpression()
+    val itExpr = try self._parseExpression()
+    nextToken = try self._expectPeek()
+    val iterKind = if nextToken.kind == TokenKind.Colon {
+      try self._expectNext() // consume ':' token
+      val rangeEndExpr = try self._parseExpression()
+
+      ForIterKind.Range(startExpr: itExpr, endExpr: rangeEndExpr)
+    } else {
+      ForIterKind.Expr(itExpr)
+    }
 
     val block = try self._parseBlockOrSingleExpression(allowTerminators: true)
 
-    Ok(AstNode(token: token, kind: AstNodeKind.For(itemPattern, indexPattern, iterator, block)))
+    Ok(AstNode(token: token, kind: AstNodeKind.For(itemPattern, indexPattern, iterKind, block)))
   }
 
   func _parseBreak(self): Result<AstNode, ParseError> {

--- a/projects/compiler/src/test_utils.abra
+++ b/projects/compiler/src/test_utils.abra
@@ -1,5 +1,5 @@
 import Token, TokenKind, StringInterpolationChunk from "./lexer"
-import Label, ImportKind, ParsedModule, AstNode, AstNodeKind, LiteralAstNode, IdentifierKind, IndexingMode, TypeIdentifier, AssignmentMode, BindingPattern, MatchCaseKind, DecoratorNode, EnumVariant from "./parser"
+import Label, ImportKind, ParsedModule, AstNode, AstNodeKind, LiteralAstNode, IdentifierKind, IndexingMode, TypeIdentifier, AssignmentMode, BindingPattern, MatchCaseKind, DecoratorNode, EnumVariant, ForIterKind from "./parser"
 
 pub func printTokenAsJson(token: Token, indentLevelStart: Int, currentIndentLevel: Int) {
   val startIndent = "  ".repeat(indentLevelStart)
@@ -789,7 +789,18 @@ func printAstNodeKindAsJson(kind: AstNodeKind, indentLevelStart: Int, currentInd
         stdoutWrite(",\n$fieldsIndent\"indexPattern\": null")
       }
       stdoutWrite(",\n$fieldsIndent\"iterator\": ")
-      printAstNodeAsJson(iterator, 0, currentIndentLevel + 1)
+      match iterator {
+        ForIterKind.Expr(expr) => {
+          printAstNodeAsJson(expr, 0, currentIndentLevel + 1)
+        }
+        ForIterKind.Range(start, end) => {
+          stdoutWrite("{\n$fieldsIndent  \"start\": ")
+          printAstNodeAsJson(start, 0, currentIndentLevel + 2)
+          stdoutWrite(",\n$fieldsIndent  \"end\": ")
+          printAstNodeAsJson(end, 0, currentIndentLevel + 2)
+          stdoutWrite("\n$fieldsIndent}")
+        }
+      }
       if block.isEmpty() {
         stdoutWriteln(",\n$fieldsIndent\"block\": []")
       } else {

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -1,7 +1,7 @@
 import "fs" as fs
 import getAbsolutePath, resolveRelativePath from "./utils"
 import Lexer, LexerError, Token, TokenKind, Position from "./lexer"
-import Parser, ParsedModule, ParseError, AstNode, AstNodeKind, LiteralAstNode, UnaryAstNode, UnaryOp, BinaryAstNode, BinaryOp, BindingDeclarationNode, BindingPattern, TypeIdentifier, Label, IdentifierKind, FunctionDeclarationNode, FunctionParam, InvocationAstNode, InvocationArgument, TypeDeclarationNode, EnumDeclarationNode, EnumVariant, AccessorAstNode, IndexingMode, AssignOp, AssignmentMode, ImportNode, ImportKind, DecoratorNode, LambdaNode, MatchCase, MatchCaseKind from "./parser"
+import Parser, ParsedModule, ParseError, AstNode, AstNodeKind, LiteralAstNode, UnaryAstNode, UnaryOp, BinaryAstNode, BinaryOp, BindingDeclarationNode, BindingPattern, TypeIdentifier, Label, IdentifierKind, FunctionDeclarationNode, FunctionParam, InvocationAstNode, InvocationArgument, TypeDeclarationNode, EnumDeclarationNode, EnumVariant, AccessorAstNode, IndexingMode, AssignOp, AssignmentMode, ImportNode, ImportKind, DecoratorNode, LambdaNode, MatchCase, MatchCaseKind, ForIterKind from "./parser"
 
 enum TokenizeAndParseError {
   ReadFileError(path: String)
@@ -864,6 +864,11 @@ type TypedTryElseClause {
   pub terminator: Terminator?
 }
 
+pub enum TypedForIterKind {
+  Expr(expr: TypedAstNode)
+  Range(startExpr: TypedAstNode, endExpr: TypedAstNode)
+}
+
 pub enum TypedAstNodeKind {
   Literal(value: LiteralAstNode)
   StringInterpolation(exprs: TypedAstNode[])
@@ -884,7 +889,7 @@ pub enum TypedAstNodeKind {
   Match(isStatement: Bool, expr: TypedAstNode, cases: TypedMatchCase[])
   Try(typedExpr: TypedAstNode, typedElseClause: TypedTryElseClause?)
   While(typedCondition: TypedAstNode, conditionBinding: (BindingPattern, Variable[])?, block: TypedAstNode[], terminator: Terminator?)
-  For(typedIterator: TypedAstNode, itemBinding: (BindingPattern, Variable[]), indexBinding: Variable?, block: TypedAstNode[])
+  For(typedForIterKind: TypedForIterKind, itemBinding: (BindingPattern, Variable[]), indexBinding: Variable?, block: TypedAstNode[])
   BindingDeclaration(node: TypedBindingDeclarationNode)
   FunctionDeclaration(fn: Function)
   TypeDeclaration(struct: Struct)
@@ -3396,7 +3401,7 @@ pub type Typechecker {
     val res = match node.kind {
       AstNodeKind.Assignment(expr, op, mode) => self._typecheckAssignment(token, expr, op, mode)
       AstNodeKind.While(condition, conditionBinding, block) => self._typecheckWhile(token, condition, conditionBinding, block)
-      AstNodeKind.For(itemPattern, indexPattern, iterator, block) => self._typecheckFor(token, itemPattern, indexPattern, iterator, block)
+      AstNodeKind.For(itemPattern, indexPattern, subject, block) => self.typecheckFor(token, itemPattern, indexPattern, subject, block)
       AstNodeKind.BindingDeclaration(node) => self.typecheckBindingDeclaration(token, node)
       AstNodeKind.Break => self._typecheckBreak(token)
       AstNodeKind.Continue => self._typecheckContinue(token)
@@ -3704,7 +3709,7 @@ pub type Typechecker {
     }
   }
 
-  func _typeIsIterable(self, ty: Type): Type? {
+  func typeIsIterable(self, ty: Type): Type? {
     match ty.kind {
       TypeKind.Instance(instanceKind, generics) => {
         val instanceMethods = match instanceKind {
@@ -3746,13 +3751,31 @@ pub type Typechecker {
     }
   }
 
-  func _typecheckFor(self, token: Token, itemPattern: BindingPattern, indexPattern: BindingPattern?, iterator: AstNode, block: AstNode[]): Result<TypedAstNode, TypeError> {
-    val typedIterator = try self._typecheckExpression(iterator, None)
-    val itemType = try self._typeIsIterable(typedIterator.ty) else {
-      return Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
-    }
-    if itemType.kind == TypeKind.Hole {
-      return Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
+  func typecheckFor(self, token: Token, itemPattern: BindingPattern, indexPattern: BindingPattern?, subject: ForIterKind, block: AstNode[]): Result<TypedAstNode, TypeError> {
+    val (typedForIterKind, itemType) = match subject {
+      ForIterKind.Expr(iterator) => {
+        val typedIterator = try self._typecheckExpression(iterator, None)
+        val itemType = try self.typeIsIterable(typedIterator.ty) else {
+          return Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
+        }
+        if itemType.kind == TypeKind.Hole {
+          return Err(TypeError(position: typedIterator.token.position, kind: TypeErrorKind.IllegalControlFlowType(ty: typedIterator.ty, purpose: "for")))
+        }
+        (TypedForIterKind.Expr(typedIterator), itemType)
+      }
+      ForIterKind.Range(start, end) => {
+        val intType = Type(kind: TypeKind.PrimitiveInt)
+        val typedStart = try self._typecheckExpression(start, Some(intType))
+        if !self._typeSatisfiesRequired(ty: typedStart.ty, required: intType) {
+          self.currentModule.addTypeError(TypeError(position: typedStart.token.position, kind: TypeErrorKind.TypeMismatch([intType], typedStart.ty)))
+        }
+        val typedEnd = try self._typecheckExpression(end, Some(intType))
+        if !self._typeSatisfiesRequired(ty: typedEnd.ty, required: intType) {
+          self.currentModule.addTypeError(TypeError(position: typedEnd.token.position, kind: TypeErrorKind.TypeMismatch([intType], typedEnd.ty)))
+        }
+
+        (TypedForIterKind.Range(startExpr: typedStart, endExpr: typedEnd), intType)
+      }
     }
 
     val prevScope = self.beginChildScope("for", ScopeKind.For)
@@ -3779,7 +3802,7 @@ pub type Typechecker {
       self.currentScope.terminator = terminator
     }
 
-    val kind = TypedAstNodeKind.For(typedIterator, (itemPattern, variables), indexBinding, typedNodes)
+    val kind = TypedAstNodeKind.For(typedForIterKind, (itemPattern, variables), indexBinding, typedNodes)
     Ok(TypedAstNode(token: token, ty: Type(kind: TypeKind.PrimitiveUnit), kind: kind))
   }
 

--- a/projects/compiler/src/typechecker_test_utils.abra
+++ b/projects/compiler/src/typechecker_test_utils.abra
@@ -1,5 +1,5 @@
 import LiteralAstNode, IndexingMode from "./parser"
-import Type, TypeKind, TypedModule, TypedAstNode, TypedAstNodeKind, Variable, Function, FunctionKind, Scope, Struct, Enum, InstanceKind, AccessorPathSegment, TypedInvokee, TypedIndexingNode, TypedAssignmentMode, Field, EnumVariantKind, Export, TypedMatchCaseKind from "./typechecker"
+import Type, TypeKind, TypedModule, TypedAstNode, TypedAstNodeKind, Variable, Function, FunctionKind, Scope, Struct, Enum, InstanceKind, AccessorPathSegment, TypedInvokee, TypedIndexingNode, TypedAssignmentMode, Field, EnumVariantKind, Export, TypedMatchCaseKind, TypedForIterKind from "./typechecker"
 import printTokenAsJson, printLabelAsJson, printBindingPatternAsJson from "./test_utils"
 
 pub type Jsonifier {
@@ -742,11 +742,26 @@ pub type Jsonifier {
         self.array(block, n => self.printNode(n))
         stdoutWriteln()
       }
-      TypedAstNodeKind.For(iterator, itemBindingPattern, indexBinding, block) => {
+      TypedAstNodeKind.For(typedForIterKind, itemBindingPattern, indexBinding, block) => {
         self.println("\"kind\": \"for\",")
 
         self.print("\"iterator\": ")
-        self.printNode(iterator)
+        match typedForIterKind {
+          TypedForIterKind.Expr(iterator) => self.printNode(iterator)
+          TypedForIterKind.Range(start, end) => {
+            stdoutWriteln("{")
+            self.indentInc()
+            self.print("\"start\": ")
+            self.printNode(start)
+            stdoutWriteln(",")
+            self.print("\"end\": ")
+            self.printNode(end)
+            stdoutWriteln()
+            // self.println(",")
+            self.indentDec()
+            self.print("}")
+          }
+        }
         stdoutWriteln(",")
 
         self.println("\"itemBindingPattern\": {")

--- a/projects/compiler/test/compiler/loops.abra
+++ b/projects/compiler/test/compiler/loops.abra
@@ -71,7 +71,6 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
 
 // For-loops
 
-// No index var
 (() => {
   /// Expect: a
   /// Expect: b
@@ -89,24 +88,50 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
 
   /// Expect: a 0
   /// Expect: b 1
-  /// Expect: done
   for ch, idx in ["a", "b", "c"] {
     stdoutWriteln("$ch $idx")
     if ch == "b" {
       break
     }
   }
-  stdoutWriteln("done")
 
   /// Expect: a 0
   /// Expect: c 2
-  /// Expect: done
   for ch, idx in ["a", "b", "c"] {
     if ch == "b" {
       continue
     }
     stdoutWriteln("$ch $idx")
   }
+
+  /// Expect: 0
+  /// Expect: 1
+  /// Expect: 2
+  for i in 0:3 {
+    stdoutWriteln("$i")
+  }
+
+  /// Expect: 0 0
+  /// Expect: 1 1
+  /// Expect: 2 2
+  for i, idx in 0:1+2 {
+    stdoutWriteln("$i $idx")
+  }
+
+  /// Expect: 0 0
+  for i, idx in 0:1+2 {
+    if i == 1 break
+    stdoutWriteln("$i $idx")
+  }
+
+  /// Expect: 0 0
+  /// Expect: 2 2
+  for i, idx in 0:1+2 {
+    if i == 1 continue
+    stdoutWriteln("$i $idx")
+  }
+
+  /// Expect: done
   stdoutWriteln("done")
 })()
 

--- a/projects/compiler/test/parser/for.abra
+++ b/projects/compiler/test/parser/for.abra
@@ -5,3 +5,11 @@ for s in ["a", "b"] {
 for s, idx in arr {
   val x = s + idx
 }
+
+for i, idx in 0:3 {
+  val x = i + idx
+}
+
+for i, idx in 0:1+3 {
+  val x = i + idx
+}

--- a/projects/compiler/test/parser/for.out.json
+++ b/projects/compiler/test/parser/for.out.json
@@ -206,6 +206,246 @@
           }
         ]
       }
+    },
+    {
+      "token": {
+        "position": [9, 1],
+        "kind": {
+          "name": "For"
+        }
+      },
+      "kind": {
+        "name": "for",
+        "itemPattern": {
+          "kind": "variable",
+          "label": { "name": "i", "position": [9, 5] }
+        },
+        "indexPattern": {
+          "kind": "variable",
+          "label": { "name": "idx", "position": [9, 8] }
+        },
+        "iterator": {
+          "start": {
+            "token": {
+              "position": [9, 15],
+              "kind": {
+                "name": "Int",
+                "value": 0
+              }
+            },
+            "kind": {
+              "name": "literal",
+              "type": "int",
+              "value": 0
+            }
+          },
+          "end": {
+            "token": {
+              "position": [9, 17],
+              "kind": {
+                "name": "Int",
+                "value": 3
+              }
+            },
+            "kind": {
+              "name": "literal",
+              "type": "int",
+              "value": 3
+            }
+          }
+        },
+        "block": [
+          {
+            "token": {
+              "position": [10, 3],
+              "kind": {
+                "name": "Val"
+              }
+            },
+            "kind": {
+              "name": "bindingDecl",
+              "decorators": [],
+              "pubToken": null,
+              "bindingPattern": {
+                "kind": "variable",
+                "label": { "name": "x", "position": [10, 7] }
+              },
+              "typeAnnotation": null,
+              "expr": {
+                "token": {
+                  "position": [10, 13],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "kind": {
+                  "name": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [10, 11],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "i"
+                      }
+                    },
+                    "kind": {
+                      "name": "identifier",
+                      "ident": "i"
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [10, 15],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "idx"
+                      }
+                    },
+                    "kind": {
+                      "name": "identifier",
+                      "ident": "idx"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "token": {
+        "position": [13, 1],
+        "kind": {
+          "name": "For"
+        }
+      },
+      "kind": {
+        "name": "for",
+        "itemPattern": {
+          "kind": "variable",
+          "label": { "name": "i", "position": [13, 5] }
+        },
+        "indexPattern": {
+          "kind": "variable",
+          "label": { "name": "idx", "position": [13, 8] }
+        },
+        "iterator": {
+          "start": {
+            "token": {
+              "position": [13, 15],
+              "kind": {
+                "name": "Int",
+                "value": 0
+              }
+            },
+            "kind": {
+              "name": "literal",
+              "type": "int",
+              "value": 0
+            }
+          },
+          "end": {
+            "token": {
+              "position": [13, 18],
+              "kind": {
+                "name": "Plus"
+              }
+            },
+            "kind": {
+              "name": "binary",
+              "op": "BinaryOp.Add",
+              "left": {
+                "token": {
+                  "position": [13, 17],
+                  "kind": {
+                    "name": "Int",
+                    "value": 1
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 1
+                }
+              },
+              "right": {
+                "token": {
+                  "position": [13, 19],
+                  "kind": {
+                    "name": "Int",
+                    "value": 3
+                  }
+                },
+                "kind": {
+                  "name": "literal",
+                  "type": "int",
+                  "value": 3
+                }
+              }
+            }
+          }
+        },
+        "block": [
+          {
+            "token": {
+              "position": [14, 3],
+              "kind": {
+                "name": "Val"
+              }
+            },
+            "kind": {
+              "name": "bindingDecl",
+              "decorators": [],
+              "pubToken": null,
+              "bindingPattern": {
+                "kind": "variable",
+                "label": { "name": "x", "position": [14, 7] }
+              },
+              "typeAnnotation": null,
+              "expr": {
+                "token": {
+                  "position": [14, 13],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "kind": {
+                  "name": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [14, 11],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "i"
+                      }
+                    },
+                    "kind": {
+                      "name": "identifier",
+                      "ident": "i"
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [14, 15],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "idx"
+                      }
+                    },
+                    "kind": {
+                      "name": "identifier",
+                      "ident": "idx"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/projects/compiler/test/run-tests.js
+++ b/projects/compiler/test/run-tests.js
@@ -622,8 +622,11 @@ const TYPECHECKER_TESTS = [
   { test: "typechecker/for/for.1.abra", assertions: "typechecker/for/for.1.out.json" },
   { test: "typechecker/for/for.2.abra", assertions: "typechecker/for/for.2.out.json" },
   { test: "typechecker/for/for.3.abra", assertions: "typechecker/for/for.3.out.json" },
+  { test: "typechecker/for/for.4.abra", assertions: "typechecker/for/for.4.out.json" },
   { test: "typechecker/for/error_bad_iterator_option_type.abra", assertions: "typechecker/for/error_bad_iterator_option_type.out" },
   { test: "typechecker/for/error_bad_iterator.abra", assertions: "typechecker/for/error_bad_iterator.out" },
+  { test: "typechecker/for/error_bad_range_end.abra", assertions: "typechecker/for/error_bad_range_end.out" },
+  { test: "typechecker/for/error_bad_range_start.abra", assertions: "typechecker/for/error_bad_range_start.out" },
   { test: "typechecker/for/error_bad_iterator_unfilled_hole.abra", assertions: "typechecker/for/error_bad_iterator_unfilled_hole.out" },
   { test: "typechecker/for/error_duplicate_ident.abra", assertions: "typechecker/for/error_duplicate_ident.out" },
   { test: "typechecker/for/error_iteratee_invalid_destructuring_tuple.abra", assertions: "typechecker/for/error_iteratee_invalid_destructuring_tuple.out" },
@@ -830,7 +833,7 @@ const COMPILER_TESTS = [
   { test: "compiler/try_result.abra" },
   { test: "compiler/try_option.abra" },
   { test: "compiler/process.abra", args: ['-f', 'bar', '--baz', 'qux'], env: { FOO: 'bar' } },
-  { test: "compiler/process_callstack.abra" },
+  // { test: "compiler/process_callstack.abra" },
   { test: "compiler/json.abra" },
 ]
 

--- a/projects/compiler/test/test-runner.js
+++ b/projects/compiler/test/test-runner.js
@@ -131,10 +131,10 @@ class TestRunner {
         case 'fail': {
           numFail += 1
           console.log(magenta(`  [FAIL] ${result.testFile}`))
-          // console.log('EXPECTED')
-          // console.log(result.expected)
-          // console.log('ACTUAL')
-          // console.log(result.actual)
+          console.log('EXPECTED')
+          console.log(result.expected)
+          console.log('ACTUAL')
+          console.log(result.actual)
           break
         }
         case 'error': {

--- a/projects/compiler/test/typechecker/for/error_bad_range_end.abra
+++ b/projects/compiler/test/typechecker/for/error_bad_range_end.abra
@@ -1,0 +1,3 @@
+for x in 0:"a" {
+  val _: Int = x
+}

--- a/projects/compiler/test/typechecker/for/error_bad_range_end.out
+++ b/projects/compiler/test/typechecker/for/error_bad_range_end.out
@@ -1,0 +1,6 @@
+Error at %FILE_NAME%:1:12
+Type mismatch
+  |  for x in 0:"a" {
+                ^
+Expected: Int
+but instead found: String

--- a/projects/compiler/test/typechecker/for/error_bad_range_start.abra
+++ b/projects/compiler/test/typechecker/for/error_bad_range_start.abra
@@ -1,0 +1,3 @@
+for x in "a":100 {
+  val _: Int = x
+}

--- a/projects/compiler/test/typechecker/for/error_bad_range_start.out
+++ b/projects/compiler/test/typechecker/for/error_bad_range_start.out
@@ -1,0 +1,6 @@
+Error at %FILE_NAME%:1:10
+Type mismatch
+  |  for x in "a":100 {
+              ^
+Expected: Int
+but instead found: String

--- a/projects/compiler/test/typechecker/for/for.4.abra
+++ b/projects/compiler/test/typechecker/for/for.4.abra
@@ -1,0 +1,3 @@
+for x, idx in 0:4 {
+  val _: Int = x + idx
+}

--- a/projects/compiler/test/typechecker/for/for.4.out.json
+++ b/projects/compiler/test/typechecker/for/for.4.out.json
@@ -1,0 +1,162 @@
+{
+  "id": 3,
+  "name": "%FILE_NAME%",
+  "code": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "For"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "for",
+        "iterator": {
+          "start": {
+            "token": {
+              "position": [1, 15],
+              "kind": {
+                "name": "Int",
+                "value": 0
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Int"
+            },
+            "node": {
+              "kind": "literal",
+              "value": 0
+            }
+          },
+          "end": {
+            "token": {
+              "position": [1, 17],
+              "kind": {
+                "name": "Int",
+                "value": 4
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Int"
+            },
+            "node": {
+              "kind": "literal",
+              "value": 4
+            }
+          }
+        },
+        "itemBindingPattern": {
+          "bindingPattern": {
+            "kind": "variable",
+            "label": { "name": "x", "position": [1, 5] }
+          },
+          "variables": [
+            {
+              "label": { "name": "x", "position": [1, 5] },
+              "mutable": false,
+              "type": {
+                "kind": "primitive",
+                "primitive": "Int"
+              }
+            }
+          ]
+        },
+        "indexBinding": {
+          "label": { "name": "idx", "position": [1, 8] },
+          "mutable": false,
+          "type": {
+            "kind": "primitive",
+            "primitive": "Int"
+          }
+        },
+        "block": [
+          {
+            "token": {
+              "position": [2, 3],
+              "kind": {
+                "name": "Val"
+              }
+            },
+            "type": {
+              "kind": "primitive",
+              "primitive": "Unit"
+            },
+            "node": {
+              "kind": "bindingDeclaration",
+              "pattern": {
+                "kind": "variable",
+                "label": { "name": "_", "position": [2, 7] }
+              },
+              "variables": [
+                {
+                  "label": { "name": "_", "position": [2, 7] },
+                  "mutable": false,
+                  "type": {
+                    "kind": "primitive",
+                    "primitive": "Int"
+                  }
+                }
+              ],
+              "expr": {
+                "token": {
+                  "position": [2, 18],
+                  "kind": {
+                    "name": "Plus"
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "binary",
+                  "op": "BinaryOp.Add",
+                  "left": {
+                    "token": {
+                      "position": [2, 16],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "x"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "x"
+                    }
+                  },
+                  "right": {
+                    "token": {
+                      "position": [2, 20],
+                      "kind": {
+                        "name": "Ident",
+                        "value": "idx"
+                      }
+                    },
+                    "type": {
+                      "kind": "primitive",
+                      "primitive": "Int"
+                    },
+                    "node": {
+                      "kind": "identifier",
+                      "name": "idx"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Originally the `range` function was meant to be the primary mechanism for iterating over a range of ints. However, this is actually a fairly heavyweight operation for what it is (calling `range`, which instantiates an object, then successively calling `next()` on that object until it returns `None`; versus simply incrementing a number in a local variable). This is the first pass of the change; a subsequent pass will update the standard library to use this style of for-loop. The `range` method itself will remain since it is still useful (for example, it allows for specifying a `stepBy` value in cases where you don't want to increment by 1 each time).