### PR TITLE
Updating qbe version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install QBE
         run: |
-          git clone -b fork --single-branch https://github.com/kengorab/qbe-mirror
+          git clone -b foldint-fix --single-branch https://github.com/kengorab/qbe-mirror
           mv qbe-mirror qbe
           cd qbe
           make

--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install QBE
       run: |
-        git clone -b fork --single-branch https://github.com/kengorab/qbe-mirror
+        git clone -b foldint-fix --single-branch https://github.com/kengorab/qbe-mirror
         mv qbe-mirror qbe
         cd qbe
         make


### PR DESCRIPTION
I had previously been using a (forked version of a) fairly old version of qbe (from Jan 2024). When I had forked it, I did so to add a fix for the use of the `x18` register on aarch64 (which is a platform register and is discouraged to use). Since then, qbe has added a (better) fix for the `x18` register problem, so I attempted to update to just use the latest version. However, there was a separate issue in the latest version, which I have reported here on their mailing list:
  https://lists.sr.ht/~mpu/qbe/%3CCAOv5s62Oasn9rLPenVAVUGMr3cYEFXe_N1=udRe-X15o0ux+fA@mail.gmail.com%3E

Until this is fixed, I will continue to use my fork, which I have updated to be based off of the current version of the original repo, with the additional fix applied.