### PR TITLE
For-loop cleanup (and tests)

### DIFF
--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -51,7 +51,7 @@ type CompileError {
     if contents.lines()[position.line - 1] |line| {
       val len = position.col - 1 + cursorLength
       val cursor = Array.fill(len, " ")
-      for i in range(len - cursorLength, len) {
+      for i in (len - cursorLength):len {
         cursor[i] = "^"
       }
       "  |  $line\n     ${cursor.join()}"

--- a/projects/compiler/src/lexer.abra
+++ b/projects/compiler/src/lexer.abra
@@ -221,7 +221,7 @@ pub type LexerError {
     if contents.lines()[position.line - 1] |line| {
       val len = position.col - 1 + cursorLength
       val cursor = Array.fill(len, " ")
-      for i in range(len - cursorLength, len) {
+      for i in (len - cursorLength):len {
         cursor[i] = "^"
       }
       "  |  $line\n     ${cursor.join()}"
@@ -625,7 +625,7 @@ pub type Lexer {
     self._advance() // consume 'u'
 
     var value = 0
-    for i in range(0, 4) {
+    for i in 0:4 {
       if self._cursor + i >= self._input.length {
         val escSeq = "\\u${self._input[self._cursor:self._cursor + i]}"
         return Err(LexerError(position: startPos, kind: LexerErrorKind.UnsupportedEscapeSequence(seq: escSeq, isUnicode: true)))

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -344,7 +344,7 @@ pub type ParseError {
     if contents.lines()[position.line - 1] |line| {
       val len = position.col - 1 + cursorLength
       val cursor = Array.fill(len, " ")
-      for i in range(len - cursorLength, len) {
+      for i in (len - cursorLength):len {
         cursor[i] = "^"
       }
       "  |  $line\n     ${cursor.join()}"

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -1463,7 +1463,7 @@ type TypeError {
     if contents.lines()[position.line - 1] |line| {
       val len = position.col - 1 + cursorLength
       val cursor = Array.fill(len, " ")
-      for i in range(len - cursorLength, len) {
+      for i in (len - cursorLength):len {
         cursor[i] = "^"
       }
       "  |  $line\n     ${cursor.join()}"
@@ -1738,7 +1738,7 @@ pub type Typechecker {
     }
 
     val types: Type[] = []
-    for i in range(0, num) {
+    for i in 0:num {
       val typeIdent = try typeArguments.get(i) else unreachable("verified above that typeArguments.length == num")
       val ty = try self.resolveTypeIdentifier(typeIdent)
       types.push(ty)

--- a/projects/compiler/test/compiler/arrays.abra
+++ b/projects/compiler/test/compiler/arrays.abra
@@ -1,18 +1,10 @@
-// // Test raw construction of array
-// (() => {
-//   val arr = Array<Int>(length: 0, _buffer: Pointer.malloc<Int>(1), _capacity: 1)
-//   arr.push(12)
-//   /// Expect: [12]
-//   stdoutWriteln(arr)
-// })()
-
 /// Expect: 1
 stdoutWriteln([1].length.toString())
 /// Expect: 2
 stdoutWriteln([[1, 2], [3, 4]].length.toString())
 
 // Test array literal construction
-(() => {
+if true {
   val emptyArr: Int[] = []
   /// Expect: []
   stdoutWriteln(emptyArr.toString())
@@ -32,10 +24,10 @@ stdoutWriteln([[1, 2], [3, 4]].length.toString())
   val nestedArr = [[1, 2], [3, 4], [5, 6]]
   /// Expect: [[1, 2], [3, 4], [5, 6]]
   stdoutWriteln(nestedArr.toString())
-})()
+}
 
 // Test array indexing assignment
-(() => {
+if true {
   val emptyArr: Int[] = []
   emptyArr[0] = 123
   /// Expect: []
@@ -80,10 +72,10 @@ stdoutWriteln([[1, 2], [3, 4]].length.toString())
   nestedArr[-1] = [3, 2]
   /// Expect: [[0, 1], [3, 4], [3, 2]]
   stdoutWriteln(nestedArr.toString())
-})()
+}
 
 // == operator (also Array#eq)
-(() => {
+if true {
   val arr = [1, 2]
 
   /// Expect: true
@@ -94,10 +86,10 @@ stdoutWriteln([[1, 2], [3, 4]].length.toString())
   stdoutWriteln(([1.2, 3.4] != [5.6, 7.8]).toString())
   /// Expect: true
   stdoutWriteln(([true, false] != [false, true]).toString())
-})()
+}
 
 // Indexing (also Array#get(index: Int))
-(() => {
+if true {
   val arr = [1, 2, 3]
   /// Expect: Option.None
   stdoutWriteln(arr[-4].toString())
@@ -115,10 +107,10 @@ stdoutWriteln([[1, 2], [3, 4]].length.toString())
   stdoutWriteln(arr[2].toString())
   /// Expect: Option.None
   stdoutWriteln(arr[3].toString())
-})()
+}
 
 // Range indexing (also Array#getRange(startIndex: Int, endIndex: Int))
-(() => {
+if true {
   val arr = [1, 2, 3, 4, 5]
 
   /// Expect: [2, 3, 4]
@@ -148,10 +140,10 @@ stdoutWriteln([[1, 2], [3, 4]].length.toString())
   stdoutWriteln(arr[x:].toString())
   /// Expect: [1]
   stdoutWriteln(arr[:x].toString())
-})()
+}
 
 // Array.fill
-(() => {
+if true {
   val zeroes = Array.fill(5, 0)
   /// Expect: [0, 0, 0, 0, 0]
   stdoutWriteln(zeroes.toString())
@@ -163,10 +155,10 @@ stdoutWriteln([[1, 2], [3, 4]].length.toString())
   arr.push(3)
   /// Expect: [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
   stdoutWriteln(refs.toString())
-})()
+}
 
 // Array.fillBy
-(() => {
+if true {
   val zero = 0
   val zeroes = Array.fillBy(5, () => zero)
   /// Expect: [0, 0, 0, 0, 0]
@@ -190,20 +182,20 @@ stdoutWriteln([[1, 2], [3, 4]].length.toString())
   if uniqueRefs[0] |arr| arr[1] = 0
   /// Expect: [[1, 0], [1, 2], [1, 2]]
   stdoutWriteln(uniqueRefs.toString())
-})()
+}
 
 // Array#hash
-(() => {
+if true {
   val arr = [1, 2, 3]
   /// Expect: true
   stdoutWriteln((arr.hash() == [1, 2, 3].hash()).toString())
 
   /// Expect: false
   stdoutWriteln((arr.hash() == [1, 2].hash()).toString())
-})()
+}
 
 // Array#iterator
-(() => {
+if true {
   val a = [1.23, 4.56, 7.89]
   val iter = a.iterator()
   /// Expect: Option.Some(value: 1.23)
@@ -216,7 +208,7 @@ stdoutWriteln([[1, 2], [3, 4]].length.toString())
   stdoutWriteln(iter.next().toString())
   /// Expect: Option.None
   stdoutWriteln(iter.next().toString())
-})()
+}
 
 // For-loops
 /// Expect: a
@@ -227,7 +219,7 @@ for ch in ["a", "b", "c"] {
 }
 
 // Array#push
-(() => {
+if true {
   val intArr = [1, 2, 3]
   /// Expect: [1, 2, 3] 3 4
   stdoutWriteln("$intArr ${intArr.length} ${intArr.getCapacity()}")
@@ -252,10 +244,10 @@ for ch in ["a", "b", "c"] {
   strArr.push("e")
   /// Expect: [[a, b, c, d, e], [a, b, c, d, e]] 5 8
   stdoutWriteln("$arrArr ${strArr.length} ${strArr.getCapacity()}")
-})()
+}
 
 // Array#pop
-(() => {
+if true {
   val arr = [1, 2, 3]
   /// Expect: Option.Some(value: 3)
   stdoutWriteln(arr.pop().toString())
@@ -276,23 +268,23 @@ for ch in ["a", "b", "c"] {
   stdoutWriteln(arr.pop().toString())
   /// Expect: []
   stdoutWriteln(arr.toString())
-})()
+}
 
 // Array#concat
-(() => {
+if true {
   val arr1 = [1, 2, 3, 4]
   val arr2 = [5, 6, 7]
   /// Expect: [1, 2, 3, 4, 5, 6, 7]
   stdoutWriteln(arr1.concat(arr2).toString())
   /// Expect: [1, 2, 3, 4] [5, 6, 7]
   stdoutWriteln("$arr1 $arr2") // verify originals unmodified
-})()
+}
 
 // Array#map
 func addOne(i: Int): Int = i + 1
 func exclaim(i: Int, _: Int, x = "!"): String = i + x //"$i$x"
 // val one = 1
-(() => {
+if true {
   val arr = [1, 2, 3, 4]
 
   /// Expect: [2, 3, 4, 5]
@@ -306,30 +298,30 @@ func exclaim(i: Int, _: Int, x = "!"): String = i + x //"$i$x"
   stdoutWriteln(arr.map(exclaim).toString())
   /// Expect: [1!, 2!, 3!, 4!]
   stdoutWriteln(arr.map((i, _, x = "!") => i + x).toString())
-})()
+}
 
 // Array#flatMap
-(() => {
+if true {
   val arr = [1, 2, 3, 4]
 
   /// Expect: [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
   stdoutWriteln(arr.flatMap(i => Array.fill(i, i)).toString())
-})()
+}
 
 // Array#filter
 func isEven(i: Int): Bool = i % 2 == 0
-(() => {
+if true {
   val arr = [1, 2, 3, 4]
 
   /// Expect: [2, 4]
   stdoutWriteln(arr.filter(isEven).toString())
   /// Expect: [2, 4]
   stdoutWriteln(arr.filter(x => x % 2 == 0).toString())
-})()
+}
 
 // Array#reduce
 func doSum(acc: Int, i: Int): Int = acc + i
-(() => {
+if true {
   val arr = [1, 2, 3, 4]
 
   // TODO: I shouldn't need r1/r2 below, but otherwise I get a typechecker error:
@@ -345,11 +337,11 @@ func doSum(acc: Int, i: Int): Int = acc + i
   /// Expect: 10
   val r2 = arr.reduce(0, (acc, i) => acc + i)
   stdoutWriteln(r2.toString())
-})()
+}
 
 // Array#forEach
 func printItem(item: Int) = stdoutWriteln(item.toString())
-(() => {
+if true {
   val arr = [1, 2, 3, 4]
 
   /// Expect: 1
@@ -364,10 +356,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   arr.forEach(i => {
     stdoutWriteln(i.toString())
   })
-})()
+}
 
 // Array#join
-(() => {
+if true {
   val arr = [123, 456, 789]
   /// Expect: 123|456|789
   stdoutWriteln(arr.join("|"))
@@ -376,10 +368,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
 
   /// Expect: 1
   stdoutWriteln([1].join(", "))
-})()
+}
 
 // Array#contains
-(() => {
+if true {
   val intArr = [123, 456, 789]
   /// Expect: true
   stdoutWriteln(intArr.contains(123).toString())
@@ -395,10 +387,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   stdoutWriteln(strArr.contains("hello").toString())
   /// Expect: false
   stdoutWriteln(strArr.contains("HELLO").toString())
-})()
+}
 
 // Array#find
-(() => {
+if true {
   val intArr = [123, 456, 789]
   /// Expect: Option.Some(value: 123)
   stdoutWriteln(intArr.find(i => i == 123).toString())
@@ -414,10 +406,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   stdoutWriteln(strArr.find(s => s == "hello").toString())
   /// Expect: Option.None
   stdoutWriteln(strArr.find(s => s == "HELLO").toString())
-})()
+}
 
 // Array#findIndex
-(() => {
+if true {
   val intArr = [123, 456, 789]
   /// Expect: Option.Some(value: (123, 0))
   stdoutWriteln(intArr.findIndex(i => i == 123).toString())
@@ -433,10 +425,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   stdoutWriteln(strArr.findIndex(s => s == "hello").toString())
   /// Expect: Option.None
   stdoutWriteln(strArr.findIndex(s => s == "HELLO").toString())
-})()
+}
 
 // Array#any
-(() => {
+if true {
   val intArr = [123, 456, 789]
   /// Expect: true
   stdoutWriteln(intArr.any(i => i == 123).toString())
@@ -452,10 +444,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   stdoutWriteln(strArr.any(s => s == "hello").toString())
   /// Expect: false
   stdoutWriteln(strArr.any(s => s == "HELLO").toString())
-})()
+}
 
 // Array#all
-(() => {
+if true {
   val intArr = [123, 456, 789]
   /// Expect: true
   stdoutWriteln(intArr.all(i => i > 0).toString())
@@ -471,10 +463,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   stdoutWriteln(strArr.all(s => s.length > 0).toString())
   /// Expect: false
   stdoutWriteln(strArr.all(s => s == "HELLO").toString())
-})()
+}
 
 // Array#sortBy
-(() => {
+if true {
   val strings = ["abc", "d", "efgh", "ij", "k", "lm", "nopqr", "stu", "v", "wxyz"]
   val sorted = strings.sortBy(s => s.length)
   /// Expect: [abc, d, efgh, ij, k, lm, nopqr, stu, v, wxyz]
@@ -488,10 +480,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   stdoutWriteln(arrays.toString()) // original should be unmodified
   /// Expect: [[7, 8, 9, 10], [3, 4, 5], [1, 2], [6], []]
   stdoutWriteln(sortedRev.toString())
-})()
+}
 
 // Array#keyBy
-(() => {
+if true {
   val empty: String[] = []
   /// Expect: {}
   stdoutWriteln(empty.keyBy(s => s.length).toString())
@@ -499,10 +491,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
   /// Expect: { 3: dog, 4: lazy, 5: brown, 6: jumped }
   stdoutWriteln(strArr.keyBy(s => s.length).toString())
-})()
+}
 
 // Array#indexBy
-(() => {
+if true {
   val empty: String[] = []
   /// Expect: {}
   stdoutWriteln(empty.indexBy(s => s.length).toString())
@@ -510,10 +502,10 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
   /// Expect: { 3: [The, fox, the, dog], 4: [over, lazy], 5: [quick, brown], 6: [jumped] }
   stdoutWriteln(strArr.indexBy(s => s.length).toString())
-})()
+}
 
 // Array#asSet
-(() => {
+if true {
   val empty: String[] = []
   val emptySet: Set<String> = #{}
   /// Expect: true
@@ -522,4 +514,4 @@ func printItem(item: Int) = stdoutWriteln(item.toString())
   val arr = [1, 2, 3, 4, 3, 2, 1]
   /// Expect: true
   stdoutWriteln((arr.asSet() == #{1, 2, 3, 4}).toString())
-})()
+}

--- a/projects/compiler/test/compiler/ifs.abra
+++ b/projects/compiler/test/compiler/ifs.abra
@@ -60,16 +60,14 @@ stdoutWriteln((if arr[0] |item| { item + 100 } else { 0 }).toString())
 stdoutWriteln((if arr[5] |item| { item + 100 } else { 0 }).toString())
 
 // Destructuring condition binding as tuple
-(() => {
-  val pairs = [("a", 1), ("b", 2)]
-  // Statement
-  if pairs[0] |(k, v)| {
-    /// Expect: a 1
-    stdoutWriteln("$k $v")
-  }
+val pairs = [("a", 1), ("b", 2)]
+// Statement
+if pairs[0] |(k, v)| {
+  /// Expect: a 1
+  stdoutWriteln("$k $v")
+}
 
-  // Expression
-  val x = if pairs[0] |(k, v)| k.length + v else 0
-  /// Expect: 2
-  stdoutWriteln(x.toString())
-})()
+// Expression
+val x = if pairs[0] |(k, v)| k.length + v else 0
+/// Expect: 2
+stdoutWriteln(x.toString())

--- a/projects/compiler/test/compiler/ints.abra
+++ b/projects/compiler/test/compiler/ints.abra
@@ -105,8 +105,8 @@ printlnBool(17 >= 18.0)
 /// Expect: true
 printlnBool(17 >= 15.1)
 
-// // Int#unsignedToString
-// (() => {
+// Int#unsignedToString
+if true {
   val i1 = 118
   /// Expect: 118
   stdoutWriteln(i1.toString())
@@ -119,7 +119,7 @@ printlnBool(17 >= 15.1)
   /// Expect: 9223372039002259456
   stdoutWriteln(i2.unsignedToString())
 
-//   val i3 = 0b1000000000000000000000000000000010000000000000000000000000000000
-//   /// Expect: -9223372034707292160 9223372039002259456
-//   stdoutWriteln(i3.toString(), i3.unsignedToString())
-// })()
+  //val i3 = 0b1000000000000000000000000000000010000000000000000000000000000000
+  ///// Expect: -9223372034707292160 9223372039002259456
+  //stdoutWriteln(i3.toString(), i3.unsignedToString())
+}

--- a/projects/compiler/test/compiler/json.abra
+++ b/projects/compiler/test/compiler/json.abra
@@ -1,7 +1,7 @@
 import JsonParser from "json"
 
 // Testing basic values
-(() => {
+if true {
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Left(left: 1)))
   stdoutWriteln(JsonParser.parseString("1").toString())
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: 2.5)))
@@ -14,10 +14,10 @@ import JsonParser from "json"
   stdoutWriteln(JsonParser.parseString("false").toString())
   /// Expect: Result.Ok(value: JsonValue.Null)
   stdoutWriteln(JsonParser.parseString("null").toString())
-})()
+}
 
 // Testing numbers
-(() => {
+if true {
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Left(left: -2)))
   stdoutWriteln(JsonParser.parseString("-2").toString())
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: -2.05)))
@@ -44,10 +44,10 @@ import JsonParser from "json"
   stdoutWriteln(JsonParser.parseString("0.2e-03").toString())
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: -0.0002)))
   stdoutWriteln(JsonParser.parseString("-0.2e-03").toString())
-})()
+}
 
 // Testing strings
-(() => {
+if true {
   // escape sequences
   /// Expect: Result.Ok(value: "JsonValue.String(value: "" \ \n \r \t /")")
   stdoutWriteln(
@@ -64,10 +64,10 @@ import JsonParser from "json"
   // // unicode characters
   // /// Expect: Result.Ok(value: JsonValue.String(value: "日"))
   // stdoutWriteln(JsonParser.parseString("\"日\""))
-})()
+}
 
 // Testing array values
-(() => {
+if true {
   /// Expect: Result.Ok(value: JsonValue.Array(items: []))
   stdoutWriteln(JsonParser.parseString("[]").toString())
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Number(value: Either.Left(left: 1))]))
@@ -92,10 +92,10 @@ import JsonParser from "json"
   stdoutWriteln(JsonParser.parseString("[[\"hello\"]]").toString())
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Object(obj: JsonObject(_map: { foo: JsonValue.Number(value: Either.Left(left: 1)) }))]))
   stdoutWriteln(JsonParser.parseString("[{\"foo\": 1}]").toString())
-})()
+}
 
 // Testing object values
-(() => {
+if true {
   /// Expect: Result.Ok(value: JsonValue.Object(obj: JsonObject(_map: {})))
   stdoutWriteln(JsonParser.parseString("{}").toString())
   /// Expect: Result.Ok(value: JsonValue.Object(obj: JsonObject(_map: { foo: JsonValue.Number(value: Either.Left(left: 1)) })))
@@ -104,10 +104,10 @@ import JsonParser from "json"
   stdoutWriteln(JsonParser.parseString("{ \"foo\" : 1 , \"bar\": [\"baz\"]}").toString())
   /// Expect: Result.Ok(value: "JsonValue.Object(obj: JsonObject(_map: { fo\no: JsonValue.Number(value: Either.Left(left: 1)) }))")
   stdoutWriteln(JsonParser.parseString("{\"fo\\no\": 1}").map(v => v.toString().replaceAll("\n", "\\n")).toString())
-})()
+}
 
 // Testing parsing errors
-(() => {
+if true {
   /// Expect: Result.Err(error: JsonParseError.UnexpectedEndOfNumber)
   stdoutWriteln(JsonParser.parseString("2.").toString())
 
@@ -140,4 +140,4 @@ import JsonParser from "json"
   stdoutWriteln(JsonParser.parseString("{ \"foo\":  1 \"bar\": 2}").toString())
   /// Expect: Result.Err(error: JsonParseError.CommaOrClosingBracketExpected)
   stdoutWriteln(JsonParser.parseString("{ \"foo\":  1 ").toString())
-})()
+}

--- a/projects/compiler/test/compiler/loops.abra
+++ b/projects/compiler/test/compiler/loops.abra
@@ -1,7 +1,7 @@
 func printlnInt(i: Int) = stdoutWriteln(i.toString())
 
 // While-loops
-(() => {
+if true {
   var i = 0
   while i < 3 {
     printlnInt(i)
@@ -12,10 +12,10 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
   /// Expect: 2
   /// Expect: done
   stdoutWriteln("done")
-})()
+}
 
 // Condition bindings
-(() => {
+if true {
   val arr = [1, 2, 3]
   var n = 0
   while arr[n] |item| {
@@ -27,10 +27,10 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
   /// Expect: 103
   /// Expect: done
   stdoutWriteln("done")
-})()
+}
 
 // Destructuring condition binding as tuple
-(() => {
+if true {
   val arr = [("a", 1), ("bc", 2)]
   var n = 0
   while arr[n] |(k, v)| {
@@ -41,10 +41,10 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
   /// Expect: 104
   /// Expect: done
   stdoutWriteln("done")
-})()
+}
 
 // Control flow within loops
-(() => {
+if true {
   /// Expect: first loop
   /// Expect: done
   while true {
@@ -67,11 +67,11 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
     x += 1
   }
   stdoutWriteln("done")
-})()
+}
 
 // For-loops
 
-(() => {
+if true {
   /// Expect: a
   /// Expect: b
   /// Expect: c
@@ -133,10 +133,10 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
 
   /// Expect: done
   stdoutWriteln("done")
-})()
+}
 
 // Destructuring iteratee binding as tuple
-(() => {
+if true {
   val arr = [("a", 1), ("bc", 2)]
   for (k, v) in arr {
     printlnInt(100 + k.length + v)
@@ -145,10 +145,10 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
   /// Expect: 104
   /// Expect: done
   stdoutWriteln("done")
-})()
+}
 
 // Iterating over `Iterator` type
-(() => {
+if true {
   /// Expect: 0
   /// Expect: 2
   /// Expect: 4
@@ -157,4 +157,4 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
     printlnInt(i)
   }
   stdoutWriteln("done")
-})()
+}

--- a/projects/compiler/test/compiler/maps.abra
+++ b/projects/compiler/test/compiler/maps.abra
@@ -1,7 +1,7 @@
 func printlnBool(b: Bool) = stdoutWriteln(b.toString())
 
 // Test raw construction of map
-(() => {
+if true {
   val m0: Map<Int, String> = Map.new()
   /// Expect: {}
   stdoutWriteln(m0.toString())
@@ -23,10 +23,10 @@ func printlnBool(b: Bool) = stdoutWriteln(b.toString())
   m3.insert(m3.getCapacity() + 1, "world")
   /// Expect: { 1: hello, 17: world }
   stdoutWriteln(m3.toString())
-})()
+}
 
 // Test map literal construction
-(() => {
+if true {
   val m0: Map<Int, String> = {}
   /// Expect: {}
   stdoutWriteln(m0.toString())
@@ -43,30 +43,30 @@ func printlnBool(b: Bool) = stdoutWriteln(b.toString())
   val m3 = { (1): "hello", (17): "world" }
   /// Expect: { 1: hello, 17: world }
   stdoutWriteln(m3.toString())
-})()
+}
 
 // == operator (also Map#eq)
-(() => {
+if true {
   val map = { a: "abc", b: "def" }
 
   /// Expect: true
   printlnBool(map == { b: "def", a: "abc" })
   /// Expect: true
   printlnBool({ (1): { (1): ["a"], (2): ["b"] } } == { (1): { (1): ["a"], (2): ["b"] } })
-})()
+}
 
 // Map.fromPairs
-(() => {
+if true {
   // TODO: The typechecker won't recognize this if it's inlined for some reason
   val pairs = [("a", 1), ("b", 2), ("c", 3)]
   val m = Map.fromPairs(pairs)
 
   /// Expect: { c: 3, b: 2, a: 1 }
   stdoutWriteln(m.toString())
-})()
+}
 
 // Map#keys
-(() => {
+if true {
   val map1 = { a: 1, b: 2 }
   /// Expect: #{b, a}
   stdoutWriteln(map1.keys().toString())
@@ -74,10 +74,10 @@ func printlnBool(b: Bool) = stdoutWriteln(b.toString())
   val map2 = { ((1, 1)): true, ((0, 1)): false }
   /// Expect: #{(0, 1), (1, 1)}
   stdoutWriteln(map2.keys().toString())
-})()
+}
 
 // Map#values
-(() => {
+if true {
   val map1 = { a: 1, b: 2 }
   /// Expect: [2, 1]
   stdoutWriteln(map1.values().toString())
@@ -85,10 +85,10 @@ func printlnBool(b: Bool) = stdoutWriteln(b.toString())
   val map2 = { ((1, 1)): true, ((0, 1)): false }
   /// Expect: [false, true]
   stdoutWriteln(map2.values().toString())
-})()
+}
 
 // Map#entries
-(() => {
+if true {
   val map1 = { a: 1, b: 2 }
   /// Expect: #{("b", 2), ("a", 1)}
   stdoutWriteln(map1.entries().toString())
@@ -96,10 +96,10 @@ func printlnBool(b: Bool) = stdoutWriteln(b.toString())
   val map2 = { ((1, 1)): true, ((0, 1)): false }
   /// Expect: #{((1, 1), true), ((0, 1), false)}
   stdoutWriteln(map2.entries().toString())
-})()
+}
 
 // Map#iterator
-(() => {
+if true {
   val m = { a: 1, b: 2, c: 3 }
   val iter = m.iterator()
 
@@ -113,7 +113,7 @@ func printlnBool(b: Bool) = stdoutWriteln(b.toString())
   stdoutWriteln(iter.next().toString())
   /// Expect: Option.None
   stdoutWriteln(iter.next().toString())
-})()
+}
 
 // For-loops
 /// Expect: ("c", 3) 0
@@ -124,17 +124,17 @@ for ch, idx in { a: 1, b: 2, c: 3 } {
 }
 
 // Map#containsKey
-(() => {
+if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: true
   stdoutWriteln(m.containsKey(1).toString())
   /// Expect: false
   stdoutWriteln(m.containsKey(3).toString())
-})()
+}
 
 // Map#mapValues
-(() => {
+if true {
   val m1 = { (1): "abc", (2): "defg" }
 
   val m2 = m1.mapValues((_, v) => v + "!")
@@ -144,10 +144,10 @@ for ch, idx in { a: 1, b: 2, c: 3 } {
   val m3 = m1.mapValues((_, v) => v.length)
   /// Expect: { 1: 3, 2: 4 }
   stdoutWriteln(m3.toString())
-})()
+}
 
 // Map#insert (also []= operator)
-(() => {
+if true {
   val m = { a: 1, b: 2 }
   m.insert("c", 3)
   m["d"] = 4
@@ -163,10 +163,10 @@ for ch, idx in { a: 1, b: 2, c: 3 } {
   stdoutWriteln(m.toString())
   /// Expect: false
   stdoutWriteln(m._needsResize().toString())
-})()
+}
 
 // Map#get
-(() => {
+if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: Option.Some(value: "a")
@@ -175,10 +175,10 @@ for ch, idx in { a: 1, b: 2, c: 3 } {
   stdoutWriteln(m.get(2).toString())
   /// Expect: Option.None
   stdoutWriteln(m.get(3).toString())
-})()
+}
 
 // Map#getOr
-(() => {
+if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: a
@@ -187,10 +187,10 @@ for ch, idx in { a: 1, b: 2, c: 3 } {
   stdoutWriteln(m.getOr(2, "c"))
   /// Expect: c
   stdoutWriteln(m.getOr(3, "c"))
-})()
+}
 
 // Map#getOrElse
-(() => {
+if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: a
@@ -209,10 +209,10 @@ for ch, idx in { a: 1, b: 2, c: 3 } {
     stdoutWriteln("calling default fn")
     "c"
   }))
-})()
+}
 
 // Map#update
-(() => {
+if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: { 1: a, 2: b }
@@ -229,10 +229,10 @@ for ch, idx in { a: 1, b: 2, c: 3 } {
   stdoutWriteln(m.toString())
   /// Expect: Option.None
   stdoutWriteln(old2.toString())
-})()
+}
 
 // Map#remove
-(() => {
+if true {
   val m = {
     a: 1,
     b: 2,
@@ -288,4 +288,4 @@ for ch, idx in { a: 1, b: 2, c: 3 } {
   stdoutWriteln(m.toString())
   /// Expect: 1
   stdoutWriteln(m.size.toString())
-})()
+}

--- a/projects/compiler/test/compiler/match.abra
+++ b/projects/compiler/test/compiler/match.abra
@@ -1,7 +1,7 @@
 func printlnInt(i: Int) = stdoutWriteln(i.toString())
 
 // Basic test (catch-all case)
-(() => {
+if true {
   /// Expect: here
   match "abc" {
     _ => stdoutWriteln("here")
@@ -12,10 +12,10 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
   match "abc" {
     else => stdoutWriteln("here")
   }
-})()
+}
 
 // Testing constant cases
-(() => {
+if true {
   /// Expect: case 1: 1
   /// Expect: case 2: 2
   /// Expect: case 3: 34
@@ -65,10 +65,10 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
   // TODO: remove this, lambda is unhappy to have a for-loop be the last statement for some reason
   /// Expect: done
   stdoutWriteln("done")
-})()
+}
 
 // Testing option type
-(() => {
+if true {
   val arr = [1, 2, 3, 4]
 
   /// Expect: found a number
@@ -173,7 +173,7 @@ func printlnInt(i: Int) = stdoutWriteln(i.toString())
 //     1 => stdoutWriteln(15)
 //     _ => stdoutWriteln(100)
 //   }
-})()
+}
 
 // With enums
 
@@ -184,7 +184,7 @@ enum Color {
   RGB(r: Int, g: Int, b: Int)
 }
 
-(() => {
+if true {
   val colors = [Color.Red, Color.Blue, Color.Green, Color.RGB(r: 1, g: 2, b: 3)]
   /// Expect: red
   /// Expect: blue
@@ -244,10 +244,10 @@ enum Color {
 //   }
 //   /// Expect: Color.RGB(r: 1, g: 2, b: 100)
 //   stdoutWriteln(c)
-})()
+}
 
 // Testing match as expression
-(() => {
+if true {
   val arr = [1, 2, 3, 4]
   val x = match arr[1] {
     None => -1
@@ -262,7 +262,7 @@ enum Color {
   }
   /// Expect: -1
   printlnInt(y)
-})()
+}
 
 // Testing terminator in block
 

--- a/projects/compiler/test/compiler/optionals.abra
+++ b/projects/compiler/test/compiler/optionals.abra
@@ -26,7 +26,7 @@ type Foo {
 // Workaround because optionals technically don't have _any_ directly-callable methods
 func hash<T>(t: T): Int = t.hash()
 // Hashes
-(() => {
+if true {
   val i: Int? = None
   /// Expect: 1
   stdoutWriteln(hash(i).toString())
@@ -34,10 +34,10 @@ func hash<T>(t: T): Int = t.hash()
   val x = Some(17)
   /// Expect: false
   printlnBool(hash(x) == (17).hash())
-})()
+}
 
 // == operator
-(() => {
+if true {
   // Test with primitive
   val i1: Int? = None
   val i2 = Some(17)
@@ -63,10 +63,10 @@ func hash<T>(t: T): Int = t.hash()
   printlnBool(s2 == s4)
   /// Expect: true
   printlnBool(s2 == s3)
-})()
+}
 
 // Coalescing (?:)
-(() => {
+if true {
   val i1: Int? = None
   /// Expect: 17
   stdoutWriteln((i1 ?: 17).toString())
@@ -74,7 +74,7 @@ func hash<T>(t: T): Int = t.hash()
   val i2 = Some(value: 9)
   /// Expect: 9
   stdoutWriteln((i2 ?: 17).toString())
-})()
+}
 
 val xyz = "abc"
 type TestOptChainingMethodInvocation {
@@ -83,7 +83,7 @@ type TestOptChainingMethodInvocation {
 }
 
 // Optional-chaining accessor
-(() => {
+if true {
   val arr = ["a", "b", "c", "d"]
 
 //   // Getting field of known-non-None value
@@ -128,7 +128,7 @@ type TestOptChainingMethodInvocation {
   val t4 = Some(TestOptChainingMethodInvocation())
   /// Expect: Option.Some(value: 3)
   stdoutWriteln(t4?.closure().toString())
-})()
+}
 
 // Negate operator
 val someInt = Some(123)
@@ -151,10 +151,10 @@ enum Color {
   Green
   Blue
 }
-(() => {
+if true {
   val colors = [Color.Red, Color.Green, Color.Blue]
   /// Expect: Option.None
   stdoutWriteln(colors[3]?.toString().toString())
   /// Expect: Option.Some(value: "Color.Blue")
   stdoutWriteln(colors[2]?.toString().toString())
-})()
+}

--- a/projects/compiler/test/compiler/sets.abra
+++ b/projects/compiler/test/compiler/sets.abra
@@ -6,7 +6,7 @@ type Person {
 }
 
 // Test raw construction of set
-(() => {
+if true {
   val set: Set<Int> = Set.new()
   set.insert(1)
   set.insert(2)
@@ -17,10 +17,10 @@ type Person {
   stdoutWriteln(set.size.toString())
   /// Expect: #{1, 2, 3}
   stdoutWriteln(set.toString())
-})()
+}
 
 // Test set literal construction
-(() => {
+if true {
   // Primitives
   val set1 = #{1, 2, 3, 3}
 
@@ -40,10 +40,10 @@ type Person {
   stdoutWriteln(set2.size.toString())
   /// Expect: #{Person(name: "Goo", age: 102), Person(name: "Foo", age: 100), Person(name: "Boo", age: 101)}
   stdoutWriteln(set2.toString())
-})()
+}
 
 // == operator (also Set#eq)
-(() => {
+if true {
   val set = #{1, 2, 3}
 
   /// Expect: true
@@ -52,10 +52,10 @@ type Person {
   printlnBool(#{[1, 2], [3, 4]} == #{[3, 4], [1, 2]})
   /// Expect: false
   printlnBool(set == #{1, 2, 3, 4})
-})()
+}
 
 // Set#isEmpty
-(() => {
+if true {
   val set: Set<Int> = #{}
   /// Expect: true
   stdoutWriteln(set.isEmpty().toString())
@@ -63,10 +63,10 @@ type Person {
   set.insert(1)
   /// Expect: false
   stdoutWriteln(set.isEmpty().toString())
-})()
+}
 
 // Set#iterator
-(() => {
+if true {
   val s = #{"a", "b", "a", "c"}
   val iter = s.iterator()
   /// Expect: Option.Some(value: "c")
@@ -79,7 +79,7 @@ type Person {
   stdoutWriteln(iter.next().toString())
   /// Expect: Option.None
   stdoutWriteln(iter.next().toString())
-})()
+}
 
 // For-loops
 /// Expect: c 0
@@ -90,7 +90,7 @@ for ch, idx in #{"a", "b", "c"} {
 }
 
 // Set#contains
-(() => {
+if true {
   val set: Set<Int> = #{}
   /// Expect: false
   stdoutWriteln(set.contains(1).toString())
@@ -100,65 +100,65 @@ for ch, idx in #{"a", "b", "c"} {
   stdoutWriteln(set.contains(1).toString())
   /// Expect: false
   stdoutWriteln(set.contains(12).toString())
-})()
+}
 
 // Set#forEach
-(() => {
+if true {
   val set = #{1, 17, 0, 16}
   /// Expect: 0
   /// Expect: 16
   /// Expect: 1
   /// Expect: 17
   set.forEach(i => stdoutWriteln(i.toString()))
-})()
+}
 
 // Set#map
-(() => {
+if true {
   val set = #{1, 17, 0, 16}
   /// Expect: [0, 0, 1, 1]
   stdoutWriteln(set.map(i => i % 16).toString())
-})()
+}
 
 // Set#filter
-(() => {
+if true {
   val set = #{1, 17, 0, 16}
   /// Expect: #{16, 17}
   stdoutWriteln(set.filter(i => i >= 16).toString())
-})()
+}
 
 // Set#asArray
-(() => {
+if true {
   val set1 = #{0, 1, 1, 2, 3, 3, 4}
   /// Expect: [0, 1, 2, 3, 4]
   stdoutWriteln(set1.asArray().toString())
-})()
+}
 
 // Set#union
-(() => {
+if true {
   val evens = #{0, 2, 4, 6}
   val odds = #{1, 3, 5, 7}
   /// Expect: #{0, 1, 2, 3, 4, 5, 6, 7}
   stdoutWriteln(evens.union(odds).toString())
   /// Expect: #{0, 1, 2, 3, 4, 5, 6, 7}
   stdoutWriteln(odds.union(evens).toString())
-})()
+}
 
 // Set#difference
-(() => {
+if true {
   val set1 = #{1, 2, 3, 4}
   val set2 = #{0, 2, 3, 5}
   /// Expect: #{1, 4}
   stdoutWriteln(set1.difference(set2).toString())
   /// Expect: #{0, 5}
   stdoutWriteln(set2.difference(set1).toString())
-})()
+}
 
 // Set#intersection
-(() => {
+if true {
   val set1 = #{1, 2, 3, 4}
   val set2 = #{0, 2, 3, 5}
   /// Expect: #{2, 3}
   stdoutWriteln(set1.intersection(set2).toString())
   /// Expect: #{2, 3}
   stdoutWriteln(set2.intersection(set1).toString())
-})()
+}

--- a/projects/compiler/test/compiler/strings.abra
+++ b/projects/compiler/test/compiler/strings.abra
@@ -1,23 +1,11 @@
 func printlnBool(b: Bool) = stdoutWriteln(b.toString())
 
-// // Test raw string construction
-// (() => {
-//   val s = String.withLength(3)
-//   s._buffer.offset(0).store(Byte.fromInt(65))
-//   s._buffer.offset(1).store(Byte.fromInt(66))
-//   s._buffer.offset(2).store(Byte.fromInt(67))
-//   /// Expect: ABC
-//   stdoutWriteln(s)
-//   /// Expect: false
-//   stdoutWriteln(s.isEmpty())
-// })()
-
 // Test literal construction
 /// Expect: hello
 stdoutWriteln("hello")
 
 // + operator
-(() => {
+if true {
   /// Expect: helloworld
   stdoutWriteln("hello" + "world")
   /// Expect: hello12
@@ -36,10 +24,10 @@ stdoutWriteln("hello")
   stdoutWriteln("hello" + [1, 2, 3])
   /// Expect: [1, 2, 3]hello
   stdoutWriteln([1, 2, 3] + "hello")
-})()
+}
 
 // == operator (also String#eq)
-(() => {
+if true {
   val s1 = "string"
   /// Expect: true
   printlnBool(s1 == s1)
@@ -50,17 +38,17 @@ stdoutWriteln("hello")
   printlnBool(s1 != s1)
   /// Expect: true
   printlnBool(s1 != "string!")
-})()
+}
 
 // Interpolation
-(() => {
+if true {
   val array = [1, 2, 3]
   /// Expect: length of [1, 2, 3] is 3
   stdoutWriteln("length of $array is ${array.length}")
-})()
+}
 
 // String#replaceAll(pattern: String, replacement: String)
-(() => {
+if true {
   /// Expect: LLaaLLa
   stdoutWriteln("laala".replaceAll("l", "LL"))
 
@@ -96,10 +84,10 @@ stdoutWriteln("hello")
 
   // /// Expect: "hello"
   // stdoutWriteln("\"hello\"".replaceAll("\"", "\\\""))
-})()
+}
 
 // String#chars
-(() => {
+if true {
   val chars = "hello".chars()
   /// Expect: h 0
   /// Expect: e 1
@@ -112,10 +100,10 @@ stdoutWriteln("hello")
 
   /// Expect: done
   stdoutWriteln("done")
-})()
+}
 
 // Indexing (also String#get(index: Int))
-(() => {
+if true {
   val s1 = "abc"
 
   /// Expect: |  a b c a b c  |
@@ -131,10 +119,10 @@ stdoutWriteln("hello")
 
   /// Expect:   end
   stdoutWriteln("${s2[5]} ${s2[-6]} end")
-})()
+}
 
 // Range indexing (also String#getRange(startIndex: Int, endIndex: Int))
-(() => {
+if true {
   val s = "hello"
 
   /// Expect: ell ell
@@ -154,10 +142,10 @@ stdoutWriteln("hello")
 
   /// Expect: ello h
   stdoutWriteln("${s[a:]} ${s[:a]}")
-})()
+}
 
 // String#hash
-(() => {
+if true {
   val empty = ""
   /// Expect: true
   printlnBool(empty.hash() == "".hash())
@@ -165,10 +153,10 @@ stdoutWriteln("hello")
   val nonEmpty = "hello"
   /// Expect: true
   printlnBool(nonEmpty.hash() == "hello".hash())
-})()
+}
 
 // String#isEmpty
-(() => {
+if true {
   val empty = ""
   /// Expect: true
   stdoutWriteln(empty.isEmpty().toString())
@@ -176,26 +164,26 @@ stdoutWriteln("hello")
   val nonEmpty = "hello"
   /// Expect: false
   stdoutWriteln(nonEmpty.isEmpty().toString())
-})()
+}
 
 // String#toLower
-(() => {
+if true {
   /// Expect: ||
   stdoutWriteln("|" + "".toLower() + "|")
   /// Expect: -hello!
   stdoutWriteln("-hElLo!".toLower())
-})()
+}
 
 // String#toUpper
-(() => {
+if true {
   /// Expect: ||
   stdoutWriteln("|" + "".toUpper() + "|")
   /// Expect: -HELLO!
   stdoutWriteln("-hElLo!".toUpper())
-})()
+}
 
 // String#split
-(() => {
+if true {
   /// Expect: [a, s, d, f]
   stdoutWriteln("a s d f".split(by: " ").toString())
 
@@ -210,10 +198,10 @@ stdoutWriteln("hello")
 
   /// Expect: [asdf]
   stdoutWriteln("asdf".split("qwer").toString())
-})()
+}
 
 // String#lines
-(() => {
+if true {
   /// Expect: [a s d f]
   stdoutWriteln("a s d f".lines().toString())
 
@@ -222,10 +210,10 @@ stdoutWriteln("hello")
 
   /// Expect: [a, s, d, f]
   stdoutWriteln("a\ns\nd\nf".lines().toString())
-})()
+}
 
 // String#startsWith
-(() => {
+if true {
   /// Expect: true
   stdoutWriteln("".startsWith("").toString())
   /// Expect: true
@@ -238,10 +226,10 @@ stdoutWriteln("hello")
   stdoutWriteln("hello".startsWith("hex").toString())
   /// Expect: false
   stdoutWriteln("hello".startsWith("hhello").toString())
-})()
+}
 
 // String#endsWith
-(() => {
+if true {
   /// Expect: true
   stdoutWriteln("".endsWith("").toString())
   /// Expect: true
@@ -254,10 +242,10 @@ stdoutWriteln("hello")
   stdoutWriteln("hello".endsWith("lo!").toString())
   /// Expect: false
   stdoutWriteln("hello".endsWith("hhello").toString())
-})()
+}
 
 // String#repeat
-(() => {
+if true {
   /// Expect: ||
   stdoutWriteln("|" + "abc".repeat(0) + "|")
 
@@ -266,4 +254,4 @@ stdoutWriteln("hello")
 
   /// Expect: abcabcabc
   stdoutWriteln("abc".repeat(3))
-})()
+}

--- a/projects/compiler/test/compiler/tuples.abra
+++ b/projects/compiler/test/compiler/tuples.abra
@@ -22,11 +22,9 @@ stdoutWriteln(quad[3][0].toString())
 // stdoutWriteln(quad.hash() == (1, "two", ["three"], (2, 3)).hash())
 
 // == operator
-(() => {
-  val t1 = (1, "abc", [true, false])
+val t1 = (1, "abc", [true, false])
 
-  /// Expect: true
-  printlnBool(t1 == (1, "abc", [true, false]))
-  /// Expect: true
-  printlnBool((1, "two", [3]) == (1, "tw" + "o", [2 + 1]))
-})()
+/// Expect: true
+printlnBool(t1 == (1, "abc", [true, false]))
+/// Expect: true
+printlnBool((1, "two", [3]) == (1, "tw" + "o", [2 + 1]))

--- a/projects/lsp/src/main.abra
+++ b/projects/lsp/src/main.abra
@@ -49,7 +49,7 @@ func main() {
     val input = if chunk.startsWith(contentLengthHeader) {
       val chars = chunk.chars()
       // skip content-length header
-      for _ in range(0, contentLengthHeader.length) chars.next()
+      for _ in 0:(contentLengthHeader.length) chars.next()
       var offset = contentLengthHeader.length
 
       // parse content-length as integer (can assume ascii encoding)

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -306,7 +306,7 @@ type String {
 
     val str = String.withLength(length)
 
-    for i in range(0, length) {
+    for i in 0:length {
       val ch = choices._buffer.loadAt(libc.rand() % choices.length)
       str._buffer.storeAt(ch, i)
     }
@@ -332,7 +332,7 @@ type String {
 
   pub func hash(self): Int {
     var hash = 31 * self.length
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val byte = self._buffer.loadAt(i)
       hash = hash + 31 * byte.asInt()
     }
@@ -342,7 +342,7 @@ type String {
   pub func eq(self, other: String): Bool {
     if self.length != other.length { return false }
 
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val selfCh = self._buffer.loadAt(i).asInt()
       val otherCh = other._buffer.loadAt(i).asInt()
       if selfCh != otherCh { return false }
@@ -365,7 +365,7 @@ type String {
 
   pub func toLower(self): String {
     val str = String.withLength(self.length)
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val ch = self._buffer.loadAt(i).asInt()
       val lowerCh = if 65 <= ch && ch <= 90 {
         ch + 32
@@ -380,7 +380,7 @@ type String {
 
   pub func toUpper(self): String {
     val str = String.withLength(self.length)
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val ch = self._buffer.loadAt(i).asInt()
       val upperCh = if 97 <= ch && ch <= 122 {
         ch - 32
@@ -622,7 +622,7 @@ type String {
     if times <= 0 return ""
 
     val str = String.withLength(self.length * times)
-    for i in range(0, times) {
+    for i in 0:times {
       str._buffer.copyFrom(self.length * i, self._buffer, 0, self.length)
     }
     str
@@ -655,7 +655,7 @@ type Array<T> {
 
   pub func fill<T>(length: Int, value: T): T[] {
     val buffer = Pointer.malloc<T>(length)
-    for i in range(0, length) {
+    for i in 0:length {
       buffer.storeAt(value, i)
     }
 
@@ -664,7 +664,7 @@ type Array<T> {
 
   pub func fillBy<T>(length: Int, fn: (Int) => T): T[] {
     val buffer = Pointer.malloc<T>(length)
-    for i in range(0, length) {
+    for i in 0:length {
       val item = fn(i)
       buffer.storeAt(item, i)
     }
@@ -717,7 +717,7 @@ type Array<T> {
 
   pub func hash(self): Int {
     var hash = 31 * self.length
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       hash = hash + 31 * item.hash()
     }
@@ -727,7 +727,7 @@ type Array<T> {
   pub func eq(self, other: Array<T>): Bool {
     if self.length != other.length return false
 
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val selfItem = self._buffer.loadAt(i)
       val otherItem = other._buffer.loadAt(i)
 
@@ -776,7 +776,7 @@ type Array<T> {
 
   pub func map<U>(self, fn: (T, Int) => U): U[] {
     val newArray: U[] = Array.withCapacity(self.length)
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       val result = fn(item, i)
       newArray.push(result)
@@ -787,7 +787,7 @@ type Array<T> {
 
   pub func flatMap<U>(self, fn: (T, Int) => U[]): U[] {
     val newArray: U[] = Array.withCapacity(self.length)
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       val result = fn(item, i)
       for resultItem in result {
@@ -800,7 +800,7 @@ type Array<T> {
 
   pub func filter(self, fn: (T, Int) => Bool): T[] {
     val newArray: T[] = Array.withCapacity(self.length)
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       if fn(item, i) {
         newArray.push(item)
@@ -812,7 +812,7 @@ type Array<T> {
 
   pub func reduce<U>(self, initialValue: U, fn: (U, T, Int) => U): U {
     var acc = initialValue
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       acc = fn(acc, item, i)
     }
@@ -821,7 +821,7 @@ type Array<T> {
   }
 
   pub func forEach(self, fn: (T, Int) => Unit) {
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       fn(item, i)
     }
@@ -830,7 +830,7 @@ type Array<T> {
   pub func join(self, joiner = ""): String {
     val reprs: String[] = Array.withCapacity(self.length)
     var length = 0
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       val repr = item.toString()
       reprs.push(repr)
@@ -842,7 +842,7 @@ type Array<T> {
 
     val str = String.withLength(length)
     var offset = 0
-    for i in range(0, reprs.length) {
+    for i in 0:reprs.length {
       val repr = reprs._buffer.loadAt(i)
       str._buffer.copyFrom(offset, repr._buffer, 0, repr.length)
       offset += repr.length
@@ -856,7 +856,7 @@ type Array<T> {
   }
 
   pub func contains(self, item: T): Bool {
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val selfItem = self._buffer.loadAt(i)
       if selfItem == item return true
     }
@@ -865,7 +865,7 @@ type Array<T> {
   }
 
   pub func find(self, fn: (T) => Bool): T? {
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       if fn(item) return Some(item)
     }
@@ -874,7 +874,7 @@ type Array<T> {
   }
 
   pub func findIndex(self, fn: (T) => Bool): (T, Int)? {
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       if fn(item) return Some((item, i))
     }
@@ -883,7 +883,7 @@ type Array<T> {
   }
 
   pub func any(self, fn: (T) => Bool): Bool {
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       if fn(item) return true
     }
@@ -892,7 +892,7 @@ type Array<T> {
   }
 
   pub func all(self, fn: (T) => Bool): Bool {
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       if !fn(item) return false
     }
@@ -971,7 +971,7 @@ type Array<T> {
   pub func keyBy<U>(self, fn: (T) => U): Map<U, T> {
     val map: Map<U, T> = Map.new()
 
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       val key = fn(item)
       map[key] = item
@@ -983,7 +983,7 @@ type Array<T> {
   pub func indexBy<U>(self, fn: (T) => U): Map<U, T[]> {
     val map: Map<U, T[]> = Map.new()
 
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       val key = fn(item)
       if map[key] |arr| {
@@ -999,7 +999,7 @@ type Array<T> {
   pub func asSet(self): Set<T> {
     val set: Set<T> = Set.new()
 
-    for i in range(0, self.length) {
+    for i in 0:self.length {
       val item = self._buffer.loadAt(i)
       set.insert(item)
     }
@@ -1240,7 +1240,7 @@ type Map<K, V> {
     }
 
     val entries: MapEntry<K, V>[] = Array.withCapacity(capacity)
-    for _ in range(0, capacity) {
+    for _ in 0:capacity {
       entries.push(MapEntry.empty())
     }
 
@@ -1259,7 +1259,7 @@ type Map<K, V> {
     if self.isEmpty() return "{}"
 
     val reprs: String[] = Array.withCapacity(self.size)
-    for i in range(0, self._entries.length) {
+    for i in 0:self._entries.length {
       if self._entries[i] |bucket| {
         if bucket._empty continue
 
@@ -1278,7 +1278,7 @@ type Map<K, V> {
   pub func eq(self, other: Map<K, V>): Bool {
     if self.size != other.size return false
 
-    for i in range(0, self._entries.length) {
+    for i in 0:self._entries.length {
       if self._entries[i] |bucket| {
         if bucket._empty continue
 
@@ -1303,7 +1303,7 @@ type Map<K, V> {
   pub func isEmpty(self): Bool = self.size == 0
 
   pub func forEach(self, fn: (K, V) => Unit) {
-    for i in range(0, self._entries.length) {
+    for i in 0:self._entries.length {
       if self._entries[i] |bucket| {
         if bucket._empty continue
 
@@ -1353,7 +1353,7 @@ type Map<K, V> {
 
   pub func mapValues<U>(self, fn: (K, V) => U): Map<K, U> {
     val newMap: Map<K, U> = Map.new()
-    for i in range(0, self._entries.length) {
+    for i in 0:self._entries.length {
       if self._entries[i] |bucket| {
         if bucket._empty continue
 
@@ -1417,7 +1417,7 @@ type Map<K, V> {
     val newCapacity = self._capacity * 2
 
     val newEntries: MapEntry<K, V>[] = Array.withCapacity(newCapacity)
-    for _ in range(0, newCapacity) {
+    for _ in 0:newCapacity {
       newEntries.push(MapEntry.empty())
     }
 

--- a/projects/std/src/process.abra
+++ b/projects/std/src/process.abra
@@ -10,7 +10,7 @@ pub func args(): String[] {
   val argv = intrinsics.argv()
 
   val args: String[] = Array.withCapacity(argc)
-  for i in range(0, argc) {
+  for i in 0:argc {
     val str = argv.loadAt(i)
     val len = libc.strlen(str)
     args.push(String(length: len, _buffer: str))


### PR DESCRIPTION
Replace nearly all instances of `range()` in for-loops with the simplified special ranged for-loop form. This is cleaner and also much more efficient, and almost entirely removes the need for the `range` function. It also greatly simplifies IR generation for for-loops, since it does not require any complex iterator logic to be implemented in order to get started.
Also, this removes all of the anonymous lambdas that had been created during the compiler tests - instead it replaced it with `if true {...}` construction, which is effectively just an isolated scope. In the future, this may be replaced with a construction like `do { ... }`, but more likely it'll be replaced with some kind of built-in testing capabilities.