### PR TITLE
CLI: Building the cli natively, rather than sh

### DIFF
--- a/projects/cli/cmd/build.abra
+++ b/projects/cli/cmd/build.abra
@@ -1,0 +1,124 @@
+import "process" as process
+import "fs" as fs
+import "libc" as libc
+import Path from "path"
+import ModuleLoader, Project, Typechecker, TypedModule from "../../compiler/src/typechecker"
+import Compiler from "../../compiler/src/compiler"
+
+pub type BuildCmd {
+  pub outputFile: String?
+  pub run: Bool
+  pub inputFile: String
+  pub programArguments: String[]
+}
+
+func typecheck(stdRoot: String, filePath: Path): Project {
+  val moduleLoader = ModuleLoader(stdRoot: stdRoot)
+  val project = Project()
+  val typechecker = Typechecker(moduleLoader: moduleLoader, project: project)
+
+  typechecker.typecheckEntrypoint(filePath.asString())
+
+  val readFileErrors: String[] = []
+  val errorMessages: String[] = []
+  for mod in project.modules.values().sortBy(m => -m.id) {
+    if mod.readFileError {
+      readFileErrors.push(mod.name)
+      continue
+    }
+
+    val contents = try moduleLoader.loadFileContents(mod.name) else {
+      // Any unreadable modules should have had the `readFileError` field set, which is checked above
+      unreachable("Could not read file '${mod.name}'")
+    }
+
+    for err in mod.lexParseErrors {
+      errorMessages.push(err.getMessage(mod.name, contents))
+    }
+
+    for err in mod.typeErrors {
+      errorMessages.push(err.getMessage(mod.name, contents))
+    }
+  }
+
+  if !errorMessages.isEmpty() {
+    for msg, idx in errorMessages {
+      stdoutWriteln(msg)
+      if idx != errorMessages.length - 1 stdoutWriteln("") // spacer
+    }
+    process.exit(1)
+  } else if !readFileErrors.isEmpty() {
+    for path, idx in readFileErrors {
+      stdoutWriteln("Could not read file '$path'")
+      if idx != readFileErrors.length - 1 stdoutWriteln("") // spacer
+    }
+    process.exit(1)
+  }
+
+  project
+}
+
+pub func build(cmd: BuildCmd) {
+  val abraStdRoot = try process.getEnvVar("ABRA_HOME") else {
+    stdoutWriteln("Could not find ABRA_HOME (make sure \$ABRA_HOME environment variable is set)")
+    process.exit(1)
+  }
+
+  val inputPath = Path.fromString(cmd.inputFile)
+  val project = typecheck(abraStdRoot, inputPath)
+
+  val builder = try Compiler.compile(project) else |e| {
+    stdoutWriteln(e.getMessage())
+    process.exit(1)
+  }
+
+  val cwd = fs.getCurrentWorkingDirectory()
+  val dotAbraDir = "$cwd/._abra"
+  val outFileName = cmd.outputFile ?: (try inputPath.segments[-1] else unreachable()).replaceAll(".abra", "") //"_main"
+
+  val ssaOutPath = "$dotAbraDir/$outFileName.ssa"
+  val ssaOutFile = try fs.File.create(ssaOutPath) else |e| {
+    stdoutWriteln(e.toString())
+    process.exit(1)
+  }
+
+  builder.writeToFile(ssaOutFile)
+  ssaOutFile.close()
+
+  val objOutPath = "$dotAbraDir/$outFileName.s"
+  val qbeCmdRes = process.Command(program: "qbe")
+    .addArg("-o").addArg(objOutPath)
+    .addArg(ssaOutPath)
+    .execAndCaptureOutput()
+  if !qbeCmdRes.status.isSuccess() {
+    stdoutWriteln("qbe error:")
+    stdoutWriteln(qbeCmdRes.stderr)
+    process.exit(1)
+  }
+
+  val execOutPath = "$dotAbraDir/$outFileName"
+  val clangCmdRes = process.Command(program: "clang")
+    .addArg("/Users/kengorab/.abra/include/libgc.a")
+    .addArg(objOutPath)
+    .addArg("-o").addArg(execOutPath)
+    .addArg("-lm")
+    .addArg("-Wno-override-module")
+    .addArg("-Wl,-w")
+    .execAndCaptureOutput()
+  if !clangCmdRes.status.isSuccess() {
+    stdoutWriteln("clang error:")
+    stdoutWriteln(clangCmdRes.stderr)
+    process.exit(1)
+  }
+
+  if cmd.run {
+    val runCmdRes = process.Command(program: execOutPath, arguments: cmd.programArguments)
+      .execAndCaptureOutput()
+    if !runCmdRes.status.isSuccess() {
+      stdoutWriteln(runCmdRes.stderr)
+      process.exit(1)
+    }
+
+    stdoutWriteln(runCmdRes.stdout)
+  }
+}

--- a/projects/cli/example4.ssa
+++ b/projects/cli/example4.ssa
@@ -1,0 +1,241 @@
+data $__argc = { l 0 }
+data $__argv = { l 0 }
+data $__callstack = { z 8192 }
+data $__callstackp = { l 0 }
+data $__modnames = { b "/Users/kennethg/.abra/std/_intrinsics.abra", b 0, b "/Users/kennethg/.abra/std/libc.abra", b 0, b "/Users/kennethg/.abra/std/prelude.abra", b 0, b "/Users/kennethg/Desktop/abra-lang/projects/compiler/example.abra", b 0, b 0 }
+data $__fnnames = { b "stdoutWrite", b 0, b "String.toString", b 0, b "stdoutWriteln", b 0, b 0 }
+data $mod1_EFAULT.slot = { l 0 }
+data $mod1_EMFILE.slot = { l 0 }
+data $mod1_ENFILE.slot = { l 0 }
+data $mod1_O_RDONLY.slot = { l 0 }
+data $mod1_O_WRONLY.slot = { l 0 }
+data $mod1_O_RDWR.slot = { l 0 }
+data $mod1_O_CREAT.slot = { l 0 }
+data $mod1_SEEK_SET.slot = { l 0 }
+data $mod1_SEEK_CUR.slot = { l 0 }
+data $mod1_SEEK_END.slot = { l 0 }
+data $mod1_STDIN_FILENO.slot = { l 0 }
+data $mod1_STDOUT_FILENO.slot = { l 0 }
+data $mod1_STDERR_FILENO.slot = { l 0 }
+data $mod1_PATH_MAX.slot = { l 0 }
+data $_20 = { b "asdf", b 0 }
+data $_21 = { b "\n", b 0 }
+data $_22 = { b ":", b 0 }
+
+# main entrypoint function
+export function w $main(l %argc, l %argv) {
+@start
+  storel %argc, $__argc
+  storel %argv, $__argv
+  %_0 =l call $time(l 0)
+  call $srand(l %_0)
+  call $GC_init()
+  call $..module_0()
+  call $..module_1()
+  call $..module_2()
+  call $..module_3()
+  ret 0
+}
+
+# /Users/kennethg/.abra/std/_intrinsics.abra
+function  $..module_0() {
+@start
+  ret 
+}
+
+# /Users/kennethg/.abra/std/libc.abra
+function  $..module_1() {
+@start
+  storel 14, $mod1_EFAULT.slot
+  storel 24, $mod1_EMFILE.slot
+  storel 23, $mod1_ENFILE.slot
+  storel 0, $mod1_O_RDONLY.slot
+  storel 1, $mod1_O_WRONLY.slot
+  storel 2, $mod1_O_RDWR.slot
+  storel 512, $mod1_O_CREAT.slot
+  storel 0, $mod1_SEEK_SET.slot
+  storel 1, $mod1_SEEK_CUR.slot
+  storel 2, $mod1_SEEK_END.slot
+  storel 0, $mod1_STDIN_FILENO.slot
+  storel 1, $mod1_STDOUT_FILENO.slot
+  storel 2, $mod1_STDERR_FILENO.slot
+  storel 4096, $mod1_PATH_MAX.slot
+  ret 
+}
+
+# /Users/kennethg/.abra/std/prelude.abra
+function  $..module_2() {
+@start
+  ret 
+}
+
+# /Users/kennethg/Desktop/abra-lang/projects/compiler/example.abra
+function  $..module_3() {
+@start
+  %_0 =l call $.2.String.init(l 4, l $_20)
+  %s.0.slot =l alloc8 1
+  storel %_0, %s.0.slot
+  # begin string interpolation...
+  %_1 =l call $.2.String.init(l 1, l $_22)
+  # begin __callstack push...
+  %_2 =l loadl $__callstackp
+  %_3 =l add %_2, $__callstack
+  storel 8590196749, %_3
+  %_4 =l add 8, %_2
+  storel %_4, $__callstackp
+  # ...__callstack push end
+  %_5 =l call $.2.String..toString(l %_1)
+  # begin __callstack pop...
+  %_6 =l loadl $__callstackp
+  %_7 =l sub %_6, 8
+  storel %_7, $__callstackp
+  # ...__callstack pop end
+  %_8 =l loadl %_5
+  %_9 =l add 0, %_8
+  %_10 =l loadl %s.0.slot
+  # begin __callstack push...
+  %_11 =l loadl $__callstackp
+  %_12 =l add %_11, $__callstack
+  storel 8590196749, %_12
+  %_13 =l add 8, %_11
+  storel %_13, $__callstackp
+  # ...__callstack push end
+  %_14 =l call $.2.String..toString(l %_10)
+  # begin __callstack pop...
+  %_15 =l loadl $__callstackp
+  %_16 =l sub %_15, 8
+  storel %_16, $__callstackp
+  # ...__callstack pop end
+  %_17 =l loadl %_14
+  %_18 =l add %_9, %_17
+  %_19 =l call $.2.String.init(l 1, l $_22)
+  # begin __callstack push...
+  %_20 =l loadl $__callstackp
+  %_21 =l add %_20, $__callstack
+  storel 8590196749, %_21
+  %_22 =l add 8, %_20
+  storel %_22, $__callstackp
+  # ...__callstack push end
+  %_23 =l call $.2.String..toString(l %_19)
+  # begin __callstack pop...
+  %_24 =l loadl $__callstackp
+  %_25 =l sub %_24, 8
+  storel %_25, $__callstackp
+  # ...__callstack pop end
+  %_26 =l loadl %_23
+  %_27 =l add %_18, %_26
+  %_28 =l call $.2.String..withLength(l %_27)
+  %_29 =l add 8, %_28
+  %_30 =l loadl %_29
+  %_31 =l loadl %_5
+  %_32 =l add 8, %_5
+  %_33 =l loadl %_32
+  call $memcpy(l %_30, l %_33, l %_31)
+  %_34 =l add %_30, %_31
+  %_35 =l loadl %_14
+  %_36 =l add 8, %_14
+  %_37 =l loadl %_36
+  call $memcpy(l %_34, l %_37, l %_35)
+  %_38 =l add %_34, %_35
+  %_39 =l loadl %_23
+  %_40 =l add 8, %_23
+  %_41 =l loadl %_40
+  call $memcpy(l %_38, l %_41, l %_39)
+  %_42 =l add %_38, %_39
+  # ...string interpolation end
+  # begin __callstack push...
+  %_43 =l loadl $__callstackp
+  %_44 =l add %_43, $__callstack
+  storel 12885164045, %_44
+  %_45 =l add 8, %_43
+  storel %_45, $__callstackp
+  # ...__callstack push end
+  call $.stdoutWriteln(l %_28)
+  # begin __callstack pop...
+  %_46 =l loadl $__callstackp
+  %_47 =l sub %_46, 8
+  storel %_47, $__callstackp
+  # ...__callstack pop end
+  ret 
+}
+
+# type String {
+#   length: Int
+#   _buffer: Pointer<Byte>
+# }
+function l $.2.String.init(l %length, l %_buffer) {
+@start
+  %struct.mem =l call $GC_malloc(l 16)
+  %mem_offset_length =l add 0, %struct.mem
+  storel %length, %mem_offset_length
+  %mem_offset__buffer =l add 8, %struct.mem
+  storel %_buffer, %mem_offset__buffer
+  ret %struct.mem
+}
+
+# stdoutWriteln(str: String)
+function  $.stdoutWriteln(l %str) {
+@start
+  # begin __callstack push...
+  %_0 =l loadl $__callstackp
+  %_1 =l add %_0, $__callstack
+  storel 4295163916, %_1
+  %_2 =l add 8, %_0
+  storel %_2, $__callstackp
+  # ...__callstack push end
+  call $.stdoutWrite(l %str)
+  # begin __callstack pop...
+  %_3 =l loadl $__callstackp
+  %_4 =l sub %_3, 8
+  storel %_4, $__callstackp
+  # ...__callstack pop end
+  %_5 =l call $.2.String.init(l 1, l $_21)
+  # begin __callstack push...
+  %_6 =l loadl $__callstackp
+  %_7 =l add %_6, $__callstack
+  storel 4295163917, %_7
+  %_8 =l add 8, %_6
+  storel %_8, $__callstackp
+  # ...__callstack push end
+  call $.stdoutWrite(l %_5)
+  # begin __callstack pop...
+  %_9 =l loadl $__callstackp
+  %_10 =l sub %_9, 8
+  storel %_10, $__callstackp
+  # ...__callstack pop end
+  ret 
+}
+
+# stdoutWrite(str: String)
+function  $.stdoutWrite(l %str) {
+@start
+  # %str: String
+  %_0 =l loadl $mod1_STDOUT_FILENO.slot
+  %_1 =l add 8, %str
+  # %str: String
+  # %_2: %str._buffer
+  %_2 =l loadl %_1
+  %_3 =l add 0, %str
+  # %_4: %str.length
+  %_4 =l loadl %_3
+  %_5 =l call $write(l %_0, l %_2, l %_4)
+  ret 
+}
+
+# String#toString(self): String
+function l $.2.String..toString(l %self) {
+@start
+  ret %self
+}
+
+# String.withLength(length: Int): String
+function l $.2.String..withLength(l %length) {
+@start
+  # begin pointer_malloc...
+  %_0 =l add %length, 1
+  %_1 =l mul 1, %_0
+  %ptr.mem =l call $GC_malloc(l %_1)
+  # ...pointer_malloc end
+  %_2 =l call $.2.String.init(l %length, l %ptr.mem)
+  ret %_2
+}

--- a/projects/cli/foo.c
+++ b/projects/cli/foo.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <time.h>
+
+extern int errno;
+
+int main() {
+    printf("EFAULT=%d\n", EFAULT);
+    printf("EMFILE=%d\n", EMFILE);
+    printf("ENFILE=%d\n", ENFILE);
+
+    printf("O_CREAT=%d\n", O_CREAT);
+    printf("O_TRUNC=%d\n", O_TRUNC);
+
+    // char filename[256];
+    // snprintf(filename, sizeof(filename), "/Users/kennethg/Desktop/abra-lang/projects/cli/._abra/example%ld.ssa", time(NULL));
+    // mode_t m = umask(0);
+    // printf("opening file...\n");
+    char* filename = "/Users/kennethg/Desktop/abra-lang/projects/cli/._abra/example2.ssa";
+    if (open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644) < 0) {
+        perror("failed to create file");
+        return 1;
+    }
+    // umask(m);
+
+    // pid_t pid = fork();
+    
+    // if (pid == -1) {
+    //     perror("fork failed");
+    //     exit(1);
+    // }
+    
+    // if (pid == 0) {
+    //     // Child process
+    //     char *args[] = {"ls", "-l", NULL};
+        
+    //     printf("Child: About to execute 'ls -l'\n");
+    //     execvp("ls", args);
+        
+    //     // This line will only execute if execvp fails
+    //     perror("execvp failed");
+    //     exit(1);
+    // } else {
+    //     // Parent process
+    //     int status;
+    //     wait(&status);
+    //     printf("Parent: Child process completed (status=%d)\n", status);
+    // }
+    
+    return 0;
+}

--- a/projects/cli/main.abra
+++ b/projects/cli/main.abra
@@ -1,0 +1,136 @@
+import "process" as process
+import BuildCmd, build from "./cmd/build"
+
+enum SubcommandParseError {
+  NoCommand
+  MissingRequiredValue(name: String, subcommand: String? = None)
+  MissingRequiredPositionalArg(name: String, subcommand: String? = None)
+  UnknownFlag(name: String, subcommand: String? = None)
+}
+
+type DefaultCmd {
+  inputFile: String
+  programArguments: String[]
+}
+
+enum Subcommand {
+  Help
+  Build(inner: BuildCmd)
+  Default(inner: DefaultCmd)
+
+  func printUsage() {
+    stdoutWriteln("USAGE")
+    stdoutWriteln("  abra <file-path> [<program-args>...]")
+    stdoutWriteln("  abra [subcommand]")
+    stdoutWriteln()
+    stdoutWriteln("DEFAULT MODE              Compiles and runs abra source file")
+    stdoutWriteln("  USAGE")
+    stdoutWriteln("    abra <file-path> [<program-args>...]")
+    stdoutWriteln("  ARGS")
+    stdoutWriteln("    <file-path>           Path to the abra root source file to build and run")
+    stdoutWriteln("    <program-args>...     Arguments to pass to the built abra program when running")
+    stdoutWriteln()
+    stdoutWriteln("SUBCOMMANDS")
+    stdoutWriteln("  help/-h                 Prints this usage info")
+    stdoutWriteln("    USAGE")
+    stdoutWriteln("      abra help")
+    stdoutWriteln("      abra -h")
+    stdoutWriteln()
+    stdoutWriteln("  build                   Compiles the abra source file to selected target")
+    stdoutWriteln("    USAGE")
+    stdoutWriteln("      abra build [OPTIONS] <input-path> [<program-args>...]")
+    stdoutWriteln("    OPTIONS")
+    stdoutWriteln("      -r/--run            Run after building, forwarding <program-args>")
+    stdoutWriteln("      -o <out-path>       Where the built artifact should be placed")
+    stdoutWriteln("    ARGS")
+    stdoutWriteln("      <file-path>         Path to the abra root source file to build")
+    stdoutWriteln("      <program-args>...   Arguments to pass to the built abra program if [-r/--run] is passed;")
+    stdoutWriteln("                          will be discarded if [-r/--run] is not passed")
+  }
+
+  func parse(programArguments: String[]): Result<Subcommand, SubcommandParseError> {
+    val args = programArguments.iterator()
+
+    val progName = try args.next() else unreachable("prog name is always first arg")
+
+    val subcommand = try args.next() else return Err(SubcommandParseError.NoCommand)
+    match subcommand {
+      "help" => Ok(Subcommand.Help)
+      "-h" => Ok(Subcommand.Help)
+      "build" => {
+        var outputFile: String? = None
+        var run = false
+        var inputFileArg: String? = None
+
+        while true {
+          match args.next() {
+            "-o" => {
+              val dir = try args.next() else return Err(SubcommandParseError.MissingRequiredValue("-o", Some("build")))
+              outputFile = Some(dir)
+            }
+            "-r" => run = true
+            "--run" => run = true
+            None => break
+            else arg => {
+              if arg.startsWith("-") return Err(SubcommandParseError.UnknownFlag(arg, Some("build")))
+
+              inputFileArg = Some(arg)
+              break
+            }
+          }
+        }
+        val inputFile = try inputFileArg else return Err(SubcommandParseError.MissingRequiredPositionalArg("input file", Some("build")))
+
+        val programArgs: String[] = []
+        while args.next() |arg| programArgs.push(arg)
+
+        val cmd = BuildCmd(outputFile: outputFile, run: run, inputFile: inputFile, programArguments: programArgs)
+        Ok(Subcommand.Build(cmd))
+      }
+      else arg => {
+        if arg.startsWith("-") return Err(SubcommandParseError.UnknownFlag(arg))
+
+        val programArgs: String[] = []
+        while args.next() |arg| programArgs.push(arg)
+
+        val cmd = DefaultCmd(inputFile: arg, programArguments: programArgs)
+        Ok(Subcommand.Default(cmd))
+      }
+    }
+  }
+}
+
+func handleDefault(cmd: DefaultCmd) {
+  
+}
+
+func main() {
+  val cmd = try Subcommand.parse(process.args()) else |err| {
+    var msg = match err {
+      SubcommandParseError.NoCommand => "no command given"
+      SubcommandParseError.MissingRequiredValue(name, cmd) => {
+        val suffix = if cmd |cmd| " for command '$cmd'" else ""
+        "value required for option '$name'$suffix"
+      }
+      SubcommandParseError.MissingRequiredPositionalArg(name, cmd) => {
+        val suffix = if cmd |cmd| " for command '$cmd'" else ""
+        "value required for positional argument '$name'$suffix"
+      }
+      SubcommandParseError.UnknownFlag(name, cmd) => {
+        val suffix = if cmd |cmd| " for command '$cmd'" else ""
+        "unknown flag '$name'$suffix"
+      }
+    }
+    stdoutWriteln("Error: $msg\n")
+
+    Subcommand.printUsage()
+    process.exit(1)
+  }
+
+  match cmd {
+    Subcommand.Help => Subcommand.printUsage()
+    Subcommand.Build(cmd) => build(cmd)
+    Subcommand.Default(cmd) => handleDefault(cmd)
+  }
+}
+main()

--- a/projects/cli/nob.h
+++ b/projects/cli/nob.h
@@ -1,0 +1,2169 @@
+/* nob - v1.20.6 - Public Domain - https://github.com/tsoding/nob.h
+
+   This library is the next generation of the [NoBuild](https://github.com/tsoding/nobuild) idea.
+
+   # Quick Example
+
+      ```c
+      // nob.c
+      #define NOB_IMPLEMENTATION
+      #include "nob.h"
+
+      int main(int argc, char **argv)
+      {
+          NOB_GO_REBUILD_URSELF(argc, argv);
+          Nob_Cmd cmd = {0};
+          nob_cmd_append(&cmd, "cc", "-Wall", "-Wextra", "-o", "main", "main.c");
+          if (!nob_cmd_run_sync(cmd)) return 1;
+          return 0;
+      }
+      ```
+
+      ```console
+      $ cc -o nob nob.c
+      $ ./nob
+      ```
+
+      The `nob` automatically rebuilds itself if `nob.c` is modified thanks to
+      the `NOB_GO_REBUILD_URSELF` macro (don't forget to check out how it works below)
+
+   # The Zoo of `nob_cmd_run_*` Functions
+
+      `Nob_Cmd` is just a dynamic array of strings which represents a command and its arguments.
+      First you append the arguments
+
+      ```c
+      Nob_Cmd cmd = {0};
+      nob_cmd_append(&cmd, "cc", "-Wall", "-Wextra", "-o", "main", "main.c");
+      ```
+
+      Then you run it
+
+      ```c
+      if (!nob_cmd_run_sync(cmd)) return 1;
+      ```
+
+      `*_sync` at the end indicates that the function blocks until the command finishes executing
+      and returns `true` on success and `false` on failure. You can run the command asynchronously
+      but you have to explitictly wait for it afterwards:
+
+      ```c
+      Nob_Proc p = nob_cmd_run_async(cmd);
+      if (p == NOB_INVALID_PROC) return 1;
+      if (!nob_proc_wait(p)) return 1;
+      ```
+
+      One of the problems with running commands like that is that `Nob_Cmd` still contains the arguments
+      from the previously run command. If you want to reuse the same `Nob_Cmd` you have to not forget to reset
+      it
+
+      ```c
+      Nob_Cmd cmd = {0};
+
+      nob_cmd_append(&cmd, "cc", "-Wall", "-Wextra", "-o", "main", "main.c");
+      if (!nob_cmd_run_sync(cmd)) return 1;
+      cmd.count = 0;
+
+      nob_cmd_append(&cmd, "./main", "foo", "bar", "baz");
+      if (!nob_cmd_run_sync(cmd)) return 1;
+      cmd.count = 0;
+      ```
+
+      Which is a bit error prone. To make it a bit easier we have `nob_cmd_run_sync_and_reset()` which
+      accepts `Nob_Cmd` by reference and resets it for you:
+
+      ```c
+      Nob_Cmd cmd = {0};
+
+      nob_cmd_append(&cmd, "cc", "-Wall", "-Wextra", "-o", "main", "main.c");
+      if (!nob_cmd_run_sync_and_reset(&cmd)) return 1;
+
+      nob_cmd_append(&cmd, "./main", "foo", "bar", "baz");
+      if (!nob_cmd_run_sync_and_reset(&cmd)) return 1;
+      ```
+
+      There is of course also `nob_cmd_run_async_and_reset()` to maintain the pattern.
+
+      The stdin, stdout and stderr of any command can be redirected by using `Nob_Cmd_Redirect` structure
+      along with `nob_cmd_run_sync_redirect()` or `nob_cmd_run_async_redirect()`
+
+      ```c
+      // Opening all the necessary files
+      Nob_Fd fdin = nob_fd_open_for_read("input.txt");
+      if (fdin == NOB_INVALID_FD) return 1;
+      Nob_Fd fdout = nob_fd_open_for_write("output.txt");
+      if (fdout == NOB_INVALID_FD) return 1;
+      Nob_Fd fderr = nob_fd_open_for_write("error.txt");
+      if (fderr == NOB_INVALID_FD) return 1;
+
+      // Preparing the command
+      Nob_Cmd cmd = {0};
+      nob_cmd_append(&cmd, "./main", "foo", "bar", "baz");
+
+      // Running the command synchronously redirecting the standard streams
+      bool ok = nob_cmd_run_sync_redirect(cmd, (Nob_Cmd_Redirect) {
+          .fdin = fdin,
+          .fdout = fdout,
+          .fderr = fderr,
+      });
+      if (!ok) return 1;
+
+      // Closing all the files
+      nob_fd_close(fdin);
+      nob_fd_close(fdout);
+      nob_fd_close(fderr);
+
+      // Reseting the command
+      cmd.count = 0;
+      ```
+
+      And of course if you find closing the files and reseting the command annoying we have
+      `nob_cmd_run_sync_redirect_and_reset()` and `nob_cmd_run_async_redirect_and_reset()`
+      which do all of that for you automatically.
+
+      All the Zoo of `nob_cmd_run_*` functions follows the same pattern: sync/async,
+      redirect/no redirect, and_reset/no and_reset. They always come in that order.
+
+   # Stripping off `nob_` Prefixes
+
+      Since Pure C does not have any namespaces we prefix each name of the API with the `nob_` to avoid any
+      potential conflicts with any other names in your code. But sometimes it is very annoying and makes
+      the code noisy. If you know that none of the names from nob.h conflict with anything in your code
+      you can enable NOB_STRIP_PREFIX macro and just drop all the prefixes:
+
+      ```c
+      // nob.c
+      #define NOB_IMPLEMENTATION
+      #define NOB_STRIP_PREFIX
+      #include "nob.h"
+
+      int main(int argc, char **argv)
+      {
+          NOB_GO_REBUILD_URSELF(argc, argv);
+          Cmd cmd = {0};
+          cmd_append(&cmd, "cc", "-Wall", "-Wextra", "-o", "main", "main.c");
+          if (!cmd_run_sync(cmd)) return 1;
+          return 0;
+      }
+      ```
+
+      Not all the names have strippable prefixes. All the redefinable names like `NOB_GO_REBUILD_URSELF`
+      for instance will retain their prefix even if NOB_STRIP_PREFIX is enabled. Notable exception is the
+      nob_log() function. Stripping away the prefix results in log() which was historically always referring
+      to the natural logarithmic function that is already defined in math.h. So there is no reason to strip
+      off the prefix for nob_log(). Another exception is nob_rename() which collides with the widely known
+      POSIX function rename(2) if you strip the prefix off.
+
+      The prefixes are stripped off only on the level of preprocessor. The names of the functions in the
+      compiled object file will still retain the `nob_` prefix. Keep that in mind when you FFI with nob.h
+      from other languages (for whatever reason).
+
+      If only few specific names create conflicts for you, you can just #undef those names after the
+      `#include <nob.h>` since they are macros anyway.
+*/
+
+#ifndef NOB_H_
+#define NOB_H_
+
+#ifndef NOB_ASSERT
+#include <assert.h>
+#define NOB_ASSERT assert
+#endif /* NOB_ASSERT */
+
+#ifndef NOB_REALLOC
+#include <stdlib.h>
+#define NOB_REALLOC realloc
+#endif /* NOB_REALLOC */
+
+#ifndef NOB_FREE
+#include <stdlib.h>
+#define NOB_FREE free
+#endif /* NOB_FREE */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+#include <limits.h>
+
+#ifdef _WIN32
+#    define WIN32_LEAN_AND_MEAN
+#    define _WINUSER_
+#    define _WINGDI_
+#    define _IMM_
+#    define _WINCON_
+#    include <windows.h>
+#    include <direct.h>
+#    include <shellapi.h>
+#else
+#    include <sys/types.h>
+#    include <sys/wait.h>
+#    include <sys/stat.h>
+#    include <unistd.h>
+#    include <fcntl.h>
+#endif
+
+#ifdef _WIN32
+#    define NOB_LINE_END "\r\n"
+#else
+#    define NOB_LINE_END "\n"
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+//   https://gcc.gnu.org/onlinedocs/gcc-4.7.2/gcc/Function-Attributes.html
+#    ifdef __MINGW_PRINTF_FORMAT
+#        define NOB_PRINTF_FORMAT(STRING_INDEX, FIRST_TO_CHECK) __attribute__ ((format (__MINGW_PRINTF_FORMAT, STRING_INDEX, FIRST_TO_CHECK)))
+#    else
+#        define NOB_PRINTF_FORMAT(STRING_INDEX, FIRST_TO_CHECK) __attribute__ ((format (printf, STRING_INDEX, FIRST_TO_CHECK)))
+#    endif // __MINGW_PRINTF_FORMAT
+#else
+//   TODO: implement NOB_PRINTF_FORMAT for MSVC
+#    define NOB_PRINTF_FORMAT(STRING_INDEX, FIRST_TO_CHECK)
+#endif
+
+#define NOB_UNUSED(value) (void)(value)
+#define NOB_TODO(message) do { fprintf(stderr, "%s:%d: TODO: %s\n", __FILE__, __LINE__, message); abort(); } while(0)
+#define NOB_UNREACHABLE(message) do { fprintf(stderr, "%s:%d: UNREACHABLE: %s\n", __FILE__, __LINE__, message); abort(); } while(0)
+
+#define NOB_ARRAY_LEN(array) (sizeof(array)/sizeof(array[0]))
+#define NOB_ARRAY_GET(array, index) \
+    (NOB_ASSERT((size_t)index < NOB_ARRAY_LEN(array)), array[(size_t)index])
+
+typedef enum {
+    NOB_INFO,
+    NOB_WARNING,
+    NOB_ERROR,
+    NOB_NO_LOGS,
+} Nob_Log_Level;
+
+// Any messages with the level below nob_minimal_log_level are going to be suppressed.
+extern Nob_Log_Level nob_minimal_log_level;
+
+void nob_log(Nob_Log_Level level, const char *fmt, ...) NOB_PRINTF_FORMAT(2, 3);
+
+// It is an equivalent of shift command from bash. It basically pops an element from
+// the beginning of a sized array.
+#define nob_shift(xs, xs_sz) (NOB_ASSERT((xs_sz) > 0), (xs_sz)--, *(xs)++)
+// NOTE: nob_shift_args() is an alias for an old variant of nob_shift that only worked with
+// the command line arguments passed to the main() function. nob_shift() is more generic.
+// So nob_shift_args() is semi-deprecated, but I don't see much reason to urgently
+// remove it. This alias does not hurt anybody.
+#define nob_shift_args(argc, argv) nob_shift(*argv, *argc)
+
+typedef struct {
+    const char **items;
+    size_t count;
+    size_t capacity;
+} Nob_File_Paths;
+
+typedef enum {
+    NOB_FILE_REGULAR = 0,
+    NOB_FILE_DIRECTORY,
+    NOB_FILE_SYMLINK,
+    NOB_FILE_OTHER,
+} Nob_File_Type;
+
+bool nob_mkdir_if_not_exists(const char *path);
+bool nob_copy_file(const char *src_path, const char *dst_path);
+bool nob_copy_directory_recursively(const char *src_path, const char *dst_path);
+bool nob_read_entire_dir(const char *parent, Nob_File_Paths *children);
+bool nob_write_entire_file(const char *path, const void *data, size_t size);
+Nob_File_Type nob_get_file_type(const char *path);
+bool nob_delete_file(const char *path);
+
+#define nob_return_defer(value) do { result = (value); goto defer; } while(0)
+
+// Initial capacity of a dynamic array
+#ifndef NOB_DA_INIT_CAP
+#define NOB_DA_INIT_CAP 256
+#endif
+
+#define nob_da_reserve(da, expected_capacity)                                              \
+    do {                                                                                   \
+        if ((expected_capacity) > (da)->capacity) {                                        \
+            if ((da)->capacity == 0) {                                                     \
+                (da)->capacity = NOB_DA_INIT_CAP;                                          \
+            }                                                                              \
+            while ((expected_capacity) > (da)->capacity) {                                 \
+                (da)->capacity *= 2;                                                       \
+            }                                                                              \
+            (da)->items = NOB_REALLOC((da)->items, (da)->capacity * sizeof(*(da)->items)); \
+            NOB_ASSERT((da)->items != NULL && "Buy more RAM lol");                         \
+        }                                                                                  \
+    } while (0)
+
+// Append an item to a dynamic array
+#define nob_da_append(da, item)                \
+    do {                                       \
+        nob_da_reserve((da), (da)->count + 1); \
+        (da)->items[(da)->count++] = (item);   \
+    } while (0)
+
+#define nob_da_free(da) NOB_FREE((da).items)
+
+// Append several items to a dynamic array
+#define nob_da_append_many(da, new_items, new_items_count)                                      \
+    do {                                                                                        \
+        nob_da_reserve((da), (da)->count + (new_items_count));                                  \
+        memcpy((da)->items + (da)->count, (new_items), (new_items_count)*sizeof(*(da)->items)); \
+        (da)->count += (new_items_count);                                                       \
+    } while (0)
+
+#define nob_da_resize(da, new_size)     \
+    do {                                \
+        nob_da_reserve((da), new_size); \
+        (da)->count = (new_size);       \
+    } while (0)
+
+#define nob_da_last(da) (da)->items[(NOB_ASSERT((da)->count > 0), (da)->count-1)]
+#define nob_da_remove_unordered(da, i)               \
+    do {                                             \
+        size_t j = (i);                              \
+        NOB_ASSERT(j < (da)->count);                 \
+        (da)->items[j] = (da)->items[--(da)->count]; \
+    } while(0)
+
+// Foreach over Dynamic Arrays. Example:
+// ```c
+// typedef struct {
+//     int *items;
+//     size_t count;
+//     size_t capacity;
+// } Numbers;
+//
+// Numbers xs = {0};
+//
+// nob_da_append(&xs, 69);
+// nob_da_append(&xs, 420);
+// nob_da_append(&xs, 1337);
+//
+// nob_da_foreach(int, x, &xs) {
+//     // `x` here is a pointer to the current element. You can get its index by taking a difference
+//     // between `x` and the start of the array which is `x.items`.
+//     size_t index = x - xs.items;
+//     nob_log(INFO, "%zu: %d", index, *x);
+// }
+// ```
+#define nob_da_foreach(Type, it, da) for (Type *it = (da)->items; it < (da)->items + (da)->count; ++it)
+
+typedef struct {
+    char *items;
+    size_t count;
+    size_t capacity;
+} Nob_String_Builder;
+
+bool nob_read_entire_file(const char *path, Nob_String_Builder *sb);
+int nob_sb_appendf(Nob_String_Builder *sb, const char *fmt, ...) NOB_PRINTF_FORMAT(2, 3);
+
+// Append a sized buffer to a string builder
+#define nob_sb_append_buf(sb, buf, size) nob_da_append_many(sb, buf, size)
+
+// Append a NULL-terminated string to a string builder
+#define nob_sb_append_cstr(sb, cstr)  \
+    do {                              \
+        const char *s = (cstr);       \
+        size_t n = strlen(s);         \
+        nob_da_append_many(sb, s, n); \
+    } while (0)
+
+// Append a single NULL character at the end of a string builder. So then you can
+// use it a NULL-terminated C string
+#define nob_sb_append_null(sb) nob_da_append_many(sb, "", 1)
+
+// Free the memory allocated by a string builder
+#define nob_sb_free(sb) NOB_FREE((sb).items)
+
+// Process handle
+#ifdef _WIN32
+typedef HANDLE Nob_Proc;
+#define NOB_INVALID_PROC INVALID_HANDLE_VALUE
+typedef HANDLE Nob_Fd;
+#define NOB_INVALID_FD INVALID_HANDLE_VALUE
+#else
+typedef int Nob_Proc;
+#define NOB_INVALID_PROC (-1)
+typedef int Nob_Fd;
+#define NOB_INVALID_FD (-1)
+#endif // _WIN32
+
+Nob_Fd nob_fd_open_for_read(const char *path);
+Nob_Fd nob_fd_open_for_write(const char *path);
+void nob_fd_close(Nob_Fd fd);
+
+typedef struct {
+    Nob_Proc *items;
+    size_t count;
+    size_t capacity;
+} Nob_Procs;
+
+// Wait until the process has finished
+bool nob_proc_wait(Nob_Proc proc);
+// Wait until all the processes have finished
+bool nob_procs_wait(Nob_Procs procs);
+// Wait until all the processes have finished and empty the procs array
+bool nob_procs_wait_and_reset(Nob_Procs *procs);
+// Append a new process to procs array and if procs.count reaches max_procs_count call nob_procs_wait_and_reset() on it
+bool nob_procs_append_with_flush(Nob_Procs *procs, Nob_Proc proc, size_t max_procs_count);
+
+// A command - the main workhorse of Nob. Nob is all about building commands and running them
+typedef struct {
+    const char **items;
+    size_t count;
+    size_t capacity;
+} Nob_Cmd;
+
+// Example:
+// ```c
+// Nob_Fd fdin = nob_fd_open_for_read("input.txt");
+// if (fdin == NOB_INVALID_FD) fail();
+// Nob_Fd fdout = nob_fd_open_for_write("output.txt");
+// if (fdout == NOB_INVALID_FD) fail();
+// Nob_Cmd cmd = {0};
+// nob_cmd_append(&cmd, "cat");
+// if (!nob_cmd_run_sync_redirect_and_reset(&cmd, (Nob_Cmd_Redirect) {
+//     .fdin = &fdin,
+//     .fdout = &fdout
+// })) fail();
+// ```
+typedef struct {
+    Nob_Fd *fdin;
+    Nob_Fd *fdout;
+    Nob_Fd *fderr;
+} Nob_Cmd_Redirect;
+
+// Render a string representation of a command into a string builder. Keep in mind the the
+// string builder is not NULL-terminated by default. Use nob_sb_append_null if you plan to
+// use it as a C string.
+void nob_cmd_render(Nob_Cmd cmd, Nob_String_Builder *render);
+
+// TODO: implement C++ support for nob.h
+#define nob_cmd_append(cmd, ...) \
+    nob_da_append_many(cmd, \
+                       ((const char*[]){__VA_ARGS__}), \
+                       (sizeof((const char*[]){__VA_ARGS__})/sizeof(const char*)))
+
+#define nob_cmd_extend(cmd, other_cmd) \
+    nob_da_append_many(cmd, (other_cmd)->items, (other_cmd)->count)
+
+// Free all the memory allocated by command arguments
+#define nob_cmd_free(cmd) NOB_FREE(cmd.items)
+
+// Run command asynchronously
+#define nob_cmd_run_async(cmd) nob_cmd_run_async_redirect(cmd, (Nob_Cmd_Redirect) {0})
+// NOTE: nob_cmd_run_async_and_reset() is just like nob_cmd_run_async() except it also resets cmd.count to 0
+// so the Nob_Cmd instance can be seamlessly used several times in a row
+Nob_Proc nob_cmd_run_async_and_reset(Nob_Cmd *cmd);
+// Run redirected command asynchronously
+Nob_Proc nob_cmd_run_async_redirect(Nob_Cmd cmd, Nob_Cmd_Redirect redirect);
+// Run redirected command asynchronously and set cmd.count to 0 and close all the opened files
+Nob_Proc nob_cmd_run_async_redirect_and_reset(Nob_Cmd *cmd, Nob_Cmd_Redirect redirect);
+
+// Run command synchronously
+bool nob_cmd_run_sync(Nob_Cmd cmd);
+// NOTE: nob_cmd_run_sync_and_reset() is just like nob_cmd_run_sync() except it also resets cmd.count to 0
+// so the Nob_Cmd instance can be seamlessly used several times in a row
+bool nob_cmd_run_sync_and_reset(Nob_Cmd *cmd);
+// Run redirected command synchronously
+bool nob_cmd_run_sync_redirect(Nob_Cmd cmd, Nob_Cmd_Redirect redirect);
+// Run redirected command synchronously and set cmd.count to 0 and close all the opened files
+bool nob_cmd_run_sync_redirect_and_reset(Nob_Cmd *cmd, Nob_Cmd_Redirect redirect);
+
+#ifndef NOB_TEMP_CAPACITY
+#define NOB_TEMP_CAPACITY (8*1024*1024)
+#endif // NOB_TEMP_CAPACITY
+char *nob_temp_strdup(const char *cstr);
+void *nob_temp_alloc(size_t size);
+char *nob_temp_sprintf(const char *format, ...) NOB_PRINTF_FORMAT(1, 2);
+void nob_temp_reset(void);
+size_t nob_temp_save(void);
+void nob_temp_rewind(size_t checkpoint);
+
+// Given any path returns the last part of that path.
+// "/path/to/a/file.c" -> "file.c"; "/path/to/a/directory" -> "directory"
+const char *nob_path_name(const char *path);
+bool nob_rename(const char *old_path, const char *new_path);
+int nob_needs_rebuild(const char *output_path, const char **input_paths, size_t input_paths_count);
+int nob_needs_rebuild1(const char *output_path, const char *input_path);
+int nob_file_exists(const char *file_path);
+const char *nob_get_current_dir_temp(void);
+bool nob_set_current_dir(const char *path);
+
+// TODO: we should probably document somewhere all the compiler we support
+
+// The nob_cc_* macros try to abstract away the specific compiler.
+// They are verify basic and not particularly flexible, but you can redefine them if you need to
+// or not use them at all and create your own abstraction on top of Nob_Cmd.
+
+#ifndef nob_cc
+#  if _WIN32
+#    if defined(__GNUC__)
+#       define nob_cc(cmd) nob_cmd_append(cmd, "cc")
+#    elif defined(__clang__)
+#       define nob_cc(cmd) nob_cmd_append(cmd, "clang")
+#    elif defined(_MSC_VER)
+#       define nob_cc(cmd) nob_cmd_append(cmd, "cl.exe")
+#    endif
+#  else
+#    define nob_cc(cmd) nob_cmd_append(cmd, "cc")
+#  endif
+#endif // nob_cc
+
+#ifndef nob_cc_flags
+#  if defined(_MSC_VER) && !defined(__clang__)
+#    define nob_cc_flags(...)  // TODO: Add some cool recommended flags for MSVC (I don't really know any)
+#  else
+#    define nob_cc_flags(cmd) nob_cmd_append(cmd, "-Wall", "-Wextra")
+#  endif
+#endif // nob_cc_output
+
+#ifndef nob_cc_output
+#  if defined(_MSC_VER) && !defined(__clang__)
+#    define nob_cc_output(cmd, output_path) nob_cmd_append(cmd, nob_temp_sprintf("/Fe:%s", (output_path)))
+#  else
+#    define nob_cc_output(cmd, output_path) nob_cmd_append(cmd, "-o", (output_path))
+#  endif
+#endif // nob_cc_output
+
+#ifndef nob_cc_inputs
+#  define nob_cc_inputs(cmd, ...) nob_cmd_append(cmd, __VA_ARGS__)
+#endif // nob_cc_inputs
+
+// TODO: add MinGW support for Go Rebuild Urself™ Technology and all the nob_cc_* macros above
+//   Musializer contributors came up with a pretty interesting idea of an optional prefix macro which could be useful for
+//   MinGW support:
+//   https://github.com/tsoding/musializer/blob/b7578cc76b9ecb573d239acc9ccf5a04d3aba2c9/src_build/nob_win64_mingw.c#L3-L9
+// TODO: Maybe instead NOB_REBUILD_URSELF macro, the Go Rebuild Urself™ Technology should use the
+//   user defined nob_cc_* macros instead?
+#ifndef NOB_REBUILD_URSELF
+#  if defined(_WIN32)
+#    if defined(__GNUC__)
+#       define NOB_REBUILD_URSELF(binary_path, source_path) "gcc", "-o", binary_path, source_path
+#    elif defined(__clang__)
+#       define NOB_REBUILD_URSELF(binary_path, source_path) "clang", "-o", binary_path, source_path
+#    elif defined(_MSC_VER)
+#       define NOB_REBUILD_URSELF(binary_path, source_path) "cl.exe", nob_temp_sprintf("/Fe:%s", (binary_path)), source_path
+#    endif
+#  else
+#    define NOB_REBUILD_URSELF(binary_path, source_path) "cc", "-o", binary_path, source_path
+#  endif
+#endif
+
+// Go Rebuild Urself™ Technology
+//
+//   How to use it:
+//     int main(int argc, char** argv) {
+//         NOB_GO_REBUILD_URSELF(argc, argv);
+//         // actual work
+//         return 0;
+//     }
+//
+//   After your added this macro every time you run ./nob it will detect
+//   that you modified its original source code and will try to rebuild itself
+//   before doing any actual work. So you only need to bootstrap your build system
+//   once.
+//
+//   The modification is detected by comparing the last modified times of the executable
+//   and its source code. The same way the make utility usually does it.
+//
+//   The rebuilding is done by using the NOB_REBUILD_URSELF macro which you can redefine
+//   if you need a special way of bootstraping your build system. (which I personally
+//   do not recommend since the whole idea of NoBuild is to keep the process of bootstrapping
+//   as simple as possible and doing all of the actual work inside of ./nob)
+//
+void nob__go_rebuild_urself(int argc, char **argv, const char *source_path, ...);
+#define NOB_GO_REBUILD_URSELF(argc, argv) nob__go_rebuild_urself(argc, argv, __FILE__, NULL)
+// Sometimes your nob.c includes additional files, so you want the Go Rebuild Urself™ Technology to check
+// if they also were modified and rebuild nob.c accordingly. For that we have NOB_GO_REBUILD_URSELF_PLUS():
+// ```c
+// #define NOB_IMPLEMENTATION
+// #include "nob.h"
+//
+// #include "foo.c"
+// #include "bar.c"
+//
+// int main(int argc, char **argv)
+// {
+//     NOB_GO_REBUILD_URSELF_PLUS(argc, argv, "foo.c", "bar.c");
+//     // ...
+//     return 0;
+// }
+#define NOB_GO_REBUILD_URSELF_PLUS(argc, argv, ...) nob__go_rebuild_urself(argc, argv, __FILE__, __VA_ARGS__, NULL);
+
+typedef struct {
+    size_t count;
+    const char *data;
+} Nob_String_View;
+
+const char *nob_temp_sv_to_cstr(Nob_String_View sv);
+
+Nob_String_View nob_sv_chop_by_delim(Nob_String_View *sv, char delim);
+Nob_String_View nob_sv_chop_left(Nob_String_View *sv, size_t n);
+Nob_String_View nob_sv_trim(Nob_String_View sv);
+Nob_String_View nob_sv_trim_left(Nob_String_View sv);
+Nob_String_View nob_sv_trim_right(Nob_String_View sv);
+bool nob_sv_eq(Nob_String_View a, Nob_String_View b);
+bool nob_sv_end_with(Nob_String_View sv, const char *cstr);
+bool nob_sv_starts_with(Nob_String_View sv, Nob_String_View expected_prefix);
+Nob_String_View nob_sv_from_cstr(const char *cstr);
+Nob_String_View nob_sv_from_parts(const char *data, size_t count);
+// nob_sb_to_sv() enables you to just view Nob_String_Builder as Nob_String_View
+#define nob_sb_to_sv(sb) nob_sv_from_parts((sb).items, (sb).count)
+
+// printf macros for String_View
+#ifndef SV_Fmt
+#define SV_Fmt "%.*s"
+#endif // SV_Fmt
+#ifndef SV_Arg
+#define SV_Arg(sv) (int) (sv).count, (sv).data
+#endif // SV_Arg
+// USAGE:
+//   String_View name = ...;
+//   printf("Name: "SV_Fmt"\n", SV_Arg(name));
+
+
+// minirent.h HEADER BEGIN ////////////////////////////////////////
+// Copyright 2021 Alexey Kutepov <reximkut@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// ============================================================
+//
+// minirent — 0.0.1 — A subset of dirent interface for Windows.
+//
+// https://github.com/tsoding/minirent
+//
+// ============================================================
+//
+// ChangeLog (https://semver.org/ is implied)
+//
+//    0.0.2 Automatically include dirent.h on non-Windows
+//          platforms
+//    0.0.1 First Official Release
+
+#ifndef _WIN32
+#include <dirent.h>
+#else // _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include "windows.h"
+
+struct dirent
+{
+    char d_name[MAX_PATH+1];
+};
+
+typedef struct DIR DIR;
+
+static DIR *opendir(const char *dirpath);
+static struct dirent *readdir(DIR *dirp);
+static int closedir(DIR *dirp);
+
+#endif // _WIN32
+// minirent.h HEADER END ////////////////////////////////////////
+
+#ifdef _WIN32
+
+char *nob_win32_error_message(DWORD err);
+
+#endif // _WIN32
+
+#endif // NOB_H_
+
+// #ifdef NOB_IMPLEMENTATION
+
+// Any messages with the level below nob_minimal_log_level are going to be suppressed.
+Nob_Log_Level nob_minimal_log_level = NOB_INFO;
+
+#ifdef _WIN32
+
+// Base on https://stackoverflow.com/a/75644008
+// > .NET Core uses 4096 * sizeof(WCHAR) buffer on stack for FormatMessageW call. And...thats it.
+// >
+// > https://github.com/dotnet/runtime/blob/3b63eb1346f1ddbc921374a5108d025662fb5ffd/src/coreclr/utilcode/posterror.cpp#L264-L265
+#ifndef NOB_WIN32_ERR_MSG_SIZE
+#define NOB_WIN32_ERR_MSG_SIZE (4 * 1024)
+#endif // NOB_WIN32_ERR_MSG_SIZE
+
+char *nob_win32_error_message(DWORD err) {
+    static char win32ErrMsg[NOB_WIN32_ERR_MSG_SIZE] = {0};
+    DWORD errMsgSize = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, err, LANG_USER_DEFAULT, win32ErrMsg,
+                                      NOB_WIN32_ERR_MSG_SIZE, NULL);
+
+    if (errMsgSize == 0) {
+        if (GetLastError() != ERROR_MR_MID_NOT_FOUND) {
+            if (sprintf(win32ErrMsg, "Could not get error message for 0x%lX", err) > 0) {
+                return (char *)&win32ErrMsg;
+            } else {
+                return NULL;
+            }
+        } else {
+            if (sprintf(win32ErrMsg, "Invalid Windows Error code (0x%lX)", err) > 0) {
+                return (char *)&win32ErrMsg;
+            } else {
+                return NULL;
+            }
+        }
+    }
+
+    while (errMsgSize > 1 && isspace(win32ErrMsg[errMsgSize - 1])) {
+        win32ErrMsg[--errMsgSize] = '\0';
+    }
+
+    return win32ErrMsg;
+}
+
+#endif // _WIN32
+
+// The implementation idea is stolen from https://github.com/zhiayang/nabs
+void nob__go_rebuild_urself(int argc, char **argv, const char *source_path, ...)
+{
+    const char *binary_path = nob_shift(argv, argc);
+#ifdef _WIN32
+    // On Windows executables almost always invoked without extension, so
+    // it's ./nob, not ./nob.exe. For renaming the extension is a must.
+    if (!nob_sv_end_with(nob_sv_from_cstr(binary_path), ".exe")) {
+        binary_path = nob_temp_sprintf("%s.exe", binary_path);
+    }
+#endif
+
+    Nob_File_Paths source_paths = {0};
+    nob_da_append(&source_paths, source_path);
+    va_list args;
+    va_start(args, source_path);
+    for (;;) {
+        const char *path = va_arg(args, const char*);
+        if (path == NULL) break;
+        nob_da_append(&source_paths, path);
+    }
+    va_end(args);
+
+    int rebuild_is_needed = nob_needs_rebuild(binary_path, source_paths.items, source_paths.count);
+    if (rebuild_is_needed < 0) exit(1); // error
+    if (!rebuild_is_needed) {           // no rebuild is needed
+        NOB_FREE(source_paths.items);
+        return;
+    }
+
+    Nob_Cmd cmd = {0};
+
+    const char *old_binary_path = nob_temp_sprintf("%s.old", binary_path);
+
+    if (!nob_rename(binary_path, old_binary_path)) exit(1);
+    nob_cmd_append(&cmd, NOB_REBUILD_URSELF(binary_path, source_path));
+    if (!nob_cmd_run_sync_and_reset(&cmd)) {
+        nob_rename(old_binary_path, binary_path);
+        exit(1);
+    }
+#ifdef NOB_EXPERIMENTAL_DELETE_OLD
+    // TODO: this is an experimental behavior behind a compilation flag.
+    // Once it is confirmed that it does not cause much problems on both POSIX and Windows
+    // we may turn it on by default.
+    nob_delete_file(old_binary_path);
+#endif // NOB_EXPERIMENTAL_DELETE_OLD
+
+    nob_cmd_append(&cmd, binary_path);
+    nob_da_append_many(&cmd, argv, argc);
+    if (!nob_cmd_run_sync_and_reset(&cmd)) exit(1);
+    exit(0);
+}
+
+static size_t nob_temp_size = 0;
+static char nob_temp[NOB_TEMP_CAPACITY] = {0};
+
+bool nob_mkdir_if_not_exists(const char *path)
+{
+#ifdef _WIN32
+    int result = mkdir(path);
+#else
+    int result = mkdir(path, 0755);
+#endif
+    if (result < 0) {
+        if (errno == EEXIST) {
+            nob_log(NOB_INFO, "directory `%s` already exists", path);
+            return true;
+        }
+        nob_log(NOB_ERROR, "could not create directory `%s`: %s", path, strerror(errno));
+        return false;
+    }
+
+    nob_log(NOB_INFO, "created directory `%s`", path);
+    return true;
+}
+
+bool nob_copy_file(const char *src_path, const char *dst_path)
+{
+    nob_log(NOB_INFO, "copying %s -> %s", src_path, dst_path);
+#ifdef _WIN32
+    if (!CopyFile(src_path, dst_path, FALSE)) {
+        nob_log(NOB_ERROR, "Could not copy file: %s", nob_win32_error_message(GetLastError()));
+        return false;
+    }
+    return true;
+#else
+    int src_fd = -1;
+    int dst_fd = -1;
+    size_t buf_size = 32*1024;
+    char *buf = NOB_REALLOC(NULL, buf_size);
+    NOB_ASSERT(buf != NULL && "Buy more RAM lol!!");
+    bool result = true;
+
+    src_fd = open(src_path, O_RDONLY);
+    if (src_fd < 0) {
+        nob_log(NOB_ERROR, "Could not open file %s: %s", src_path, strerror(errno));
+        nob_return_defer(false);
+    }
+
+    struct stat src_stat;
+    if (fstat(src_fd, &src_stat) < 0) {
+        nob_log(NOB_ERROR, "Could not get mode of file %s: %s", src_path, strerror(errno));
+        nob_return_defer(false);
+    }
+
+    dst_fd = open(dst_path, O_CREAT | O_TRUNC | O_WRONLY, src_stat.st_mode);
+    if (dst_fd < 0) {
+        nob_log(NOB_ERROR, "Could not create file %s: %s", dst_path, strerror(errno));
+        nob_return_defer(false);
+    }
+
+    for (;;) {
+        ssize_t n = read(src_fd, buf, buf_size);
+        if (n == 0) break;
+        if (n < 0) {
+            nob_log(NOB_ERROR, "Could not read from file %s: %s", src_path, strerror(errno));
+            nob_return_defer(false);
+        }
+        char *buf2 = buf;
+        while (n > 0) {
+            ssize_t m = write(dst_fd, buf2, n);
+            if (m < 0) {
+                nob_log(NOB_ERROR, "Could not write to file %s: %s", dst_path, strerror(errno));
+                nob_return_defer(false);
+            }
+            n    -= m;
+            buf2 += m;
+        }
+    }
+
+defer:
+    NOB_FREE(buf);
+    close(src_fd);
+    close(dst_fd);
+    return result;
+#endif
+}
+
+void nob_cmd_render(Nob_Cmd cmd, Nob_String_Builder *render)
+{
+    for (size_t i = 0; i < cmd.count; ++i) {
+        const char *arg = cmd.items[i];
+        if (arg == NULL) break;
+        if (i > 0) nob_sb_append_cstr(render, " ");
+        if (!strchr(arg, ' ')) {
+            nob_sb_append_cstr(render, arg);
+        } else {
+            nob_da_append(render, '\'');
+            nob_sb_append_cstr(render, arg);
+            nob_da_append(render, '\'');
+        }
+    }
+}
+
+#ifdef _WIN32
+// https://learn.microsoft.com/en-gb/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
+static void nob__win32_cmd_quote(Nob_Cmd cmd, Nob_String_Builder *quoted)
+{
+    for (size_t i = 0; i < cmd.count; ++i) {
+        const char *arg = cmd.items[i];
+        if (arg == NULL) break;
+        size_t len = strlen(arg);
+        if (i > 0) nob_da_append(quoted, ' ');
+        if (len != 0 && NULL == strpbrk(arg, " \t\n\v\"")) {
+            // no need to quote
+            nob_da_append_many(quoted, arg, len);
+        } else {
+            // we need to escape:
+            // 1. double quotes in the original arg
+            // 2. consequent backslashes before a double quote
+            size_t backslashes = 0;
+            nob_da_append(quoted, '\"');
+            for (size_t j = 0; j < len; ++j) {
+                char x = arg[j];
+                if (x == '\\') {
+                    backslashes += 1;
+                } else {
+                    if (x == '\"') {
+                        // escape backslashes (if any) and the double quote
+                        for (size_t k = 0; k < 1+backslashes; ++k) {
+                            nob_da_append(quoted, '\\');
+                        }
+                    }
+                    backslashes = 0;
+                }
+                nob_da_append(quoted, x);
+            }
+            // escape backslashes (if any)
+            for (size_t k = 0; k < backslashes; ++k) {
+                nob_da_append(quoted, '\\');
+            }
+            nob_da_append(quoted, '\"');
+        }
+    }
+}
+#endif
+
+Nob_Proc nob_cmd_run_async_redirect(Nob_Cmd cmd, Nob_Cmd_Redirect redirect)
+{
+    if (cmd.count < 1) {
+        nob_log(NOB_ERROR, "Could not run empty command");
+        return NOB_INVALID_PROC;
+    }
+
+    Nob_String_Builder sb = {0};
+    nob_cmd_render(cmd, &sb);
+    nob_sb_append_null(&sb);
+    nob_log(NOB_INFO, "CMD: %s", sb.items);
+    nob_sb_free(sb);
+    memset(&sb, 0, sizeof(sb));
+
+#ifdef _WIN32
+    // https://docs.microsoft.com/en-us/windows/win32/procthread/creating-a-child-process-with-redirected-input-and-output
+
+    STARTUPINFO siStartInfo;
+    ZeroMemory(&siStartInfo, sizeof(siStartInfo));
+    siStartInfo.cb = sizeof(STARTUPINFO);
+    // NOTE: theoretically setting NULL to std handles should not be a problem
+    // https://docs.microsoft.com/en-us/windows/console/getstdhandle?redirectedfrom=MSDN#attachdetach-behavior
+    // TODO: check for errors in GetStdHandle
+    siStartInfo.hStdError = redirect.fderr ? *redirect.fderr : GetStdHandle(STD_ERROR_HANDLE);
+    siStartInfo.hStdOutput = redirect.fdout ? *redirect.fdout : GetStdHandle(STD_OUTPUT_HANDLE);
+    siStartInfo.hStdInput = redirect.fdin ? *redirect.fdin : GetStdHandle(STD_INPUT_HANDLE);
+    siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
+
+    PROCESS_INFORMATION piProcInfo;
+    ZeroMemory(&piProcInfo, sizeof(PROCESS_INFORMATION));
+
+    nob__win32_cmd_quote(cmd, &sb);
+    nob_sb_append_null(&sb);
+    BOOL bSuccess = CreateProcessA(NULL, sb.items, NULL, NULL, TRUE, 0, NULL, NULL, &siStartInfo, &piProcInfo);
+    nob_sb_free(sb);
+
+    if (!bSuccess) {
+        nob_log(NOB_ERROR, "Could not create child process for %s: %s", cmd.items[0], nob_win32_error_message(GetLastError()));
+        return NOB_INVALID_PROC;
+    }
+
+    CloseHandle(piProcInfo.hThread);
+
+    return piProcInfo.hProcess;
+#else
+    pid_t cpid = fork();
+    if (cpid < 0) {
+        nob_log(NOB_ERROR, "Could not fork child process: %s", strerror(errno));
+        return NOB_INVALID_PROC;
+    }
+
+    if (cpid == 0) {
+        if (redirect.fdin) {
+            if (dup2(*redirect.fdin, STDIN_FILENO) < 0) {
+                nob_log(NOB_ERROR, "Could not setup stdin for child process: %s", strerror(errno));
+                exit(1);
+            }
+        }
+
+        if (redirect.fdout) {
+            if (dup2(*redirect.fdout, STDOUT_FILENO) < 0) {
+                nob_log(NOB_ERROR, "Could not setup stdout for child process: %s", strerror(errno));
+                exit(1);
+            }
+        }
+
+        if (redirect.fderr) {
+            if (dup2(*redirect.fderr, STDERR_FILENO) < 0) {
+                nob_log(NOB_ERROR, "Could not setup stderr for child process: %s", strerror(errno));
+                exit(1);
+            }
+        }
+
+        // NOTE: This leaks a bit of memory in the child process.
+        // But do we actually care? It's a one off leak anyway...
+        Nob_Cmd cmd_null = {0};
+        nob_da_append_many(&cmd_null, cmd.items, cmd.count);
+        nob_cmd_append(&cmd_null, NULL);
+
+        printf("item[0]: \"%s\"\n", cmd.items[0]);
+        printf("cmd_null.items[0]: \"%s\"\n", cmd_null.items[0]);
+        // printf("cmd_null.items[1]: \"%s\"\n", cmd_null.items[1]);
+
+        char* arg = "ls";
+        // char* args = {&arg};
+        if (execvp(cmd.items[0], (char * const*) &arg) < 0) {
+            nob_log(NOB_ERROR, "Could not exec child process for %s: %s", cmd.items[0], strerror(errno));
+            exit(1);
+        }
+        NOB_UNREACHABLE("nob_cmd_run_async_redirect");
+    }
+
+    return cpid;
+#endif
+}
+
+Nob_Proc nob_cmd_run_async_and_reset(Nob_Cmd *cmd)
+{
+    Nob_Proc proc = nob_cmd_run_async(*cmd);
+    cmd->count = 0;
+    return proc;
+}
+
+Nob_Proc nob_cmd_run_async_redirect_and_reset(Nob_Cmd *cmd, Nob_Cmd_Redirect redirect)
+{
+    Nob_Proc proc = nob_cmd_run_async_redirect(*cmd, redirect);
+    cmd->count = 0;
+    if (redirect.fdin) {
+        nob_fd_close(*redirect.fdin);
+        *redirect.fdin = NOB_INVALID_FD;
+    }
+    if (redirect.fdout) {
+        nob_fd_close(*redirect.fdout);
+        *redirect.fdout = NOB_INVALID_FD;
+    }
+    if (redirect.fderr) {
+        nob_fd_close(*redirect.fderr);
+        *redirect.fderr = NOB_INVALID_FD;
+    }
+    return proc;
+}
+
+Nob_Fd nob_fd_open_for_read(const char *path)
+{
+#ifndef _WIN32
+    Nob_Fd result = open(path, O_RDONLY);
+    if (result < 0) {
+        nob_log(NOB_ERROR, "Could not open file %s: %s", path, strerror(errno));
+        return NOB_INVALID_FD;
+    }
+    return result;
+#else
+    // https://docs.microsoft.com/en-us/windows/win32/fileio/opening-a-file-for-reading-or-writing
+    SECURITY_ATTRIBUTES saAttr = {0};
+    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle = TRUE;
+
+    Nob_Fd result = CreateFile(
+                    path,
+                    GENERIC_READ,
+                    0,
+                    &saAttr,
+                    OPEN_EXISTING,
+                    FILE_ATTRIBUTE_READONLY,
+                    NULL);
+
+    if (result == INVALID_HANDLE_VALUE) {
+        nob_log(NOB_ERROR, "Could not open file %s: %s", path, nob_win32_error_message(GetLastError()));
+        return NOB_INVALID_FD;
+    }
+
+    return result;
+#endif // _WIN32
+}
+
+Nob_Fd nob_fd_open_for_write(const char *path)
+{
+#ifndef _WIN32
+    Nob_Fd result = open(path,
+                     O_WRONLY | O_CREAT | O_TRUNC,
+                     S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    if (result < 0) {
+        nob_log(NOB_ERROR, "could not open file %s: %s", path, strerror(errno));
+        return NOB_INVALID_FD;
+    }
+    return result;
+#else
+    SECURITY_ATTRIBUTES saAttr = {0};
+    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle = TRUE;
+
+    Nob_Fd result = CreateFile(
+                    path,                            // name of the write
+                    GENERIC_WRITE,                   // open for writing
+                    0,                               // do not share
+                    &saAttr,                         // default security
+                    CREATE_ALWAYS,                   // create always
+                    FILE_ATTRIBUTE_NORMAL,           // normal file
+                    NULL                             // no attr. template
+                );
+
+    if (result == INVALID_HANDLE_VALUE) {
+        nob_log(NOB_ERROR, "Could not open file %s: %s", path, nob_win32_error_message(GetLastError()));
+        return NOB_INVALID_FD;
+    }
+
+    return result;
+#endif // _WIN32
+}
+
+void nob_fd_close(Nob_Fd fd)
+{
+#ifdef _WIN32
+    CloseHandle(fd);
+#else
+    close(fd);
+#endif // _WIN32
+}
+
+bool nob_procs_wait(Nob_Procs procs)
+{
+    bool success = true;
+    for (size_t i = 0; i < procs.count; ++i) {
+        success = nob_proc_wait(procs.items[i]) && success;
+    }
+    return success;
+}
+
+bool nob_procs_wait_and_reset(Nob_Procs *procs)
+{
+    bool success = nob_procs_wait(*procs);
+    procs->count = 0;
+    return success;
+}
+
+bool nob_proc_wait(Nob_Proc proc)
+{
+    if (proc == NOB_INVALID_PROC) return false;
+
+#ifdef _WIN32
+    DWORD result = WaitForSingleObject(
+                       proc,    // HANDLE hHandle,
+                       INFINITE // DWORD  dwMilliseconds
+                   );
+
+    if (result == WAIT_FAILED) {
+        nob_log(NOB_ERROR, "could not wait on child process: %s", nob_win32_error_message(GetLastError()));
+        return false;
+    }
+
+    DWORD exit_status;
+    if (!GetExitCodeProcess(proc, &exit_status)) {
+        nob_log(NOB_ERROR, "could not get process exit code: %s", nob_win32_error_message(GetLastError()));
+        return false;
+    }
+
+    if (exit_status != 0) {
+        nob_log(NOB_ERROR, "command exited with exit code %lu", exit_status);
+        return false;
+    }
+
+    CloseHandle(proc);
+
+    return true;
+#else
+    for (;;) {
+        int wstatus = 0;
+        if (waitpid(proc, &wstatus, 0) < 0) {
+            nob_log(NOB_ERROR, "could not wait on command (pid %d): %s", proc, strerror(errno));
+            return false;
+        }
+
+        if (WIFEXITED(wstatus)) {
+            int exit_status = WEXITSTATUS(wstatus);
+            if (exit_status != 0) {
+                nob_log(NOB_ERROR, "command exited with exit code %d", exit_status);
+                return false;
+            }
+
+            break;
+        }
+
+        if (WIFSIGNALED(wstatus)) {
+            nob_log(NOB_ERROR, "command process was terminated by signal %d", WTERMSIG(wstatus));
+            return false;
+        }
+    }
+
+    return true;
+#endif
+}
+
+bool nob_procs_append_with_flush(Nob_Procs *procs, Nob_Proc proc, size_t max_procs_count)
+{
+    nob_da_append(procs, proc);
+
+    if (procs->count >= max_procs_count) {
+        if (!nob_procs_wait_and_reset(procs)) return false;
+    }
+
+    return true;
+}
+
+bool nob_cmd_run_sync_redirect(Nob_Cmd cmd, Nob_Cmd_Redirect redirect)
+{
+    Nob_Proc p = nob_cmd_run_async_redirect(cmd, redirect);
+    if (p == NOB_INVALID_PROC) return false;
+    return nob_proc_wait(p);
+}
+
+bool nob_cmd_run_sync(Nob_Cmd cmd)
+{
+    Nob_Proc p = nob_cmd_run_async(cmd);
+    if (p == NOB_INVALID_PROC) return false;
+    return nob_proc_wait(p);
+}
+
+bool nob_cmd_run_sync_and_reset(Nob_Cmd *cmd)
+{
+    bool p = nob_cmd_run_sync(*cmd);
+    cmd->count = 0;
+    return p;
+}
+
+bool nob_cmd_run_sync_redirect_and_reset(Nob_Cmd *cmd, Nob_Cmd_Redirect redirect)
+{
+    bool p = nob_cmd_run_sync_redirect(*cmd, redirect);
+    cmd->count = 0;
+    if (redirect.fdin) {
+        nob_fd_close(*redirect.fdin);
+        *redirect.fdin = NOB_INVALID_FD;
+    }
+    if (redirect.fdout) {
+        nob_fd_close(*redirect.fdout);
+        *redirect.fdout = NOB_INVALID_FD;
+    }
+    if (redirect.fderr) {
+        nob_fd_close(*redirect.fderr);
+        *redirect.fderr = NOB_INVALID_FD;
+    }
+    return p;
+}
+
+void nob_log(Nob_Log_Level level, const char *fmt, ...)
+{
+    if (level < nob_minimal_log_level) return;
+
+    switch (level) {
+    case NOB_INFO:
+        fprintf(stderr, "[INFO] ");
+        break;
+    case NOB_WARNING:
+        fprintf(stderr, "[WARNING] ");
+        break;
+    case NOB_ERROR:
+        fprintf(stderr, "[ERROR] ");
+        break;
+    case NOB_NO_LOGS: return;
+    default:
+        NOB_UNREACHABLE("nob_log");
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+}
+
+bool nob_read_entire_dir(const char *parent, Nob_File_Paths *children)
+{
+    bool result = true;
+    DIR *dir = NULL;
+
+    dir = opendir(parent);
+    if (dir == NULL) {
+        #ifdef _WIN32
+        nob_log(NOB_ERROR, "Could not open directory %s: %s", parent, nob_win32_error_message(GetLastError()));
+        #else
+        nob_log(NOB_ERROR, "Could not open directory %s: %s", parent, strerror(errno));
+        #endif // _WIN32
+        nob_return_defer(false);
+    }
+
+    errno = 0;
+    struct dirent *ent = readdir(dir);
+    while (ent != NULL) {
+        nob_da_append(children, nob_temp_strdup(ent->d_name));
+        ent = readdir(dir);
+    }
+
+    if (errno != 0) {
+        #ifdef _WIN32
+        nob_log(NOB_ERROR, "Could not read directory %s: %s", parent, nob_win32_error_message(GetLastError()));
+        #else
+        nob_log(NOB_ERROR, "Could not read directory %s: %s", parent, strerror(errno));
+        #endif // _WIN32
+        nob_return_defer(false);
+    }
+
+defer:
+    if (dir) closedir(dir);
+    return result;
+}
+
+bool nob_write_entire_file(const char *path, const void *data, size_t size)
+{
+    bool result = true;
+
+    FILE *f = fopen(path, "wb");
+    if (f == NULL) {
+        nob_log(NOB_ERROR, "Could not open file %s for writing: %s\n", path, strerror(errno));
+        nob_return_defer(false);
+    }
+
+    //           len
+    //           v
+    // aaaaaaaaaa
+    //     ^
+    //     data
+
+    const char *buf = data;
+    while (size > 0) {
+        size_t n = fwrite(buf, 1, size, f);
+        if (ferror(f)) {
+            nob_log(NOB_ERROR, "Could not write into file %s: %s\n", path, strerror(errno));
+            nob_return_defer(false);
+        }
+        size -= n;
+        buf  += n;
+    }
+
+defer:
+    if (f) fclose(f);
+    return result;
+}
+
+Nob_File_Type nob_get_file_type(const char *path)
+{
+#ifdef _WIN32
+    DWORD attr = GetFileAttributesA(path);
+    if (attr == INVALID_FILE_ATTRIBUTES) {
+        nob_log(NOB_ERROR, "Could not get file attributes of %s: %s", path, nob_win32_error_message(GetLastError()));
+        return -1;
+    }
+
+    if (attr & FILE_ATTRIBUTE_DIRECTORY) return NOB_FILE_DIRECTORY;
+    // TODO: detect symlinks on Windows (whatever that means on Windows anyway)
+    return NOB_FILE_REGULAR;
+#else // _WIN32
+    struct stat statbuf;
+    if (stat(path, &statbuf) < 0) {
+        nob_log(NOB_ERROR, "Could not get stat of %s: %s", path, strerror(errno));
+        return -1;
+    }
+
+    if (S_ISREG(statbuf.st_mode)) return NOB_FILE_REGULAR;
+    if (S_ISDIR(statbuf.st_mode)) return NOB_FILE_DIRECTORY;
+    if (S_ISLNK(statbuf.st_mode)) return NOB_FILE_SYMLINK;
+    return NOB_FILE_OTHER;
+#endif // _WIN32
+}
+
+bool nob_delete_file(const char *path)
+{
+    nob_log(NOB_INFO, "deleting %s", path);
+#ifdef _WIN32
+    if (!DeleteFileA(path)) {
+        nob_log(NOB_ERROR, "Could not delete file %s: %s", path, nob_win32_error_message(GetLastError()));
+        return false;
+    }
+    return true;
+#else
+    if (remove(path) < 0) {
+        nob_log(NOB_ERROR, "Could not delete file %s: %s", path, strerror(errno));
+        return false;
+    }
+    return true;
+#endif // _WIN32
+}
+
+bool nob_copy_directory_recursively(const char *src_path, const char *dst_path)
+{
+    bool result = true;
+    Nob_File_Paths children = {0};
+    Nob_String_Builder src_sb = {0};
+    Nob_String_Builder dst_sb = {0};
+    size_t temp_checkpoint = nob_temp_save();
+
+    Nob_File_Type type = nob_get_file_type(src_path);
+    if (type < 0) return false;
+
+    switch (type) {
+        case NOB_FILE_DIRECTORY: {
+            if (!nob_mkdir_if_not_exists(dst_path)) nob_return_defer(false);
+            if (!nob_read_entire_dir(src_path, &children)) nob_return_defer(false);
+
+            for (size_t i = 0; i < children.count; ++i) {
+                if (strcmp(children.items[i], ".") == 0) continue;
+                if (strcmp(children.items[i], "..") == 0) continue;
+
+                src_sb.count = 0;
+                nob_sb_append_cstr(&src_sb, src_path);
+                nob_sb_append_cstr(&src_sb, "/");
+                nob_sb_append_cstr(&src_sb, children.items[i]);
+                nob_sb_append_null(&src_sb);
+
+                dst_sb.count = 0;
+                nob_sb_append_cstr(&dst_sb, dst_path);
+                nob_sb_append_cstr(&dst_sb, "/");
+                nob_sb_append_cstr(&dst_sb, children.items[i]);
+                nob_sb_append_null(&dst_sb);
+
+                if (!nob_copy_directory_recursively(src_sb.items, dst_sb.items)) {
+                    nob_return_defer(false);
+                }
+            }
+        } break;
+
+        case NOB_FILE_REGULAR: {
+            if (!nob_copy_file(src_path, dst_path)) {
+                nob_return_defer(false);
+            }
+        } break;
+
+        case NOB_FILE_SYMLINK: {
+            nob_log(NOB_WARNING, "TODO: Copying symlinks is not supported yet");
+        } break;
+
+        case NOB_FILE_OTHER: {
+            nob_log(NOB_ERROR, "Unsupported type of file %s", src_path);
+            nob_return_defer(false);
+        } break;
+
+        default: NOB_UNREACHABLE("nob_copy_directory_recursively");
+    }
+
+defer:
+    nob_temp_rewind(temp_checkpoint);
+    nob_da_free(src_sb);
+    nob_da_free(dst_sb);
+    nob_da_free(children);
+    return result;
+}
+
+char *nob_temp_strdup(const char *cstr)
+{
+    size_t n = strlen(cstr);
+    char *result = nob_temp_alloc(n + 1);
+    NOB_ASSERT(result != NULL && "Increase NOB_TEMP_CAPACITY");
+    memcpy(result, cstr, n);
+    result[n] = '\0';
+    return result;
+}
+
+void *nob_temp_alloc(size_t size)
+{
+    if (nob_temp_size + size > NOB_TEMP_CAPACITY) return NULL;
+    void *result = &nob_temp[nob_temp_size];
+    nob_temp_size += size;
+    return result;
+}
+
+char *nob_temp_sprintf(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    int n = vsnprintf(NULL, 0, format, args);
+    va_end(args);
+
+    NOB_ASSERT(n >= 0);
+    char *result = nob_temp_alloc(n + 1);
+    NOB_ASSERT(result != NULL && "Extend the size of the temporary allocator");
+    // TODO: use proper arenas for the temporary allocator;
+    va_start(args, format);
+    vsnprintf(result, n + 1, format, args);
+    va_end(args);
+
+    return result;
+}
+
+void nob_temp_reset(void)
+{
+    nob_temp_size = 0;
+}
+
+size_t nob_temp_save(void)
+{
+    return nob_temp_size;
+}
+
+void nob_temp_rewind(size_t checkpoint)
+{
+    nob_temp_size = checkpoint;
+}
+
+const char *nob_temp_sv_to_cstr(Nob_String_View sv)
+{
+    char *result = nob_temp_alloc(sv.count + 1);
+    NOB_ASSERT(result != NULL && "Extend the size of the temporary allocator");
+    memcpy(result, sv.data, sv.count);
+    result[sv.count] = '\0';
+    return result;
+}
+
+int nob_needs_rebuild(const char *output_path, const char **input_paths, size_t input_paths_count)
+{
+#ifdef _WIN32
+    BOOL bSuccess;
+
+    HANDLE output_path_fd = CreateFile(output_path, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_READONLY, NULL);
+    if (output_path_fd == INVALID_HANDLE_VALUE) {
+        // NOTE: if output does not exist it 100% must be rebuilt
+        if (GetLastError() == ERROR_FILE_NOT_FOUND) return 1;
+        nob_log(NOB_ERROR, "Could not open file %s: %s", output_path, nob_win32_error_message(GetLastError()));
+        return -1;
+    }
+    FILETIME output_path_time;
+    bSuccess = GetFileTime(output_path_fd, NULL, NULL, &output_path_time);
+    CloseHandle(output_path_fd);
+    if (!bSuccess) {
+        nob_log(NOB_ERROR, "Could not get time of %s: %s", output_path, nob_win32_error_message(GetLastError()));
+        return -1;
+    }
+
+    for (size_t i = 0; i < input_paths_count; ++i) {
+        const char *input_path = input_paths[i];
+        HANDLE input_path_fd = CreateFile(input_path, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_READONLY, NULL);
+        if (input_path_fd == INVALID_HANDLE_VALUE) {
+            // NOTE: non-existing input is an error cause it is needed for building in the first place
+            nob_log(NOB_ERROR, "Could not open file %s: %s", input_path, nob_win32_error_message(GetLastError()));
+            return -1;
+        }
+        FILETIME input_path_time;
+        bSuccess = GetFileTime(input_path_fd, NULL, NULL, &input_path_time);
+        CloseHandle(input_path_fd);
+        if (!bSuccess) {
+            nob_log(NOB_ERROR, "Could not get time of %s: %s", input_path, nob_win32_error_message(GetLastError()));
+            return -1;
+        }
+
+        // NOTE: if even a single input_path is fresher than output_path that's 100% rebuild
+        if (CompareFileTime(&input_path_time, &output_path_time) == 1) return 1;
+    }
+
+    return 0;
+#else
+    struct stat statbuf = {0};
+
+    if (stat(output_path, &statbuf) < 0) {
+        // NOTE: if output does not exist it 100% must be rebuilt
+        if (errno == ENOENT) return 1;
+        nob_log(NOB_ERROR, "could not stat %s: %s", output_path, strerror(errno));
+        return -1;
+    }
+    int output_path_time = statbuf.st_mtime;
+
+    for (size_t i = 0; i < input_paths_count; ++i) {
+        const char *input_path = input_paths[i];
+        if (stat(input_path, &statbuf) < 0) {
+            // NOTE: non-existing input is an error cause it is needed for building in the first place
+            nob_log(NOB_ERROR, "could not stat %s: %s", input_path, strerror(errno));
+            return -1;
+        }
+        int input_path_time = statbuf.st_mtime;
+        // NOTE: if even a single input_path is fresher than output_path that's 100% rebuild
+        if (input_path_time > output_path_time) return 1;
+    }
+
+    return 0;
+#endif
+}
+
+int nob_needs_rebuild1(const char *output_path, const char *input_path)
+{
+    return nob_needs_rebuild(output_path, &input_path, 1);
+}
+
+const char *nob_path_name(const char *path)
+{
+#ifdef _WIN32
+    const char *p1 = strrchr(path, '/');
+    const char *p2 = strrchr(path, '\\');
+    const char *p = (p1 > p2)? p1 : p2;  // NULL is ignored if the other search is successful
+    return p ? p + 1 : path;
+#else
+    const char *p = strrchr(path, '/');
+    return p ? p + 1 : path;
+#endif // _WIN32
+}
+
+bool nob_rename(const char *old_path, const char *new_path)
+{
+    nob_log(NOB_INFO, "renaming %s -> %s", old_path, new_path);
+#ifdef _WIN32
+    if (!MoveFileEx(old_path, new_path, MOVEFILE_REPLACE_EXISTING)) {
+        nob_log(NOB_ERROR, "could not rename %s to %s: %s", old_path, new_path, nob_win32_error_message(GetLastError()));
+        return false;
+    }
+#else
+    if (rename(old_path, new_path) < 0) {
+        nob_log(NOB_ERROR, "could not rename %s to %s: %s", old_path, new_path, strerror(errno));
+        return false;
+    }
+#endif // _WIN32
+    return true;
+}
+
+bool nob_read_entire_file(const char *path, Nob_String_Builder *sb)
+{
+    bool result = true;
+
+    FILE *f = fopen(path, "rb");
+    if (f == NULL)                 nob_return_defer(false);
+    if (fseek(f, 0, SEEK_END) < 0) nob_return_defer(false);
+#ifndef _WIN32
+    long m = ftell(f);
+#else
+    long long m = _ftelli64(f);
+#endif
+    if (m < 0)                     nob_return_defer(false);
+    if (fseek(f, 0, SEEK_SET) < 0) nob_return_defer(false);
+
+    size_t new_count = sb->count + m;
+    if (new_count > sb->capacity) {
+        sb->items = NOB_REALLOC(sb->items, new_count);
+        NOB_ASSERT(sb->items != NULL && "Buy more RAM lool!!");
+        sb->capacity = new_count;
+    }
+
+    fread(sb->items + sb->count, m, 1, f);
+    if (ferror(f)) {
+        // TODO: Afaik, ferror does not set errno. So the error reporting in defer is not correct in this case.
+        nob_return_defer(false);
+    }
+    sb->count = new_count;
+
+defer:
+    if (!result) nob_log(NOB_ERROR, "Could not read file %s: %s", path, strerror(errno));
+    if (f) fclose(f);
+    return result;
+}
+
+int nob_sb_appendf(Nob_String_Builder *sb, const char *fmt, ...)
+{
+    va_list args;
+
+    va_start(args, fmt);
+    int n = vsnprintf(NULL, 0, fmt, args);
+    va_end(args);
+
+    // NOTE: the new_capacity needs to be +1 because of the null terminator.
+    // However, further below we increase sb->count by n, not n + 1.
+    // This is because we don't want the sb to include the null terminator. The user can always sb_append_null() if they want it
+    nob_da_reserve(sb, sb->count + n + 1);
+    char *dest = sb->items + sb->count;
+    va_start(args, fmt);
+    vsnprintf(dest, n+1, fmt, args);
+    va_end(args);
+
+    sb->count += n;
+
+    return n;
+}
+
+Nob_String_View nob_sv_chop_by_delim(Nob_String_View *sv, char delim)
+{
+    size_t i = 0;
+    while (i < sv->count && sv->data[i] != delim) {
+        i += 1;
+    }
+
+    Nob_String_View result = nob_sv_from_parts(sv->data, i);
+
+    if (i < sv->count) {
+        sv->count -= i + 1;
+        sv->data  += i + 1;
+    } else {
+        sv->count -= i;
+        sv->data  += i;
+    }
+
+    return result;
+}
+
+Nob_String_View nob_sv_chop_left(Nob_String_View *sv, size_t n)
+{
+    if (n > sv->count) {
+        n = sv->count;
+    }
+
+    Nob_String_View result = nob_sv_from_parts(sv->data, n);
+
+    sv->data  += n;
+    sv->count -= n;
+
+    return result;
+}
+
+Nob_String_View nob_sv_from_parts(const char *data, size_t count)
+{
+    Nob_String_View sv;
+    sv.count = count;
+    sv.data = data;
+    return sv;
+}
+
+Nob_String_View nob_sv_trim_left(Nob_String_View sv)
+{
+    size_t i = 0;
+    while (i < sv.count && isspace(sv.data[i])) {
+        i += 1;
+    }
+
+    return nob_sv_from_parts(sv.data + i, sv.count - i);
+}
+
+Nob_String_View nob_sv_trim_right(Nob_String_View sv)
+{
+    size_t i = 0;
+    while (i < sv.count && isspace(sv.data[sv.count - 1 - i])) {
+        i += 1;
+    }
+
+    return nob_sv_from_parts(sv.data, sv.count - i);
+}
+
+Nob_String_View nob_sv_trim(Nob_String_View sv)
+{
+    return nob_sv_trim_right(nob_sv_trim_left(sv));
+}
+
+Nob_String_View nob_sv_from_cstr(const char *cstr)
+{
+    return nob_sv_from_parts(cstr, strlen(cstr));
+}
+
+bool nob_sv_eq(Nob_String_View a, Nob_String_View b)
+{
+    if (a.count != b.count) {
+        return false;
+    } else {
+        return memcmp(a.data, b.data, a.count) == 0;
+    }
+}
+
+bool nob_sv_end_with(Nob_String_View sv, const char *cstr)
+{
+    size_t cstr_count = strlen(cstr);
+    if (sv.count >= cstr_count) {
+        size_t ending_start = sv.count - cstr_count;
+        Nob_String_View sv_ending = nob_sv_from_parts(sv.data + ending_start, cstr_count);
+        return nob_sv_eq(sv_ending, nob_sv_from_cstr(cstr));
+    }
+    return false;
+}
+
+
+bool nob_sv_starts_with(Nob_String_View sv, Nob_String_View expected_prefix)
+{
+    if (expected_prefix.count <= sv.count) {
+        Nob_String_View actual_prefix = nob_sv_from_parts(sv.data, expected_prefix.count);
+        return nob_sv_eq(expected_prefix, actual_prefix);
+    }
+
+    return false;
+}
+
+// RETURNS:
+//  0 - file does not exists
+//  1 - file exists
+// -1 - error while checking if file exists. The error is logged
+int nob_file_exists(const char *file_path)
+{
+#if _WIN32
+    // TODO: distinguish between "does not exists" and other errors
+    DWORD dwAttrib = GetFileAttributesA(file_path);
+    return dwAttrib != INVALID_FILE_ATTRIBUTES;
+#else
+    struct stat statbuf;
+    if (stat(file_path, &statbuf) < 0) {
+        if (errno == ENOENT) return 0;
+        nob_log(NOB_ERROR, "Could not check if file %s exists: %s", file_path, strerror(errno));
+        return -1;
+    }
+    return 1;
+#endif
+}
+
+const char *nob_get_current_dir_temp(void)
+{
+#ifdef _WIN32
+    DWORD nBufferLength = GetCurrentDirectory(0, NULL);
+    if (nBufferLength == 0) {
+        nob_log(NOB_ERROR, "could not get current directory: %s", nob_win32_error_message(GetLastError()));
+        return NULL;
+    }
+
+    char *buffer = (char*) nob_temp_alloc(nBufferLength);
+    if (GetCurrentDirectory(nBufferLength, buffer) == 0) {
+        nob_log(NOB_ERROR, "could not get current directory: %s", nob_win32_error_message(GetLastError()));
+        return NULL;
+    }
+
+    return buffer;
+#else
+    char *buffer = (char*) nob_temp_alloc(PATH_MAX);
+    if (getcwd(buffer, PATH_MAX) == NULL) {
+        nob_log(NOB_ERROR, "could not get current directory: %s", strerror(errno));
+        return NULL;
+    }
+
+    return buffer;
+#endif // _WIN32
+}
+
+bool nob_set_current_dir(const char *path)
+{
+#ifdef _WIN32
+    if (!SetCurrentDirectory(path)) {
+        nob_log(NOB_ERROR, "could not set current directory to %s: %s", path, nob_win32_error_message(GetLastError()));
+        return false;
+    }
+    return true;
+#else
+    if (chdir(path) < 0) {
+        nob_log(NOB_ERROR, "could not set current directory to %s: %s", path, strerror(errno));
+        return false;
+    }
+    return true;
+#endif // _WIN32
+}
+
+// minirent.h SOURCE BEGIN ////////////////////////////////////////
+#ifdef _WIN32
+struct DIR
+{
+    HANDLE hFind;
+    WIN32_FIND_DATA data;
+    struct dirent *dirent;
+};
+
+DIR *opendir(const char *dirpath)
+{
+    NOB_ASSERT(dirpath);
+
+    char buffer[MAX_PATH];
+    snprintf(buffer, MAX_PATH, "%s\\*", dirpath);
+
+    DIR *dir = (DIR*)NOB_REALLOC(NULL, sizeof(DIR));
+    memset(dir, 0, sizeof(DIR));
+
+    dir->hFind = FindFirstFile(buffer, &dir->data);
+    if (dir->hFind == INVALID_HANDLE_VALUE) {
+        // TODO: opendir should set errno accordingly on FindFirstFile fail
+        // https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+        errno = ENOSYS;
+        goto fail;
+    }
+
+    return dir;
+
+fail:
+    if (dir) {
+        NOB_FREE(dir);
+    }
+
+    return NULL;
+}
+
+struct dirent *readdir(DIR *dirp)
+{
+    NOB_ASSERT(dirp);
+
+    if (dirp->dirent == NULL) {
+        dirp->dirent = (struct dirent*)NOB_REALLOC(NULL, sizeof(struct dirent));
+        memset(dirp->dirent, 0, sizeof(struct dirent));
+    } else {
+        if(!FindNextFile(dirp->hFind, &dirp->data)) {
+            if (GetLastError() != ERROR_NO_MORE_FILES) {
+                // TODO: readdir should set errno accordingly on FindNextFile fail
+                // https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+                errno = ENOSYS;
+            }
+
+            return NULL;
+        }
+    }
+
+    memset(dirp->dirent->d_name, 0, sizeof(dirp->dirent->d_name));
+
+    strncpy(
+        dirp->dirent->d_name,
+        dirp->data.cFileName,
+        sizeof(dirp->dirent->d_name) - 1);
+
+    return dirp->dirent;
+}
+
+int closedir(DIR *dirp)
+{
+    NOB_ASSERT(dirp);
+
+    if(!FindClose(dirp->hFind)) {
+        // TODO: closedir should set errno accordingly on FindClose fail
+        // https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+        errno = ENOSYS;
+        return -1;
+    }
+
+    if (dirp->dirent) {
+        NOB_FREE(dirp->dirent);
+    }
+    NOB_FREE(dirp);
+
+    return 0;
+}
+#endif // _WIN32
+// minirent.h SOURCE END ////////////////////////////////////////
+
+// #endif // NOB_IMPLEMENTATION
+
+#ifndef NOB_STRIP_PREFIX_GUARD_
+#define NOB_STRIP_PREFIX_GUARD_
+    // NOTE: The name stripping should be part of the header so it's not accidentally included
+    // several times. At the same time, it should be at the end of the file so to not create any
+    // potential conflicts in the NOB_IMPLEMENTATION. The header obviously cannot be at the end
+    // of the file because NOB_IMPLEMENTATION needs the forward declarations from there. So the
+    // solution is to split the header into two parts where the name stripping part is at the
+    // end of the file after the NOB_IMPLEMENTATION.
+    #ifdef NOB_STRIP_PREFIX
+        #define TODO NOB_TODO
+        #define UNREACHABLE NOB_UNREACHABLE
+        #define UNUSED NOB_UNUSED
+        #define ARRAY_LEN NOB_ARRAY_LEN
+        #define ARRAY_GET NOB_ARRAY_GET
+        #define INFO NOB_INFO
+        #define WARNING NOB_WARNING
+        #define ERROR NOB_ERROR
+        #define NO_LOGS NOB_NO_LOGS
+        #define Log_Level Nob_Log_Level
+        #define minimal_log_level nob_minimal_log_level
+        // NOTE: Name log is already defined in math.h and historically always was the natural logarithmic function.
+        // So there should be no reason to strip the `nob_` prefix in this specific case.
+        // #define log nob_log
+        #define shift nob_shift
+        #define shift_args nob_shift_args
+        #define File_Paths Nob_File_Paths
+        #define FILE_REGULAR NOB_FILE_REGULAR
+        #define FILE_DIRECTORY NOB_FILE_DIRECTORY
+        #define FILE_SYMLINK NOB_FILE_SYMLINK
+        #define FILE_OTHER NOB_FILE_OTHER
+        #define File_Type Nob_File_Type
+        #define mkdir_if_not_exists nob_mkdir_if_not_exists
+        #define copy_file nob_copy_file
+        #define copy_directory_recursively nob_copy_directory_recursively
+        #define read_entire_dir nob_read_entire_dir
+        #define write_entire_file nob_write_entire_file
+        #define get_file_type nob_get_file_type
+        #define delete_file nob_delete_file
+        #define return_defer nob_return_defer
+        #define da_append nob_da_append
+        #define da_free nob_da_free
+        #define da_append_many nob_da_append_many
+        #define da_resize nob_da_resize
+        #define da_reserve nob_da_reserve
+        #define da_last nob_da_last
+        #define da_remove_unordered nob_da_remove_unordered
+        #define da_foreach nob_da_foreach
+        #define String_Builder Nob_String_Builder
+        #define read_entire_file nob_read_entire_file
+        #define sb_appendf nob_sb_appendf
+        #define sb_append_buf nob_sb_append_buf
+        #define sb_append_cstr nob_sb_append_cstr
+        #define sb_append_null nob_sb_append_null
+        #define sb_free nob_sb_free
+        #define Proc Nob_Proc
+        #define INVALID_PROC NOB_INVALID_PROC
+        #define Fd Nob_Fd
+        #define INVALID_FD NOB_INVALID_FD
+        #define fd_open_for_read nob_fd_open_for_read
+        #define fd_open_for_write nob_fd_open_for_write
+        #define fd_close nob_fd_close
+        #define Procs Nob_Procs
+        #define proc_wait nob_proc_wait
+        #define procs_wait nob_procs_wait
+        #define procs_wait_and_reset nob_procs_wait_and_reset
+        #define procs_append_with_flush nob_procs_append_with_flush
+        #define Cmd Nob_Cmd
+        #define Cmd_Redirect Nob_Cmd_Redirect
+        #define cmd_render nob_cmd_render
+        #define cmd_append nob_cmd_append
+        #define cmd_extend nob_cmd_extend
+        #define cmd_free nob_cmd_free
+        #define cmd_run_async nob_cmd_run_async
+        #define cmd_run_async_and_reset nob_cmd_run_async_and_reset
+        #define cmd_run_async_redirect nob_cmd_run_async_redirect
+        #define cmd_run_async_redirect_and_reset nob_cmd_run_async_redirect_and_reset
+        #define cmd_run_sync nob_cmd_run_sync
+        #define cmd_run_sync_and_reset nob_cmd_run_sync_and_reset
+        #define cmd_run_sync_redirect nob_cmd_run_sync_redirect
+        #define cmd_run_sync_redirect_and_reset nob_cmd_run_sync_redirect_and_reset
+        #define temp_strdup nob_temp_strdup
+        #define temp_alloc nob_temp_alloc
+        #define temp_sprintf nob_temp_sprintf
+        #define temp_reset nob_temp_reset
+        #define temp_save nob_temp_save
+        #define temp_rewind nob_temp_rewind
+        #define path_name nob_path_name
+        // NOTE: rename(2) is widely known POSIX function. We never wanna collide with it.
+        // #define rename nob_rename
+        #define needs_rebuild nob_needs_rebuild
+        #define needs_rebuild1 nob_needs_rebuild1
+        #define file_exists nob_file_exists
+        #define get_current_dir_temp nob_get_current_dir_temp
+        #define set_current_dir nob_set_current_dir
+        #define String_View Nob_String_View
+        #define temp_sv_to_cstr nob_temp_sv_to_cstr
+        #define sv_chop_by_delim nob_sv_chop_by_delim
+        #define sv_chop_left nob_sv_chop_left
+        #define sv_trim nob_sv_trim
+        #define sv_trim_left nob_sv_trim_left
+        #define sv_trim_right nob_sv_trim_right
+        #define sv_eq nob_sv_eq
+        #define sv_starts_with nob_sv_starts_with
+        #define sv_end_with nob_sv_end_with
+        #define sv_from_cstr nob_sv_from_cstr
+        #define sv_from_parts nob_sv_from_parts
+        #define sb_to_sv nob_sb_to_sv
+        #define win32_error_message nob_win32_error_message
+    #endif // NOB_STRIP_PREFIX
+#endif // NOB_STRIP_PREFIX_GUARD_
+
+/*
+   Revision history:
+
+     1.20.6 (2025-05-16) Never strip nob_* suffix from nob_rename (By @rexim)
+     1.20.5 (2025-05-16) NOB_PRINTF_FORMAT() support for MinGW (By @KillerxDBr)
+     1.20.4 (2025-05-16) More reliable rendering of the Windows command (By @vylsaz)
+     1.20.3 (2025-05-16) Add check for __clang__ along with _MSC_VER checks (By @nashiora)
+     1.20.2 (2025-04-24) Report the program name that failed to start up in nob_cmd_run_async_redirect() (By @rexim)
+     1.20.1 (2025-04-16) Use vsnprintf() in nob_sb_appendf() instead of vsprintf() (By @LainLayer)
+     1.20.0 (2025-04-16) Introduce nob_cc(), nob_cc_flags(), nob_cc_inputs(), nob_cc_output() macros (By @rexim)
+     1.19.0 (2025-03-25) Add nob_procs_append_with_flush() (By @rexim and @anion155)
+     1.18.0 (2025-03-24) Add nob_da_foreach() (By @rexim)
+                         Allow file sizes greater than 2GB to be read on windows (By @satchelfrost and @KillerxDBr)
+                         Fix nob_fd_open_for_write behaviour on windows so it truncates the opened files (By @twixuss)
+     1.17.0 (2025-03-16) Factor out nob_da_reserve() (By @rexim)
+                         Add nob_sb_appendf() (By @angelcaru)
+     1.16.1 (2025-03-16) Make nob_da_resize() exponentially grow capacity similar to no_da_append_many()
+     1.16.0 (2025-03-16) Introduce NOB_PRINTF_FORMAT
+     1.15.1 (2025-03-16) Make nob.h compilable in gcc/clang with -std=c99 on POSIX. This includes:
+                           not using strsignal()
+                           using S_IS* stat macros instead of S_IF* flags
+     1.15.0 (2025-03-03) Add nob_sv_chop_left()
+     1.14.1 (2025-03-02) Add NOB_EXPERIMENTAL_DELETE_OLD flag that enables deletion of nob.old in Go Rebuild Urself™ Technology
+     1.14.0 (2025-02-17) Add nob_da_last()
+                         Add nob_da_remove_unordered()
+     1.13.1 (2025-02-17) Fix segfault in nob_delete_file() (By @SileNce5k)
+     1.13.0 (2025-02-11) Add nob_da_resize() (By @satchelfrost)
+     1.12.0 (2025-02-04) Add nob_delete_file()
+                         Add nob_sv_start_with()
+     1.11.0 (2025-02-04) Add NOB_GO_REBUILD_URSELF_PLUS() (By @rexim)
+     1.10.0 (2025-02-04) Make NOB_ASSERT, NOB_REALLOC, and NOB_FREE redefinable (By @OleksiiBulba)
+      1.9.1 (2025-02-04) Fix signature of nob_get_current_dir_temp() (By @julianstoerig)
+      1.9.0 (2024-11-06) Add Nob_Cmd_Redirect mechanism (By @rexim)
+                         Add nob_path_name() (By @0dminnimda)
+      1.8.0 (2024-11-03) Add nob_cmd_extend() (By @0dminnimda)
+      1.7.0 (2024-11-03) Add nob_win32_error_message and NOB_WIN32_ERR_MSG_SIZE (By @KillerxDBr)
+      1.6.0 (2024-10-27) Add nob_cmd_run_sync_and_reset()
+                         Add nob_sb_to_sv()
+                         Add nob_procs_wait_and_reset()
+      1.5.1 (2024-10-25) Include limits.h for Linux musl libc (by @pgalkin)
+      1.5.0 (2024-10-23) Add nob_get_current_dir_temp()
+                         Add nob_set_current_dir()
+      1.4.0 (2024-10-21) Fix UX issues with NOB_GO_REBUILD_URSELF on Windows when you call nob without the .exe extension (By @pgalkin)
+                         Add nob_sv_end_with (By @pgalkin)
+      1.3.2 (2024-10-21) Fix unreachable error in nob_log on passing NOB_NO_LOGS
+      1.3.1 (2024-10-21) Fix redeclaration error for minimal_log_level (By @KillerxDBr)
+      1.3.0 (2024-10-17) Add NOB_UNREACHABLE
+      1.2.2 (2024-10-16) Fix compilation of nob_cmd_run_sync_and_reset on Windows (By @KillerxDBr)
+      1.2.1 (2024-10-16) Add a separate include guard for NOB_STRIP_PREFIX.
+      1.2.0 (2024-10-15) Make NOB_DA_INIT_CAP redefinable
+                         Add NOB_STRIP_PREFIX which strips off nob_* prefix from all the user facing names
+                         Add NOB_UNUSED macro
+                         Add NOB_TODO macro
+                         Add nob_sv_trim_left and nob_sv_trim_right declarations to the header part
+      1.1.1 (2024-10-15) Remove forward declaration for is_path1_modified_after_path2
+      1.1.0 (2024-10-15) nob_minimal_log_level
+                         nob_cmd_run_sync_and_reset
+      1.0.0 (2024-10-15) first release based on https://github.com/tsoding/musializer/blob/4ac7cce9874bc19e02d8c160c8c6229de8919401/nob.h
+*/
+
+/*
+   Version Conventions:
+
+      We are following https://semver.org/ so the version has a format MAJOR.MINOR.PATCH:
+      - Modifying comments does not update the version.
+      - PATCH is incremented in case of a bug fix or refactoring without touching the API.
+      - MINOR is incremented when new functions and/or types are added in a way that does
+        not break any existing user code. We want to do this in the majority of the situation.
+        If we want to delete a certain function or type in favor of another one we should
+        just add the new function/type and deprecate the old one in a backward compatible way
+        and let them co-exist for a while.
+      - MAJOR update should be just a periodic cleanup of the deprecated functions and types
+        without really modifying any existing functionality.
+
+   Naming Conventions:
+
+      - All the user facing names should be prefixed with `nob_` or `NOB_` depending on the case.
+      - The prefixes of non-redefinable names should be strippable with NOB_STRIP_PREFIX (unless
+        explicitly stated otherwise like in case of nob_log).
+      - Internal functions should be prefixed with `nob__` (double underscore).
+*/
+
+/*
+   ------------------------------------------------------------------------------
+   This software is available under 2 licenses -- choose whichever you prefer.
+   ------------------------------------------------------------------------------
+   ALTERNATIVE A - MIT License
+   Copyright (c) 2024 Alexey Kutepov
+   Permission is hereby granted, free of charge, to any person obtaining a copy of
+   this software and associated documentation files (the "Software"), to deal in
+   the Software without restriction, including without limitation the rights to
+   use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is furnished to do
+   so, subject to the following conditions:
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+   ------------------------------------------------------------------------------
+   ALTERNATIVE B - Public Domain (www.unlicense.org)
+   This is free and unencumbered software released into the public domain.
+   Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+   software, either in source code form or as a compiled binary, for any purpose,
+   commercial or non-commercial, and by any means.
+   In jurisdictions that recognize copyright laws, the author or authors of this
+   software dedicate any and all copyright interest in the software to the public
+   domain. We make this dedication for the benefit of the public at large and to
+   the detriment of our heirs and successors. We intend this dedication to be an
+   overt act of relinquishment in perpetuity of all present and future rights to
+   this software under copyright law.
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+   ------------------------------------------------------------------------------
+*/

--- a/projects/cli/test.rs
+++ b/projects/cli/test.rs
@@ -1,0 +1,18 @@
+use std::fs::OpenOptions;
+use std::os::unix::fs::OpenOptionsExt;
+//use std::fs::File;
+
+fn main() {
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o644)
+        .open("/Users/kennethg/Desktop/abra-lang/projects/cli/._abra/example2.ssa");
+    //let file = File::create("/Users/kennethg/Desktop/abra-lang/projects/cli/._abra/example2.ssa");
+    
+    match file {
+        Ok(_) => println!("Rust succeeded"),
+        Err(e) => println!("Rust failed: {}", e),
+    }
+}

--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -2782,6 +2782,9 @@ pub type Compiler {
 
         try self._callMalloc(sizeVal, Some("ptr.mem"))
       }
+      "pointer_null" => {
+        try self._currentFn.block.buildAdd(Value.Int(0), Value.Int(0)) else |e| return qbeError(e)
+      }
       "pointer_realloc" => {
         val (ptr, count) = self._intrinsicArgs2(intrinsicFnName, arguments)
         val ptrVal = try self._compileExpression(ptr)
@@ -2949,6 +2952,12 @@ pub type Compiler {
       }
       "functionnames" => {
         try self._currentFn.block.buildAdd(Value.Int(0), self._fnNamesPtr) else |e| return qbeError(e)
+      }
+      "pointer_address" => {
+        val arg = self._intrinsicArgs1(intrinsicFnName, arguments)
+        val argVal = try self._compileExpression(arg)
+
+        try self._currentFn.block.buildAdd(Value.Int(0), argVal) else |e| return qbeError(e)
       }
       _ => unreachable("unsupported intrinsic '$intrinsicFnName'")
     }

--- a/projects/compiler/test/compiler/process_callstack.abra
+++ b/projects/compiler/test/compiler/process_callstack.abra
@@ -26,7 +26,7 @@ val arr = [1].map((i, _) => {
 /// Expect:   at baz (%TEST_DIR%/compiler/process_callstack.abra:10)
 /// Expect:   at bar (%TEST_DIR%/compiler/process_callstack.abra:5)
 /// Expect:   at foo (%TEST_DIR%/compiler/process_callstack.abra:19)
-/// Expect:   at <expression> (%STD_DIR%/prelude.abra:781)
+/// Expect:   at <expression> (%STD_DIR%/prelude.abra:786)
 /// Expect:   at Array.map (%TEST_DIR%/compiler/process_callstack.abra:18)
 
 type OneTwoThreeIterator {

--- a/projects/std/src/_intrinsics.abra
+++ b/projects/std/src/_intrinsics.abra
@@ -57,6 +57,9 @@ pub type Pointer<T> {
   @intrinsic("pointer_malloc")
   pub func malloc<T>(count: Int): Pointer<T>
 
+  @intrinsic("pointer_null")
+  pub func null<T>(): Pointer<T>
+
   @intrinsic("pointer_is_null")
   pub func isNullPtr(self): Bool
 

--- a/projects/std/src/fs.abra
+++ b/projects/std/src/fs.abra
@@ -55,6 +55,34 @@ pub type File {
   accessMode: AccessMode
   path: String
 
+  // Opens a file in read-only mode.
+  pub func open(path: String): Result<File, FileIOError> {
+    val accessMode = AccessMode.ReadOnly
+    val oflag = accessMode._toUnderlying()
+    val fd = libc.open(path._buffer, oflag, 0)
+    if fd == -1 {
+      val errMsg = _strerror(libc.errno())
+      return Err(error: FileIOError.CouldNotOpen(message: "Could not open '$path' for reading: $errMsg"))
+    }
+
+    Ok(File(_fd: fd, accessMode: accessMode, path: path))
+  }
+
+  // Opens a file in write-only mode; will create a file if none exists, and will truncate it if it does.
+  pub func create(path: String): Result<File, FileIOError> {
+    val accessMode = AccessMode.WriteOnly
+    var oflag = accessMode._toUnderlying() || libc.O_CREAT || libc.O_TRUNC
+
+    val mode = 420 // 420 is 0644, but octal numbers aren't supported yet...
+    val fd = libc.open(path._buffer, oflag, mode)
+    if fd == -1 {
+      val errMsg = _strerror(libc.errno())
+      return Err(error: FileIOError.CouldNotOpen(message: "Could not open '$path' for writing: $errMsg"))
+    }
+
+    Ok(File(_fd: fd, accessMode: accessMode, path: path))
+  }
+
   pub func close(self): Result<Int, FileIOError> {
     if libc.close(self._fd) == -1 {
       val errMsg = _strerror(libc.errno())
@@ -75,6 +103,7 @@ pub type File {
   }
 }
 
+// TODO: replace with File.open
 pub func openFile(path: String, accessMode: AccessMode): Result<File, FileIOError> {
   val oflag = accessMode._toUnderlying()
   val fd = libc.open(path._buffer, oflag, 0)
@@ -86,6 +115,7 @@ pub func openFile(path: String, accessMode: AccessMode): Result<File, FileIOErro
   Ok(File(_fd: fd, accessMode: accessMode, path: path))
 }
 
+// TODO: replace with File.create
 pub func createFile(path: String, accessMode: AccessMode): Result<File, FileIOError> {
   var oflag = accessMode._toUnderlying() || libc.O_CREAT
 

--- a/projects/std/src/io.abra
+++ b/projects/std/src/io.abra
@@ -1,0 +1,67 @@
+import "libc" as libc
+import Pointer, Byte from "./_intrinsics"
+
+pub enum MakePipeError {
+  BadAddress(message: String)
+  TooManyOpenFiles(message: String)
+  SystemFileTableFull(message: String)
+  Unknown(message: String)
+}
+
+// TODO: create dedicated reader/writer types rather than passing around file descriptors
+pub type Pipe {
+  pub writerFd: Int
+  pub readerFd: Int
+}
+
+pub func makePipe(): Result<Pipe, MakePipeError> {
+  val pipefds = Pointer.malloc<Int>(1) 
+  if libc.pipe(pipefds) == -1 {
+    val errno = libc.errno()
+    val msg = strerror(errno)
+    val err = if errno == libc.EFAULT {
+      MakePipeError.BadAddress(message: msg)
+    } else if errno == libc.EMFILE {
+      MakePipeError.TooManyOpenFiles(message: msg)
+    } else if errno == libc.ENFILE {
+      MakePipeError.SystemFileTableFull(message: msg)
+    } else {
+      MakePipeError.Unknown(message: msg)
+    }
+
+    return Err(err)
+  }
+
+  val pipefdsVal = pipefds.loadAt(0)
+  val pipeFdWrite = pipefdsVal >> 32
+  val pipeFdRead = pipefdsVal && ((1 << 32) - 1)
+
+  Ok(Pipe(writerFd: pipeFdWrite, readerFd: pipeFdRead))
+}
+
+func strerror(errno: Int): String {
+  val buf = libc.strerror(errno)
+  val len = libc.strlen(buf)
+  val str = String.withLength(len)
+  str._buffer.copyFrom(0, buf, 0, len)
+  str
+}
+
+pub type BufferedReader {
+  fd: Int
+  bufSize: Int = 1024
+
+  pub func readAllToString(self): Result<String, Int> {
+    val readBuffer: String[] = []
+    val buf = Pointer.malloc<Byte>(self.bufSize)
+    while true {
+      val bytesRead = libc.read(self.fd, buf, self.bufSize) // todo: handle error
+      if bytesRead == -1 unreachable(strerror(libc.errno()))
+
+      readBuffer.push(String(length: bytesRead, _buffer: buf))
+      if bytesRead < self.bufSize break
+    }
+
+    Ok(readBuffer.join())
+  }
+}

--- a/projects/std/src/libc.abra
+++ b/projects/std/src/libc.abra
@@ -2,6 +2,26 @@ import Pointer, Byte, intrinsic from "./_intrinsics"
 
 pub decorator external { name: String }
 
+pub func NULL<T>(): Pointer<T> = Pointer.null()
+
+pub val EFAULT = 14
+pub val EMFILE = 24
+pub val ENFILE = 23
+@external("pipe")
+pub func pipe(fds: Pointer<Int>): Int
+
+@external("dup2")
+pub func dup2(fd1: Int, fd2: Int): Int
+
+@external("wait")
+pub func wait(status: Pointer<Int>): Int
+
+@external("fork") 
+pub func fork(): Int
+
+@external("execvp") 
+pub func execvp(file: Pointer<Byte>, args: Pointer<Pointer<Byte>>): Int
+
 @external("getenv")
 pub func getenv(name: Pointer<Byte>): Pointer<Byte>
 
@@ -15,6 +35,7 @@ pub val O_RDONLY = 0
 pub val O_WRONLY = 1
 pub val O_RDWR   = 2
 pub val O_CREAT  = 512
+pub val O_TRUNC  = 1024
 
 @external("open")
 pub func open(pathname: Pointer<Byte>, flags: Int, mode: Int): Int
@@ -53,8 +74,34 @@ pub func strlen(s: Pointer<Byte>): Int
 @external("uname")
 pub func uname(utsnameBuf: Pointer<Byte>): Int
 
+@external("umask")
+pub func umask(cmask: Int): Int
+
 @external("rand")
 pub func rand(): Int
 
+@external("sleep")
+pub func sleep(secs: Int): Unit
+
+@external("fchmod")
+pub func fchmod(fildes: Int, mode: Int): Int
+
+@external("time")
+pub func time(seed: Int): Int
+
 @external("exit")
 pub func exit(status: Int): Unit
+
+func WSTATUS(status: Int): Int = status && 0x7f
+
+// #define WIFEXITED(x)    (_WSTATUS(x) == 0)
+pub func WIFEXITED(status: Int): Bool = WSTATUS(status) == 0
+
+// #define WEXITSTATUS(x)  ((_W_INT(x) >> 8) & 0x000000ff)
+pub func WEXITSTATUS(status: Int): Int = (status >> 8) && 0xff
+
+// #define WIFSIGNALED(x)  (_WSTATUS(x) != _WSTOPPED && _WSTATUS(x) != 0)
+pub func WIFSIGNALED(status: Int): Bool = WSTATUS(status) != 0x7f && WSTATUS(status) != 0
+
+// #define WTERMSIG(x)     (_WSTATUS(x))
+pub func WTERMSIG(status: Int): Int = WSTATUS(status)

--- a/projects/std/src/path.abra
+++ b/projects/std/src/path.abra
@@ -1,0 +1,32 @@
+import "fs" as fs
+
+pub type Path {
+  pub segments: String[]
+
+  pub func fromString(fileName: String): Path {
+    val parts = if fileName[0] == "/" {
+      fileName.split("/")
+    } else {
+      val cwd = fs.getCurrentWorkingDirectory()
+      val path = cwd + "/" + fileName
+      path.split("/")
+    }
+
+    val segments: String[] = []
+    for part in parts {
+      if part.isEmpty() || part == "." continue
+      if part == ".." {
+        segments.pop()
+        continue
+      }
+
+      segments.push(part)
+    }
+
+    Path(segments: segments)
+  }
+
+  pub func asString(self): String {
+    "/${self.segments.join("/")}"
+  }
+}

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -291,7 +291,7 @@ type CharsIterator {
 
 type String {
   pub length: Int
-  _buffer: Pointer<Byte>
+  pub _buffer: Pointer<Byte>
 
   pub func withLength(length: Int): String {
     // Allocate length + 1 bytes; each String ends in a \0 byte. Even though we know the length, and memory-based
@@ -420,7 +420,7 @@ type String {
 
   pub func padLeft(self, totalSize: Int, padding = " "): String = todo("String#padLeft")
 
-  pub func trim(self): String {
+  func getTrimStartOffset(self): Int {
     var i = 0
     while i < self.length {
       val char = Char.fromInt(self._buffer.loadAt(i).asInt())
@@ -431,21 +431,26 @@ type String {
       }
     }
 
-    var j = self.length - 1
-    while j >= 0 {
-      val char = Char.fromInt(self._buffer.loadAt(j).asInt())
+    i
+  }
+
+  func getTrimEndOffset(self): Int {
+    var i = self.length - 1
+    while i >= 0 {
+      val char = Char.fromInt(self._buffer.loadAt(i).asInt())
       if char == ' ' || char == '\n' || char == '\t' || char == '\r' {
-        j -= 1
+        i -= 1
       } else {
         break
       }
     }
 
-    self.getRange(i, j + 1)
+    i + 1
   }
 
-  pub func trimStart(self, pattern = ""): String = todo("String#trimStart")
-  pub func trimEnd(self, pattern = ""): String = todo("String#trimEnd")
+  pub func trim(self): String = self.getRange(self.getTrimStartOffset(), self.getTrimEndOffset())
+  pub func trimStart(self, pattern = ""): String = self.getRange(self.getTrimStartOffset(), self.length)
+  pub func trimEnd(self, pattern = ""): String = self.getRange(0, self.getTrimEndOffset())
 
   pub func split(self, by = ""): String[] {
     if by.isEmpty() {
@@ -645,7 +650,7 @@ type ArrayIterator<T> {
 
 type Array<T> {
   pub length: Int
-  _buffer: Pointer<T>
+  pub _buffer: Pointer<T>
   _capacity: Int = 0
 
   pub func withCapacity<T>(initialCapacity: Int): T[] {

--- a/projects/std/src/process.abra
+++ b/projects/std/src/process.abra
@@ -1,6 +1,7 @@
 import "./_intrinsics" as intrinsics
 import Pointer, Byte from "./_intrinsics"
 import "libc" as libc
+import "io" as io
 
 var _args: String[]? = None
 pub func args(): String[] {
@@ -219,4 +220,89 @@ pub func stdin(): Stdin {
   val stdin = Stdin()
   _stdin = Some(stdin)
   stdin
+}
+
+pub enum ExitStatus {
+  Success
+  Failure(code: Int)
+  Signaled(signal: Int)
+
+  pub func isSuccess(self): Bool = self == ExitStatus.Success
+}
+
+pub type CommandOutput {
+  pub status: ExitStatus
+  pub stdout: String
+  pub stderr: String
+}
+
+pub type Command {
+  pub program: String
+  pub arguments: String[] = []
+
+  pub func addArg(self, arg: String): Command {
+    self.arguments.push(arg)
+    self
+  }
+
+  pub func execAndCaptureOutput(self): CommandOutput {
+    val stdoutPipe = try io.makePipe() else |e| unreachable(""+e)
+    val stderrPipe = try io.makePipe() else |e| unreachable(""+e)
+
+    val pid = libc.fork()
+    if pid < 0 unreachable("fork failed")
+
+    if pid == 0 {
+      val arguments = [self.program._buffer]
+      for arg in self.arguments {
+        arguments.push(arg._buffer)
+      }
+      arguments.push(libc.NULL())
+
+      libc.close(stdoutPipe.readerFd)
+      if libc.dup2(stdoutPipe.writerFd, libc.STDOUT_FILENO) < 0 unreachable("failed to set up stdout redirect")
+      libc.close(stdoutPipe.writerFd)
+
+      libc.close(stderrPipe.readerFd)
+      if libc.dup2(stderrPipe.writerFd, libc.STDERR_FILENO) < 0 unreachable("failed to set up stderr redirect")
+      libc.close(stderrPipe.writerFd)
+
+      libc.execvp(self.program._buffer, arguments._buffer)
+      unreachable("current process is replaced by program execution")
+    } else {
+      libc.close(stdoutPipe.writerFd)
+      libc.close(stderrPipe.writerFd)
+
+      val stdout = io.BufferedReader(fd: stdoutPipe.readerFd)
+      val stdoutOutput = (try stdout.readAllToString() else unreachable("failed to read from stdoutPipe write end")).trimEnd()
+
+      val stderr = io.BufferedReader(fd: stderrPipe.readerFd)
+      val stderrOutput = (try stderr.readAllToString() else unreachable("failed to read from stderrPipe write end")).trimEnd()
+
+      libc.close(stdoutPipe.readerFd)
+      libc.close(stderrPipe.readerFd)
+
+      val status = Pointer.malloc<Int>(1)
+      while true {
+        if libc.wait(status) < 0 unreachable("failed to wait on child process")
+
+        val wstatus = status.loadAt(0)
+        if libc.WIFEXITED(wstatus) {
+          val exitStatus = libc.WEXITSTATUS(wstatus)
+          if exitStatus != 0 {
+            return CommandOutput(status: ExitStatus.Failure(code: exitStatus), stdout: stdoutOutput, stderr: stderrOutput)
+          }
+
+          break
+        }
+
+        if libc.WIFSIGNALED(wstatus) {
+          val signal = libc.WTERMSIG(wstatus)
+          return CommandOutput(status: ExitStatus.Signaled(signal: signal), stdout: stdoutOutput, stderr: stderrOutput)
+        }
+      }
+
+      CommandOutput(status: ExitStatus.Success, stdout: stdoutOutput, stderr: stderrOutput)
+    }
+  }
 }


### PR DESCRIPTION
In order to accomplish this, there were quite a few things that had to be done. I needed some way of executing external programs from abra (to call out to `qbe` and `clang`), and to do that I needed to do a lot of groudwork with forking, creating pipes to redirect and capture io, etc. There are a _ton_ of improvements to be made here, but I wanted to take this first initial step (which does work! it supports the `build` subcommand) and commit it because it represented a lot of work.