### PR TITLE
Add macros to prelude

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,3 +1,8 @@
-// import "process" as process
+// println(1, "hello", 1.23)
 
-stdoutWriteln("hello")
+// val x = 123
+// val y = debug(x) + 1
+// val z = debug(x + y) + 1
+// println(z)
+
+println([1].length.toString())

--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,8 +1,7 @@
-// println(1, "hello", 1.23)
+val m = { (1): "a", (2): "b" }
 
-// val x = 123
-// val y = debug(x) + 1
-// val z = debug(x + y) + 1
-// println(z)
-
-println([1].length.toString())
+val v = m.getOrElse(1, () => {
+  println("calling default fn")
+  "c"
+})
+println(v)

--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -165,6 +165,7 @@ pub type Compiler {
   _fnNamesPtr: Value
   _resolvedGenerics: ResolvedGenerics = ResolvedGenerics()
   _loopStack: LoopBounds[] = []
+  _lambdaCount: Int = 0
   // cached things
   _printf: QbeFunction = QbeFunction.spec(name: "printf", returnType: None, parameters: [], variadicIdx: Some(1))
   _snprintf: QbeFunction = QbeFunction.spec(name: "snprintf", returnType: Some(QbeType.U64), parameters: [], variadicIdx: Some(3))
@@ -4444,7 +4445,15 @@ pub type Compiler {
     Ok("$enumTypeName.${variant.label.name}")
   }
 
-  func _fnName(self, fn: Function): String = ".${fn.label.name}"
+  func _fnName(self, fn: Function): String {
+    if fn.isLambda {
+      val suffix = self._lambdaCount
+      self._lambdaCount += 1
+      ".lambda_$suffix"
+    } else {
+      ".${fn.label.name}"
+    }
+  }
 
   func _structMethodFnName(self, struct: Struct, fn: Function): Result<String, CompileError> {
     val sep = match fn.kind {

--- a/projects/compiler/src/comptime_evaluator.abra
+++ b/projects/compiler/src/comptime_evaluator.abra
@@ -1,7 +1,7 @@
 import Pointer, Byte from "_intrinsics"
 import Lexer, LexerError, Token, TokenKind, Position from "./lexer"
-import Parser, ParseError, ParsedModule, AstNode, LiteralAstNode, ImportNode, ImportKind, Label, IndexingMode from "./parser"
-import Project, Function, Struct, Type, TypedAstNode, TypedAstNodeKind, InstanceKind, TypedInvokee, AccessorPathSegment, TypedIndexingNode, FunctionKind from "./typechecker"
+import Parser, ParseError, ParsedModule, AstNode, LiteralAstNode, ImportNode, ImportKind, Label, IndexingMode, BindingPattern from "./parser"
+import Project, Function, Struct, Type, TypedAstNode, TypedAstNodeKind, InstanceKind, TypedInvokee, AccessorPathSegment, TypedIndexingNode, FunctionKind, BuiltinModule from "./typechecker"
 import Generator from "./ir"
 import VM, VmValue, Instance, VmFunction, unmarshallString from "./ir_vm"
 import InjectedCode from "meta"
@@ -49,8 +49,31 @@ func stringifyTypedNode(node: TypedAstNode): String {
       LiteralAstNode.Int(i) => "$i"
       LiteralAstNode.Float(f) => "$f"
       LiteralAstNode.Bool(b) => "$b"
-      LiteralAstNode.String(s) => "\"$s\""
-      else => todo("stringify: other literal kinds")
+      LiteralAstNode.Char(code) => {
+        // TODO: extract out into a new `Char#escaped(self):String` method
+        val ch = match Char.fromInt(code) {
+          '\0' => "\\0"
+          '\b' => "\\b"
+          '\n' => "\\n"
+          '\f' => "\\f"
+          '\\' => "\\\\"
+          '\r' => "\\r"
+          '\t' => "\\t"
+          '\'' => "\\'"
+          else c => "$c"
+        }
+        "'$ch'"
+      }
+      LiteralAstNode.String(s) => {
+        // TODO: extract out into a new `String#escaped(self):String` method
+        val str = s
+          .replaceAll("\\", "\\\\")
+          .replaceAll("\"", "\\\"")
+          .replaceAll("\n", "\\n")
+          .replaceAll("\r", "\\r")
+          .replaceAll("\t", "\\t")
+        "\"$str\""
+      }
     }
     TypedAstNodeKind.StringInterpolation(chunks) => {
       val chunkStrs = ["\""]
@@ -74,27 +97,34 @@ func stringifyTypedNode(node: TypedAstNode): String {
       "${op.repr()}${stringifyTypedNode(expr)}"
     }
     TypedAstNodeKind.Binary(left, op, right) => {
-      val chunks: String[] = []
-
-      chunks.push(stringifyTypedNode(left))
-      chunks.push(" ${op.repr()} ")
-      chunks.push(stringifyTypedNode(right))
-
-      chunks.join()
+      "${stringifyTypedNode(left)} ${op.repr()} ${stringifyTypedNode(right)}"
     }
     TypedAstNodeKind.Grouped(inner) => {
-      val str = stringifyTypedNode(inner)
-      "($str)"
+      "(${stringifyTypedNode(inner)})"
     }
     TypedAstNodeKind.Identifier(name, _, _, _) => name
     TypedAstNodeKind.Accessor(head, middle, tail) => {
       val chunks: String[] = []
 
-      chunks.push(stringifyTypedNode(head))
-      for seg in middle {
+      val headStr = stringifyTypedNode(head)
+      if headStr != "Option" {
+        chunks.push(headStr)
+      }
+      for seg in middle.concat([tail]) {
         match seg {
-          AccessorPathSegment.EnumVariant(label, ty, enum_, variant) => todo("stringifyTypedNode: Accessor: EnumVariant")
-          AccessorPathSegment.Method(label, fn, optSafe, typeHint) => todo("stringifyTypedNode: Accessor: Method")
+          AccessorPathSegment.EnumVariant(label, ty, enum_, variant) => {
+            val variantName = variant.label.name
+            if headStr == "Option" && variantName == "None" {
+              chunks.push(variantName)
+            } else {
+              chunks.push(".$variantName")
+            }
+          }
+          AccessorPathSegment.Method(label, fn, optSafe, typeHint) => {
+            val dot = if optSafe "?." else "."
+            chunks.push(dot)
+            chunks.push(label.name)
+          }
           AccessorPathSegment.Field(label, _, _, optSafe) => {
             val dot = if optSafe "?." else "."
             chunks.push(dot)
@@ -103,20 +133,11 @@ func stringifyTypedNode(node: TypedAstNode): String {
         }
       }
 
-      match tail {
-        AccessorPathSegment.EnumVariant(label, ty, enum_, variant) => todo("stringifyTypedNode: Accessor: EnumVariant")
-        AccessorPathSegment.Method(label, fn, optSafe, typeHint) => todo("stringifyTypedNode: Accessor: Method")
-        AccessorPathSegment.Field(label, _, _, optSafe) => {
-          val dot = if optSafe "?." else "."
-          chunks.push(dot)
-          chunks.push(label.name)
-        }
-      }
-
       chunks.join()
     }
     TypedAstNodeKind.Invocation(invokee, arguments, _) => {
       val chunks: String[] = []
+      var argLabels: String[]? = None
       match invokee {
         TypedInvokee.Method(fn, selfVal, isOptSafe) => {
           chunks.push(stringifyTypedNode(selfVal))
@@ -137,15 +158,39 @@ func stringifyTypedNode(node: TypedAstNode): String {
           }
           chunks.push(fn.label.name)
         }
-        TypedInvokee.Struct(struct) => todo("stringifyTypedNode: Invocation:Struct")
-        TypedInvokee.Expr(expr) => todo("stringifyTypedNode: Invocation:Expr")
-        TypedInvokee.EnumVariant(enum_, variant) => todo("stringifyTypedNode: Invocation:EnumVariant")
+        TypedInvokee.Struct(struct) => {
+          // todo: this doesn't cover every case (eg. mod.Type(...))
+          chunks.push(struct.label.name)
+          argLabels = Some(struct.fields.map(f => f.name.name))
+        }
+        TypedInvokee.Expr(expr) => chunks.push(stringifyTypedNode(expr))
+        TypedInvokee.EnumVariant(enum_, variant) => {
+          // todo: this doesn't cover every case (eg. mod.Enum.Variant)
+          val enumName = enum_.label.name
+          val variantName = variant.label.name
+          val str = if enumName == "Option" && enum_.builtin == Some(BuiltinModule.Prelude) {
+            variantName
+          } else {
+            "$enumName.$variantName"
+          }
+          chunks.push(str)
+        }
       }
 
       chunks.push("(")
       for _arg, idx in arguments {
+        val label = if argLabels |labels| {
+          Some(try labels[idx] else unreachable("expected label for arg idx=$idx"))
+        } else {
+          None
+        }
         val arg = try _arg else continue
+
         val stringifiedArg = stringifyTypedNode(arg)
+        if label |l| {
+          chunks.push(l)
+          chunks.push(": ")
+        }
         chunks.push(stringifiedArg)
         if idx != arguments.length - 1 {
           chunks.push(", ")
@@ -181,8 +226,46 @@ func stringifyTypedNode(node: TypedAstNode): String {
       chunks.push("}")
       chunks.join()
     }
-    TypedAstNodeKind.Map => todo("stringifyTypedNode: Map")
-    TypedAstNodeKind.Tuple => todo("stringifyTypedNode: Tuple")
+    TypedAstNodeKind.Map(items) => {
+      if items.isEmpty() return "{}"
+
+      val chunks = ["{"]
+
+      for (key, value), idx in items {
+        val surroundWithParens = match key.kind {
+          TypedAstNodeKind.Identifier => false
+          TypedAstNodeKind.Literal(lit) => match lit { LiteralAstNode.String => false, else => true }
+          TypedAstNodeKind.StringInterpolation => false
+          else => true
+        }
+        val keyStr = if surroundWithParens {
+          "(${stringifyTypedNode(key)})"
+        } else {
+          stringifyTypedNode(key)
+        }
+        chunks.push(keyStr)
+        chunks.push(": ")
+        chunks.push(stringifyTypedNode(value))
+        if idx != items.length - 1 {
+          chunks.push(", ")
+        }
+      }
+      chunks.push("}")
+
+      chunks.join()
+    }
+    TypedAstNodeKind.Tuple(items) => {
+      val chunks = ["("]
+      for item, idx in items {
+        chunks.push(stringifyTypedNode(item))
+        if idx != items.length - 1 {
+          chunks.push(", ")
+        }
+      }
+      chunks.push(")")
+
+      chunks.join()
+    }
     TypedAstNodeKind.Indexing(node) => {
       match node {
         TypedIndexingNode.ArrayLike(expr, indexingMode) => {
@@ -198,8 +281,17 @@ func stringifyTypedNode(node: TypedAstNode): String {
 
           "$exprStr[$idxStr]"
         }
-        TypedIndexingNode.Map(expr, idx) => todo("stringifyTypedNode: Indexing: Map")
-        TypedIndexingNode.Tuple(tupleExpr, idx) => todo("stringifyTypedNode: Indexing: Tuple")
+        TypedIndexingNode.Map(expr, idx) => {
+          val exprStr = stringifyTypedNode(expr)
+          val idxStr = stringifyTypedNode(idx)
+
+          "$exprStr[$idxStr]"
+        }
+        TypedIndexingNode.Tuple(expr, idx) => {
+          val exprStr = stringifyTypedNode(expr)
+
+          "$exprStr[$idx]"
+        }
       }
     }
     TypedAstNodeKind.Lambda(fn, _) => {
@@ -229,12 +321,64 @@ func stringifyTypedNode(node: TypedAstNode): String {
       chunks.join()
     }
     TypedAstNodeKind.Assignment => todo("stringifyTypedNode: Assignment")
-    TypedAstNodeKind.If => todo("stringifyTypedNode: If")
+    TypedAstNodeKind.If(_, cond, binding, ifBlock, _, elseBlock, _) => {
+      val chunks = ["if ", stringifyTypedNode(cond)]
+
+      if binding |(pat, _)| {
+        chunks.push("|")
+        stringifyBindingPattern(pat, chunks)
+        chunks.push("|")
+      }
+
+      chunks.push(" ")
+
+      if ifBlock.length == 1 {
+        chunks.push(stringifyTypedNode(try ifBlock[0] else unreachable()))
+      } else {
+        chunks.push("{")
+        for node, idx in ifBlock {
+          chunks.push("\n  ")
+          chunks.push(stringifyTypedNode(node))
+          if idx != ifBlock.length - 1 {
+            chunks.push("\n")
+          }
+        }
+        chunks.push("}")
+      }
+
+      if elseBlock.length == 1 {
+        chunks.push(" else ")
+        chunks.push(stringifyTypedNode(try elseBlock[0] else unreachable()))
+      } else {
+        chunks.push(" else {")
+        for node, idx in elseBlock {
+          chunks.push("\n  ")
+          chunks.push(stringifyTypedNode(node))
+          if idx != elseBlock.length - 1 {
+            chunks.push("\n")
+          }
+        }
+        chunks.push("}")
+      }
+
+      chunks.join()
+    }
     TypedAstNodeKind.Match => todo("stringifyTypedNode: Match")
     TypedAstNodeKind.Try => todo("stringifyTypedNode: Try")
     TypedAstNodeKind.While => todo("stringifyTypedNode: While")
     TypedAstNodeKind.For => todo("stringifyTypedNode: For")
-    TypedAstNodeKind.BindingDeclaration => todo("stringifyTypedNode: BindingDeclaration")
+    TypedAstNodeKind.BindingDeclaration(node) => {
+      val v = try node.variables[0] else unreachable("binding decl must contain at least 1 variable")
+      val chunks = [if v.mutable "var " else "val "]
+
+      stringifyBindingPattern(node.bindingPattern, chunks)
+      if node.expr |expr| {
+        chunks.push(" = ")
+        chunks.push(stringifyTypedNode(expr))
+      }
+
+      chunks.join()
+    }
     TypedAstNodeKind.FunctionDeclaration => todo("stringifyTypedNode: FunctionDeclaration")
     TypedAstNodeKind.TypeDeclaration => todo("stringifyTypedNode: TypeDeclaration")
     TypedAstNodeKind.EnumDeclaration => todo("stringifyTypedNode: EnumDeclaration")
@@ -242,6 +386,22 @@ func stringifyTypedNode(node: TypedAstNode): String {
     TypedAstNodeKind.Continue => todo("stringifyTypedNode: Continue")
     TypedAstNodeKind.Return => todo("stringifyTypedNode: Return")
     TypedAstNodeKind.Placeholder => unreachable("stringifyTypedNode: Placeholder")
+  }
+}
+
+func stringifyBindingPattern(pat: BindingPattern, chunks: String[]) {
+  match pat {
+    BindingPattern.Variable(v) => chunks.push(v.name)
+    BindingPattern.Tuple(_, pats) => {
+      chunks.push("(")
+      for p, idx in pats {
+        stringifyBindingPattern(p, chunks)
+        if idx != pats.length - 1 {
+          chunks.push(", ")
+        }
+      }
+      chunks.push(")")
+    }
   }
 }
 

--- a/projects/compiler/src/comptime_evaluator.abra
+++ b/projects/compiler/src/comptime_evaluator.abra
@@ -1,7 +1,7 @@
 import Pointer, Byte from "_intrinsics"
 import Lexer, LexerError, Token, TokenKind, Position from "./lexer"
-import Parser, ParseError, ParsedModule, AstNode, LiteralAstNode, ImportNode, ImportKind, Label from "./parser"
-import Project, Function, Struct, Type, TypedAstNode, TypedAstNodeKind, InstanceKind, TypedInvokee from "./typechecker"
+import Parser, ParseError, ParsedModule, AstNode, LiteralAstNode, ImportNode, ImportKind, Label, IndexingMode from "./parser"
+import Project, Function, Struct, Type, TypedAstNode, TypedAstNodeKind, InstanceKind, TypedInvokee, AccessorPathSegment, TypedIndexingNode, FunctionKind from "./typechecker"
 import Generator from "./ir"
 import VM, VmValue, Instance, VmFunction, unmarshallString from "./ir_vm"
 import InjectedCode from "meta"
@@ -70,16 +70,71 @@ func stringifyTypedNode(node: TypedAstNode): String {
       chunkStrs.push("\"")
       chunkStrs.join()
     }
-    TypedAstNodeKind.Unary => todo("stringifyTypedNode: Unary")
-    TypedAstNodeKind.Binary => todo("stringifyTypedNode: Binary")
-    TypedAstNodeKind.Grouped => todo("stringifyTypedNode: Grouped")
+    TypedAstNodeKind.Unary(op, expr) => {
+      "${op.repr()}${stringifyTypedNode(expr)}"
+    }
+    TypedAstNodeKind.Binary(left, op, right) => {
+      val chunks: String[] = []
+
+      chunks.push(stringifyTypedNode(left))
+      chunks.push(" ${op.repr()} ")
+      chunks.push(stringifyTypedNode(right))
+
+      chunks.join()
+    }
+    TypedAstNodeKind.Grouped(inner) => {
+      val str = stringifyTypedNode(inner)
+      "($str)"
+    }
     TypedAstNodeKind.Identifier(name, _, _, _) => name
-    TypedAstNodeKind.Accessor => todo("stringifyTypedNode: Accessor")
+    TypedAstNodeKind.Accessor(head, middle, tail) => {
+      val chunks: String[] = []
+
+      chunks.push(stringifyTypedNode(head))
+      for seg in middle {
+        match seg {
+          AccessorPathSegment.EnumVariant(label, ty, enum_, variant) => todo("stringifyTypedNode: Accessor: EnumVariant")
+          AccessorPathSegment.Method(label, fn, optSafe, typeHint) => todo("stringifyTypedNode: Accessor: Method")
+          AccessorPathSegment.Field(label, _, _, optSafe) => {
+            val dot = if optSafe "?." else "."
+            chunks.push(dot)
+            chunks.push(label.name)
+          }
+        }
+      }
+
+      match tail {
+        AccessorPathSegment.EnumVariant(label, ty, enum_, variant) => todo("stringifyTypedNode: Accessor: EnumVariant")
+        AccessorPathSegment.Method(label, fn, optSafe, typeHint) => todo("stringifyTypedNode: Accessor: Method")
+        AccessorPathSegment.Field(label, _, _, optSafe) => {
+          val dot = if optSafe "?." else "."
+          chunks.push(dot)
+          chunks.push(label.name)
+        }
+      }
+
+      chunks.join()
+    }
     TypedAstNodeKind.Invocation(invokee, arguments, _) => {
       val chunks: String[] = []
       match invokee {
-        TypedInvokee.Method(fn, selfVal, isOptSafe) => todo("stringifyTypedNode: Invocation:Method")
+        TypedInvokee.Method(fn, selfVal, isOptSafe) => {
+          chunks.push(stringifyTypedNode(selfVal))
+          val dot = if isOptSafe "?." else "."
+          chunks.push(dot)
+          chunks.push(fn.label.name)
+        }
         TypedInvokee.Function(fn) => {
+          match fn.kind {
+            FunctionKind.StaticMethod(instanceKind, _) => {
+              // todo: this doesn't cover every case (eg. mod.Type.fn())
+              match instanceKind {
+                InstanceKind.Struct(struct) => chunks.push(struct.label.name)
+                InstanceKind.Enum(enum_) => chunks.push(enum_.label.name)
+              }
+              chunks.push(".")
+            }
+          }
           chunks.push(fn.label.name)
         }
         TypedInvokee.Struct(struct) => todo("stringifyTypedNode: Invocation:Struct")
@@ -88,22 +143,91 @@ func stringifyTypedNode(node: TypedAstNode): String {
       }
 
       chunks.push("(")
-      for _arg in arguments {
+      for _arg, idx in arguments {
         val arg = try _arg else continue
         val stringifiedArg = stringifyTypedNode(arg)
         chunks.push(stringifiedArg)
-        chunks.push(", ")
+        if idx != arguments.length - 1 {
+          chunks.push(", ")
+        }
       }
       chunks.push(")")
 
       chunks.join()
     }
-    TypedAstNodeKind.Array => todo("stringifyTypedNode: Array")
-    TypedAstNodeKind.Set => todo("stringifyTypedNode: Set")
+    TypedAstNodeKind.Array(items) => {
+      val chunks = ["["]
+
+      for item, idx in items {
+        chunks.push(stringifyTypedNode(item))
+        if idx != items.length - 1 {
+          chunks.push(", ")
+        }
+      }
+
+      chunks.push("]")
+      chunks.join()
+    }
+    TypedAstNodeKind.Set(items) => {
+      val chunks = ["#{"]
+
+      for item, idx in items {
+        chunks.push(stringifyTypedNode(item))
+        if idx != items.length - 1 {
+          chunks.push(", ")
+        }
+      }
+
+      chunks.push("}")
+      chunks.join()
+    }
     TypedAstNodeKind.Map => todo("stringifyTypedNode: Map")
     TypedAstNodeKind.Tuple => todo("stringifyTypedNode: Tuple")
-    TypedAstNodeKind.Indexing => todo("stringifyTypedNode: Indexing")
-    TypedAstNodeKind.Lambda => todo("stringifyTypedNode: Lambda")
+    TypedAstNodeKind.Indexing(node) => {
+      match node {
+        TypedIndexingNode.ArrayLike(expr, indexingMode) => {
+          val exprStr = stringifyTypedNode(expr)
+          val idxStr = match indexingMode {
+            IndexingMode.Single(expr) => stringifyTypedNode(expr)
+            IndexingMode.Range(start, end) => {
+              val startStr = if start |s| stringifyTypedNode(s) else ""
+              val endStr = if end |e| stringifyTypedNode(e) else ""
+              "$startStr:$endStr"
+            }
+          }
+
+          "$exprStr[$idxStr]"
+        }
+        TypedIndexingNode.Map(expr, idx) => todo("stringifyTypedNode: Indexing: Map")
+        TypedIndexingNode.Tuple(tupleExpr, idx) => todo("stringifyTypedNode: Indexing: Tuple")
+      }
+    }
+    TypedAstNodeKind.Lambda(fn, _) => {
+      val chunks = ["("]
+      for param, idx in fn.params {
+        chunks.push(param.label.name)
+        if param.defaultValue |v| {
+          chunks.push(" = ")
+          chunks.push(stringifyTypedNode(v))
+        }
+
+        if idx != fn.params.length - 1 {
+          chunks.push(", ")
+        }
+      }
+      chunks.push(") => ")
+
+      val bodyIsSingleExpr = fn.body.length != 1
+      if bodyIsSingleExpr chunks.push("{")
+      for node, idx in fn.body {
+        if bodyIsSingleExpr chunks.push("  ")
+        chunks.push(stringifyTypedNode(node))
+        if bodyIsSingleExpr chunks.push("\n")
+      }
+      if bodyIsSingleExpr chunks.push("}")
+
+      chunks.join()
+    }
     TypedAstNodeKind.Assignment => todo("stringifyTypedNode: Assignment")
     TypedAstNodeKind.If => todo("stringifyTypedNode: If")
     TypedAstNodeKind.Match => todo("stringifyTypedNode: Match")

--- a/projects/compiler/src/parser.abra
+++ b/projects/compiler/src/parser.abra
@@ -30,7 +30,15 @@ pub enum LiteralAstNode {
   String(value: String)
 }
 
-pub enum UnaryOp { Minus, Negate }
+pub enum UnaryOp {
+  Minus
+  Negate
+
+  pub func repr(self): String = match self {
+    UnaryOp.Minus => "-"
+    UnaryOp.Negate => "!"
+  }
+}
 
 pub type UnaryAstNode {
   pub op: UnaryOp

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -357,7 +357,7 @@ pub type Enum {
   pub variants: TypedEnumVariant[] = []
   pub instanceMethods: Function[] = []
   pub staticMethods: Function[] = []
-  builtin: BuiltinModule? = None
+  pub builtin: BuiltinModule? = None
 
   func memberwiseCopy(target: Enum, source: Enum) {
     target.moduleId = source.moduleId

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -92,6 +92,7 @@ type ImportedModule {
 pub enum IdentifierKindMeta {
   Variable(mutable: Bool, typeRepr: String)
   Function(typeParams: String[], params: String[], returnTypeRepr: String, methodTy: (Bool, String)?)
+  Macro(params: String[], expanded: String)
   Type(isEnum: Bool, typeParams: String[])
   Module(moduleFilePath: String)
   Field(fieldTy: String, parentTypeRepr: String)
@@ -821,7 +822,7 @@ pub type Function {
   pub returnType: Type
   pub body: TypedAstNode[] = []
   pub isGenerated: Bool = false
-  isLambda: Bool = false
+  pub isLambda: Bool = false
   pub decorators: Decorator[] = []
   pub captures: Variable[] = []
   pub capturedClosures: Function[] = []
@@ -5603,7 +5604,7 @@ pub type Typechecker {
 
     // If the function being invoked is a macro, invoke the function at compile-time and typecheck its returned node as if it were present in the original source
     if fn.isMacro {
-      val res = self.typecheckMacroInvocation(token, fn, typedArguments, resolvedGenerics)
+      val res = self.typecheckMacroInvocation(token, invokeePosition, fn, typedArguments, resolvedGenerics)
       return Ok(res)
     }
 
@@ -5638,7 +5639,7 @@ pub type Typechecker {
     Ok(TypedAstNode(token: token, ty: returnType, kind: TypedAstNodeKind.Invocation(typedInvokee, typedArguments, resolvedGenerics)))
   }
 
-  func typecheckMacroInvocation(self, token: Token, fn: Function, typedArguments: TypedAstNode?[], resolvedGenerics: Map<String, Type>): TypedAstNode {
+  func typecheckMacroInvocation(self, token: Token, invokeePosition: Position, fn: Function, typedArguments: TypedAstNode?[], resolvedGenerics: Map<String, Type>): TypedAstNode {
     // If there's any errors in the module in which the macro function is declared, then assume that we cannot accurately invoke the function at compile-time.
     // Note: this is not a great assumption, since the function itself may not have any related errors, and may not depend on anything in the module which
     // has any errors. However, this is difficult to verify at the moment.
@@ -5660,6 +5661,29 @@ pub type Typechecker {
       return TypedAstNode(token: token, ty: Type(kind: TypeKind.CouldNotDetermine), kind: TypedAstNodeKind.Placeholder)
     }
     val contents = injectedCode.chunks.join()
+
+    val lspMode = if self.lspMode {
+      if self.currentModule.identsByLine[invokeePosition.line - 1] |identsByLine| {
+        for (colStart, colEnd, ident) in identsByLine {
+          if colStart <= invokeePosition.col && invokeePosition.col <= colEnd {
+            match ident.kind {
+              IdentifierKindMeta.Function(_, params, _, _) => {
+                val imports = injectedCode.imports.entries()
+                  .map(_i => "import \"${_i[0]}\" as ${_i[1]}")
+                  .join("\n")
+                ident.kind = IdentifierKindMeta.Macro(params, "$imports\n\n$contents")
+              }
+            }
+            break
+          }
+        }
+      }
+      true
+    } else {
+      false
+    }
+    self.lspMode = false
+
     val parsedModule = try tokenizeAndParse(contents) else |e| {
       val kind = TypeErrorKind.ErrorWithinMacroOutput(macroName: fn.label.name, generatedContents: contents, innerError: ErrorWithinMacroOutputKind.LexerOrParseError(e))
       self.addTypeError(TypeError(position: token.position, kind: kind))
@@ -5700,6 +5724,8 @@ pub type Typechecker {
       val kind = TypeErrorKind.ErrorWithinMacroOutput(macroName: fn.label.name, generatedContents: contents, innerError: ErrorWithinMacroOutputKind.TypeError(err))
       self.addTypeError(TypeError(position: token.position, kind: kind))
     }
+
+    self.lspMode = lspMode
 
     // todo: somehow allow this
     try resultNode else {

--- a/projects/compiler/test/compiler/arrays.abra
+++ b/projects/compiler/test/compiler/arrays.abra
@@ -1,29 +1,29 @@
 /// Expect: 1
-stdoutWriteln([1].length.toString())
+println([1].length)
 /// Expect: 2
-stdoutWriteln([[1, 2], [3, 4]].length.toString())
+println([[1, 2], [3, 4]].length)
 
 // Test array literal construction
 if true {
   val emptyArr: Int[] = []
   /// Expect: []
-  stdoutWriteln(emptyArr.toString())
+  println(emptyArr)
 
   val intArr = [1, 2, 3, 4]
   /// Expect: [1, 2, 3, 4]
-  stdoutWriteln(intArr.toString())
+  println(intArr)
 
   val floatArr = [0.12, 3.45, 6.0]
   /// Expect: [0.12, 3.45, 6]
-  stdoutWriteln(floatArr.toString())
+  println(floatArr)
 
   val stringArr = ["ab", "cd", "ef"]
   /// Expect: [ab, cd, ef]
-  stdoutWriteln(stringArr.toString())
+  println(stringArr)
 
   val nestedArr = [[1, 2], [3, 4], [5, 6]]
   /// Expect: [[1, 2], [3, 4], [5, 6]]
-  stdoutWriteln(nestedArr.toString())
+  println(nestedArr)
 }
 
 // Test array indexing assignment
@@ -31,47 +31,47 @@ if true {
   val emptyArr: Int[] = []
   emptyArr[0] = 123
   /// Expect: []
-  stdoutWriteln(emptyArr.toString())
+  println(emptyArr)
 
   val intArr = [1, 2, 3, 4]
   /// Expect: [1, 2, 3, 4]
-  stdoutWriteln(intArr.toString())
+  println(intArr)
   intArr[0] = 0
   /// Expect: [0, 2, 3, 4]
-  stdoutWriteln(intArr.toString())
+  println(intArr)
   intArr[-1] = 0
   /// Expect: [0, 2, 3, 0]
-  stdoutWriteln(intArr.toString())
+  println(intArr)
 
   val floatArr = [0.12, 3.45, 6.0]
   /// Expect: [0.12, 3.45, 6]
-  stdoutWriteln(floatArr.toString())
+  println(floatArr)
   floatArr[0] = 0.001
   /// Expect: [0.001, 3.45, 6]
-  stdoutWriteln(floatArr.toString())
+  println(floatArr)
   floatArr[-1] = 0.001
   /// Expect: [0.001, 3.45, 0.001]
-  stdoutWriteln(floatArr.toString())
+  println(floatArr)
 
   val stringArr = ["ab", "cd", "ef"]
   /// Expect: [ab, cd, ef]
-  stdoutWriteln(stringArr.toString())
+  println(stringArr)
   stringArr[0] = "ba"
   /// Expect: [ba, cd, ef]
-  stdoutWriteln(stringArr.toString())
+  println(stringArr)
   stringArr[-1] = "fe"
   /// Expect: [ba, cd, fe]
-  stdoutWriteln(stringArr.toString())
+  println(stringArr)
 
   val nestedArr = [[1, 2], [3, 4], [5, 6]]
   /// Expect: [[1, 2], [3, 4], [5, 6]]
-  stdoutWriteln(nestedArr.toString())
+  println(nestedArr)
   nestedArr[0] = [0, 1]
   /// Expect: [[0, 1], [3, 4], [5, 6]]
-  stdoutWriteln(nestedArr.toString())
+  println(nestedArr)
   nestedArr[-1] = [3, 2]
   /// Expect: [[0, 1], [3, 4], [3, 2]]
-  stdoutWriteln(nestedArr.toString())
+  println(nestedArr)
 }
 
 // == operator (also Array#eq)
@@ -79,34 +79,34 @@ if true {
   val arr = [1, 2]
 
   /// Expect: true
-  stdoutWriteln((arr == [1, 2]).toString())
+  println((arr == [1, 2]))
   /// Expect: true
-  stdoutWriteln(([[1, 2], [3, 4]] == [[1, 2], [3, 4]]).toString())
+  println(([[1, 2], [3, 4]] == [[1, 2], [3, 4]]))
   /// Expect: true
-  stdoutWriteln(([1.2, 3.4] != [5.6, 7.8]).toString())
+  println(([1.2, 3.4] != [5.6, 7.8]))
   /// Expect: true
-  stdoutWriteln(([true, false] != [false, true]).toString())
+  println(([true, false] != [false, true]))
 }
 
 // Indexing (also Array#get(index: Int))
 if true {
   val arr = [1, 2, 3]
   /// Expect: Option.None
-  stdoutWriteln(arr[-4].toString())
+  println(arr[-4])
   /// Expect: Option.Some(value: 1)
-  stdoutWriteln(arr[-3].toString())
+  println(arr[-3])
   /// Expect: Option.Some(value: 2)
-  stdoutWriteln(arr[-2].toString())
+  println(arr[-2])
   /// Expect: Option.Some(value: 3)
-  stdoutWriteln(arr[-1].toString())
+  println(arr[-1])
   /// Expect: Option.Some(value: 1)
-  stdoutWriteln(arr[0].toString())
+  println(arr[0])
   /// Expect: Option.Some(value: 2)
-  stdoutWriteln(arr[1].toString())
+  println(arr[1])
   /// Expect: Option.Some(value: 3)
-  stdoutWriteln(arr[2].toString())
+  println(arr[2])
   /// Expect: Option.None
-  stdoutWriteln(arr[3].toString())
+  println(arr[3])
 }
 
 // Range indexing (also Array#getRange(startIndex: Int, endIndex: Int))
@@ -114,47 +114,47 @@ if true {
   val arr = [1, 2, 3, 4, 5]
 
   /// Expect: [2, 3, 4]
-  stdoutWriteln(arr[1:4].toString())
+  println(arr[1:4])
   /// Expect: [2, 3, 4]
-  stdoutWriteln(arr[-4:4].toString())
+  println(arr[-4:4])
   /// Expect: [2, 3, 4]
-  stdoutWriteln(arr[1:-1].toString())
+  println(arr[1:-1])
 
   /// Expect: []
-  stdoutWriteln(arr[1:1].toString())
+  println(arr[1:1])
 
   val x = 1
   val y = 4
 
   /// Expect: [2, 3, 4]
-  stdoutWriteln(arr[x:y].toString())
+  println(arr[x:y])
   /// Expect: [2, 3, 4]
-  stdoutWriteln(arr[-y:y].toString())
+  println(arr[-y:y])
 
   /// Expect: [2, 3, 4, 5]
-  stdoutWriteln(arr[1:].toString())
+  println(arr[1:])
   /// Expect: [1]
-  stdoutWriteln(arr[:1].toString())
+  println(arr[:1])
 
   /// Expect: [2, 3, 4, 5]
-  stdoutWriteln(arr[x:].toString())
+  println(arr[x:])
   /// Expect: [1]
-  stdoutWriteln(arr[:x].toString())
+  println(arr[:x])
 }
 
 // Array.fill
 if true {
   val zeroes = Array.fill(5, 0)
   /// Expect: [0, 0, 0, 0, 0]
-  stdoutWriteln(zeroes.toString())
+  println(zeroes)
 
   val arr = [1, 2]
   val refs = Array.fill(3, arr)
   /// Expect: [[1, 2], [1, 2], [1, 2]]
-  stdoutWriteln(refs.toString())
+  println(refs)
   arr.push(3)
   /// Expect: [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
-  stdoutWriteln(refs.toString())
+  println(refs)
 }
 
 // Array.fillBy
@@ -162,36 +162,36 @@ if true {
   val zero = 0
   val zeroes = Array.fillBy(5, () => zero)
   /// Expect: [0, 0, 0, 0, 0]
-  stdoutWriteln(zeroes.toString())
+  println(zeroes)
 
   val nums = Array.fillBy(5, i => i + 1)
   /// Expect: [1, 2, 3, 4, 5]
-  stdoutWriteln(nums.toString())
+  println(nums)
 
   val arr = [1, 2]
   val sharedRefs = Array.fillBy(3, () => arr)
   /// Expect: [[1, 2], [1, 2], [1, 2]]
-  stdoutWriteln(sharedRefs.toString())
+  println(sharedRefs)
   arr.push(3)
   /// Expect: [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
-  stdoutWriteln(sharedRefs.toString())
+  println(sharedRefs)
 
   val uniqueRefs = Array.fillBy(3, () => [1, 2])
   /// Expect: [[1, 2], [1, 2], [1, 2]]
-  stdoutWriteln(uniqueRefs.toString())
+  println(uniqueRefs)
   if uniqueRefs[0] |arr| arr[1] = 0
   /// Expect: [[1, 0], [1, 2], [1, 2]]
-  stdoutWriteln(uniqueRefs.toString())
+  println(uniqueRefs)
 }
 
 // Array#hash
 if true {
   val arr = [1, 2, 3]
   /// Expect: true
-  stdoutWriteln((arr.hash() == [1, 2, 3].hash()).toString())
+  println((arr.hash() == [1, 2, 3].hash()))
 
   /// Expect: false
-  stdoutWriteln((arr.hash() == [1, 2].hash()).toString())
+  println((arr.hash() == [1, 2].hash()))
 }
 
 // Array#iterator
@@ -199,15 +199,15 @@ if true {
   val a = [1.23, 4.56, 7.89]
   val iter = a.iterator()
   /// Expect: Option.Some(value: 1.23)
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.Some(value: 4.56)
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.Some(value: 7.89)
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.None
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.None
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
 }
 
 // For-loops
@@ -215,59 +215,59 @@ if true {
 /// Expect: b
 /// Expect: c
 for ch in ["a", "b", "c"] {
-  stdoutWriteln(ch)
+  println(ch)
 }
 
 // Array#push
 if true {
   val intArr = [1, 2, 3]
   /// Expect: [1, 2, 3] 3 4
-  stdoutWriteln("$intArr ${intArr.length} ${intArr.getCapacity()}")
+  println(intArr, intArr.length, intArr.getCapacity())
   // Pushing beyond the capacity should expand the array
   intArr.push(4)
   intArr.push(5)
   /// Expect: [1, 2, 3, 4, 5] 5 8
-  stdoutWriteln("$intArr ${intArr.length} ${intArr.getCapacity()}")
+  println(intArr, intArr.length, intArr.getCapacity())
 
   // Popping element should leave _capacity
   intArr.pop()
   intArr.pop()
   /// Expect: [1, 2, 3] 3 8
-  stdoutWriteln("$intArr ${intArr.length} ${intArr.getCapacity()}")
+  println(intArr, intArr.length, intArr.getCapacity())
 
   val strArr = ["a", "b", "c"]
   val arrArr = [strArr, strArr]
   /// Expect: [[a, b, c], [a, b, c]] 3 4
-  stdoutWriteln("$arrArr ${strArr.length} ${strArr.getCapacity()}")
+  println(arrArr, strArr.length, strArr.getCapacity())
   // Pushing beyond the capacity should expand the array
   strArr.push("d")
   strArr.push("e")
   /// Expect: [[a, b, c, d, e], [a, b, c, d, e]] 5 8
-  stdoutWriteln("$arrArr ${strArr.length} ${strArr.getCapacity()}")
+  println(arrArr, strArr.length, strArr.getCapacity())
 }
 
 // Array#pop
 if true {
   val arr = [1, 2, 3]
   /// Expect: Option.Some(value: 3)
-  stdoutWriteln(arr.pop().toString())
+  println(arr.pop())
   /// Expect: [1, 2]
-  stdoutWriteln(arr.toString())
+  println(arr)
 
   /// Expect: Option.Some(value: 2)
-  stdoutWriteln(arr.pop().toString())
+  println(arr.pop())
   /// Expect: [1]
-  stdoutWriteln(arr.toString())
+  println(arr)
 
   /// Expect: Option.Some(value: 1)
-  stdoutWriteln(arr.pop().toString())
+  println(arr.pop())
   /// Expect: []
-  stdoutWriteln(arr.toString())
+  println(arr)
 
   /// Expect: Option.None
-  stdoutWriteln(arr.pop().toString())
+  println(arr.pop())
   /// Expect: []
-  stdoutWriteln(arr.toString())
+  println(arr)
 }
 
 // Array#concat
@@ -275,29 +275,29 @@ if true {
   val arr1 = [1, 2, 3, 4]
   val arr2 = [5, 6, 7]
   /// Expect: [1, 2, 3, 4, 5, 6, 7]
-  stdoutWriteln(arr1.concat(arr2).toString())
+  println(arr1.concat(arr2))
   /// Expect: [1, 2, 3, 4] [5, 6, 7]
-  stdoutWriteln("$arr1 $arr2") // verify originals unmodified
+  println(arr1, arr2) // verify originals unmodified
 }
 
 // Array#map
 func addOne(i: Int): Int = i + 1
-func exclaim(i: Int, _: Int, x = "!"): String = i + x //"$i$x"
+func exclaim(i: Int, _: Int, x = "!"): String = i + x
 // val one = 1
 if true {
   val arr = [1, 2, 3, 4]
 
   /// Expect: [2, 3, 4, 5]
-  stdoutWriteln(arr.map(addOne).toString())
+  println(arr.map(addOne))
   /// Expect: [2, 3, 4, 5]
-  stdoutWriteln(arr.map(i => i + 1).toString())
+  println(arr.map(i => i + 1))
   // /// Expect: [2, 3, 4, 5]
-  // stdoutWriteln(arr.map(i => i + one))
+  // println(arr.map(i => i + one))
 
   /// Expect: [1!, 2!, 3!, 4!]
-  stdoutWriteln(arr.map(exclaim).toString())
+  println(arr.map(exclaim))
   /// Expect: [1!, 2!, 3!, 4!]
-  stdoutWriteln(arr.map((i, _, x = "!") => i + x).toString())
+  println(arr.map((i, _, x = "!") => i + x))
 }
 
 // Array#flatMap
@@ -305,7 +305,7 @@ if true {
   val arr = [1, 2, 3, 4]
 
   /// Expect: [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
-  stdoutWriteln(arr.flatMap(i => Array.fill(i, i)).toString())
+  println(arr.flatMap(i => Array.fill(i, i)))
 }
 
 // Array#filter
@@ -314,9 +314,9 @@ if true {
   val arr = [1, 2, 3, 4]
 
   /// Expect: [2, 4]
-  stdoutWriteln(arr.filter(isEven).toString())
+  println(arr.filter(isEven))
   /// Expect: [2, 4]
-  stdoutWriteln(arr.filter(x => x % 2 == 0).toString())
+  println(arr.filter(x => x % 2 == 0))
 }
 
 // Array#reduce
@@ -324,23 +324,14 @@ func doSum(acc: Int, i: Int): Int = acc + i
 if true {
   val arr = [1, 2, 3, 4]
 
-  // TODO: I shouldn't need r1/r2 below, but otherwise I get a typechecker error:
-  //   Type mismatch for parameter 'initialValue'
-  //     |    println(arr.reduce(0, doSum))
-  //                             ^
-  //   Expected: Any
-  //   but instead found: Int
-
   /// Expect: 10
-  val r1 = arr.reduce(0, doSum)
-  stdoutWriteln(r1.toString())
+  println(arr.reduce(0, doSum))
   /// Expect: 10
-  val r2 = arr.reduce(0, (acc, i) => acc + i)
-  stdoutWriteln(r2.toString())
+  println(arr.reduce(0, (acc, i) => acc + i))
 }
 
 // Array#forEach
-func printItem(item: Int) = stdoutWriteln(item.toString())
+func printItem(item: Int) = println(item)
 if true {
   val arr = [1, 2, 3, 4]
 
@@ -353,116 +344,114 @@ if true {
   /// Expect: 2
   /// Expect: 3
   /// Expect: 4
-  arr.forEach(i => {
-    stdoutWriteln(i.toString())
-  })
+  arr.forEach(i => println(i))
 }
 
 // Array#join
 if true {
   val arr = [123, 456, 789]
   /// Expect: 123|456|789
-  stdoutWriteln(arr.join("|"))
+  println(arr.join("|"))
   /// Expect: 123456789
-  stdoutWriteln(arr.join())
+  println(arr.join())
 
   /// Expect: 1
-  stdoutWriteln([1].join(", "))
+  println([1].join(", "))
 }
 
 // Array#contains
 if true {
   val intArr = [123, 456, 789]
   /// Expect: true
-  stdoutWriteln(intArr.contains(123).toString())
+  println(intArr.contains(123))
   /// Expect: false
-  stdoutWriteln(intArr.contains(10).toString())
+  println(intArr.contains(10))
 
   val empty: Int[] = []
   /// Expect: false
-  stdoutWriteln(empty.contains(123).toString())
+  println(empty.contains(123))
 
   val strArr = ["hello", "world"]
   /// Expect: true
-  stdoutWriteln(strArr.contains("hello").toString())
+  println(strArr.contains("hello"))
   /// Expect: false
-  stdoutWriteln(strArr.contains("HELLO").toString())
+  println(strArr.contains("HELLO"))
 }
 
 // Array#find
 if true {
   val intArr = [123, 456, 789]
   /// Expect: Option.Some(value: 123)
-  stdoutWriteln(intArr.find(i => i == 123).toString())
+  println(intArr.find(i => i == 123))
   /// Expect: Option.None
-  stdoutWriteln(intArr.find(i => i == 10).toString())
+  println(intArr.find(i => i == 10))
 
   val empty: Int[] = []
   /// Expect: Option.None
-  stdoutWriteln(empty.find(i => i == 123).toString())
+  println(empty.find(i => i == 123))
 
   val strArr = ["hello", "world"]
   /// Expect: Option.Some(value: "hello")
-  stdoutWriteln(strArr.find(s => s == "hello").toString())
+  println(strArr.find(s => s == "hello"))
   /// Expect: Option.None
-  stdoutWriteln(strArr.find(s => s == "HELLO").toString())
+  println(strArr.find(s => s == "HELLO"))
 }
 
 // Array#findIndex
 if true {
   val intArr = [123, 456, 789]
   /// Expect: Option.Some(value: (123, 0))
-  stdoutWriteln(intArr.findIndex(i => i == 123).toString())
+  println(intArr.findIndex(i => i == 123))
   /// Expect: Option.None
-  stdoutWriteln(intArr.findIndex(i => i == 10).toString())
+  println(intArr.findIndex(i => i == 10))
 
   val empty: Int[] = []
   /// Expect: Option.None
-  stdoutWriteln(empty.findIndex(i => i == 123).toString())
+  println(empty.findIndex(i => i == 123))
 
   val strArr = ["hello", "world"]
   /// Expect: Option.Some(value: ("hello", 0))
-  stdoutWriteln(strArr.findIndex(s => s == "hello").toString())
+  println(strArr.findIndex(s => s == "hello"))
   /// Expect: Option.None
-  stdoutWriteln(strArr.findIndex(s => s == "HELLO").toString())
+  println(strArr.findIndex(s => s == "HELLO"))
 }
 
 // Array#any
 if true {
   val intArr = [123, 456, 789]
   /// Expect: true
-  stdoutWriteln(intArr.any(i => i == 123).toString())
+  println(intArr.any(i => i == 123))
   /// Expect: false
-  stdoutWriteln(intArr.any(i => i == 10).toString())
+  println(intArr.any(i => i == 10))
 
   val empty: Int[] = []
   /// Expect: false
-  stdoutWriteln(empty.any(i => i == 123).toString())
+  println(empty.any(i => i == 123))
 
   val strArr = ["hello", "world"]
   /// Expect: true
-  stdoutWriteln(strArr.any(s => s == "hello").toString())
+  println(strArr.any(s => s == "hello"))
   /// Expect: false
-  stdoutWriteln(strArr.any(s => s == "HELLO").toString())
+  println(strArr.any(s => s == "HELLO"))
 }
 
 // Array#all
 if true {
   val intArr = [123, 456, 789]
   /// Expect: true
-  stdoutWriteln(intArr.all(i => i > 0).toString())
+  println(intArr.all(i => i > 0))
   /// Expect: false
-  stdoutWriteln(intArr.all(i => i == 10).toString())
+  println(intArr.all(i => i == 10))
 
   val empty: Int[] = []
   /// Expect: true
-  stdoutWriteln(empty.all(i => i == 123).toString())
+  println(empty.all(i => i == 123))
 
   val strArr = ["hello", "world"]
   /// Expect: true
-  stdoutWriteln(strArr.all(s => s.length > 0).toString())
+  println(strArr.all(s => s.length > 0))
   /// Expect: false
-  stdoutWriteln(strArr.all(s => s == "HELLO").toString())
+  println(strArr.all(s => s == "HELLO"))
 }
 
 // Array#sortBy
@@ -470,38 +459,38 @@ if true {
   val strings = ["abc", "d", "efgh", "ij", "k", "lm", "nopqr", "stu", "v", "wxyz"]
   val sorted = strings.sortBy(s => s.length)
   /// Expect: [abc, d, efgh, ij, k, lm, nopqr, stu, v, wxyz]
-  stdoutWriteln(strings.toString()) // original should be unmodified
+  println(strings) // original should be unmodified
   /// Expect: [d, k, v, ij, lm, stu, abc, efgh, wxyz, nopqr]
-  stdoutWriteln(sorted.toString())
+  println(sorted)
 
   val arrays = [[1, 2], [], [3, 4, 5], [6], [7, 8, 9, 10]]
   val sortedRev = arrays.sortBy(fn: a => a.length, reverse: true)
   /// Expect: [[1, 2], [], [3, 4, 5], [6], [7, 8, 9, 10]]
-  stdoutWriteln(arrays.toString()) // original should be unmodified
+  println(arrays) // original should be unmodified
   /// Expect: [[7, 8, 9, 10], [3, 4, 5], [1, 2], [6], []]
-  stdoutWriteln(sortedRev.toString())
+  println(sortedRev)
 }
 
 // Array#keyBy
 if true {
   val empty: String[] = []
   /// Expect: {}
-  stdoutWriteln(empty.keyBy(s => s.length).toString())
+  println(empty.keyBy(s => s.length))
 
   val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
   /// Expect: { 3: dog, 4: lazy, 5: brown, 6: jumped }
-  stdoutWriteln(strArr.keyBy(s => s.length).toString())
+  println(strArr.keyBy(s => s.length))
 }
 
 // Array#indexBy
 if true {
   val empty: String[] = []
   /// Expect: {}
-  stdoutWriteln(empty.indexBy(s => s.length).toString())
+  println(empty.indexBy(s => s.length))
 
   val strArr = "The quick brown fox jumped over the lazy dog".split(" ")
   /// Expect: { 3: [The, fox, the, dog], 4: [over, lazy], 5: [quick, brown], 6: [jumped] }
-  stdoutWriteln(strArr.indexBy(s => s.length).toString())
+  println(strArr.indexBy(s => s.length))
 }
 
 // Array#asSet
@@ -509,9 +498,9 @@ if true {
   val empty: String[] = []
   val emptySet: Set<String> = #{}
   /// Expect: true
-  stdoutWriteln((empty.asSet() == emptySet).toString())
+  println((empty.asSet() == emptySet))
 
   val arr = [1, 2, 3, 4, 3, 2, 1]
   /// Expect: true
-  stdoutWriteln((arr.asSet() == #{1, 2, 3, 4}).toString())
+  println((arr.asSet() == #{1, 2, 3, 4}))
 }

--- a/projects/compiler/test/compiler/bools.abra
+++ b/projects/compiler/test/compiler/bools.abra
@@ -1,53 +1,51 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-
 /// Expect: true
-printlnBool(true)
+println(true)
 
 /// Expect: false
-printlnBool(false)
+println(false)
 
 // Unary operation
 /// Expect: true
-printlnBool(!false)
+println(!false)
 /// Expect: false
-printlnBool(!!false)
+println(!!false)
 /// Expect: false
-printlnBool(!true)
+println(!true)
 /// Expect: true
-printlnBool(!!true)
+println(!!true)
 
 // Binary operations
 func returnsFalse(): Bool {
-  stdoutWriteln("boolFunc called")
+  println("boolFunc called")
   false
 }
 
 /// Expect: boolFunc called
 /// Expect: false
-printlnBool(true && returnsFalse())
+println(true && returnsFalse())
 /// Expect: false
-printlnBool(false && returnsFalse())
+println(false && returnsFalse())
 
 /// Expect: true
-printlnBool(true || returnsFalse())
+println(true || returnsFalse())
 /// Expect: boolFunc called
 /// Expect: false
-printlnBool(false || returnsFalse())
+println(false || returnsFalse())
 
 /// Expect: true
-printlnBool(true ^ false)
+println(true ^ false)
 /// Expect: true
-printlnBool(false ^ true)
+println(false ^ true)
 /// Expect: false
-printlnBool(false ^ false)
+println(false ^ false)
 /// Expect: false
-printlnBool(true ^ true)
+println(true ^ true)
 
 /// Expect: true
-printlnBool(true == true)
+println(true == true)
 /// Expect: false
-printlnBool(true != true)
+println(true != true)
 /// Expect: false
-printlnBool(false == true)
+println(false == true)
 /// Expect: true
-printlnBool(true != false)
+println(true != false)

--- a/projects/compiler/test/compiler/chars.abra
+++ b/projects/compiler/test/compiler/chars.abra
@@ -1,31 +1,29 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-
 val a = 'a'
 val b = 'b'
 
 /// Expect: a b
-stdoutWriteln("$a $b")
+println(a, b)
 
 /// Expect: false
-printlnBool(a == b)
+println(a == b)
 /// Expect: true
-printlnBool(a == 'a')
+println(a == 'a')
 /// Expect: false
-printlnBool(b != b)
+println(b != b)
 /// Expect: true
-printlnBool(b != 'a')
+println(b != 'a')
 
 // Test escape sequences in char literals
 /// Expect: true
-printlnBool('\\' == '\u005C')
+println('\\' == '\u005C')
 
 val m = { 'a': 1, 'b': 2 }
 /// Expect: { a: 1, b: 2 }
-stdoutWriteln(m.toString())
+println(m.toString())
 /// Expect: Option.None
-stdoutWriteln(m['c'].toString())
+println(m['c'].toString())
 /// Expect: Option.Some(value: 1)
-stdoutWriteln(m['a'].toString())
+println(m['a'].toString())
 
 // Test UTF-8 encoding/decoding
 val chars = "a£￫😀".chars()
@@ -34,9 +32,9 @@ val chars = "a£￫😀".chars()
 /// Expect: ￫ 65515 [0b11101111, 0b10111111, 0b10101011]
 /// Expect: 😀 128512 [0b11110000, 0b10011111, 0b10011000, 0b10000000]
 for ch in chars {
-  stdoutWriteln("$ch ${ch.asInt()} ${ch.bytes().map(b => b.binary())}")
+  println(ch, ch.asInt(), ch.bytes().map(b => b.binary()))
 }
 
 val ch = Char.fromInt(0xD800)
 /// Expect: �
-stdoutWriteln(ch.toString())
+println(ch.toString())

--- a/projects/compiler/test/compiler/enums.abra
+++ b/projects/compiler/test/compiler/enums.abra
@@ -34,81 +34,79 @@ val cyan = Color.RGB2(g: 255, b: 255)
 val yellow = Color.RGB2(r: 255, g: 255)
 
 /// Expect: Color.RGB2(r: 0, g: 0, b: 0)
-stdoutWriteln(black.toString())
+println(black)
 /// Expect: Color.RGB2(r: 255, g: 255, b: 255)
-stdoutWriteln(white.toString())
+println(white)
 /// Expect: Color.RGB2(r: 255, g: 0, b: 0)
-stdoutWriteln(red.toString())
+println(red)
 /// Expect: Color.RGB2(r: 0, g: 255, b: 0)
-stdoutWriteln(green.toString())
+println(green)
 /// Expect: Color.RGB2(r: 0, g: 0, b: 255)
-stdoutWriteln(blue.toString())
+println(blue)
 /// Expect: Color.RGB2(r: 255, g: 0, b: 255)
-stdoutWriteln(pink.toString())
+println(pink)
 /// Expect: Color.RGB2(r: 0, g: 255, b: 255)
-stdoutWriteln(cyan.toString())
+println(cyan)
 /// Expect: Color.RGB2(r: 255, g: 255, b: 0)
-stdoutWriteln(yellow.toString())
+println(yellow)
 
 // Test default toString method
 /// Expect: Color.Red
-stdoutWriteln(r.toString())
+println(r)
 /// Expect: Color.Red
-stdoutWriteln(Color.Red.toString())
+println(Color.Red)
 /// Expect: Color.Green
-stdoutWriteln(g.toString())
+println(g)
 /// Expect: Color.Green
-stdoutWriteln(Color.Green.toString())
+println(Color.Green)
 /// Expect: Color.Blue
-stdoutWriteln(b.toString())
+println(b)
 /// Expect: Color.Blue
-stdoutWriteln(Color.Blue.toString())
+println(Color.Blue)
 /// Expect: Color.RGB(r: 170, g: 170, b: 170)
-stdoutWriteln(gray.toString())
+println(gray)
 /// Expect: Color.RGB(r: 170, g: 170, b: 170)
-stdoutWriteln(Color.RGB(r: 0xaa, g: 0xaa, b: 0xaa).toString())
-
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
+println(Color.RGB(r: 0xaa, g: 0xaa, b: 0xaa))
 
 // Test default hash method
 /// Expect: true
-printlnBool(r.hash() == Color.Red.hash())
+println(r.hash() == Color.Red.hash())
 /// Expect: true
-printlnBool(g.hash() == Color.Green.hash())
+println(g.hash() == Color.Green.hash())
 /// Expect: true
-printlnBool(b.hash() == Color.Blue.hash())
+println(b.hash() == Color.Blue.hash())
 /// Expect: true
-printlnBool(gray.hash() == Color.RGB(r: 0xaa, g: 0xaa, b: 0xaa).hash())
+println(gray.hash() == Color.RGB(r: 0xaa, g: 0xaa, b: 0xaa).hash())
 /// Expect: false
-printlnBool(r.hash() == Color.Blue.hash())
+println(r.hash() == Color.Blue.hash())
 /// Expect: false
-printlnBool(r.hash() == Color.Green.hash())
+println(r.hash() == Color.Green.hash())
 /// Expect: false
-printlnBool(gray.hash() == Color.Red.hash())
+println(gray.hash() == Color.Red.hash())
 
 // Test default eq method
 /// Expect: true
-printlnBool(r == Color.Red)
+println(r == Color.Red)
 /// Expect: false
-printlnBool(r == Color.Green)
+println(r == Color.Green)
 /// Expect: false
-printlnBool(r == Color.Blue)
+println(r == Color.Blue)
 /// Expect: true
-printlnBool(gray == Color.RGB(r: 0xaa, g: 0xaa, b: 0xaa))
+println(gray == Color.RGB(r: 0xaa, g: 0xaa, b: 0xaa))
 /// Expect: false
-printlnBool(gray == Color.RGB(r: 0x33, g: 0x33, b: 0x33))
+println(gray == Color.RGB(r: 0x33, g: 0x33, b: 0x33))
 /// Expect: false
-printlnBool(gray == Color.Green)
+println(gray == Color.Green)
 
 // Test calling method
 /// Expect: 0xFF0000 0xFF0000
-stdoutWriteln("${Color.Red.hex()} ${r.hex()}")
+println(Color.Red.hex(), r.hex())
 /// Expect: 0x00FF00 0x00FF00
-stdoutWriteln("${Color.Green.hex()} ${g.hex()}")
+println(Color.Green.hex(), g.hex())
 /// Expect: 0x0000FF 0x0000FF
-stdoutWriteln("${Color.Blue.hex()} ${b.hex()}")
+println(Color.Blue.hex(), b.hex())
 /// Expect: todo todo
-stdoutWriteln("${Color.RGB(r: 0xaa, g: 0xaa, b: 0xaa).hex()} ${gray.hex()}")
+println(Color.RGB(r: 0xaa, g: 0xaa, b: 0xaa).hex(), gray.hex())
 
 enum Color2 {
   Red
@@ -118,23 +116,23 @@ enum Color2 {
   func toString(self): String = "custom Color2#toString implementation"
   func hash(self): Int = 17
   func eq(self, other: Color2): Bool {
-    stdoutWriteln("[Color2#eq] here")
+    println("[Color2#eq] here")
     false
   }
 }
 
 // Test custom toString method
 /// Expect: custom Color2#toString implementation
-stdoutWriteln(Color2.Red.toString())
+println(Color2.Red)
 
 // Test custom hash method
 /// Expect: 17
-stdoutWriteln(Color2.Green.hash().toString())
+println(Color2.Green.hash())
 
 // Test custom eq method
 /// Expect: [Color2#eq] here
 /// Expect: false
-printlnBool(Color2.Blue == Color2.Blue)
+println(Color2.Blue == Color2.Blue)
 
 // Test generic enum
 
@@ -166,6 +164,6 @@ enum List<T> {
 
 val list = List.Cons(value: "a", next: List.Cons(value: "b", next: List.Cons(value: "c", next: List.Nil)))
 /// Expect: 3
-stdoutWriteln(list.length().toString())
+println(list.length())
 /// Expect: 3
-stdoutWriteln(List.lengthOf(list).toString())
+println(List.lengthOf(list))

--- a/projects/compiler/test/compiler/functions'.abra
+++ b/projects/compiler/test/compiler/functions'.abra
@@ -2,35 +2,35 @@
 func foo(a: Int, b = bar(a), c = bar(a, b), arr = [a, b, c]): Int = a + b + c + arr.length
 func bar(x: Int, y = 10): Int = x + y
 /// Expect: 31
-stdoutWriteln(foo(2).toString())
+println(foo(2))
 
 // Functions, methods, and closures as value (lambdas too)
 // func abc(): Int = 24
 // /// Expect: <#function>
-// stdoutWriteln("$abc")
+// println("$abc")
 // val abcVal = abc
 // /// Expect: <#function> 24
-// stdoutWriteln("$abcVal ${abcVal()}")
+// println("$abcVal ${abcVal()}")
 
 // /// Expect: <#function>
-// stdoutWriteln("${"abc".isEmpty}")
+// println("${"abc".isEmpty}")
 
 // func def(a: Int): Int = a + 1
 // val defVal = def
 // /// Expect: 24
-// stdoutWriteln(defVal(23).toString())
+// println(defVal(23))
 
 // func ghi(a: Int, b: Int): Int = a + b
 // val ghiVal = ghi
 // /// Expect: 24
-// stdoutWriteln(ghiVal(11, 13).toString())
+// println(ghiVal(11, 13))
 
 (() => {
   val bang = "!"
   val bangbang = () => bang + "!"
   val functionReferencingClosureAsValue = () => {
     val fn = bangbang
-    stdoutWriteln(fn())
+    println(fn())
   }
   /// Expect: !!
   functionReferencingClosureAsValue()
@@ -38,9 +38,9 @@ stdoutWriteln(foo(2).toString())
 
 // Test passing function/closure values as parameters
 
-func callFn(fn: (Int) => Int) = stdoutWriteln(fn(16).toString())
-func callFn2(fn: (Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18).toString())
-func callFn3(fn: (Int, Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18, 19).toString())
+func callFn(fn: (Int) => Int) = println(fn(16))
+func callFn2(fn: (Int, Int, Int) => Int) = println(fn(16, 17, 18))
+func callFn3(fn: (Int, Int, Int, Int) => Int) = println(fn(16, 17, 18, 19))
 
 (() => {
   val xyz = "xyz"
@@ -167,25 +167,25 @@ func callFn3(fn: (Int, Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18, 19)
     x
   }
   /// Expect: 1.1
-  stdoutWriteln(capturedFloat.toString())
+  println(capturedFloat)
   /// Expect: 3.2
-  stdoutWriteln(closure1(1).toString())
+  println(closure1(1))
   /// Expect: 2.2
-  stdoutWriteln(capturedFloat.toString())
+  println(capturedFloat)
 
   capturedFloat = 10.1
   /// Expect: 10.1
-  stdoutWriteln(capturedFloat.toString())
+  println(capturedFloat)
   /// Expect: 12.2
-  stdoutWriteln(closure1(1).toString())
+  println(closure1(1))
   /// Expect: 11.2
-  stdoutWriteln(capturedFloat.toString())
+  println(capturedFloat)
 })()
 
 // // Temporarily moved here from above, since there's something wrong with the order in which generics are resolved which
 // // otherwise causes issues when attempting to print a Float value.
 // // Variadic parameters
-// func variadic(*items: Int[]) = stdoutWriteln(items.toString())
+// func variadic(*items: Int[]) = println(items)
 // /// Expect: [1, 2, 3]
 // variadic(1, 2, 3)
 // /// Expect: []
@@ -198,14 +198,14 @@ func callFn3(fn: (Int, Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18, 19)
     capturedArray.length + zero
   }
   /// Expect: [1, 2, 3]
-  stdoutWriteln(capturedArray.toString())
+  println(capturedArray)
   /// Expect: 2
-  stdoutWriteln(closure2().toString())
+  println(closure2())
   /// Expect: [1, 2]
-  stdoutWriteln(capturedArray.toString())
+  println(capturedArray)
   capturedArray.push(3)
   /// Expect: [1, 2, 3]
-  stdoutWriteln(capturedArray.toString())
+  println(capturedArray)
 })()
 
 (() => {
@@ -214,23 +214,23 @@ func callFn3(fn: (Int, Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18, 19)
 //   capturedInt += arr.length + extra
 // }
 // /// Expect: 1
-// stdoutWriteln(capturedInt.toString())
+// println(capturedInt)
 // closure3([1, 2, 3])
 // /// Expect: 4
-// stdoutWriteln(capturedInt.toString())
+// println(capturedInt)
 // capturedInt = 1
 // closure3(["a", "b"], 12)
 // /// Expect: 15
-// stdoutWriteln(capturedInt.toString())
+// println(capturedInt)
 
   // These lambdas are identical, except for the type inferred from the hint which recontextualizes the parameters
   val closure4_1: (Int, Int) => Int = (a: Int, b = a + capturedInt) => a + b
   /// Expect: 3
-  stdoutWriteln(closure4_1(1, 2).toString())
+  println(closure4_1(1, 2))
   /// Expect: 16
   val closure4_2 = (a: Int, b = a + capturedInt) => a + b
   capturedInt = 14
-  stdoutWriteln(closure4_2(1).toString())
+  println(closure4_2(1))
 })()
 
 (() => {
@@ -243,20 +243,20 @@ func callFn3(fn: (Int, Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18, 19)
   val containsClosures2 = () => { containsClosures1() }
 
   /// Expect: 1
-  stdoutWriteln(capturedInt.toString())
+  println(capturedInt)
   containsClosures2()
   /// Expect: 3
-  stdoutWriteln(capturedInt.toString())
+  println(capturedInt)
   containsClosures2()
   /// Expect: 5
-  stdoutWriteln(capturedInt.toString())
+  println(capturedInt)
 })()
 
 // Returning a function/closure value
 func makeNonClosure(): (Int) => Int = i => i + 1
 val nonClosure = makeNonClosure()
 /// Expect: 12
-stdoutWriteln(nonClosure(11).toString())
+println(nonClosure(11))
 
 func makeClosure(): (Int) => Int {
   val x = 123
@@ -264,7 +264,7 @@ func makeClosure(): (Int) => Int {
 }
 val closure = makeClosure()
 /// Expect: 134
-stdoutWriteln(closure(11).toString())
+println(closure(11))
 
 (() => {
   val one = 1
@@ -273,7 +273,7 @@ stdoutWriteln(closure(11).toString())
   }
   val closureCapturingOutside1 = makeClosureCapturingOutside()
   /// Expect: 12
-  stdoutWriteln(closureCapturingOutside1(11).toString())
+  println(closureCapturingOutside1(11))
   // Even more ridiculous example
   val getClosureCapturingOutside: () => (Int) => Int = () => {
     val fn = () => makeClosureCapturingOutside()
@@ -281,7 +281,7 @@ stdoutWriteln(closure(11).toString())
   }
   val closureCapturingOutside2 = getClosureCapturingOutside()
   /// Expect: 12
-  stdoutWriteln(closureCapturingOutside2(11).toString())
+  println(closureCapturingOutside2(11))
 })()
 
 func makeAdder(x: Int): (Int) => Int {
@@ -289,7 +289,7 @@ func makeAdder(x: Int): (Int) => Int {
 }
 val addOne = makeAdder(1)
 /// Expect: 12
-stdoutWriteln(addOne(11).toString())
+println(addOne(11))
 
 (() => {
   val one = 1
@@ -301,12 +301,12 @@ stdoutWriteln(addOne(11).toString())
   }
   val closureCapturingOutsideAndParam = makeClosureCapturingOutsideAndParam(capturedArr)
   /// Expect: [1, 2]
-  stdoutWriteln(capturedArr.toString())
+  println(capturedArr)
   capturedArr.push(3)
   /// Expect: [1, 2, 3]
-  stdoutWriteln(capturedArr.toString())
+  println(capturedArr)
   /// Expect: 15
-  stdoutWriteln(closureCapturingOutsideAndParam(11).toString())
+  println(closureCapturingOutsideAndParam(11))
 })()
 
 // This is a pretty cool stress-test for closures and functions as values
@@ -339,15 +339,15 @@ func makeJankClass(className: String, a: Int, b: Float[]): JankInstance<Int, Flo
 }
 val jank = makeJankClass("Wow", 1, [2.3, 4.5])
 /// Expect: Wow(a: 1, b: [2.3, 4.5])
-stdoutWriteln(jank.toString())
+println(jank)
 jank.setA(2)
 jank.b.push(6.7)
 /// Expect: Wow(a: 2, b: [2.3, 4.5, 6.7])
-stdoutWriteln(jank.toString())
+println(jank)
 jank.setA(0)
 jank.setB([1.2, 3.4])
 /// Expect: Wow(a: 0, b: [1.2, 3.4])
-stdoutWriteln(jank.toString())
+println(jank)
 
 // Returns
 
@@ -356,9 +356,9 @@ func finalIfExpressionReturns(b: Bool): Int {
 }
 
 /// Expect: 1
-stdoutWriteln(finalIfExpressionReturns(true).toString())
+println(finalIfExpressionReturns(true))
 /// Expect: 2
-stdoutWriteln(finalIfExpressionReturns(false).toString())
+println(finalIfExpressionReturns(false))
 
 // Return statements in if-expressions
 func returnExprInArr(i: Int): Int[] {
@@ -371,9 +371,9 @@ func returnExprInArr(i: Int): Int[] {
   arr
 }
 /// Expect: []
-stdoutWriteln(returnExprInArr(0).toString())
+println(returnExprInArr(0))
 /// Expect: [1, 2, 3]
-stdoutWriteln(returnExprInArr(1).toString())
+println(returnExprInArr(1))
 
 func returnInVarDecl(i: Int): Int {
   val a = if i == 100 {
@@ -386,6 +386,6 @@ func returnInVarDecl(i: Int): Int {
 }
 
 /// Expect: 17
-stdoutWriteln(returnInVarDecl(100).toString())
+println(returnInVarDecl(100))
 /// Expect: -1
-stdoutWriteln(returnInVarDecl(0).toString())
+println(returnInVarDecl(0))

--- a/projects/compiler/test/compiler/functions.abra
+++ b/projects/compiler/test/compiler/functions.abra
@@ -2,11 +2,11 @@
 func foo(a: Int, b = bar(a), c = bar(a, b), arr = [a, b, c]): Int = a + b + c + arr.length
 func bar(x: Int, y = 10): Int = x + y
 /// Expect: 31
-stdoutWriteln(foo(2).toString())
+println(foo(2))
 
 // Temporarily moved lower; see comment below
 // // Variadic parameters
-// func variadic(*items: Int[]) = stdoutWriteln(items)
+// func variadic(*items: Int[]) = println(items)
 // /// Expect: [1, 2, 3]
 // variadic(1, 2, 3)
 // /// Expect: []
@@ -15,30 +15,30 @@ stdoutWriteln(foo(2).toString())
 // Functions, methods, and closures as value (lambdas too)
 func abc(): Int = 24
 /// Expect: <#function>
-stdoutWriteln("$abc")
+println("$abc")
 val abcVal = abc
 /// Expect: <#function> 24
-stdoutWriteln("$abcVal ${abcVal()}")
+println("$abcVal", abcVal())
 
 /// Expect: <#function>
-stdoutWriteln("${"abc".isEmpty}")
+println("${"abc".isEmpty}")
 
 func def(a: Int): Int = a + 1
 val defVal = def
 /// Expect: 24
-stdoutWriteln(defVal(23).toString())
+println(defVal(23))
 
 func ghi(a: Int, b: Int): Int = a + b
 val ghiVal = ghi
 /// Expect: 24
-stdoutWriteln(ghiVal(11, 13).toString())
+println(ghiVal(11, 13))
 
 // Test reference to closure as value, from a nested scope
 // val bang = "!"
 // func bangbang(): String = bang + "!"
 // func functionReferencingClosureAsValue() {
 //   val fn = bangbang
-//   stdoutWriteln(fn())
+//   println(fn())
 // }
 // /// Expect: !!
 // functionReferencingClosureAsValue()
@@ -47,7 +47,7 @@ stdoutWriteln(ghiVal(11, 13).toString())
   val bangbang = () => bang + "!"
   val functionReferencingClosureAsValue = () => {
     val fn = bangbang
-    stdoutWriteln(fn())
+    println(fn())
   }
   /// Expect: !!
   functionReferencingClosureAsValue()
@@ -55,9 +55,9 @@ stdoutWriteln(ghiVal(11, 13).toString())
 
 // Test passing function/closure values as parameters
 
-func callFn(fn: (Int) => Int) = stdoutWriteln(fn(16).toString())
-func callFn2(fn: (Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18).toString())
-func callFn3(fn: (Int, Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18, 19).toString())
+func callFn(fn: (Int) => Int) = println(fn(16))
+func callFn2(fn: (Int, Int, Int) => Int) = println(fn(16, 17, 18))
+func callFn3(fn: (Int, Int, Int, Int) => Int) = println(fn(16, 17, 18, 19))
 
 val xyz = "xyz"
 
@@ -157,24 +157,24 @@ func closure1(one: Int): Float {
   x
 }
 /// Expect: 1.1
-stdoutWriteln(capturedFloat.toString())
+println(capturedFloat)
 /// Expect: 3.2
-stdoutWriteln(closure1(one: 1).toString())
+println(closure1(one: 1))
 /// Expect: 2.2
-stdoutWriteln(capturedFloat.toString())
+println(capturedFloat)
 
 capturedFloat = 10.1
 /// Expect: 10.1
-stdoutWriteln(capturedFloat.toString())
+println(capturedFloat)
 /// Expect: 12.2
-stdoutWriteln(closure1(one: 1).toString())
+println(closure1(one: 1))
 /// Expect: 11.2
-stdoutWriteln(capturedFloat.toString())
+println(capturedFloat)
 
 // Temporarily moved here from above, since there's something wrong with the order in which generics are resolved which
 // otherwise causes issues when attempting to print a Float value.
 // Variadic parameters
-func variadic(*items: Int[]) = stdoutWriteln(items.toString())
+func variadic(*items: Int[]) = println(items)
 /// Expect: [1, 2, 3]
 variadic(1, 2, 3)
 /// Expect: []
@@ -186,14 +186,14 @@ func closure2(zero = 0): Int {
   capturedArray.length + zero
 }
 /// Expect: [1, 2, 3]
-stdoutWriteln(capturedArray.toString())
+println(capturedArray)
 /// Expect: 2
-stdoutWriteln(closure2().toString())
+println(closure2())
 /// Expect: [1, 2]
-stdoutWriteln(capturedArray.toString())
+println(capturedArray)
 capturedArray.push(3)
 /// Expect: [1, 2, 3]
-stdoutWriteln(capturedArray.toString())
+println(capturedArray)
 
 var capturedInt = 1
 func closure3<T>(arr: T[], extra = 0) {
@@ -201,21 +201,21 @@ func closure3<T>(arr: T[], extra = 0) {
 }
 
 /// Expect: 1
-stdoutWriteln(capturedInt.toString())
+println(capturedInt)
 closure3([1, 2, 3])
 /// Expect: 4
-stdoutWriteln(capturedInt.toString())
+println(capturedInt)
 capturedInt = 1
 closure3(["a", "b"], 12)
 /// Expect: 15
-stdoutWriteln(capturedInt.toString())
+println(capturedInt)
 
 func closure4(a: Int, b = a + capturedInt): Int = a + b
 /// Expect: 3
-stdoutWriteln(closure4(1, 2).toString())
+println(closure4(1, 2))
 /// Expect: 16
 capturedInt = 14
-stdoutWriteln(closure4(1).toString())
+println(closure4(1))
 
 capturedInt = 1
 func closure5() { capturedInt += 2 }
@@ -223,19 +223,19 @@ func containsClosures1() { closure5() }
 func containsClosures2() { containsClosures1() }
 
 /// Expect: 1
-stdoutWriteln(capturedInt.toString())
+println(capturedInt)
 containsClosures2()
 /// Expect: 3
-stdoutWriteln(capturedInt.toString())
+println(capturedInt)
 containsClosures2()
 /// Expect: 5
-stdoutWriteln(capturedInt.toString())
+println(capturedInt)
 
 // Returning a function/closure value
 func makeNonClosure(): (Int) => Int = i => i + 1
 val nonClosure = makeNonClosure()
 /// Expect: 12
-stdoutWriteln(nonClosure(11).toString())
+println(nonClosure(11))
 
 func makeClosure(): (Int) => Int {
   val x = 123
@@ -243,7 +243,7 @@ func makeClosure(): (Int) => Int {
 }
 val closure = makeClosure()
 /// Expect: 134
-stdoutWriteln(closure(11).toString())
+println(closure(11))
 
 val one = 1
 func makeClosureCapturingOutside(): (Int) => Int {
@@ -251,7 +251,7 @@ func makeClosureCapturingOutside(): (Int) => Int {
 }
 val closureCapturingOutside1 = makeClosureCapturingOutside()
 /// Expect: 12
-stdoutWriteln(closureCapturingOutside1(11).toString())
+println(closureCapturingOutside1(11))
 // Even more ridiculous example
 func getClosureCapturingOutside(): (Int) => Int {
   val fn = () => makeClosureCapturingOutside()
@@ -259,14 +259,14 @@ func getClosureCapturingOutside(): (Int) => Int {
 }
 val closureCapturingOutside2 = getClosureCapturingOutside()
 /// Expect: 12
-stdoutWriteln(closureCapturingOutside2(11).toString())
+println(closureCapturingOutside2(11))
 
 func makeAdder(x: Int): (Int) => Int {
   i => i + x
 }
 val addOne = makeAdder(1)
 /// Expect: 12
-stdoutWriteln(addOne(11).toString())
+println(addOne(11))
 
 val capturedArr = [1, 2, 3]
 func makeClosureCapturingOutsideAndParam(arr: Int[]): (Int) => Int {
@@ -276,12 +276,12 @@ func makeClosureCapturingOutsideAndParam(arr: Int[]): (Int) => Int {
 }
 val closureCapturingOutsideAndParam = makeClosureCapturingOutsideAndParam(capturedArr)
 /// Expect: [1, 2]
-stdoutWriteln(capturedArr.toString())
+println(capturedArr)
 capturedArr.push(3)
 /// Expect: [1, 2, 3]
-stdoutWriteln(capturedArr.toString())
+println(capturedArr)
 /// Expect: 15
-stdoutWriteln(closureCapturingOutsideAndParam(11).toString())
+println(closureCapturingOutsideAndParam(11))
 
 // This is a pretty cool stress-test for closures and functions as values
 // TODO: there's some issue here with the generics. the error is: "unexpected generic 'A' at this point"
@@ -313,15 +313,15 @@ func makeJankClass(className: String, a: Int, b: Float[]): JankInstance {
 }
 val jank = makeJankClass("Wow", 1, [2.3, 4.5])
 /// Expect: Wow(a: 1, b: [2.3, 4.5])
-stdoutWriteln(jank.toString())
+println(jank)
 jank.setA(2)
 jank.b.push(6.7)
 /// Expect: Wow(a: 2, b: [2.3, 4.5, 6.7])
-stdoutWriteln(jank.toString())
+println(jank)
 jank.setA(0)
 jank.setB([1.2, 3.4])
 /// Expect: Wow(a: 0, b: [1.2, 3.4])
-stdoutWriteln(jank.toString())
+println(jank)
 
 // Returns
 
@@ -330,9 +330,9 @@ func finalIfExpressionReturns(b: Bool): Int {
 }
 
 /// Expect: 1
-stdoutWriteln(finalIfExpressionReturns(true).toString())
+println(finalIfExpressionReturns(true))
 /// Expect: 2
-stdoutWriteln(finalIfExpressionReturns(false).toString())
+println(finalIfExpressionReturns(false))
 
 // Return statements in if-expressions
 func returnExprInArr(i: Int): Int[] {
@@ -345,9 +345,9 @@ func returnExprInArr(i: Int): Int[] {
   arr
 }
 /// Expect: []
-stdoutWriteln(returnExprInArr(0).toString())
+println(returnExprInArr(0))
 /// Expect: [1, 2, 3]
-stdoutWriteln(returnExprInArr(1).toString())
+println(returnExprInArr(1))
 
 func returnInVarDecl(i: Int): Int {
   val a = if i == 100 {
@@ -360,6 +360,6 @@ func returnInVarDecl(i: Int): Int {
 }
 
 /// Expect: 17
-stdoutWriteln(returnInVarDecl(100).toString())
+println(returnInVarDecl(100))
 /// Expect: -1
-stdoutWriteln(returnInVarDecl(0).toString())
+println(returnInVarDecl(0))

--- a/projects/compiler/test/compiler/ifs.abra
+++ b/projects/compiler/test/compiler/ifs.abra
@@ -2,64 +2,64 @@
 
 /// Expect: here 1
 if 1 < 4 {
-  stdoutWriteln("here 1")
+  println("here 1")
 } else {
-  stdoutWriteln("here 2")
+  println("here 2")
 }
 
 /// Expect: here 2
 if 1 > 4 {
-  stdoutWriteln("here 1")
+  println("here 1")
 } else {
-  stdoutWriteln("here 2")
+  println("here 2")
 }
 
 /// Expect: here 3
 if 1 > 4 {
-  stdoutWriteln("here 1")
+  println("here 1")
 } else if 2 > 4 {
-  stdoutWriteln("here 2")
+  println("here 2")
 } else {
-  stdoutWriteln("here 3")
+  println("here 3")
 }
 
 // If expressions
 
 val a = if 1 > 0 123 else 456
 /// Expect: 123
-stdoutWriteln(a.toString())
+println(a)
 
 val b = (if 1 < 0 123 else 456) + 1000
 /// Expect: 1456
-stdoutWriteln(b.toString())
+println(b)
 
 val c = if true { Some(123) } else { None }
 /// Expect: Option.Some(value: 123)
-stdoutWriteln(c.toString())
+println(c)
 
 val d = if false { Some(123) } else { None }
 /// Expect: Option.None
-stdoutWriteln(d.toString())
+println(d)
 
 /// Expect: Option.Some(value: 3)
-stdoutWriteln((if true { Some(1 + 2) } else { None }).toString())
+println(if true { Some(1 + 2) } else { None })
 
 // Condition bindings
 val arr = [1, 2, 3, 4]
 /// Expect: 101
-stdoutWriteln((if arr[0] |item| { item + 100 } else { 0 }).toString())
+println(if arr[0] |item| { item + 100 } else { 0 })
 /// Expect: 0
-stdoutWriteln((if arr[5] |item| { item + 100 } else { 0 }).toString())
+println(if arr[5] |item| { item + 100 } else { 0 })
 
 // Destructuring condition binding as tuple
 val pairs = [("a", 1), ("b", 2)]
 // Statement
 if pairs[0] |(k, v)| {
   /// Expect: a 1
-  stdoutWriteln("$k $v")
+  println(k, v)
 }
 
 // Expression
 val x = if pairs[0] |(k, v)| k.length + v else 0
 /// Expect: 2
-stdoutWriteln(x.toString())
+println(x)

--- a/projects/compiler/test/compiler/ints.abra
+++ b/projects/compiler/test/compiler/ints.abra
@@ -1,125 +1,121 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-func printlnInt(i: Int) = stdoutWriteln(i.toString())
-func printlnFloat(f: Float) = stdoutWriteln(f.toString())
-
 /// Expect: 24
-printlnInt(24)
+println(24)
 
 // Unary operations
 /// Expect: -1
-printlnInt(-1)
+println(-1)
 /// Expect: 1
-printlnInt(--1)
+println(--1)
 
 // Binary operations
 /// Expect: 32
-printlnInt(17 + 15)
+println(17 + 15)
 /// Expect: 32.1
-printlnFloat(17 + 15.1)
+println(17 + 15.1)
 
 /// Expect: 2
-printlnInt(17 - 15)
+println(17 - 15)
 /// Expect: 1.9
-printlnFloat(17 - 15.1)
+println(17 - 15.1)
 
 /// Expect: 2550
-printlnInt(17 * 150)
+println(17 * 150)
 /// Expect: 2551.7
-printlnFloat(17 * 150.1)
+println(17 * 150.1)
 
 /// Expect: 1.13333
-printlnFloat(17 / 15)
+println(17 / 15)
 /// Expect: 1.12583
-printlnFloat(17 / 15.1)
+println(17 / 15.1)
 
 /// Expect: 2
-printlnInt(7 % 5)
+println(7 % 5)
 /// Expect: 1.8
-printlnFloat(7 % 5.2)
+println(7 % 5.2)
 
 /// Expect: 32
-printlnFloat(2 ** 5)
+println(2 ** 5)
 /// Expect: 0.03125
-printlnFloat(2 ** -5)
+println(2 ** -5)
 /// Expect: -32
-printlnFloat(-2 ** 5)
+println(-2 ** 5)
 /// Expect: -0.03125
-printlnFloat(-2 ** -5)
+println(-2 ** -5)
 
 /// Expect: true
-printlnBool(1 << 3 != 17)
+println(1 << 3 != 17)
 /// Expect: true
-printlnBool(0x00ff << 8 == 0xff00)
+println(0x00ff << 8 == 0xff00)
 /// Expect: true
-printlnBool(0xff00 >> 8 == 0x00ff)
+println(0xff00 >> 8 == 0x00ff)
 
 /// Expect: 1
-printlnInt(0xff && 1)
+println(0xff && 1)
 /// Expect: 255
-printlnInt(0xfe || 1)
+println(0xfe || 1)
 /// Expect: 255
-printlnInt(0b01010101 ^ 0b10101010)
+println(0b01010101 ^ 0b10101010)
 
 /// Expect: true
-printlnBool(17 == (15 + 2))
+println(17 == (15 + 2))
 /// Expect: false
-printlnBool(17 == 15)
+println(17 == 15)
 /// Expect: false
-printlnBool(17 != (15 + 2))
+println(17 != (15 + 2))
 /// Expect: true
-printlnBool(17 != 15)
+println(17 != 15)
 
 /// Expect: true
-printlnBool(17 < 18)
+println(17 < 18)
 /// Expect: false
-printlnBool(17 < 15)
+println(17 < 15)
 /// Expect: true
-printlnBool(17 < 18.0)
+println(17 < 18.0)
 /// Expect: false
-printlnBool(17 < 15.1)
+println(17 < 15.1)
 
 /// Expect: false
-printlnBool(17 > 18)
+println(17 > 18)
 /// Expect: true
-printlnBool(17 > 15)
+println(17 > 15)
 /// Expect: false
-printlnBool(17 > 18.0)
+println(17 > 18.0)
 /// Expect: true
-printlnBool(17 > 15.1)
+println(17 > 15.1)
 
 /// Expect: true
-printlnBool(17 <= 18)
+println(17 <= 18)
 /// Expect: false
-printlnBool(17 <= 15)
+println(17 <= 15)
 /// Expect: true
-printlnBool(17 <= 18.0)
+println(17 <= 18.0)
 /// Expect: false
-printlnBool(17 <= 15.1)
+println(17 <= 15.1)
 
 /// Expect: false
-printlnBool(17 >= 18)
+println(17 >= 18)
 /// Expect: true
-printlnBool(17 >= 15)
+println(17 >= 15)
 /// Expect: false
-printlnBool(17 >= 18.0)
+println(17 >= 18.0)
 /// Expect: true
-printlnBool(17 >= 15.1)
+println(17 >= 15.1)
 
 // Int#unsignedToString
 if true {
   val i1 = 118
   /// Expect: 118
-  stdoutWriteln(i1.toString())
+  println(i1.toString())
   /// Expect: 118
-  stdoutWriteln(i1.unsignedToString())
+  println(i1.unsignedToString())
 
   val i2 = (1 << 63) || (1 << 31)
   /// Expect: -9223372034707292160
-  stdoutWriteln(i2.toString())
+  println(i2.toString())
   /// Expect: 9223372039002259456
-  stdoutWriteln(i2.unsignedToString())
+  println(i2.unsignedToString())
 
   //val i3 = 0b1000000000000000000000000000000010000000000000000000000000000000
   ///// Expect: -9223372034707292160 9223372039002259456
-  //stdoutWriteln(i3.toString(), i3.unsignedToString())
+  //println(i3.toString(), i3.unsignedToString())
 }

--- a/projects/compiler/test/compiler/json.abra
+++ b/projects/compiler/test/compiler/json.abra
@@ -3,141 +3,140 @@ import JsonParser from "json"
 // Testing basic values
 if true {
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Left(left: 1)))
-  stdoutWriteln(JsonParser.parseString("1").toString())
+  println(JsonParser.parseString("1"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: 2.5)))
-  stdoutWriteln(JsonParser.parseString("2.5").toString())
+  println(JsonParser.parseString("2.5"))
   /// Expect: Result.Ok(value: JsonValue.String(value: "hello"))
-  stdoutWriteln(JsonParser.parseString("\"hello\"").toString())
+  println(JsonParser.parseString("\"hello\""))
   /// Expect: Result.Ok(value: JsonValue.Boolean(value: true))
-  stdoutWriteln(JsonParser.parseString("true").toString())
+  println(JsonParser.parseString("true"))
   /// Expect: Result.Ok(value: JsonValue.Boolean(value: false))
-  stdoutWriteln(JsonParser.parseString("false").toString())
+  println(JsonParser.parseString("false"))
   /// Expect: Result.Ok(value: JsonValue.Null)
-  stdoutWriteln(JsonParser.parseString("null").toString())
+  println(JsonParser.parseString("null"))
 }
 
 // Testing numbers
 if true {
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Left(left: -2)))
-  stdoutWriteln(JsonParser.parseString("-2").toString())
+  println(JsonParser.parseString("-2"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: -2.05)))
-  stdoutWriteln(JsonParser.parseString("-2.05").toString())
+  println(JsonParser.parseString("-2.05"))
 
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: 20000)))
-  stdoutWriteln(JsonParser.parseString("2e04").toString())
+  println(JsonParser.parseString("2e04"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: 20000)))
-  stdoutWriteln(JsonParser.parseString("2e+04").toString())
+  println(JsonParser.parseString("2e+04"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: -20000)))
-  stdoutWriteln(JsonParser.parseString("-2e04").toString())
+  println(JsonParser.parseString("-2e04"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: 0.0002)))
-  stdoutWriteln(JsonParser.parseString("2e-04").toString())
+  println(JsonParser.parseString("2e-04"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: -0.0002)))
-  stdoutWriteln(JsonParser.parseString("-2e-04").toString())
+  println(JsonParser.parseString("-2e-04"))
 
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: 2000)))
-  stdoutWriteln(JsonParser.parseString("0.2e04").toString())
+  println(JsonParser.parseString("0.2e04"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: 2000)))
-  stdoutWriteln(JsonParser.parseString("0.2e+04").toString())
+  println(JsonParser.parseString("0.2e+04"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: -2000)))
-  stdoutWriteln(JsonParser.parseString("-0.2e04").toString())
+  println(JsonParser.parseString("-0.2e04"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: 0.0002)))
-  stdoutWriteln(JsonParser.parseString("0.2e-03").toString())
+  println(JsonParser.parseString("0.2e-03"))
   /// Expect: Result.Ok(value: JsonValue.Number(value: Either.Right(right: -0.0002)))
-  stdoutWriteln(JsonParser.parseString("-0.2e-03").toString())
+  println(JsonParser.parseString("-0.2e-03"))
 }
 
 // Testing strings
 if true {
   // escape sequences
   /// Expect: Result.Ok(value: "JsonValue.String(value: "" \ \n \r \t /")")
-  stdoutWriteln(
+  println(
     JsonParser.parseString("\"\\\" \\\\ \\n \\r \\t \\/\"")
       .map(v => v.toString().replaceAll("\n", "\\n").replaceAll("\r", "\\r").replaceAll("\t", "\\t"))
-      .toString()
   )
 
   // unicode escape sequence
   /// Expect: Result.Ok(value: JsonValue.String(value: "PH"))
-  stdoutWriteln(JsonParser.parseString("\"\\u0050\\u0048\"").toString())
+  println(JsonParser.parseString("\"\\u0050\\u0048\""))
 
   // TODO: Uncomment when Strings support `bytelength`
   // // unicode characters
   // /// Expect: Result.Ok(value: JsonValue.String(value: "日"))
-  // stdoutWriteln(JsonParser.parseString("\"日\""))
+  // println(JsonParser.parseString("\"日\""))
 }
 
 // Testing array values
 if true {
   /// Expect: Result.Ok(value: JsonValue.Array(items: []))
-  stdoutWriteln(JsonParser.parseString("[]").toString())
+  println(JsonParser.parseString("[]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Number(value: Either.Left(left: 1))]))
-  stdoutWriteln(JsonParser.parseString("[1]").toString())
+  println(JsonParser.parseString("[1]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Number(value: Either.Left(left: 1)), JsonValue.Number(value: Either.Left(left: 2)), JsonValue.Number(value: Either.Left(left: 3))]))
-  stdoutWriteln(JsonParser.parseString("[1, 2, 3]").toString())
+  println(JsonParser.parseString("[1, 2, 3]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Number(value: Either.Right(right: 1.5))]))
-  stdoutWriteln(JsonParser.parseString("[1.5]").toString())
+  println(JsonParser.parseString("[1.5]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Null]))
-  stdoutWriteln(JsonParser.parseString("[null]").toString())
+  println(JsonParser.parseString("[null]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Boolean(value: true)]))
-  stdoutWriteln(JsonParser.parseString("[true]").toString())
+  println(JsonParser.parseString("[true]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Boolean(value: false)]))
-  stdoutWriteln(JsonParser.parseString("[false]").toString())
+  println(JsonParser.parseString("[false]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.String(value: "hello")]))
-  stdoutWriteln(JsonParser.parseString("[\"hello\"]").toString())
+  println(JsonParser.parseString("[\"hello\"]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Number(value: Either.Left(left: 0))]))
-  stdoutWriteln(JsonParser.parseString("[0]").toString())
+  println(JsonParser.parseString("[0]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Number(value: Either.Left(left: 0))]))
-  stdoutWriteln(JsonParser.parseString("[ 0 ]").toString())
+  println(JsonParser.parseString("[ 0 ]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Array(items: [JsonValue.String(value: "hello")])]))
-  stdoutWriteln(JsonParser.parseString("[[\"hello\"]]").toString())
+  println(JsonParser.parseString("[[\"hello\"]]"))
   /// Expect: Result.Ok(value: JsonValue.Array(items: [JsonValue.Object(obj: JsonObject(_map: { foo: JsonValue.Number(value: Either.Left(left: 1)) }))]))
-  stdoutWriteln(JsonParser.parseString("[{\"foo\": 1}]").toString())
+  println(JsonParser.parseString("[{\"foo\": 1}]"))
 }
 
 // Testing object values
 if true {
   /// Expect: Result.Ok(value: JsonValue.Object(obj: JsonObject(_map: {})))
-  stdoutWriteln(JsonParser.parseString("{}").toString())
+  println(JsonParser.parseString("{}"))
   /// Expect: Result.Ok(value: JsonValue.Object(obj: JsonObject(_map: { foo: JsonValue.Number(value: Either.Left(left: 1)) })))
-  stdoutWriteln(JsonParser.parseString("{\"foo\": 1}").toString())
+  println(JsonParser.parseString("{\"foo\": 1}"))
   /// Expect: Result.Ok(value: JsonValue.Object(obj: JsonObject(_map: { bar: JsonValue.Array(items: [JsonValue.String(value: "baz")]), foo: JsonValue.Number(value: Either.Left(left: 1)) })))
-  stdoutWriteln(JsonParser.parseString("{ \"foo\" : 1 , \"bar\": [\"baz\"]}").toString())
+  println(JsonParser.parseString("{ \"foo\" : 1 , \"bar\": [\"baz\"]}"))
   /// Expect: Result.Ok(value: "JsonValue.Object(obj: JsonObject(_map: { fo\no: JsonValue.Number(value: Either.Left(left: 1)) }))")
-  stdoutWriteln(JsonParser.parseString("{\"fo\\no\": 1}").map(v => v.toString().replaceAll("\n", "\\n")).toString())
+  println(JsonParser.parseString("{\"fo\\no\": 1}").map(v => v.toString().replaceAll("\n", "\\n")))
 }
 
 // Testing parsing errors
 if true {
   /// Expect: Result.Err(error: JsonParseError.UnexpectedEndOfNumber)
-  stdoutWriteln(JsonParser.parseString("2.").toString())
+  println(JsonParser.parseString("2."))
 
   /// Expect: Result.Err(error: JsonParseError.InvalidCharacterInString)
-  stdoutWriteln(JsonParser.parseString("\"\\u123z\"").toString())
+  println(JsonParser.parseString("\"\\u123z\""))
 
   /// Expect: Result.Err(error: JsonParseError.InvalidCharacterInString)
-  stdoutWriteln(JsonParser.parseString("\"hello\nworld\"").toString())
+  println(JsonParser.parseString("\"hello\nworld\""))
 
   /// Expect: Result.Err(error: JsonParseError.ValueExpected)
-  stdoutWriteln(JsonParser.parseString("[1,]").toString())
+  println(JsonParser.parseString("[1,]"))
   /// Expect: Result.Err(error: JsonParseError.EofExpected)
-  stdoutWriteln(JsonParser.parseString("[0]1").toString())
+  println(JsonParser.parseString("[0]1"))
   /// Expect: Result.Err(error: JsonParseError.EofExpected)
-  stdoutWriteln(JsonParser.parseString("[0] 1").toString())
+  println(JsonParser.parseString("[0] 1"))
   /// Expect: Result.Err(error: JsonParseError.CommaExpected)
-  stdoutWriteln(JsonParser.parseString("[0 true]").toString())
+  println(JsonParser.parseString("[0 true]"))
   /// Expect: Result.Err(error: JsonParseError.CommaOrClosingBracketExpected)
-  stdoutWriteln(JsonParser.parseString("[0 ").toString())
+  println(JsonParser.parseString("[0 "))
 
   /// Expect: Result.Err(error: JsonParseError.ObjectPropertyExpected)
-  stdoutWriteln(JsonParser.parseString("{\"foo\": 1,}").toString())
+  println(JsonParser.parseString("{\"foo\": 1,}"))
   /// Expect: Result.Err(error: JsonParseError.ObjectPropertyExpected)
-  stdoutWriteln(JsonParser.parseString("{1}").toString())
+  println(JsonParser.parseString("{1}"))
   /// Expect: Result.Err(error: JsonParseError.ColonExpected)
-  stdoutWriteln(JsonParser.parseString("{ \"foo\" 1 }").toString())
+  println(JsonParser.parseString("{ \"foo\" 1 }"))
   /// Expect: Result.Err(error: JsonParseError.ValueExpected)
-  stdoutWriteln(JsonParser.parseString("{ \"foo\": }").toString())
+  println(JsonParser.parseString("{ \"foo\": }"))
   /// Expect: Result.Err(error: JsonParseError.CommaExpected)
-  stdoutWriteln(JsonParser.parseString("{ \"foo\":  1 \"bar\": 2}").toString())
+  println(JsonParser.parseString("{ \"foo\":  1 \"bar\": 2}"))
   /// Expect: Result.Err(error: JsonParseError.CommaOrClosingBracketExpected)
-  stdoutWriteln(JsonParser.parseString("{ \"foo\":  1 ").toString())
+  println(JsonParser.parseString("{ \"foo\":  1 "))
 }

--- a/projects/compiler/test/compiler/loops.abra
+++ b/projects/compiler/test/compiler/loops.abra
@@ -1,18 +1,16 @@
-func printlnInt(i: Int) = stdoutWriteln(i.toString())
-
 // While-loops
 
 if true {
   var i = 0
   while i < 3 {
-    printlnInt(i)
+    println(i)
     i += 1
   }
   /// Expect: 0
   /// Expect: 1
   /// Expect: 2
   /// Expect: done
-  stdoutWriteln("done")
+  println("done")
 }
 
 // Condition bindings
@@ -20,14 +18,14 @@ if true {
   val arr = [1, 2, 3]
   var n = 0
   while arr[n] |item| {
-    printlnInt(100 + item)
+    println(100 + item)
     n += 1
   }
   /// Expect: 101
   /// Expect: 102
   /// Expect: 103
   /// Expect: done
-  stdoutWriteln("done")
+  println("done")
 }
 
 // Destructuring condition binding as tuple
@@ -35,13 +33,13 @@ if true {
   val arr = [("a", 1), ("bc", 2)]
   var n = 0
   while arr[n] |(k, v)| {
-    printlnInt(100 + k.length + v)
+    println(100 + k.length + v)
     n += 1
   }
   /// Expect: 102
   /// Expect: 104
   /// Expect: done
-  stdoutWriteln("done")
+  println("done")
 }
 
 // Control flow within loops
@@ -49,10 +47,10 @@ if true {
   /// Expect: first loop
   /// Expect: done
   while true {
-    stdoutWriteln("first loop")
+    println("first loop")
     break
   }
-  stdoutWriteln("done")
+  println("done")
 
   /// Expect: 0
   /// Expect: 1
@@ -64,10 +62,10 @@ if true {
       x += 1
       continue
     }
-    printlnInt(x)
+    println(x)
     x += 1
   }
-  stdoutWriteln("done")
+  println("done")
 }
 
 // For-loops
@@ -78,43 +76,43 @@ if true {
   /// Expect: 1
   /// Expect: 2
   for i in 0:3 {
-    stdoutWriteln("$i")
+    println(i)
   }
 
   /// Expect: 0 0
   /// Expect: 1 1
   /// Expect: 2 2
   for i, idx in 0:1+2 {
-    stdoutWriteln("$i $idx")
+    println(i, idx)
   }
 
   /// Expect: 0 0
   for i, idx in 0:1+2 {
     if i == 1 break
-    stdoutWriteln("$i $idx")
+    println(i, idx)
   }
 
   /// Expect: 0 0
   /// Expect: 2 2
   for i, idx in 0:1+2 {
     if i == 1 continue
-    stdoutWriteln("$i $idx")
+    println(i, idx)
   }
 
   /// Expect: done
-  stdoutWriteln("done")
+  println("done")
 }
 
 // Destructuring iteratee binding as tuple
 if true {
   val arr = [("a", 1), ("bc", 2)]
   for (k, v) in arr {
-    printlnInt(100 + k.length + v)
+    println(100 + k.length + v)
   }
   /// Expect: 102
   /// Expect: 104
   /// Expect: done
-  stdoutWriteln("done")
+  println("done")
 }
 
 // Iterating over `Iterator` type
@@ -124,9 +122,9 @@ if true {
   /// Expect: 4
   /// Expect: done
   for i in range(0, 5, 2) {
-    printlnInt(i)
+    println(i)
   }
-  stdoutWriteln("done")
+  println("done")
 }
 
 // Iterating over Array, Set, Map
@@ -135,20 +133,20 @@ if true {
   /// Expect: b
   /// Expect: c
   for ch in ["a", "b", "c"] {
-    stdoutWriteln(ch)
+    println(ch)
   }
 
   /// Expect: a 0
   /// Expect: b 1
   /// Expect: c 2
   for ch, idx in ["a", "b", "c"] {
-    stdoutWriteln("$ch $idx")
+    println(ch, idx)
   }
 
   /// Expect: a 0
   /// Expect: b 1
   for ch, idx in ["a", "b", "c"] {
-    stdoutWriteln("$ch $idx")
+    println(ch, idx)
     if ch == "b" {
       break
     }
@@ -160,20 +158,20 @@ if true {
     if ch == "b" {
       continue
     }
-    stdoutWriteln("$ch $idx")
+    println(ch, idx)
   }
 
   // /// Expect: c 0
   // /// Expect: b 1
   // /// Expect: a 2
   // for ch, idx in #{"a", "b", "c"} {
-  //   stdoutWriteln("$ch $idx")
+  //   println("$ch $idx")
   // }
 
   /// Expect: ("c", 3) 0
   /// Expect: ("b", 2) 1
   /// Expect: ("a", 1) 2
   for ch, idx in { a: 1, b: 2, c: 3 } {
-    stdoutWriteln("$ch $idx")
+    println("$ch", idx)
   }
 }

--- a/projects/compiler/test/compiler/macros.abra
+++ b/projects/compiler/test/compiler/macros.abra
@@ -5,7 +5,7 @@ func one(): InjectedCode = InjectedCode.new().append("123")
 
 val x = one() + one()
 /// Expect: 246
-stdoutWriteln("$x")
+println(x)
 
 @macro
 func makeTuple(*values: Expr[]): InjectedCode {
@@ -23,8 +23,8 @@ func makeTuple(*values: Expr[]): InjectedCode {
 
 val t1 = makeTuple(1, "two", false)
 /// Expect: (1, "two", false)
-stdoutWriteln("$t1")
+println("$t1")
 
 val t2 = makeTuple(1, "two", false, 4)
 /// Expect: (1, "two", false, 4)
-stdoutWriteln("$t2")
+println("$t2")

--- a/projects/compiler/test/compiler/maps.abra
+++ b/projects/compiler/test/compiler/maps.abra
@@ -1,48 +1,46 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-
 // Test raw construction of map
 if true {
   val m0: Map<Int, String> = Map.new()
   /// Expect: {}
-  stdoutWriteln(m0.toString())
+  println(m0)
 
   val m1: Map<Int, String> = Map.new()
   m1.insert(24, "hello")
   /// Expect: { 24: hello }
-  stdoutWriteln(m1.toString())
+  println(m1)
 
   val m2: Map<Int, String> = Map.new()
   m2.insert(24, "hello")
   m2.insert(17, "bonjour")
   /// Expect: { 17: bonjour, 24: hello }
-  stdoutWriteln(m2.toString())
+  println(m2)
 
   // Forcing a hash-collision
   val m3: Map<Int, String> = Map.new()
   m3.insert(1, "hello")
   m3.insert(m3.getCapacity() + 1, "world")
   /// Expect: { 1: hello, 17: world }
-  stdoutWriteln(m3.toString())
+  println(m3)
 }
 
 // Test map literal construction
 if true {
   val m0: Map<Int, String> = {}
   /// Expect: {}
-  stdoutWriteln(m0.toString())
+  println(m0)
 
   val m1 = { (24): "hello" }
   /// Expect: { 24: hello }
-  stdoutWriteln(m1.toString())
+  println(m1)
 
   val m2 = { (24): "hello", (17): "bonjour" }
   /// Expect: { 17: bonjour, 24: hello }
-  stdoutWriteln(m2.toString())
+  println(m2)
 
   // Forcing a hash-collision (16 initial buckets by default)
   val m3 = { (1): "hello", (17): "world" }
   /// Expect: { 1: hello, 17: world }
-  stdoutWriteln(m3.toString())
+  println(m3)
 }
 
 // == operator (also Map#eq)
@@ -50,9 +48,9 @@ if true {
   val map = { a: "abc", b: "def" }
 
   /// Expect: true
-  printlnBool(map == { b: "def", a: "abc" })
+  println(map == { b: "def", a: "abc" })
   /// Expect: true
-  printlnBool({ (1): { (1): ["a"], (2): ["b"] } } == { (1): { (1): ["a"], (2): ["b"] } })
+  println({ (1): { (1): ["a"], (2): ["b"] } } == { (1): { (1): ["a"], (2): ["b"] } })
 }
 
 // Map.fromPairs
@@ -62,40 +60,40 @@ if true {
   val m = Map.fromPairs(pairs)
 
   /// Expect: { c: 3, b: 2, a: 1 }
-  stdoutWriteln(m.toString())
+  println(m)
 }
 
 // Map#keys
 if true {
   val map1 = { a: 1, b: 2 }
   /// Expect: #{b, a}
-  stdoutWriteln(map1.keys().toString())
+  println(map1.keys())
 
   val map2 = { ((1, 1)): true, ((0, 1)): false }
   /// Expect: #{(0, 1), (1, 1)}
-  stdoutWriteln(map2.keys().toString())
+  println(map2.keys())
 }
 
 // Map#values
 if true {
   val map1 = { a: 1, b: 2 }
   /// Expect: [2, 1]
-  stdoutWriteln(map1.values().toString())
+  println(map1.values())
 
   val map2 = { ((1, 1)): true, ((0, 1)): false }
   /// Expect: [false, true]
-  stdoutWriteln(map2.values().toString())
+  println(map2.values())
 }
 
 // Map#entries
 if true {
   val map1 = { a: 1, b: 2 }
   /// Expect: #{("b", 2), ("a", 1)}
-  stdoutWriteln(map1.entries().toString())
+  println(map1.entries())
 
   val map2 = { ((1, 1)): true, ((0, 1)): false }
   /// Expect: #{((1, 1), true), ((0, 1), false)}
-  stdoutWriteln(map2.entries().toString())
+  println(map2.entries())
 }
 
 // Map#iterator
@@ -104,15 +102,15 @@ if true {
   val iter = m.iterator()
 
   /// Expect: Option.Some(value: ("c", 3))
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.Some(value: ("b", 2))
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.Some(value: ("a", 1))
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.None
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.None
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
 }
 
 // For-loops
@@ -120,7 +118,7 @@ if true {
 /// Expect: ("b", 2) 1
 /// Expect: ("a", 1) 2
 for ch, idx in { a: 1, b: 2, c: 3 } {
-  stdoutWriteln("$ch $idx")
+  println("$ch $idx")
 }
 
 // Map#containsKey
@@ -128,9 +126,9 @@ if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: true
-  stdoutWriteln(m.containsKey(1).toString())
+  println(m.containsKey(1))
   /// Expect: false
-  stdoutWriteln(m.containsKey(3).toString())
+  println(m.containsKey(3))
 }
 
 // Map#mapValues
@@ -139,11 +137,11 @@ if true {
 
   val m2 = m1.mapValues((_, v) => v + "!")
   /// Expect: { 1: abc!, 2: defg! }
-  stdoutWriteln(m2.toString())
+  println(m2)
 
   val m3 = m1.mapValues((_, v) => v.length)
   /// Expect: { 1: 3, 2: 4 }
-  stdoutWriteln(m3.toString())
+  println(m3)
 }
 
 // Map#insert (also []= operator)
@@ -152,7 +150,7 @@ if true {
   m.insert("c", 3)
   m["d"] = 4
   /// Expect: { d: 4, c: 3, b: 2, a: 1 }
-  stdoutWriteln(m.toString())
+  println(m)
 
   val letters = ["e", "f", "g", "h", "i", "j", "l", "k", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
   for ch, idx in letters {
@@ -160,9 +158,9 @@ if true {
   }
   // Map should have been resized
   /// Expect: { y: 24, w: 22, u: 20, s: 18, q: 16, o: 14, m: 12, k: 11, i: 8, g: 6, e: 4, c: 3, a: 1, z: 25, x: 23, v: 21, t: 19, r: 17, p: 15, n: 13, l: 10, j: 9, h: 7, f: 5, d: 4, b: 2 }
-  stdoutWriteln(m.toString())
+  println(m)
   /// Expect: false
-  stdoutWriteln(m._needsResize().toString())
+  println(m._needsResize())
 }
 
 // Map#get
@@ -170,11 +168,11 @@ if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: Option.Some(value: "a")
-  stdoutWriteln(m.get(1).toString())
+  println(m.get(1))
   /// Expect: Option.Some(value: "b")
-  stdoutWriteln(m.get(2).toString())
+  println(m.get(2))
   /// Expect: Option.None
-  stdoutWriteln(m.get(3).toString())
+  println(m.get(3))
 }
 
 // Map#getOr
@@ -182,11 +180,11 @@ if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: a
-  stdoutWriteln(m.getOr(1, "c"))
+  println(m.getOr(1, "c"))
   /// Expect: b
-  stdoutWriteln(m.getOr(2, "c"))
+  println(m.getOr(2, "c"))
   /// Expect: c
-  stdoutWriteln(m.getOr(3, "c"))
+  println(m.getOr(3, "c"))
 }
 
 // Map#getOrElse
@@ -194,21 +192,26 @@ if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: a
-  stdoutWriteln(m.getOrElse(1, () => {
-    stdoutWriteln("calling default fn")
+  val v1 = m.getOrElse(1, () => {
+    println("calling default fn")
     "c"
-  }))
+  })
+  println(v1)
+
   /// Expect: b
-  stdoutWriteln(m.getOrElse(2, () => {
-    stdoutWriteln("calling default fn")
+  val v2 = m.getOrElse(2, () => {
+    println("calling default fn")
     "c"
-  }))
+  })
+  println(v2)
+
   /// Expect: calling default fn
   /// Expect: c
-  stdoutWriteln(m.getOrElse(3, () => {
-    stdoutWriteln("calling default fn")
+  val v3 = m.getOrElse(3, () => {
+    println("calling default fn")
     "c"
-  }))
+  })
+  println(v3)
 }
 
 // Map#update
@@ -216,19 +219,19 @@ if true {
   val m = { (1): "a", (2): "b" }
 
   /// Expect: { 1: a, 2: b }
-  stdoutWriteln(m.toString())
+  println(m)
 
   val old1 = m.update(1, () => "A")
   /// Expect: { 1: A, 2: b }
-  stdoutWriteln(m.toString())
+  println(m)
   /// Expect: Option.Some(value: "a")
-  stdoutWriteln(old1.toString())
+  println(old1)
 
   val old2 = m.update(4, () => "???")
   /// Expect: { 1: A, 2: b }
-  stdoutWriteln(m.toString())
+  println(m)
   /// Expect: Option.None
-  stdoutWriteln(old2.toString())
+  println(old2)
 }
 
 // Map#remove
@@ -242,50 +245,50 @@ if true {
     t: 6
   }
   /// Expect: { d: 4, t: 6, c: 3, s: 5, b: 2, a: 1 }
-  stdoutWriteln(m.toString())
+  println(m)
 
   /// Expect: Option.None
-  stdoutWriteln(m.remove("x").toString())
+  println(m.remove("x"))
   /// Expect: 6
-  stdoutWriteln(m.size.toString())
+  println(m.size)
 
   /// Expect: Option.Some(value: 2)
-  stdoutWriteln(m.remove("b").toString())
+  println(m.remove("b"))
   /// Expect: { d: 4, t: 6, c: 3, s: 5, a: 1 }
-  stdoutWriteln(m.toString())
+  println(m)
   /// Expect: 5
-  stdoutWriteln(m.size.toString())
+  println(m.size)
 
   // Kinda dirty, but needed in order to test removing keys with the same hash
   /// Expect: true
-  printlnBool(m._getKeyHash("c") == m._getKeyHash("s"))
+  println(m._getKeyHash("c") == m._getKeyHash("s"))
 
   /// Expect: Option.Some(value: 5)
-  stdoutWriteln(m.remove("s").toString())
+  println(m.remove("s"))
   /// Expect: { d: 4, t: 6, c: 3, a: 1 }
-  stdoutWriteln(m.toString())
+  println(m)
   /// Expect: 4
-  stdoutWriteln(m.size.toString())
+  println(m.size)
   /// Expect: Option.Some(value: 3)
-  stdoutWriteln(m.remove("c").toString())
+  println(m.remove("c"))
   /// Expect: { d: 4, t: 6, a: 1 }
-  stdoutWriteln(m.toString())
+  println(m)
   /// Expect: 3
-  stdoutWriteln(m.size.toString())
+  println(m.size)
 
   /// Expect: true
-  printlnBool(m._getKeyHash("d") == m._getKeyHash("t"))
+  println(m._getKeyHash("d") == m._getKeyHash("t"))
 
   /// Expect: Option.Some(value: 4)
-  stdoutWriteln(m.remove("d").toString())
+  println(m.remove("d"))
   /// Expect: { t: 6, a: 1 }
-  stdoutWriteln(m.toString())
+  println(m)
   /// Expect: 2
-  stdoutWriteln(m.size.toString())
+  println(m.size)
   /// Expect: Option.Some(value: 6)
-  stdoutWriteln(m.remove("t").toString())
+  println(m.remove("t"))
   /// Expect: { a: 1 }
-  stdoutWriteln(m.toString())
+  println(m)
   /// Expect: 1
-  stdoutWriteln(m.size.toString())
+  println(m.size)
 }

--- a/projects/compiler/test/compiler/match.abra
+++ b/projects/compiler/test/compiler/match.abra
@@ -1,16 +1,14 @@
-func printlnInt(i: Int) = stdoutWriteln(i.toString())
-
 // Basic test (catch-all case)
 if true {
   /// Expect: here
   match "abc" {
-    _ => stdoutWriteln("here")
+    _ => println("here")
   }
 
   // v2 syntax
   /// Expect: here
   match "abc" {
-    else => stdoutWriteln("here")
+    else => println("here")
   }
 }
 
@@ -22,9 +20,9 @@ if true {
   /// Expect: case 3: 567
   for i in [1, 2, 34, 567] {
     match i {
-      1 v => stdoutWriteln("case 1: $v")
-      2 v => stdoutWriteln("case 2: $v")
-      _ v => stdoutWriteln("case 3: $v")
+      1 v => println("case 1: $v")
+      2 v => println("case 2: $v")
+      _ v => println("case 3: $v")
     }
   }
 
@@ -34,9 +32,9 @@ if true {
   /// Expect: case 3: 5.67
   for f in [1.1, 2.2, 3.4, 5.67] {
     match f {
-      1.1 v => stdoutWriteln("case 1: $v")
-      2.2 v => stdoutWriteln("case 2: $v")
-      _ v => stdoutWriteln("case 3: $v")
+      1.1 v => println("case 1: $v")
+      2.2 v => println("case 2: $v")
+      _ v => println("case 3: $v")
     }
   }
 
@@ -44,8 +42,8 @@ if true {
   /// Expect: case 2: false
   for b in [true, false] {
     match b {
-      true v => stdoutWriteln("case 1: $v")
-      false v => stdoutWriteln("case 2: $v")
+      true v => println("case 1: $v")
+      false v => println("case 2: $v")
     }
   }
 
@@ -54,17 +52,17 @@ if true {
   /// Expect: case 5: bonjour
   for s in ["hello", "hi", "bonjour"] {
     match s {
-      "howdy" v => stdoutWriteln("case 1: $v")
-      "hola" v => stdoutWriteln("case 2: $v")
-      "hi" v => stdoutWriteln("case 3: $v")
-      "hello" v => stdoutWriteln("case 4: $v")
-      _ v => stdoutWriteln("case 5: $v")
+      "howdy" v => println("case 1: $v")
+      "hola" v => println("case 2: $v")
+      "hi" v => println("case 3: $v")
+      "hello" v => println("case 4: $v")
+      _ v => println("case 5: $v")
     }
   }
 
   // TODO: remove this, lambda is unhappy to have a for-loop be the last statement for some reason
   /// Expect: done
-  stdoutWriteln("done")
+  println("done")
 }
 
 // Testing option type
@@ -73,105 +71,105 @@ if true {
 
   /// Expect: found a number
   match arr[1] {
-    None => stdoutWriteln("nothing here")
-    else => stdoutWriteln("found a number")
+    None => println("nothing here")
+    else => println("found a number")
   }
   /// Expect: nothing here
   match arr[14] {
-    None => stdoutWriteln("nothing here")
-    else => stdoutWriteln("found a number")
+    None => println("nothing here")
+    else => println("found a number")
   }
 
   // With case binding
 
   /// Expect: found a number: 2
   match arr[1] {
-    None v => stdoutWriteln("nothing here: $v")
-    else v => stdoutWriteln("found a number: $v")
+    None v => println("nothing here: $v")
+    else v => println("found a number: $v")
   }
   /// Expect: nothing here: Option.None
   match arr[14] {
-    None v => stdoutWriteln("nothing here: $v")
-    else v => stdoutWriteln("found a number: $v")
+    None v => println("nothing here: $v")
+    else v => println("found a number: $v")
   }
 
   // With case binding and _no_ `None` case
 
   /// Expect: value: Option.Some(value: 2)
   match arr[1] {
-    else v => stdoutWriteln("value: $v")
+    else v => println("value: $v")
   }
   /// Expect: value: Option.None
   match arr[14] {
-    else v => stdoutWriteln("value: $v")
+    else v => println("value: $v")
   }
 
   // With constant cases
 
   /// Expect: 18
   match arr[1] {
-    2 v => printlnInt(16 + v)
-    1 => printlnInt(15)
-    None => printlnInt(-4)
-    else => printlnInt(100)
+    2 v => println(16 + v)
+    1 => println(15)
+    None => println(-4)
+    else => println(100)
   }
   /// Expect: 18
   match arr[1] {
-    None => printlnInt(-4)
-    2 v => printlnInt(16 + v)
-    1 => printlnInt(15)
-    else => printlnInt(100)
+    None => println(-4)
+    2 v => println(16 + v)
+    1 => println(15)
+    else => println(100)
   }
   /// Expect: 18
   match arr[1] {
-    2 v => printlnInt(16 + v)
-    1 => printlnInt(15)
-    else => printlnInt(100)
+    2 v => println(16 + v)
+    1 => println(15)
+    else => println(100)
   }
   /// Expect: -4
   match arr[5] {
-    2 v => printlnInt(16 + v)
-    1 => printlnInt(15)
-    None => printlnInt(-4)
-    else => printlnInt(100)
+    2 v => println(16 + v)
+    1 => println(15)
+    None => println(-4)
+    else => println(100)
   }
   /// Expect: -4
   match arr[5] {
-    None => printlnInt(-4)
-    2 v => printlnInt(16 + v)
-    1 => printlnInt(15)
-    else => printlnInt(100)
+    None => println(-4)
+    2 v => println(16 + v)
+    1 => println(15)
+    else => println(100)
   }
   /// Expect: 100 Option.None
   match arr[5] {
-    2 v => printlnInt(16 + v)
-    1 => printlnInt(15)
-    else v => stdoutWriteln("${100} $v")
+    2 v => println(16 + v)
+    1 => println(15)
+    else v => println("${100} $v")
   }
   /// Expect: 100 Option.Some(value: 4)
   match arr[3] {
-    2 v => printlnInt(16 + v)
-    1 => printlnInt(15)
-    else v => stdoutWriteln("${100} $v")
+    2 v => println(16 + v)
+    1 => println(15)
+    else v => println("${100} $v")
   }
 
 //   // With type cases
 
 //   /// Expect: 2000
 //   match arr[1] {
-//     None => stdoutWriteln(-4)
-//     Int v => stdoutWriteln(v * 1000)
-//     2 v => stdoutWriteln(16 + v)
-//     1 => stdoutWriteln(15)
-//     _ => stdoutWriteln(100)
+//     None => println(-4)
+//     Int v => println(v * 1000)
+//     2 v => println(16 + v)
+//     1 => println(15)
+//     _ => println(100)
 //   }
 //   /// Expect: 18
 //   match arr[1] {
-//     None => stdoutWriteln(-4)
-//     2 v => stdoutWriteln(16 + v)
-//     Int v => stdoutWriteln(v * 1000)
-//     1 => stdoutWriteln(15)
-//     _ => stdoutWriteln(100)
+//     None => println(-4)
+//     2 v => println(16 + v)
+//     Int v => println(v * 1000)
+//     1 => println(15)
+//     _ => println(100)
 //   }
 }
 
@@ -192,45 +190,45 @@ if true {
   /// Expect: rgb(1, 2, 3)
   for color in colors {
     match color {
-      Color.Red => stdoutWriteln("red")
-      Color.Blue => stdoutWriteln("blue")
-      Color.Green => stdoutWriteln("green")
-      Color.RGB(r, g, b) => stdoutWriteln("rgb($r, $g, $b)")
+      Color.Red => println("red")
+      Color.Blue => println("blue")
+      Color.Green => println("green")
+      Color.RGB(r, g, b) => println("rgb($r, $g, $b)")
     }
   }
 
   /// Expect: blue
   match colors[1] {
-    None => stdoutWriteln("none")
-    Color.Red => stdoutWriteln("red")
-    Color.Blue => stdoutWriteln("blue")
-    Color.Green => stdoutWriteln("green")
-    Color.RGB(r, g, b) => stdoutWriteln("rgb($r, $g, $b)")
+    None => println("none")
+    Color.Red => println("red")
+    Color.Blue => println("blue")
+    Color.Green => println("green")
+    Color.RGB(r, g, b) => println("rgb($r, $g, $b)")
   }
   /// Expect: blue
   match colors[1] {
-    Color.Red => stdoutWriteln("red")
-    Color.Blue => stdoutWriteln("blue")
-    Color.Green => stdoutWriteln("green")
-    Color.RGB(r, g, b) => stdoutWriteln("rgb($r, $g, $b)")
-    None => stdoutWriteln("none")
+    Color.Red => println("red")
+    Color.Blue => println("blue")
+    Color.Green => println("green")
+    Color.RGB(r, g, b) => println("rgb($r, $g, $b)")
+    None => println("none")
   }
 
   /// Expect: none
   match colors[5] {
-    None => stdoutWriteln("none")
-    Color.Red => stdoutWriteln("red")
-    Color.Blue => stdoutWriteln("blue")
-    Color.Green => stdoutWriteln("green")
-    Color.RGB(r, g, b) => stdoutWriteln("rgb($r, $g, $b)")
+    None => println("none")
+    Color.Red => println("red")
+    Color.Blue => println("blue")
+    Color.Green => println("green")
+    Color.RGB(r, g, b) => println("rgb($r, $g, $b)")
   }
   /// Expect: none
   match colors[5] {
-    Color.Red => stdoutWriteln("red")
-    Color.Blue => stdoutWriteln("blue")
-    Color.Green => stdoutWriteln("green")
-    Color.RGB(r, g, b) => stdoutWriteln("rgb($r, $g, $b)")
-    None => stdoutWriteln("none")
+    Color.Red => println("red")
+    Color.Blue => println("blue")
+    Color.Green => println("green")
+    Color.RGB(r, g, b) => println("rgb($r, $g, $b)")
+    None => println("none")
   }
 
 //   // Updating values of enum variant
@@ -243,7 +241,7 @@ if true {
 //     _ => {}
 //   }
 //   /// Expect: Color.RGB(r: 1, g: 2, b: 100)
-//   stdoutWriteln(c)
+//   println(c)
 }
 
 // Testing match as expression
@@ -254,14 +252,14 @@ if true {
     _ v => v * 100
   }
   /// Expect: 200
-  printlnInt(x)
+  println(x)
 
   val y = match arr[14] {
     None => -1
     _ v => v * 100
   }
   /// Expect: -1
-  printlnInt(y)
+  println(y)
 }
 
 // Testing terminator in block
@@ -274,20 +272,20 @@ func matchExprCaseHasReturn(input: Int?): Int {
   x + 1
 }
 /// Expect: -1
-printlnInt(matchExprCaseHasReturn(None))
+println(matchExprCaseHasReturn(None))
 /// Expect: 401
-printlnInt(matchExprCaseHasReturn(Option.Some(value: 4)))
+println(matchExprCaseHasReturn(Option.Some(value: 4)))
 
 func matchStmtCaseHasReturn(input: Int?): Int {
   match input {
     None => return -1
-    else v => printlnInt(v * 100)
+    else v => println(v * 100)
   }
 
   1
 }
 /// Expect: -1
-printlnInt(matchStmtCaseHasReturn(None))
+println(matchStmtCaseHasReturn(None))
 /// Expect: 400
 /// Expect: 1
-printlnInt(matchStmtCaseHasReturn(Option.Some(value: 4)))
+println(matchStmtCaseHasReturn(Option.Some(value: 4)))

--- a/projects/compiler/test/compiler/optionals.abra
+++ b/projects/compiler/test/compiler/optionals.abra
@@ -1,23 +1,21 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-
 func f1(): Bool?[] = [None, Some(true), Some(false)]
 /// Expect: [Option.None, Option.Some(value: true), Option.Some(value: false)]
-stdoutWriteln(f1().toString())
+println(f1())
 
 func f2(): String?[] = if true { [Some("one"), None, Some("two")] } else []
 /// Expect: [Option.Some(value: "one"), Option.None, Option.Some(value: "two")]
-stdoutWriteln(f2().toString())
+println(f2())
 
 val arr1: Int?[] = [Some(1), None, Some(2), Some(3)]
 /// Expect: [Option.Some(value: 1), Option.None, Option.Some(value: 2), Option.Some(value: 3)]
-stdoutWriteln(arr1.toString())
+println(arr1)
 
 val arr2: Int[]? = Some([1, 2, 3])
 /// Expect: Option.Some(value: [1, 2, 3])
-stdoutWriteln(arr2.toString())
+println(arr2)
 val arr3: Int[]? = None
 /// Expect: Option.None
-stdoutWriteln(arr3.toString())
+println(arr3)
 
 type Foo {
   f: String
@@ -29,11 +27,11 @@ func hash<T>(t: T): Int = t.hash()
 if true {
   val i: Int? = None
   /// Expect: 1
-  stdoutWriteln(hash(i).toString())
+  println(hash(i))
 
   val x = Some(17)
   /// Expect: false
-  printlnBool(hash(x) == (17).hash())
+  println(hash(x) == (17).hash())
 }
 
 // == operator
@@ -45,11 +43,11 @@ if true {
   val i4 = Some(16)
 
   /// Expect: false
-  printlnBool(i1 == i2)
+  println(i1 == i2)
   /// Expect: false
-  printlnBool(i2 == i4)
+  println(i2 == i4)
   /// Expect: true
-  printlnBool(i2 == i3)
+  println(i2 == i3)
 
   // Test with object
   val s1: String? = None
@@ -58,27 +56,27 @@ if true {
   val s4 = Some("hmm")
 
   /// Expect: false
-  printlnBool(s1 == s2)
+  println(s1 == s2)
   /// Expect: false
-  printlnBool(s2 == s4)
+  println(s2 == s4)
   /// Expect: true
-  printlnBool(s2 == s3)
+  println(s2 == s3)
 }
 
 // Coalescing (?:)
 if true {
   val i1: Int? = None
   /// Expect: 17
-  stdoutWriteln((i1 ?: 17).toString())
+  println(i1 ?: 17)
 
   val i2 = Some(value: 9)
   /// Expect: 9
-  stdoutWriteln((i2 ?: 17).toString())
+  println(i2 ?: 17)
 }
 
 val xyz = "abc"
 type TestOptChainingMethodInvocation {
-  func unitMethod(self) = stdoutWriteln("TestOptChainingMethodInvocation#unitMethod")
+  func unitMethod(self) = println("TestOptChainingMethodInvocation#unitMethod")
   func closure(self): Int = xyz.length
 }
 
@@ -88,31 +86,31 @@ if true {
 
 //   // Getting field of known-non-None value
 //   /// Expect: 4
-//   stdoutWriteln(arr?.length)
+//   println(arr?.length)
 //   // Calling method of known-non-None value
 //   /// Expect: [a, b, c, d]
-//   stdoutWriteln(arr?.toString())
+//   println(arr?.toString())
 
   // Getting field of Option value
   /// Expect: Option.Some(value: 1)
-  stdoutWriteln(arr[0]?.length.toString())
+  println(arr[0]?.length)
   /// Expect: Option.None
-  stdoutWriteln(arr[6]?.length.toString())
+  println(arr[6]?.length)
 
   // Calling method of Option value
   /// Expect: Option.Some(value: false)
-  stdoutWriteln(arr[0]?.isEmpty().toString())
+  println(arr[0]?.isEmpty())
   /// Expect: Option.None
-  stdoutWriteln(arr[6]?.isEmpty().toString())
+  println(arr[6]?.isEmpty())
 
   // nested opt-safe accessors
   val foo = Foo(f: "abc")
   val fooArr = [foo]
 
   /// Expect: Option.Some(value: 3)
-  stdoutWriteln(fooArr[0]?.f?.length.toString())
+  println(fooArr[0]?.f?.length)
   /// Expect: Option.Some(value: 3)
-  stdoutWriteln(fooArr[0]?.f?.length?.abs().toString())
+  println(fooArr[0]?.f?.length?.abs())
 
   // Calling unit method of Option value
   val t1: TestOptChainingMethodInvocation? = None
@@ -124,10 +122,10 @@ if true {
   // Calling closure method of Option value
   val t3: TestOptChainingMethodInvocation? = None
   /// Expect: Option.None
-  stdoutWriteln(t3?.closure().toString())
+  println(t3?.closure())
   val t4 = Some(TestOptChainingMethodInvocation())
   /// Expect: Option.Some(value: 3)
-  stdoutWriteln(t4?.closure().toString())
+  println(t4?.closure())
 }
 
 // Negate operator
@@ -135,14 +133,14 @@ val someInt = Some(123)
 val noneInt: Int? = None
 
 /// Expect: true
-printlnBool(!noneInt)
+println(!noneInt)
 /// Expect: false
-printlnBool(!someInt)
+println(!someInt)
 
 /// Expect: false
-printlnBool(!!noneInt)
+println(!!noneInt)
 /// Expect: true
-printlnBool(!!someInt)
+println(!!someInt)
 
 // Optional enum instances
 
@@ -154,7 +152,7 @@ enum Color {
 if true {
   val colors = [Color.Red, Color.Green, Color.Blue]
   /// Expect: Option.None
-  stdoutWriteln(colors[3]?.toString().toString())
+  println(colors[3])
   /// Expect: Option.Some(value: "Color.Blue")
-  stdoutWriteln(colors[2]?.toString().toString())
+  println(colors[2]?.toString())
 }

--- a/projects/compiler/test/compiler/process.abra
+++ b/projects/compiler/test/compiler/process.abra
@@ -4,12 +4,12 @@ import "process" as process
 val args = process.args()
 
 /// Expect: [-f, bar, --baz, qux]
-stdoutWriteln(args[1:].toString())
+println(args[1:])
 
 val bogusEnvVar = process.getEnvVar("BOGUS")
 /// Expect: Option.None
-stdoutWriteln(bogusEnvVar.toString())
+println(bogusEnvVar)
 
 val fooEnvVar = process.getEnvVar("FOO")
 /// Expect: Option.Some(value: "bar")
-stdoutWriteln(fooEnvVar.toString())
+println(fooEnvVar)

--- a/projects/compiler/test/compiler/process_callstack.abra
+++ b/projects/compiler/test/compiler/process_callstack.abra
@@ -26,7 +26,7 @@ val arr = [1].map((i, _) => {
 /// Expect:   at baz (%TEST_DIR%/compiler/process_callstack.abra:10)
 /// Expect:   at bar (%TEST_DIR%/compiler/process_callstack.abra:5)
 /// Expect:   at foo (%TEST_DIR%/compiler/process_callstack.abra:19)
-/// Expect:   at <expression> (%STD_DIR%/prelude.abra:788)
+/// Expect:   at <expression> (%STD_DIR%/prelude.abra:767)
 /// Expect:   at Array.map (%TEST_DIR%/compiler/process_callstack.abra:18)
 
 type OneTwoThreeIterator {

--- a/projects/compiler/test/compiler/process_linux.abra
+++ b/projects/compiler/test/compiler/process_linux.abra
@@ -6,6 +6,6 @@ import "process" as process
 val uname = process.uname()
 
 /// Expect: Linux
-stdoutWriteln(uname.sysname)
+println(uname.sysname)
 /// Expect: x86_64
-stdoutWriteln(uname.machine)
+println(uname.machine)

--- a/projects/compiler/test/compiler/process_macos.abra
+++ b/projects/compiler/test/compiler/process_macos.abra
@@ -6,6 +6,6 @@ import "process" as process
 val uname = process.uname()
 
 /// Expect: Darwin
-stdoutWriteln(uname.sysname)
+println(uname.sysname)
 /// Expect: arm64
-stdoutWriteln(uname.machine)
+println(uname.machine)

--- a/projects/compiler/test/compiler/sets.abra
+++ b/projects/compiler/test/compiler/sets.abra
@@ -1,5 +1,3 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-
 type Person {
   name: String
   age: Int
@@ -14,9 +12,9 @@ if true {
   set.insert(3)
 
   /// Expect: 3
-  stdoutWriteln(set.size.toString())
+  println(set.size)
   /// Expect: #{1, 2, 3}
-  stdoutWriteln(set.toString())
+  println(set)
 }
 
 // Test set literal construction
@@ -25,9 +23,9 @@ if true {
   val set1 = #{1, 2, 3, 3}
 
   /// Expect: 3
-  stdoutWriteln(set1.size.toString())
+  println(set1.size)
   /// Expect: #{1, 2, 3}
-  stdoutWriteln(set1.toString())
+  println(set1)
 
   // Objects
   val set2 = #{
@@ -37,9 +35,9 @@ if true {
     Person(name: "Boo", age: 101),
   }
   /// Expect: 3
-  stdoutWriteln(set2.size.toString())
+  println(set2.size)
   /// Expect: #{Person(name: "Goo", age: 102), Person(name: "Foo", age: 100), Person(name: "Boo", age: 101)}
-  stdoutWriteln(set2.toString())
+  println(set2)
 }
 
 // == operator (also Set#eq)
@@ -47,22 +45,22 @@ if true {
   val set = #{1, 2, 3}
 
   /// Expect: true
-  printlnBool(set == #{1, 2, 3})
+  println(set == #{1, 2, 3})
   /// Expect: true
-  printlnBool(#{[1, 2], [3, 4]} == #{[3, 4], [1, 2]})
+  println(#{[1, 2], [3, 4]} == #{[3, 4], [1, 2]})
   /// Expect: false
-  printlnBool(set == #{1, 2, 3, 4})
+  println(set == #{1, 2, 3, 4})
 }
 
 // Set#isEmpty
 if true {
   val set: Set<Int> = #{}
   /// Expect: true
-  stdoutWriteln(set.isEmpty().toString())
+  println(set.isEmpty())
 
   set.insert(1)
   /// Expect: false
-  stdoutWriteln(set.isEmpty().toString())
+  println(set.isEmpty())
 }
 
 // Set#iterator
@@ -70,15 +68,15 @@ if true {
   val s = #{"a", "b", "a", "c"}
   val iter = s.iterator()
   /// Expect: Option.Some(value: "c")
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.Some(value: "b")
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.Some(value: "a")
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.None
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
   /// Expect: Option.None
-  stdoutWriteln(iter.next().toString())
+  println(iter.next())
 }
 
 // For-loops
@@ -86,20 +84,20 @@ if true {
 /// Expect: b 1
 /// Expect: a 2
 for ch, idx in #{"a", "b", "c"} {
-  stdoutWriteln("$ch $idx")
+  println("$ch $idx")
 }
 
 // Set#contains
 if true {
   val set: Set<Int> = #{}
   /// Expect: false
-  stdoutWriteln(set.contains(1).toString())
+  println(set.contains(1))
 
   set.insert(1)
   /// Expect: true
-  stdoutWriteln(set.contains(1).toString())
+  println(set.contains(1))
   /// Expect: false
-  stdoutWriteln(set.contains(12).toString())
+  println(set.contains(12))
 }
 
 // Set#forEach
@@ -109,28 +107,28 @@ if true {
   /// Expect: 16
   /// Expect: 1
   /// Expect: 17
-  set.forEach(i => stdoutWriteln(i.toString()))
+  set.forEach(i => println(i))
 }
 
 // Set#map
 if true {
   val set = #{1, 17, 0, 16}
   /// Expect: [0, 0, 1, 1]
-  stdoutWriteln(set.map(i => i % 16).toString())
+  println(set.map(i => i % 16))
 }
 
 // Set#filter
 if true {
   val set = #{1, 17, 0, 16}
   /// Expect: #{16, 17}
-  stdoutWriteln(set.filter(i => i >= 16).toString())
+  println(set.filter(i => i >= 16))
 }
 
 // Set#asArray
 if true {
   val set1 = #{0, 1, 1, 2, 3, 3, 4}
   /// Expect: [0, 1, 2, 3, 4]
-  stdoutWriteln(set1.asArray().toString())
+  println(set1.asArray())
 }
 
 // Set#union
@@ -138,9 +136,9 @@ if true {
   val evens = #{0, 2, 4, 6}
   val odds = #{1, 3, 5, 7}
   /// Expect: #{0, 1, 2, 3, 4, 5, 6, 7}
-  stdoutWriteln(evens.union(odds).toString())
+  println(evens.union(odds))
   /// Expect: #{0, 1, 2, 3, 4, 5, 6, 7}
-  stdoutWriteln(odds.union(evens).toString())
+  println(odds.union(evens))
 }
 
 // Set#difference
@@ -148,9 +146,9 @@ if true {
   val set1 = #{1, 2, 3, 4}
   val set2 = #{0, 2, 3, 5}
   /// Expect: #{1, 4}
-  stdoutWriteln(set1.difference(set2).toString())
+  println(set1.difference(set2))
   /// Expect: #{0, 5}
-  stdoutWriteln(set2.difference(set1).toString())
+  println(set2.difference(set1))
 }
 
 // Set#intersection
@@ -158,7 +156,7 @@ if true {
   val set1 = #{1, 2, 3, 4}
   val set2 = #{0, 2, 3, 5}
   /// Expect: #{2, 3}
-  stdoutWriteln(set1.intersection(set2).toString())
+  println(set1.intersection(set2))
   /// Expect: #{2, 3}
-  stdoutWriteln(set2.intersection(set1).toString())
+  println(set2.intersection(set1))
 }

--- a/projects/compiler/test/compiler/strings.abra
+++ b/projects/compiler/test/compiler/strings.abra
@@ -1,89 +1,87 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-
 // Test literal construction
 /// Expect: hello
-stdoutWriteln("hello")
+println("hello")
 
 // + operator
 if true {
   /// Expect: helloworld
-  stdoutWriteln("hello" + "world")
+  println("hello" + "world")
   /// Expect: hello12
-  stdoutWriteln("hello" + 12)
+  println("hello" + 12)
   /// Expect: 12hello
-  stdoutWriteln(12 + "hello")
+  println(12 + "hello")
   /// Expect: hello1.23
-  stdoutWriteln("hello" + 1.23)
+  println("hello" + 1.23)
   /// Expect: 1.23hello
-  stdoutWriteln(1.23 + "hello")
+  println(1.23 + "hello")
   /// Expect: hellotrue
-  stdoutWriteln("hello" + true)
+  println("hello" + true)
   /// Expect: truehello
-  stdoutWriteln(true + "hello")
+  println(true + "hello")
   /// Expect: hello[1, 2, 3]
-  stdoutWriteln("hello" + [1, 2, 3])
+  println("hello" + [1, 2, 3])
   /// Expect: [1, 2, 3]hello
-  stdoutWriteln([1, 2, 3] + "hello")
+  println([1, 2, 3] + "hello")
 }
 
 // == operator (also String#eq)
 if true {
   val s1 = "string"
   /// Expect: true
-  printlnBool(s1 == s1)
+  println(s1 == s1)
   /// Expect: true
-  printlnBool(s1 == "string")
+  println(s1 == "string")
 
   /// Expect: false
-  printlnBool(s1 != s1)
+  println(s1 != s1)
   /// Expect: true
-  printlnBool(s1 != "string!")
+  println(s1 != "string!")
 }
 
 // Interpolation
 if true {
   val array = [1, 2, 3]
   /// Expect: length of [1, 2, 3] is 3
-  stdoutWriteln("length of $array is ${array.length}")
+  println("length of $array is ${array.length}")
 }
 
 // String#replaceAll(pattern: String, replacement: String)
 if true {
   /// Expect: LLaaLLa
-  stdoutWriteln("laala".replaceAll("l", "LL"))
+  println("laala".replaceAll("l", "LL"))
 
   /// Expect: aaLLaLL
-  stdoutWriteln("aalal".replaceAll("l", "LL"))
+  println("aalal".replaceAll("l", "LL"))
 
   /// Expect: LLaaLLaLL
-  stdoutWriteln("laalal".replaceAll("l", "LL"))
+  println("laalal".replaceAll("l", "LL"))
 
   /// Expect: feebar
-  stdoutWriteln("foobar".replaceAll("o", "e"))
+  println("foobar".replaceAll("o", "e"))
 
   /// Expect: fexexbar
-  stdoutWriteln("foobar".replaceAll("o", "ex"))
+  println("foobar".replaceAll("o", "ex"))
 
   /// Expect: foobar
-  stdoutWriteln("foobar".replaceAll("x", "yz"))
+  println("foobar".replaceAll("x", "yz"))
 
   /// Expect: -ä
-  stdoutWriteln("/ä".replaceAll("/", "-"))
+  println("/ä".replaceAll("/", "-"))
 
   /// Expect: xfxoxox
-  stdoutWriteln("foo".replaceAll("", "x"))
+  println("foo".replaceAll("", "x"))
 
   /// Expect: x
-  stdoutWriteln("".replaceAll("", "x"))
+  println("".replaceAll("", "x"))
 
   /// Expect: abcd
-  stdoutWriteln("abcd".replaceAll("", ""))
+  println("abcd".replaceAll("", ""))
 
   /// Expect: fa bar baaz
-  stdoutWriteln("foo boor booooz".replaceAll("oo", "a"))
+  println("foo boor booooz".replaceAll("oo", "a"))
 
   // /// Expect: "hello"
-  // stdoutWriteln("\"hello\"".replaceAll("\"", "\\\""))
+  // println("\"hello\"".replaceAll("\"", "\\\""))
 }
 
 // String#chars
@@ -95,11 +93,11 @@ if true {
   /// Expect: l 3
   /// Expect: o 4
   for ch, idx in chars {
-    stdoutWriteln("$ch $idx")
+    println("$ch $idx")
   }
 
   /// Expect: done
-  stdoutWriteln("done")
+  println("done")
 }
 
 // Indexing (also String#get(index: Int))
@@ -107,18 +105,18 @@ if true {
   val s1 = "abc"
 
   /// Expect: |  a b c a b c  |
-  stdoutWriteln("| ${s1[-4]} ${s1[-3]} ${s1[-2]} ${s1[-1]} ${s1[0]} ${s1[1]} ${s1[2]} ${s1[3]} |")
+  println("| ${s1[-4]} ${s1[-3]} ${s1[-2]} ${s1[-1]} ${s1[0]} ${s1[1]} ${s1[2]} ${s1[3]} |")
 
   val s2 = "hello"
 
   /// Expect: h e l l o
-  stdoutWriteln("${s2[0]} ${s2[1]} ${s2[2]} ${s2[3]} ${s2[4]}")
+  println("${s2[0]} ${s2[1]} ${s2[2]} ${s2[3]} ${s2[4]}")
 
   /// Expect: o l l e h
-  stdoutWriteln("${s2[-1]} ${s2[-2]} ${s2[-3]} ${s2[-4]} ${s2[-5]}")
+  println("${s2[-1]} ${s2[-2]} ${s2[-3]} ${s2[-4]} ${s2[-5]}")
 
   /// Expect:   end
-  stdoutWriteln("${s2[5]} ${s2[-6]} end")
+  println("${s2[5]} ${s2[-6]} end")
 }
 
 // Range indexing (also String#getRange(startIndex: Int, endIndex: Int))
@@ -126,132 +124,132 @@ if true {
   val s = "hello"
 
   /// Expect: ell ell
-  stdoutWriteln("${s[1:4]} ${s[-4:4]}")
+  println("${s[1:4]} ${s[-4:4]}")
 
   /// Expect:  end
-  stdoutWriteln("${s[1:1]} end")
+  println("${s[1:1]} end")
 
   val a = 1
   val b = 4
 
   /// Expect: ell ell
-  stdoutWriteln("${s[a:b]} ${s[-b:b]}")
+  println("${s[a:b]} ${s[-b:b]}")
 
   /// Expect: ello h
-  stdoutWriteln("${s[1:]} ${s[:1]}")
+  println("${s[1:]} ${s[:1]}")
 
   /// Expect: ello h
-  stdoutWriteln("${s[a:]} ${s[:a]}")
+  println("${s[a:]} ${s[:a]}")
 }
 
 // String#hash
 if true {
   val empty = ""
   /// Expect: true
-  printlnBool(empty.hash() == "".hash())
+  println(empty.hash() == "".hash())
 
   val nonEmpty = "hello"
   /// Expect: true
-  printlnBool(nonEmpty.hash() == "hello".hash())
+  println(nonEmpty.hash() == "hello".hash())
 }
 
 // String#isEmpty
 if true {
   val empty = ""
   /// Expect: true
-  stdoutWriteln(empty.isEmpty().toString())
+  println(empty.isEmpty())
 
   val nonEmpty = "hello"
   /// Expect: false
-  stdoutWriteln(nonEmpty.isEmpty().toString())
+  println(nonEmpty.isEmpty())
 }
 
 // String#toLower
 if true {
   /// Expect: ||
-  stdoutWriteln("|" + "".toLower() + "|")
+  println("|" + "".toLower() + "|")
   /// Expect: -hello!
-  stdoutWriteln("-hElLo!".toLower())
+  println("-hElLo!".toLower())
 }
 
 // String#toUpper
 if true {
   /// Expect: ||
-  stdoutWriteln("|" + "".toUpper() + "|")
+  println("|" + "".toUpper() + "|")
   /// Expect: -HELLO!
-  stdoutWriteln("-hElLo!".toUpper())
+  println("-hElLo!".toUpper())
 }
 
 // String#split
 if true {
   /// Expect: [a, s, d, f]
-  stdoutWriteln("a s d f".split(by: " ").toString())
+  println("a s d f".split(by: " "))
 
   /// Expect: [, a, b, c d]
-  stdoutWriteln("  a  b  c d".split("  ").toString())
+  println("  a  b  c d".split("  "))
 
   /// Expect: [a, s, d, f]
-  stdoutWriteln("asdf".split("").toString())
+  println("asdf".split(""))
 
   /// Expect: [a, s, d, f]
-  stdoutWriteln("a\ns\nd\nf".split("\n").toString())
+  println("a\ns\nd\nf".split("\n"))
 
   /// Expect: [asdf]
-  stdoutWriteln("asdf".split("qwer").toString())
+  println("asdf".split("qwer"))
 }
 
 // String#lines
 if true {
   /// Expect: [a s d f]
-  stdoutWriteln("a s d f".lines().toString())
+  println("a s d f".lines())
 
   /// Expect: []
-  stdoutWriteln("".lines().toString())
+  println("".lines())
 
   /// Expect: [a, s, d, f]
-  stdoutWriteln("a\ns\nd\nf".lines().toString())
+  println("a\ns\nd\nf".lines())
 }
 
 // String#startsWith
 if true {
   /// Expect: true
-  stdoutWriteln("".startsWith("").toString())
+  println("".startsWith(""))
   /// Expect: true
-  stdoutWriteln("hello".startsWith("").toString())
+  println("hello".startsWith(""))
   /// Expect: true
-  stdoutWriteln("hello".startsWith("he").toString())
+  println("hello".startsWith("he"))
   /// Expect: true
-  stdoutWriteln("hello".startsWith("hello").toString())
+  println("hello".startsWith("hello"))
   /// Expect: false
-  stdoutWriteln("hello".startsWith("hex").toString())
+  println("hello".startsWith("hex"))
   /// Expect: false
-  stdoutWriteln("hello".startsWith("hhello").toString())
+  println("hello".startsWith("hhello"))
 }
 
 // String#endsWith
 if true {
   /// Expect: true
-  stdoutWriteln("".endsWith("").toString())
+  println("".endsWith(""))
   /// Expect: true
-  stdoutWriteln("hello".endsWith("").toString())
+  println("hello".endsWith(""))
   /// Expect: true
-  stdoutWriteln("hello".endsWith("lo").toString())
+  println("hello".endsWith("lo"))
   /// Expect: true
-  stdoutWriteln("hello".endsWith("hello").toString())
+  println("hello".endsWith("hello"))
   /// Expect: false
-  stdoutWriteln("hello".endsWith("lo!").toString())
+  println("hello".endsWith("lo!"))
   /// Expect: false
-  stdoutWriteln("hello".endsWith("hhello").toString())
+  println("hello".endsWith("hhello"))
 }
 
 // String#repeat
 if true {
   /// Expect: ||
-  stdoutWriteln("|" + "abc".repeat(0) + "|")
+  println("|" + "abc".repeat(0) + "|")
 
   /// Expect: ||
-  stdoutWriteln("|" + "abc".repeat(-1) + "|")
+  println("|" + "abc".repeat(-1) + "|")
 
   /// Expect: abcabcabc
-  stdoutWriteln("abc".repeat(3))
+  println("abc".repeat(3))
 }

--- a/projects/compiler/test/compiler/try_option.abra
+++ b/projects/compiler/test/compiler/try_option.abra
@@ -6,35 +6,35 @@ func f1(): Int? {
   Some(x + 1)
 }
 /// Expect: Option.Some(value: 124)
-stdoutWriteln(f1().toString())
+println(f1())
 
 func f2(): Int? {
   val x = try none()
   Some(x + 1)
 }
 /// Expect: Option.None
-stdoutWriteln(f2().toString())
+println(f2())
 
 func f3(): Int[]? {
   val arr = [try some(), (try some()) + 1, (try some()) + 2]
   Some(arr)
 }
 /// Expect: Option.Some(value: [123, 124, 125])
-stdoutWriteln(f3().toString())
+println(f3())
 
 func f4(): Int[]? {
   val arr = [try some(), (try none()) + 1, (try some()) + 2]
   Some(arr)
 }
 /// Expect: Option.None
-stdoutWriteln(f4().toString())
+println(f4())
 
 func f5(): Int? {
   val x = (try f1()) + (try f2()) + (try f3()).length + (try f4()).length
   Some(x)
 }
 /// Expect: Option.None
-stdoutWriteln(f5().toString())
+println(f5())
 
 // Testing else-clause with terminators
 
@@ -52,7 +52,7 @@ func f6(): Int? {
 }
 
 /// Expect: Option.Some(value: 123)
-stdoutWriteln(f6().toString())
+println(f6())
 
 func f7(): Int? {
   var acc = 0
@@ -65,7 +65,7 @@ func f7(): Int? {
 }
 
 /// Expect: Option.Some(value: 123)
-stdoutWriteln(f7().toString())
+println(f7())
 
 func f8(): Int? {
   var acc = 0
@@ -81,7 +81,7 @@ func f8(): Int? {
 }
 
 /// Expect: Option.Some(value: 199)
-stdoutWriteln(f8().toString())
+println(f8())
 
 func f9(): Int? {
   var acc = 0
@@ -94,7 +94,7 @@ func f9(): Int? {
 }
 
 /// Expect: Option.Some(value: 0)
-stdoutWriteln(f9().toString())
+println(f9())
 
 func f10(): Int? {
   var acc = 0
@@ -107,7 +107,7 @@ func f10(): Int? {
 }
 
 /// Expect: Option.Some(value: 123)
-stdoutWriteln(f10().toString())
+println(f10())
 
 func f11(): Int? {
   var acc = 0
@@ -120,7 +120,7 @@ func f11(): Int? {
 }
 
 /// Expect: Option.Some(value: 123)
-stdoutWriteln(f11().toString())
+println(f11())
 
 func f12(): Int? {
   var acc = 0
@@ -133,7 +133,7 @@ func f12(): Int? {
 }
 
 /// Expect: Option.Some(value: 12)
-stdoutWriteln(f12().toString())
+println(f12())
 
 func f13(): Int? {
   var acc = 0
@@ -146,7 +146,7 @@ func f13(): Int? {
 }
 
 /// Expect: Option.None
-stdoutWriteln(f13().toString())
+println(f13())
 
 func f14(): Int? {
   val x = try some() else return Some(12)
@@ -155,7 +155,7 @@ func f14(): Int? {
 }
 
 /// Expect: Option.Some(value: 123)
-stdoutWriteln(f14().toString())
+println(f14())
 
 func f15(): Int? {
   val x = try some() else return None
@@ -164,7 +164,7 @@ func f15(): Int? {
 }
 
 /// Expect: Option.Some(value: 123)
-stdoutWriteln(f15().toString())
+println(f15())
 
 func f16(): Int? {
   val x = try none() else return Some(12)
@@ -173,7 +173,7 @@ func f16(): Int? {
 }
 
 /// Expect: Option.Some(value: 12)
-stdoutWriteln(f16().toString())
+println(f16())
 
 func f17(): Int? {
   val x = try none() else return None
@@ -182,7 +182,7 @@ func f17(): Int? {
 }
 
 /// Expect: Option.None
-stdoutWriteln(f17().toString())
+println(f17())
 
 // Testing else-clause without terminators
 
@@ -193,7 +193,7 @@ func f18(): Int? {
 }
 
 /// Expect: Option.Some(value: 123)
-stdoutWriteln(f18().toString())
+println(f18())
 
 func f19(): Int {
   val x = try some() else 7
@@ -202,7 +202,7 @@ func f19(): Int {
 }
 
 /// Expect: 124
-stdoutWriteln(f19().toString())
+println(f19())
 
 func f20(): Int? {
   val x = try none() else 7
@@ -211,7 +211,7 @@ func f20(): Int? {
 }
 
 /// Expect: Option.Some(value: 7)
-stdoutWriteln(f20().toString())
+println(f20())
 
 func f21(): Int {
   val x = try none() else 7
@@ -220,4 +220,4 @@ func f21(): Int {
 }
 
 /// Expect: 8
-stdoutWriteln(f21().toString())
+println(f21())

--- a/projects/compiler/test/compiler/try_result.abra
+++ b/projects/compiler/test/compiler/try_result.abra
@@ -6,35 +6,35 @@ func f1(): Result<Int, String> {
   Ok(x + 1)
 }
 /// Expect: Result.Ok(value: 124)
-stdoutWriteln(f1().toString())
+println(f1())
 
 func f2(): Result<Int, String> {
   val x = try err()
   Ok(x + 1)
 }
 /// Expect: Result.Err(error: "foo")
-stdoutWriteln(f2().toString())
+println(f2())
 
 func f3(): Result<Int[], String> {
   val arr = [try ok(), (try ok()) + 1, (try ok()) + 2]
   Ok(arr)
 }
 /// Expect: Result.Ok(value: [123, 124, 125])
-stdoutWriteln(f3().toString())
+println(f3())
 
 func f4(): Result<Int[], String> {
   val arr = [try ok(), (try err()) + 1, (try ok()) + 2]
   Ok(arr)
 }
 /// Expect: Result.Err(error: "foo")
-stdoutWriteln(f4().toString())
+println(f4())
 
 func f5(): Result<Int, String> {
   val x = (try f1()) + (try f2()) + (try f3()).length + (try f4()).length
   Ok(x)
 }
 /// Expect: Result.Err(error: "foo")
-stdoutWriteln(f5().toString())
+println(f5())
 
 // Testing else-clause with terminators
 
@@ -52,7 +52,7 @@ func f6(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 123)
-stdoutWriteln(f6().toString())
+println(f6())
 
 func f7(): Result<Int, Int> {
   var acc = 0
@@ -65,7 +65,7 @@ func f7(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 123)
-stdoutWriteln(f7().toString())
+println(f7())
 
 func f8(): Result<Int, Int> {
   var acc = 0
@@ -81,7 +81,7 @@ func f8(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 199)
-stdoutWriteln(f8().toString())
+println(f8())
 
 func f9(): Result<Int, Int> {
   var acc = 0
@@ -94,7 +94,7 @@ func f9(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 0)
-stdoutWriteln(f9().toString())
+println(f9())
 
 func f10(): Result<Int, Int> {
   var acc = 0
@@ -107,7 +107,7 @@ func f10(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 123)
-stdoutWriteln(f10().toString())
+println(f10())
 
 func f11(): Result<Int, Int> {
   var acc = 0
@@ -120,7 +120,7 @@ func f11(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 123)
-stdoutWriteln(f11().toString())
+println(f11())
 
 func f12(): Result<Int, Int> {
   var acc = 0
@@ -133,7 +133,7 @@ func f12(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 12)
-stdoutWriteln(f12().toString())
+println(f12())
 
 func f13(): Result<Int, Int> {
   var acc = 0
@@ -146,7 +146,7 @@ func f13(): Result<Int, Int> {
 }
 
 /// Expect: Result.Err(error: 12)
-stdoutWriteln(f13().toString())
+println(f13())
 
 func f14(): Result<Int, Int> {
   val x = try ok() else return Ok(12)
@@ -155,7 +155,7 @@ func f14(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 123)
-stdoutWriteln(f14().toString())
+println(f14())
 
 func f15(): Result<Int, Int> {
   val x = try ok() else return Err(12)
@@ -164,7 +164,7 @@ func f15(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 123)
-stdoutWriteln(f15().toString())
+println(f15())
 
 func f16(): Result<Int, Int> {
   val x = try err() else return Ok(12)
@@ -173,7 +173,7 @@ func f16(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 12)
-stdoutWriteln(f16().toString())
+println(f16())
 
 func f17(): Result<Int, Int> {
   val x = try err() else return Err(12)
@@ -182,7 +182,7 @@ func f17(): Result<Int, Int> {
 }
 
 /// Expect: Result.Err(error: 12)
-stdoutWriteln(f17().toString())
+println(f17())
 
 // Testing else-clause without terminators
 
@@ -193,7 +193,7 @@ func f18(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 123)
-stdoutWriteln(f18().toString())
+println(f18())
 
 func f19(): Int {
   val x = try ok() else 7
@@ -202,7 +202,7 @@ func f19(): Int {
 }
 
 /// Expect: 124
-stdoutWriteln(f19().toString())
+println(f19())
 
 func f20(): Result<Int, Int> {
   val x = try err() else 7
@@ -211,7 +211,7 @@ func f20(): Result<Int, Int> {
 }
 
 /// Expect: Result.Ok(value: 7)
-stdoutWriteln(f20().toString())
+println(f20())
 
 func f21(): Int {
   val x = try err() else 7
@@ -220,4 +220,4 @@ func f21(): Int {
 }
 
 /// Expect: 8
-stdoutWriteln(f21().toString())
+println(f21())

--- a/projects/compiler/test/compiler/tuples.abra
+++ b/projects/compiler/test/compiler/tuples.abra
@@ -1,30 +1,28 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-
 // Instantiation
 val point = (0.5, 1.5, -0.75)
 /// Expect: (0.5, 1.5, -0.75)
-stdoutWriteln("$point")
+println("$point")
 
 val y = (1, "two", ["three"])
 /// Expect: (1, "two", [three])
-stdoutWriteln("$y")
+println("$y")
 
 // Indexing
 val quad = (1, "two", ["three"], (2, 3))
 val two = quad[1]
 /// Expect: two
-stdoutWriteln(two)
+println(two)
 
 /// Expect: 2
-stdoutWriteln(quad[3][0].toString())
+println(quad[3][0])
 
 // /// Expect: true
-// stdoutWriteln(quad.hash() == (1, "two", ["three"], (2, 3)).hash())
+// println(quad.hash() == (1, "two", ["three"], (2, 3)).hash())
 
 // == operator
 val t1 = (1, "abc", [true, false])
 
 /// Expect: true
-printlnBool(t1 == (1, "abc", [true, false]))
+println(t1 == (1, "abc", [true, false]))
 /// Expect: true
-printlnBool((1, "two", [3]) == (1, "tw" + "o", [2 + 1]))
+println((1, "two", [3]) == (1, "tw" + "o", [2 + 1]))

--- a/projects/compiler/test/compiler/types.abra
+++ b/projects/compiler/test/compiler/types.abra
@@ -1,5 +1,3 @@
-func printlnBool(b: Bool) = stdoutWriteln(b.toString())
-
 type Person {
   name: String
   age: Int
@@ -9,29 +7,27 @@ val p1 = Person(name: "Ken", age: 32)
 
 // Test field accesses
 /// Expect: Ken
-stdoutWriteln(p1.name)
+println(p1.name)
 /// Expect: 32
-stdoutWriteln(p1.age.toString())
+println(p1.age)
 
 // Test default toString method
 /// Expect: Person(name: "Ken", age: 32)
-stdoutWriteln(p1.toString())
-/// Expect: Person(name: "Ken", age: 32)
-stdoutWriteln(p1.toString())
+println(p1)
 
 // Test default hash method
 /// Expect: true
-printlnBool(p1.hash() == Person(name: "Ken", age: 32).hash())
+println(p1.hash() == Person(name: "Ken", age: 32).hash())
 /// Expect: false
-printlnBool(p1.hash() == Person(name: "Ken", age: 33).hash())
+println(p1.hash() == Person(name: "Ken", age: 33).hash())
 
 // Test default eq method
 /// Expect: true
-printlnBool(p1 == Person(name: "Ken", age: 32))
+println(p1 == Person(name: "Ken", age: 32))
 /// Expect: false
-printlnBool(p1 == Person(name: "Ben", age: 32))
+println(p1 == Person(name: "Ben", age: 32))
 /// Expect: false
-printlnBool(p1 == Person(name: "Ken", age: 33))
+println(p1 == Person(name: "Ken", age: 33))
 
 type Person2 {
   name: String
@@ -40,7 +36,7 @@ type Person2 {
   func toString(self): String = "custom Person#toString method"
   func hash(self): Int = 0
   func eq(self, other: Person2): Bool {
-    stdoutWriteln("[Person2#eq]  here")
+    println("[Person2#eq]  here")
     false
   }
 }
@@ -49,15 +45,13 @@ val p2 = Person2(name: "Ken", age: 32)
 
 // Test custom toString method
 /// Expect: custom Person#toString method
-stdoutWriteln(p2.toString())
-/// Expect: custom Person#toString method
-stdoutWriteln(p2.toString())
+println(p2)
 /// Expect: 0
-stdoutWriteln(p2.hash().toString())
+println(p2.hash())
 
 /// Expect: [Person2#eq]  here
 /// Expect: false
-printlnBool(p2 == Person2(name: "Ken", age: 32))
+println(p2 == Person2(name: "Ken", age: 32))
 
 // Fields with default values
 type Foo {
@@ -68,9 +62,9 @@ type Foo {
 
 val f = Foo()
 /// Expect: Foo(a: 12, b: "", c: [1, 2, 3])
-stdoutWriteln(f.toString())
+println(f)
 /// Expect: true
-printlnBool(f.hash() == Foo().hash())
+println(f.hash() == Foo().hash())
 
 // Methods that capture variables
 var capturedInt = 11
@@ -84,30 +78,30 @@ type FooWithCaptures {
 
 val fooWithCaptures = FooWithCaptures(i: 12)
 /// Expect: 23
-stdoutWriteln(fooWithCaptures.foo().toString())
+println(fooWithCaptures.foo())
 capturedInt = 17
 /// Expect: 29
-stdoutWriteln(fooWithCaptures.foo().toString())
+println(fooWithCaptures.foo())
 
 capturedInt = 17
 /// Expect: 29
-stdoutWriteln(fooWithCaptures.foo2().toString())
+println(fooWithCaptures.foo2())
 capturedInt = 17
 /// Expect: 15
-stdoutWriteln(fooWithCaptures.foo2(3).toString())
+println(fooWithCaptures.foo2(3))
 /// Expect: 17
-stdoutWriteln(FooWithCaptures.fooStatic().toString())
+println(FooWithCaptures.fooStatic())
 
 val foo1Ref1 = fooWithCaptures.foo
 func wrapper1() {
   val foo1Ref2 = fooWithCaptures.foo
 
   /// Expect: 29
-  stdoutWriteln(fooWithCaptures.foo().toString())
+  println(fooWithCaptures.foo())
   /// Expect: 29
-  stdoutWriteln(foo1Ref1().toString())
+  println(foo1Ref1())
   /// Expect: 29
-  stdoutWriteln(foo1Ref2().toString())
+  println(foo1Ref2())
 }
 wrapper1()
 
@@ -115,17 +109,17 @@ capturedInt = 11
 func wrapper() {
   val f = FooWithCaptures(i: 12)
   /// Expect: 23
-  stdoutWriteln(f.foo().toString())
+  println(f.foo())
   /// Expect: 11
-  stdoutWriteln(FooWithCaptures.fooStatic().toString())
+  println(FooWithCaptures.fooStatic())
 }
 wrapper()
 
 // Test passing function/closure values as parameters
 // This is similar to the suite of tests in `functions.abra`, but for references to methods instead
-func callFn(fn: (Int) => Int) = stdoutWriteln(fn(16).toString())
-func callFn2(fn: (Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18).toString())
-func callFn3(fn: (Int, Int, Int, Int) => Int) = stdoutWriteln(fn(16, 17, 18, 19).toString())
+func callFn(fn: (Int) => Int) = println(fn(16))
+func callFn2(fn: (Int, Int, Int) => Int) = println(fn(16, 17, 18))
+func callFn3(fn: (Int, Int, Int, Int) => Int) = println(fn(16, 17, 18, 19))
 
 val xyz = "xyz"
 type Foo2 {

--- a/projects/compiler/test/typechecker/accessor/accessor.1.out.json
+++ b/projects/compiler/test/typechecker/accessor/accessor.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/accessor/accessor.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -33,7 +33,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -54,7 +54,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -75,7 +75,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -91,7 +91,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -132,7 +132,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -190,7 +190,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               },
               "node": {

--- a/projects/compiler/test/typechecker/accessor/accessor.2.out.json
+++ b/projects/compiler/test/typechecker/accessor/accessor.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/accessor/accessor.2.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -24,7 +24,7 @@
               "name": { "name": "bar", "position": [1, 12] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Bar" },
+                "struct": { "moduleId": 6, "name": "Bar" },
                 "typeParams": []
               },
               "initializer": null
@@ -34,7 +34,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -55,7 +55,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -76,7 +76,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -92,7 +92,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -124,7 +124,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Bar", "position": [2, 6] },
           "typeParams": [],
           "fields": [
@@ -141,7 +141,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Bar::toString",
+                "name": "$root::module_6::Bar::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -162,7 +162,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Bar::hash",
+                "name": "$root::module_6::Bar::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -183,7 +183,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Bar::eq",
+                "name": "$root::module_6::Bar::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -199,7 +199,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Bar" },
+                    "struct": { "moduleId": 6, "name": "Bar" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -240,11 +240,11 @@
             "mutable": true,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": []
                 }
               ]
@@ -277,7 +277,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -296,7 +296,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -316,11 +316,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   }
                 ]
@@ -336,11 +336,11 @@
                 "name": "bar",
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Bar" },
+                      "struct": { "moduleId": 6, "name": "Bar" },
                       "typeParams": []
                     }
                   ]
@@ -352,7 +352,7 @@
               "name": "str",
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -388,7 +388,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -408,7 +408,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/accessor/accessor.3.out.json
+++ b/projects/compiler/test/typechecker/accessor/accessor.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/accessor/accessor.3.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -33,7 +33,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -54,7 +54,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -75,7 +75,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -91,7 +91,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -107,14 +107,14 @@
             {
               "label": { "name": "foo", "position": [4, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [4, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   },
@@ -164,7 +164,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 5, "name": "Foo" },
+                          "struct": { "moduleId": 6, "name": "Foo" },
                           "typeParams": []
                         },
                         "node": {
@@ -227,7 +227,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "Foo" },
+                            "struct": { "moduleId": 6, "name": "Foo" },
                             "typeParams": []
                           },
                           "node": {
@@ -272,14 +272,14 @@
             {
               "label": { "name": "fooStatic", "position": [5, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::fooStatic",
+                "name": "$root::module_6::Foo::fooStatic",
                 "variables": [
                   {
                     "label": { "name": "f", "position": [5, 18] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   },
@@ -305,7 +305,7 @@
                   "label": { "name": "f", "position": [5, 18] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -340,7 +340,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 5, "name": "Foo" },
+                          "struct": { "moduleId": 6, "name": "Foo" },
                           "typeParams": []
                         },
                         "node": {
@@ -404,7 +404,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "Foo" },
+                            "struct": { "moduleId": 6, "name": "Foo" },
                             "typeParams": []
                           },
                           "node": {
@@ -471,7 +471,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -537,7 +537,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               },
               "node": {
@@ -666,7 +666,7 @@
               },
               "type": {
                 "kind": "struct",
-                "struct": { "moduleId": 5, "name": "Foo" }
+                "struct": { "moduleId": 6, "name": "Foo" }
               },
               "node": {
                 "kind": "identifier",

--- a/projects/compiler/test/typechecker/accessor/accessor.4.out.json
+++ b/projects/compiler/test/typechecker/accessor/accessor.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/accessor/accessor.4.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "variants": [
@@ -29,7 +29,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -50,7 +50,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -71,7 +71,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -87,7 +87,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Foo" },
+                    "enum": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -128,7 +128,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo" },
+              "enum": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -142,7 +142,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo" },
+            "enum": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
@@ -157,7 +157,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 5, "name": "Foo" }
+                "enum": { "moduleId": 6, "name": "Foo" }
               },
               "node": {
                 "kind": "identifier",

--- a/projects/compiler/test/typechecker/array/array.out.json
+++ b/projects/compiler/test/typechecker/array/array.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/array/array.abra",
   "code": [
     {
@@ -11,7 +11,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -85,11 +85,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -111,7 +111,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -168,7 +168,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -242,7 +242,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -261,7 +261,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -299,7 +299,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -318,7 +318,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -408,11 +408,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -433,11 +433,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -459,7 +459,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -500,7 +500,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -520,7 +520,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -543,7 +543,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -603,11 +603,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -628,11 +628,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -654,7 +654,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -674,7 +674,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -697,7 +697,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -738,7 +738,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -784,11 +784,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -810,7 +810,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -867,7 +867,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -889,7 +889,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -949,11 +949,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -975,7 +975,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1016,7 +1016,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1057,7 +1057,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1077,7 +1077,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1100,7 +1100,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1144,15 +1144,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1176,11 +1176,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1203,7 +1203,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1263,11 +1263,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1290,7 +1290,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1350,11 +1350,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1376,7 +1376,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1399,11 +1399,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1426,7 +1426,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1503,15 +1503,15 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1534,15 +1534,15 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1567,11 +1567,11 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1593,7 +1593,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1613,7 +1613,7 @@
                           },
                           "type": {
                             "kind": "enum",
-                            "enum": { "moduleId": 4, "name": "Option" }
+                            "enum": { "moduleId": 5, "name": "Option" }
                           },
                           "node": {
                             "kind": "identifier",
@@ -1644,11 +1644,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1670,7 +1670,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1692,7 +1692,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1749,7 +1749,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1809,11 +1809,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Set" },
+            "struct": { "moduleId": 5, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1835,7 +1835,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1857,7 +1857,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1914,7 +1914,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1974,15 +1974,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Set" },
+                "struct": { "moduleId": 5, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2006,11 +2006,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2033,7 +2033,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2058,11 +2058,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2084,7 +2084,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -2107,11 +2107,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2134,7 +2134,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2197,15 +2197,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Array" },
+        "struct": { "moduleId": 5, "name": "Array" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Set" },
+                "struct": { "moduleId": 5, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2229,11 +2229,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2256,7 +2256,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2281,11 +2281,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2308,7 +2308,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/projects/compiler/test/typechecker/assignment/assignment_accessor.out.json
+++ b/projects/compiler/test/typechecker/assignment/assignment_accessor.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/assignment/assignment_accessor.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -32,7 +32,7 @@
               "name": { "name": "b", "position": [1, 20] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -47,7 +47,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -68,7 +68,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -89,7 +89,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -105,7 +105,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -146,7 +146,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -160,12 +160,12 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -193,7 +193,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -306,7 +306,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
@@ -348,7 +348,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -374,7 +374,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
@@ -388,7 +388,7 @@
             "name": "b",
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/projects/compiler/test/typechecker/assignment/assignment_indexing.out.json
+++ b/projects/compiler/test/typechecker/assignment/assignment_indexing.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/assignment/assignment_indexing.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -156,7 +156,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -224,7 +224,7 @@
                 },
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -256,7 +256,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -312,7 +312,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -405,7 +405,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -447,7 +447,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "tuple",
@@ -479,7 +479,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "tuple",
@@ -711,7 +711,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Map" },
+                "struct": { "moduleId": 5, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "tuple",

--- a/projects/compiler/test/typechecker/assignment/assignment_variable.out.json
+++ b/projects/compiler/test/typechecker/assignment/assignment_variable.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/assignment/assignment_variable.abra",
   "code": [
     {
@@ -115,7 +115,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -134,7 +134,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -223,7 +223,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -244,7 +244,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/projects/compiler/test/typechecker/binary/and.out.json
+++ b/projects/compiler/test/typechecker/binary/and.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/and.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/and_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/and_eq.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/and_eq.abra",
   "code": [
     {
@@ -262,7 +262,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [7, 6] },
           "typeParams": [],
           "fields": [
@@ -287,7 +287,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -308,7 +308,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -329,7 +329,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -345,7 +345,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -386,7 +386,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -400,12 +400,12 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -496,7 +496,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -547,7 +547,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
@@ -617,7 +617,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -668,7 +668,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {

--- a/projects/compiler/test/typechecker/binary/coalesce.1.out.json
+++ b/projects/compiler/test/typechecker/binary/coalesce.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/coalesce.1.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -129,7 +129,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/projects/compiler/test/typechecker/binary/coalesce.2.out.json
+++ b/projects/compiler/test/typechecker/binary/coalesce.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/coalesce.2.abra",
   "code": [
     {
@@ -25,11 +25,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -50,11 +50,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -77,7 +77,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -136,7 +136,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -155,7 +155,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -176,11 +176,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -204,7 +204,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -244,7 +244,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -264,7 +264,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/binary/divide.out.json
+++ b/projects/compiler/test/typechecker/binary/divide.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/divide.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/divide_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/divide_eq.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/divide_eq.abra",
   "code": [
     {
@@ -262,7 +262,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [7, 6] },
           "typeParams": [],
           "fields": [
@@ -279,7 +279,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -300,7 +300,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -321,7 +321,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -337,7 +337,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -378,7 +378,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -392,12 +392,12 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -471,7 +471,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -522,7 +522,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
@@ -592,7 +592,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -643,7 +643,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {

--- a/projects/compiler/test/typechecker/binary/eq.1.out.json
+++ b/projects/compiler/test/typechecker/binary/eq.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/eq.1.abra",
   "code": [
     {
@@ -75,7 +75,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -149,7 +149,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/binary/eq.2.out.json
+++ b/projects/compiler/test/typechecker/binary/eq.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/eq.2.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -102,7 +102,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -124,7 +124,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -144,7 +144,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 4, "name": "Option" }
+                "enum": { "moduleId": 5, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",

--- a/projects/compiler/test/typechecker/binary/gt.out.json
+++ b/projects/compiler/test/typechecker/binary/gt.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/gt.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/gte.out.json
+++ b/projects/compiler/test/typechecker/binary/gte.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/gte.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/lt.out.json
+++ b/projects/compiler/test/typechecker/binary/lt.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/lt.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/lte.out.json
+++ b/projects/compiler/test/typechecker/binary/lte.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/lte.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/minus.out.json
+++ b/projects/compiler/test/typechecker/binary/minus.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/minus.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/minus_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/minus_eq.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/minus_eq.abra",
   "code": [
     {
@@ -262,7 +262,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [7, 6] },
           "typeParams": [],
           "fields": [
@@ -279,7 +279,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -300,7 +300,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -321,7 +321,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -337,7 +337,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -378,7 +378,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -392,12 +392,12 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -471,7 +471,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -522,7 +522,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {

--- a/projects/compiler/test/typechecker/binary/mod.out.json
+++ b/projects/compiler/test/typechecker/binary/mod.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/mod.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/mod_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/mod_eq.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/mod_eq.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/neq.1.out.json
+++ b/projects/compiler/test/typechecker/binary/neq.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/neq.1.abra",
   "code": [
     {
@@ -75,7 +75,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -149,7 +149,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/binary/neq.2.out.json
+++ b/projects/compiler/test/typechecker/binary/neq.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/neq.2.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -102,7 +102,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -124,7 +124,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -144,7 +144,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 4, "name": "Option" }
+                "enum": { "moduleId": 5, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",

--- a/projects/compiler/test/typechecker/binary/or.out.json
+++ b/projects/compiler/test/typechecker/binary/or.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/or.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/or_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/or_eq.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/or_eq.abra",
   "code": [
     {
@@ -262,7 +262,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [7, 6] },
           "typeParams": [],
           "fields": [
@@ -287,7 +287,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -308,7 +308,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -329,7 +329,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -345,7 +345,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -386,7 +386,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -400,12 +400,12 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -496,7 +496,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -547,7 +547,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
@@ -617,7 +617,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -668,7 +668,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {

--- a/projects/compiler/test/typechecker/binary/plus_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/plus_eq.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/plus_eq.abra",
   "code": [
     {
@@ -462,7 +462,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [11, 6] },
           "typeParams": [],
           "fields": [
@@ -487,7 +487,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -508,7 +508,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -529,7 +529,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -545,7 +545,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -586,7 +586,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -600,12 +600,12 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -696,7 +696,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -747,7 +747,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
@@ -817,7 +817,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -868,7 +868,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
@@ -938,7 +938,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -989,7 +989,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {

--- a/projects/compiler/test/typechecker/binary/plus_numeric.out.json
+++ b/projects/compiler/test/typechecker/binary/plus_numeric.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/plus_numeric.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/plus_string_concat.out.json
+++ b/projects/compiler/test/typechecker/binary/plus_string_concat.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/plus_string_concat.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/pow.out.json
+++ b/projects/compiler/test/typechecker/binary/pow.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/pow.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/shl.out.json
+++ b/projects/compiler/test/typechecker/binary/shl.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/shl.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/shr.out.json
+++ b/projects/compiler/test/typechecker/binary/shr.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/shr.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/times.out.json
+++ b/projects/compiler/test/typechecker/binary/times.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/times.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/binary/times_eq.out.json
+++ b/projects/compiler/test/typechecker/binary/times_eq.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/binary/times_eq.abra",
   "code": [
     {
@@ -262,7 +262,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [7, 6] },
           "typeParams": [],
           "fields": [
@@ -279,7 +279,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -300,7 +300,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -321,7 +321,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -337,7 +337,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -378,7 +378,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -392,12 +392,12 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -471,7 +471,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {
@@ -522,7 +522,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {

--- a/projects/compiler/test/typechecker/bindingdecl/bindingdecl.out.json
+++ b/projects/compiler/test/typechecker/bindingdecl/bindingdecl.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/bindingdecl/bindingdecl.abra",
   "code": [
     {
@@ -209,7 +209,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -228,7 +228,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -248,7 +248,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 4, "name": "Option" }
+                "enum": { "moduleId": 5, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",
@@ -287,7 +287,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -306,7 +306,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -383,7 +383,7 @@
                 },
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -424,7 +424,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -523,7 +523,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -654,7 +654,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -694,7 +694,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/projects/compiler/test/typechecker/bindingdecl/bindingdecl_exported.out.json
+++ b/projects/compiler/test/typechecker/bindingdecl/bindingdecl_exported.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/bindingdecl/bindingdecl_exported.abra",
   "exports": [
     {
@@ -113,7 +113,7 @@
                 },
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -154,7 +154,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -253,7 +253,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -392,7 +392,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -432,7 +432,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/projects/compiler/test/typechecker/break/break_as_expr.out.json
+++ b/projects/compiler/test/typechecker/break/break_as_expr.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/break/break_as_expr.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/continue/continue_as_expr.out.json
+++ b/projects/compiler/test/typechecker/continue/continue_as_expr.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/continue/continue_as_expr.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/decorators/function_decorator.out.json
+++ b/projects/compiler/test/typechecker/decorators/function_decorator.out.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 5,
+    "id": 6,
     "name": "%TEST_DIR%/typechecker/decorators/_exports.abra",
     "exports": [
       {
@@ -27,7 +27,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "FromOtherModule1", "position": [1, 15] },
             "typeParams": [],
             "fields": [
@@ -54,7 +54,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::FromOtherModule1::toString",
+                  "name": "$root::module_6::FromOtherModule1::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -75,7 +75,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::FromOtherModule1::hash",
+                  "name": "$root::module_6::FromOtherModule1::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -96,7 +96,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::FromOtherModule1::eq",
+                  "name": "$root::module_6::FromOtherModule1::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -112,7 +112,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "FromOtherModule1" },
+                      "struct": { "moduleId": 6, "name": "FromOtherModule1" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -144,7 +144,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "FromOtherModule2", "position": [6, 15] },
             "typeParams": [],
             "fields": [
@@ -162,7 +162,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::FromOtherModule2::toString",
+                  "name": "$root::module_6::FromOtherModule2::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -183,7 +183,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::FromOtherModule2::hash",
+                  "name": "$root::module_6::FromOtherModule2::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -204,7 +204,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::FromOtherModule2::eq",
+                  "name": "$root::module_6::FromOtherModule2::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -220,7 +220,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "FromOtherModule2" },
+                      "struct": { "moduleId": 6, "name": "FromOtherModule2" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -241,7 +241,7 @@
     ]
   },
   {
-    "id": 6,
+    "id": 7,
     "name": "%TEST_DIR%/typechecker/decorators/function_decorator.abra",
     "code": [
       {
@@ -258,7 +258,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 6,
+            "moduleId": 7,
             "name": { "name": "Bar", "position": [3, 11] },
             "typeParams": [],
             "fields": [
@@ -275,7 +275,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_6::Bar::toString",
+                  "name": "$root::module_7::Bar::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -296,7 +296,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_6::Bar::hash",
+                  "name": "$root::module_7::Bar::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -317,7 +317,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_6::Bar::eq",
+                  "name": "$root::module_7::Bar::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -333,7 +333,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 6, "name": "Bar" },
+                      "struct": { "moduleId": 7, "name": "Bar" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -367,7 +367,7 @@
           "function": {
             "label": { "name": "f1", "position": [9, 6] },
             "scope": {
-              "name": "$root::module_6::f1",
+              "name": "$root::module_7::f1",
               "variables": [],
               "functions": [],
               "structs": [],
@@ -401,7 +401,7 @@
           "function": {
             "label": { "name": "f2", "position": [12, 6] },
             "scope": {
-              "name": "$root::module_6::f2",
+              "name": "$root::module_7::f2",
               "variables": [],
               "functions": [],
               "structs": [],
@@ -435,7 +435,7 @@
           "function": {
             "label": { "name": "f3", "position": [15, 6] },
             "scope": {
-              "name": "$root::module_6::f3",
+              "name": "$root::module_7::f3",
               "variables": [],
               "functions": [],
               "structs": [],
@@ -469,7 +469,7 @@
           "function": {
             "label": { "name": "f4", "position": [18, 6] },
             "scope": {
-              "name": "$root::module_6::f4",
+              "name": "$root::module_7::f4",
               "variables": [],
               "functions": [],
               "structs": [],

--- a/projects/compiler/test/typechecker/enumdecl/enumdecl.1.out.json
+++ b/projects/compiler/test/typechecker/enumdecl/enumdecl.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/enumdecl/enumdecl.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "variants": [
@@ -84,7 +84,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -105,7 +105,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -126,7 +126,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -142,7 +142,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Foo" },
+                    "enum": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -158,14 +158,14 @@
             {
               "label": { "name": "foo", "position": [6, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [6, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Foo" },
+                      "enum": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   }
@@ -208,7 +208,7 @@
             {
               "label": { "name": "fooStatic", "position": [7, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::fooStatic",
+                "name": "$root::module_6::Foo::fooStatic",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -270,7 +270,7 @@
             "mutable": true,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo" },
+              "enum": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }

--- a/projects/compiler/test/typechecker/enumdecl/enumdecl_Result_shorthand.out.json
+++ b/projects/compiler/test/typechecker/enumdecl/enumdecl_Result_shorthand.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/enumdecl/enumdecl_Result_shorthand.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "implicitReturn", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::implicitReturn",
+            "name": "$root::module_6::implicitReturn",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -30,7 +30,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -52,7 +52,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -95,7 +95,7 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -124,7 +124,7 @@
                           ],
                           "returnType": {
                             "kind": "enumInstance",
-                            "enum": { "moduleId": 4, "name": "Result" },
+                            "enum": { "moduleId": 5, "name": "Result" },
                             "typeParams": [
                               {
                                 "kind": "generic",
@@ -170,7 +170,7 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -199,7 +199,7 @@
                           ],
                           "returnType": {
                             "kind": "enumInstance",
-                            "enum": { "moduleId": 4, "name": "Result" },
+                            "enum": { "moduleId": 5, "name": "Result" },
                             "typeParams": [
                               {
                                 "kind": "generic",
@@ -257,7 +257,7 @@
         "function": {
           "label": { "name": "explicitReturn", "position": [5, 6] },
           "scope": {
-            "name": "$root::module_5::explicitReturn",
+            "name": "$root::module_6::explicitReturn",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -269,7 +269,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -336,7 +336,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -365,7 +365,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Result" },
+                                "enum": { "moduleId": 5, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -459,7 +459,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -488,7 +488,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Result" },
+                                "enum": { "moduleId": 5, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -548,7 +548,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -577,7 +577,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Result" },
+                                "enum": { "moduleId": 5, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",

--- a/projects/compiler/test/typechecker/enumdecl/enumdecl_exported.out.json
+++ b/projects/compiler/test/typechecker/enumdecl/enumdecl_exported.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/enumdecl/enumdecl_exported.abra",
   "exports": [
     {
@@ -22,7 +22,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 10] },
           "typeParams": [],
           "variants": [
@@ -35,7 +35,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -56,7 +56,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -77,7 +77,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -93,7 +93,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Foo" },
+                    "enum": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,

--- a/projects/compiler/test/typechecker/for/for.1.out.json
+++ b/projects/compiler/test/typechecker/for/for.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/for/for.1.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/for/for.2.out.json
+++ b/projects/compiler/test/typechecker/for/for.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/for/for.2.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/for/for.3.out.json
+++ b/projects/compiler/test/typechecker/for/for.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/for/for.3.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -48,7 +48,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -163,7 +163,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/for/for.4.out.json
+++ b/projects/compiler/test/typechecker/for/for.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/for/for.4.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_accessor.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_accessor.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_accessor.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -33,7 +33,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -54,7 +54,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -75,7 +75,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -91,7 +91,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -125,14 +125,14 @@
         "function": {
           "label": { "name": "foo", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [3, 10] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": []
                 }
               },
@@ -157,7 +157,7 @@
               "label": { "name": "a", "position": [3, 10] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               },
               "defaultValue": null,
@@ -192,7 +192,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     },
                     "node": {

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.1.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [1, 10] },
@@ -131,7 +131,7 @@
         "function": {
           "label": { "name": "bar", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [],
             "functions": [],
             "structs": [],

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.2.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.2.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [1, 10] },
@@ -141,7 +141,7 @@
         "function": {
           "label": { "name": "bar", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.3.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.3.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [1, 10] },
@@ -141,7 +141,7 @@
         "function": {
           "label": { "name": "bar", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "b", "position": [2, 10] },

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.4.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.4.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo1", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::foo1",
+            "name": "$root::module_6::foo1",
             "variables": [
               {
                 "label": { "name": "a", "position": [3, 11] },
@@ -174,7 +174,7 @@
         "function": {
           "label": { "name": "foo2", "position": [4, 6] },
           "scope": {
-            "name": "$root::module_5::foo2",
+            "name": "$root::module_6::foo2",
             "variables": [
               {
                 "label": { "name": "a", "position": [4, 11] },
@@ -330,7 +330,7 @@
         "function": {
           "label": { "name": "bar", "position": [6, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "i", "position": [6, 10] },

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.5.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.5.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.5.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },
@@ -164,7 +164,7 @@
         "function": {
           "label": { "name": "bar", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "a", "position": [3, 10] },

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.6.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.6.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.6.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },
@@ -174,7 +174,7 @@
         "function": {
           "label": { "name": "bar", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "i", "position": [3, 10] },

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.7.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.7.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.7.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo1", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo1",
+            "name": "$root::module_6::foo1",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 11] },
@@ -118,7 +118,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -136,7 +136,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -204,7 +204,7 @@
         "function": {
           "label": { "name": "foo2", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::foo2",
+            "name": "$root::module_6::foo2",
             "variables": [
               {
                 "label": { "name": "a", "position": [3, 11] },
@@ -320,7 +320,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -338,7 +338,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -406,7 +406,7 @@
         "function": {
           "label": { "name": "bar", "position": [5, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "t", "position": [5, 13] },

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.8.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.8.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.8.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },
@@ -182,7 +182,7 @@
         "function": {
           "label": { "name": "baz", "position": [5, 6] },
           "scope": {
-            "name": "$root::module_5::baz",
+            "name": "$root::module_6::baz",
             "variables": [
               {
                 "label": { "name": "a", "position": [5, 10] },
@@ -322,7 +322,7 @@
         "function": {
           "label": { "name": "bar", "position": [6, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "a", "position": [6, 10] },

--- a/projects/compiler/test/typechecker/funcdecl/default_param_value_call.9.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/default_param_value_call.9.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/default_param_value_call.9.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [1, 10] },
@@ -164,7 +164,7 @@
         "function": {
           "label": { "name": "bar", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [],
             "functions": [],
             "structs": [],

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl.1.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [],
             "functions": [],
             "structs": [],

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl.2.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl.2.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl.3.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl.3.abra",
   "code": [
     {
@@ -18,14 +18,14 @@
         "function": {
           "label": { "name": "f", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::f",
+            "name": "$root::module_6::f",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 8] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -44,7 +44,7 @@
                       "required": true,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -73,7 +73,7 @@
               "label": { "name": "a", "position": [2, 8] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -118,7 +118,7 @@
                           "required": true,
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 4, "name": "Array" },
+                            "struct": { "moduleId": 5, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "primitive",
@@ -150,7 +150,7 @@
                         "required": true,
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl.4.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl.4.abra",
   "code": [
     {
@@ -64,7 +64,7 @@
         "function": {
           "label": { "name": "foo", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "x", "position": [3, 10] },

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl.5.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl.5.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl.5.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo1", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo1",
+            "name": "$root::module_6::foo1",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -30,7 +30,7 @@
           "parameters": [],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -48,7 +48,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -81,7 +81,7 @@
         "function": {
           "label": { "name": "foo2", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::foo2",
+            "name": "$root::module_6::foo2",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -93,11 +93,11 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -117,11 +117,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -162,11 +162,11 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -189,7 +189,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 4, "name": "Array" },
+                            "struct": { "moduleId": 5, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "primitive",
@@ -216,11 +216,11 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -242,7 +242,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 4, "name": "Option" }
+                          "enum": { "moduleId": 5, "name": "Option" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -279,7 +279,7 @@
         "function": {
           "label": { "name": "foo3", "position": [4, 6] },
           "scope": {
-            "name": "$root::module_5::foo3",
+            "name": "$root::module_6::foo3",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -291,11 +291,11 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -315,11 +315,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -360,11 +360,11 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -386,7 +386,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 4, "name": "Option" }
+                          "enum": { "moduleId": 5, "name": "Option" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -411,11 +411,11 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -438,7 +438,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 4, "name": "Array" },
+                            "struct": { "moduleId": 5, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "primitive",
@@ -477,7 +477,7 @@
         "function": {
           "label": { "name": "foo4", "position": [5, 6] },
           "scope": {
-            "name": "$root::module_5::foo4",
+            "name": "$root::module_6::foo4",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -489,15 +489,15 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -519,15 +519,15 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -570,15 +570,15 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Option" },
+                              "enum": { "moduleId": 5, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -602,7 +602,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 4, "name": "Option" }
+                          "enum": { "moduleId": 5, "name": "Option" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -627,15 +627,15 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Option" },
+                              "enum": { "moduleId": 5, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -660,11 +660,11 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 4, "name": "Array" },
+                            "struct": { "moduleId": 5, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Option" },
+                                "enum": { "moduleId": 5, "name": "Option" },
                                 "typeParams": [
                                   {
                                     "kind": "primitive",
@@ -705,7 +705,7 @@
         "function": {
           "label": { "name": "foo5", "position": [6, 6] },
           "scope": {
-            "name": "$root::module_5::foo5",
+            "name": "$root::module_6::foo5",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -717,15 +717,15 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -747,15 +747,15 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -798,15 +798,15 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Option" },
+                              "enum": { "moduleId": 5, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -830,7 +830,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 4, "name": "Option" }
+                          "enum": { "moduleId": 5, "name": "Option" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -855,15 +855,15 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Option" },
+                              "enum": { "moduleId": 5, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -888,11 +888,11 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 4, "name": "Array" },
+                            "struct": { "moduleId": 5, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Option" },
+                                "enum": { "moduleId": 5, "name": "Option" },
                                 "typeParams": [
                                   {
                                     "kind": "primitive",
@@ -914,7 +914,7 @@
                                 },
                                 "type": {
                                   "kind": "enumInstance",
-                                  "enum": { "moduleId": 4, "name": "Option" },
+                                  "enum": { "moduleId": 5, "name": "Option" },
                                   "typeParams": [
                                     {
                                       "kind": "primitive",
@@ -934,7 +934,7 @@
                                     },
                                     "type": {
                                       "kind": "enum",
-                                      "enum": { "moduleId": 4, "name": "Option" }
+                                      "enum": { "moduleId": 5, "name": "Option" }
                                     },
                                     "node": {
                                       "kind": "identifier",

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl.6.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl.6.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl.6.abra",
   "code": [
     {
@@ -18,14 +18,14 @@
         "function": {
           "label": { "name": "foo1", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo1",
+            "name": "$root::module_6::foo1",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 12] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -77,18 +77,18 @@
         "function": {
           "label": { "name": "foo2", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::foo2",
+            "name": "$root::module_6::foo2",
             "variables": [
               {
                 "label": { "name": "arrs", "position": [3, 12] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -112,7 +112,7 @@
               "label": { "name": "arrs", "position": [3, 12] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl.7.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl.7.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl.7.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },
@@ -33,7 +33,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -89,7 +89,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -108,7 +108,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl_exported.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl_exported.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl_exported.abra",
   "exports": [
     {
@@ -24,7 +24,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 10] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [],
             "functions": [],
             "structs": [],

--- a/projects/compiler/test/typechecker/funcdecl/funcdecl_generics.out.json
+++ b/projects/compiler/test/typechecker/funcdecl/funcdecl_generics.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/funcdecl/funcdecl_generics.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "t", "position": [2, 13] },

--- a/projects/compiler/test/typechecker/identifier/identifier.out.json
+++ b/projects/compiler/test/typechecker/identifier/identifier.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/identifier/identifier.abra",
   "code": [
     {
@@ -133,7 +133,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -152,7 +152,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -172,7 +172,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 4, "name": "Option" }
+                "enum": { "moduleId": 5, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",

--- a/projects/compiler/test/typechecker/identifier/identifier_transform_OptionNone.out.json
+++ b/projects/compiler/test/typechecker/identifier/identifier_transform_OptionNone.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/identifier/identifier_transform_OptionNone.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -64,7 +64,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 4, "name": "Option" }
+                "enum": { "moduleId": 5, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",

--- a/projects/compiler/test/typechecker/if/expr.out.json
+++ b/projects/compiler/test/typechecker/if/expr.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/if/expr.abra",
   "code": [
     {
@@ -172,7 +172,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -191,7 +191,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -276,7 +276,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -318,7 +318,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -359,7 +359,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -379,7 +379,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -417,7 +417,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -436,7 +436,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -475,7 +475,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -545,7 +545,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -604,7 +604,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -624,7 +624,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -662,11 +662,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -687,11 +687,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -732,11 +732,11 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -758,7 +758,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -829,11 +829,11 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -856,7 +856,7 @@
                       },
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -918,11 +918,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -944,11 +944,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -988,11 +988,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1013,11 +1013,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1104,11 +1104,11 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1131,7 +1131,7 @@
                       },
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1176,11 +1176,11 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1202,7 +1202,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1244,11 +1244,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1270,11 +1270,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1314,7 +1314,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1333,7 +1333,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1372,7 +1372,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1415,7 +1415,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1435,7 +1435,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1477,7 +1477,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1497,7 +1497,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1535,7 +1535,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1554,7 +1554,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1593,7 +1593,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1613,7 +1613,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1638,7 +1638,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1698,7 +1698,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1718,7 +1718,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1756,7 +1756,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1775,7 +1775,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1814,7 +1814,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1853,7 +1853,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1896,7 +1896,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1942,7 +1942,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1962,7 +1962,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -2004,7 +2004,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -2024,7 +2024,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -2116,7 +2116,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "hole"
@@ -2135,7 +2135,7 @@
                           },
                           "type": {
                             "kind": "enum",
-                            "enum": { "moduleId": 4, "name": "Option" }
+                            "enum": { "moduleId": 5, "name": "Option" }
                           },
                           "node": {
                             "kind": "identifier",
@@ -2304,7 +2304,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -2323,7 +2323,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -2408,7 +2408,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2539,7 +2539,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo1", "position": [56, 6] },
           "typeParams": [],
           "fields": [
@@ -2556,7 +2556,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo1::toString",
+                "name": "$root::module_6::Foo1::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -2577,7 +2577,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo1::hash",
+                "name": "$root::module_6::Foo1::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -2598,7 +2598,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo1::eq",
+                "name": "$root::module_6::Foo1::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -2614,7 +2614,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo1" },
+                    "struct": { "moduleId": 6, "name": "Foo1" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -2655,7 +2655,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo1" },
+              "struct": { "moduleId": 6, "name": "Foo1" },
               "typeParams": []
             }
           }
@@ -2669,7 +2669,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo1" },
+            "struct": { "moduleId": 6, "name": "Foo1" },
             "typeParams": []
           },
           "node": {
@@ -2703,12 +2703,12 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo1" },
+                  "struct": { "moduleId": 6, "name": "Foo1" },
                   "typeParams": []
                 },
                 "node": {
                   "kind": "invocation",
-                  "invokee": { "moduleId": 5, "name": "Foo1" },
+                  "invokee": { "moduleId": 6, "name": "Foo1" },
                   "arguments": [
                     {
                       "token": {
@@ -2741,12 +2741,12 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo1" },
+                  "struct": { "moduleId": 6, "name": "Foo1" },
                   "typeParams": []
                 },
                 "node": {
                   "kind": "invocation",
-                  "invokee": { "moduleId": 5, "name": "Foo1" },
+                  "invokee": { "moduleId": 6, "name": "Foo1" },
                   "arguments": [
                     {
                       "token": {
@@ -2796,7 +2796,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo1" },
+              "struct": { "moduleId": 6, "name": "Foo1" },
               "typeParams": []
             }
           }
@@ -2811,7 +2811,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo1" },
+            "struct": { "moduleId": 6, "name": "Foo1" },
             "typeParams": []
           },
           "node": {
@@ -2835,7 +2835,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo2", "position": [60, 6] },
           "typeParams": [],
           "variants": [
@@ -2852,7 +2852,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo2::toString",
+                "name": "$root::module_6::Foo2::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -2873,7 +2873,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo2::hash",
+                "name": "$root::module_6::Foo2::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -2894,7 +2894,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo2::eq",
+                "name": "$root::module_6::Foo2::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -2910,7 +2910,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Foo2" },
+                    "enum": { "moduleId": 6, "name": "Foo2" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -2951,7 +2951,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo2" },
+              "enum": { "moduleId": 6, "name": "Foo2" },
               "typeParams": []
             }
           }
@@ -2965,7 +2965,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo2" },
+            "enum": { "moduleId": 6, "name": "Foo2" },
             "typeParams": []
           },
           "node": {
@@ -2999,7 +2999,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Foo2" },
+                  "enum": { "moduleId": 6, "name": "Foo2" },
                   "typeParams": []
                 },
                 "node": {
@@ -3014,7 +3014,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 5, "name": "Foo2" }
+                      "enum": { "moduleId": 6, "name": "Foo2" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -3039,7 +3039,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Foo2" },
+                  "enum": { "moduleId": 6, "name": "Foo2" },
                   "typeParams": []
                 },
                 "node": {
@@ -3054,7 +3054,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 5, "name": "Foo2" }
+                      "enum": { "moduleId": 6, "name": "Foo2" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -3096,7 +3096,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo2" },
+              "enum": { "moduleId": 6, "name": "Foo2" },
               "typeParams": []
             }
           }
@@ -3111,7 +3111,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo2" },
+            "enum": { "moduleId": 6, "name": "Foo2" },
             "typeParams": []
           },
           "node": {
@@ -3144,7 +3144,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "tuple",
@@ -3172,7 +3172,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "tuple",
@@ -3340,7 +3340,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "tuple",
@@ -3371,7 +3371,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "tuple",

--- a/projects/compiler/test/typechecker/if/stmt.out.json
+++ b/projects/compiler/test/typechecker/if/stmt.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/if/stmt.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/import/import.1.out.json
+++ b/projects/compiler/test/typechecker/import/import.1.out.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 5,
+    "id": 6,
     "name": "%TEST_DIR%/typechecker/import/_exports.abra",
     "exports": [
       {
@@ -87,7 +87,7 @@
           "function": {
             "label": { "name": "add", "position": [3, 10] },
             "scope": {
-              "name": "$root::module_5::add",
+              "name": "$root::module_6::add",
               "variables": [
                 {
                   "label": { "name": "a", "position": [3, 14] },
@@ -206,7 +206,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Foo", "position": [5, 10] },
             "typeParams": [],
             "fields": [
@@ -214,7 +214,7 @@
                 "name": { "name": "color", "position": [6, 7] },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 },
                 "initializer": null,
@@ -225,7 +225,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::toString",
+                  "name": "$root::module_6::Foo::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -246,7 +246,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::hash",
+                  "name": "$root::module_6::Foo::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -267,7 +267,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::eq",
+                  "name": "$root::module_6::Foo::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -283,7 +283,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -299,14 +299,14 @@
               {
                 "label": { "name": "foo", "position": [8, 8] },
                 "scope": {
-                  "name": "$root::module_5::Foo::foo",
+                  "name": "$root::module_6::Foo::foo",
                   "variables": [
                     {
                       "label": { "name": "self", "position": [8, 12] },
                       "mutable": false,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 5, "name": "Foo" },
+                        "struct": { "moduleId": 6, "name": "Foo" },
                         "typeParams": []
                       }
                     }
@@ -372,7 +372,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -386,12 +386,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 5, "name": "Foo" },
+              "invokee": { "moduleId": 6, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -402,7 +402,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {
@@ -417,7 +417,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 5, "name": "Color" }
+                        "enum": { "moduleId": 6, "name": "Color" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -450,7 +450,7 @@
         "node": {
           "kind": "enumDeclaration",
           "enum": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Color", "position": [12, 10] },
             "typeParams": [],
             "variants": [
@@ -504,7 +504,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::toString",
+                  "name": "$root::module_6::Color::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -525,7 +525,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::hash",
+                  "name": "$root::module_6::Color::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -546,7 +546,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::eq",
+                  "name": "$root::module_6::Color::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -562,7 +562,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Color" },
+                      "enum": { "moduleId": 6, "name": "Color" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -583,7 +583,7 @@
     ]
   },
   {
-    "id": 6,
+    "id": 7,
     "name": "%TEST_DIR%/typechecker/import/import.1.abra",
     "code": [
       {
@@ -794,7 +794,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color" },
+                "enum": { "moduleId": 6, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -808,7 +808,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color" },
+              "enum": { "moduleId": 6, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -894,7 +894,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -908,12 +908,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 5, "name": "Foo" },
+              "invokee": { "moduleId": 6, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -925,7 +925,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {

--- a/projects/compiler/test/typechecker/import/import.2.out.json
+++ b/projects/compiler/test/typechecker/import/import.2.out.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 5,
+    "id": 6,
     "name": "%TEST_DIR%/typechecker/import/_exports.abra",
     "exports": [
       {
@@ -87,7 +87,7 @@
           "function": {
             "label": { "name": "add", "position": [3, 10] },
             "scope": {
-              "name": "$root::module_5::add",
+              "name": "$root::module_6::add",
               "variables": [
                 {
                   "label": { "name": "a", "position": [3, 14] },
@@ -206,7 +206,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Foo", "position": [5, 10] },
             "typeParams": [],
             "fields": [
@@ -214,7 +214,7 @@
                 "name": { "name": "color", "position": [6, 7] },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 },
                 "initializer": null,
@@ -225,7 +225,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::toString",
+                  "name": "$root::module_6::Foo::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -246,7 +246,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::hash",
+                  "name": "$root::module_6::Foo::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -267,7 +267,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::eq",
+                  "name": "$root::module_6::Foo::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -283,7 +283,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -299,14 +299,14 @@
               {
                 "label": { "name": "foo", "position": [8, 8] },
                 "scope": {
-                  "name": "$root::module_5::Foo::foo",
+                  "name": "$root::module_6::Foo::foo",
                   "variables": [
                     {
                       "label": { "name": "self", "position": [8, 12] },
                       "mutable": false,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 5, "name": "Foo" },
+                        "struct": { "moduleId": 6, "name": "Foo" },
                         "typeParams": []
                       }
                     }
@@ -372,7 +372,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -386,12 +386,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 5, "name": "Foo" },
+              "invokee": { "moduleId": 6, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -402,7 +402,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {
@@ -417,7 +417,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 5, "name": "Color" }
+                        "enum": { "moduleId": 6, "name": "Color" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -450,7 +450,7 @@
         "node": {
           "kind": "enumDeclaration",
           "enum": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Color", "position": [12, 10] },
             "typeParams": [],
             "variants": [
@@ -504,7 +504,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::toString",
+                  "name": "$root::module_6::Color::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -525,7 +525,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::hash",
+                  "name": "$root::module_6::Color::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -546,7 +546,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::eq",
+                  "name": "$root::module_6::Color::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -562,7 +562,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Color" },
+                      "enum": { "moduleId": 6, "name": "Color" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -583,7 +583,7 @@
     ]
   },
   {
-    "id": 6,
+    "id": 7,
     "name": "%TEST_DIR%/typechecker/import/import.2.abra",
     "code": [
       {
@@ -688,7 +688,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color" },
+                "enum": { "moduleId": 6, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -702,7 +702,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color" },
+              "enum": { "moduleId": 6, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -717,7 +717,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": []
                 },
                 "node": {
@@ -731,7 +731,7 @@
                 "name": "color",
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 }
               }
@@ -974,7 +974,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color" },
+                "enum": { "moduleId": 6, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -988,7 +988,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color" },
+              "enum": { "moduleId": 6, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -1003,7 +1003,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 5, "name": "Color" }
+                  "enum": { "moduleId": 6, "name": "Color" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1042,7 +1042,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color" },
+                "enum": { "moduleId": 6, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -1056,7 +1056,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color" },
+              "enum": { "moduleId": 6, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -1071,7 +1071,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 5, "name": "Color" }
+                  "enum": { "moduleId": 6, "name": "Color" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1110,7 +1110,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color" },
+                "enum": { "moduleId": 6, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -1124,7 +1124,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color" },
+              "enum": { "moduleId": 6, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -1139,7 +1139,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 5, "name": "Color" }
+                  "enum": { "moduleId": 6, "name": "Color" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1178,7 +1178,7 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color" },
+                "enum": { "moduleId": 6, "name": "Color" },
                 "typeParams": []
               }
             }
@@ -1192,7 +1192,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color" },
+              "enum": { "moduleId": 6, "name": "Color" },
               "typeParams": []
             },
             "node": {
@@ -1278,7 +1278,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -1292,12 +1292,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 5, "name": "Foo" },
+              "invokee": { "moduleId": 6, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -1309,7 +1309,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {

--- a/projects/compiler/test/typechecker/import/import_type_identifier.1.out.json
+++ b/projects/compiler/test/typechecker/import/import_type_identifier.1.out.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 5,
+    "id": 6,
     "name": "%TEST_DIR%/typechecker/import/_exports.abra",
     "exports": [
       {
@@ -87,7 +87,7 @@
           "function": {
             "label": { "name": "add", "position": [3, 10] },
             "scope": {
-              "name": "$root::module_5::add",
+              "name": "$root::module_6::add",
               "variables": [
                 {
                   "label": { "name": "a", "position": [3, 14] },
@@ -206,7 +206,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Foo", "position": [5, 10] },
             "typeParams": [],
             "fields": [
@@ -214,7 +214,7 @@
                 "name": { "name": "color", "position": [6, 7] },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 },
                 "initializer": null,
@@ -225,7 +225,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::toString",
+                  "name": "$root::module_6::Foo::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -246,7 +246,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::hash",
+                  "name": "$root::module_6::Foo::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -267,7 +267,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::eq",
+                  "name": "$root::module_6::Foo::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -283,7 +283,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -299,14 +299,14 @@
               {
                 "label": { "name": "foo", "position": [8, 8] },
                 "scope": {
-                  "name": "$root::module_5::Foo::foo",
+                  "name": "$root::module_6::Foo::foo",
                   "variables": [
                     {
                       "label": { "name": "self", "position": [8, 12] },
                       "mutable": false,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 5, "name": "Foo" },
+                        "struct": { "moduleId": 6, "name": "Foo" },
                         "typeParams": []
                       }
                     }
@@ -372,7 +372,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -386,12 +386,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 5, "name": "Foo" },
+              "invokee": { "moduleId": 6, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -402,7 +402,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {
@@ -417,7 +417,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 5, "name": "Color" }
+                        "enum": { "moduleId": 6, "name": "Color" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -450,7 +450,7 @@
         "node": {
           "kind": "enumDeclaration",
           "enum": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Color", "position": [12, 10] },
             "typeParams": [],
             "variants": [
@@ -504,7 +504,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::toString",
+                  "name": "$root::module_6::Color::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -525,7 +525,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::hash",
+                  "name": "$root::module_6::Color::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -546,7 +546,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::eq",
+                  "name": "$root::module_6::Color::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -562,7 +562,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Color" },
+                      "enum": { "moduleId": 6, "name": "Color" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -583,7 +583,7 @@
     ]
   },
   {
-    "id": 6,
+    "id": 7,
     "name": "%TEST_DIR%/typechecker/import/import_type_identifier.1.abra",
     "code": [
       {
@@ -609,11 +609,11 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   }
                 ]
@@ -629,11 +629,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": []
                 }
               ]
@@ -650,7 +650,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -689,11 +689,11 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   }
                 ]
@@ -709,11 +709,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 }
               ]
@@ -730,7 +730,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",

--- a/projects/compiler/test/typechecker/import/import_type_identifier.2.out.json
+++ b/projects/compiler/test/typechecker/import/import_type_identifier.2.out.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 5,
+    "id": 6,
     "name": "%TEST_DIR%/typechecker/import/_exports.abra",
     "exports": [
       {
@@ -87,7 +87,7 @@
           "function": {
             "label": { "name": "add", "position": [3, 10] },
             "scope": {
-              "name": "$root::module_5::add",
+              "name": "$root::module_6::add",
               "variables": [
                 {
                   "label": { "name": "a", "position": [3, 14] },
@@ -206,7 +206,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Foo", "position": [5, 10] },
             "typeParams": [],
             "fields": [
@@ -214,7 +214,7 @@
                 "name": { "name": "color", "position": [6, 7] },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 },
                 "initializer": null,
@@ -225,7 +225,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::toString",
+                  "name": "$root::module_6::Foo::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -246,7 +246,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::hash",
+                  "name": "$root::module_6::Foo::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -267,7 +267,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::eq",
+                  "name": "$root::module_6::Foo::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -283,7 +283,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -299,14 +299,14 @@
               {
                 "label": { "name": "foo", "position": [8, 8] },
                 "scope": {
-                  "name": "$root::module_5::Foo::foo",
+                  "name": "$root::module_6::Foo::foo",
                   "variables": [
                     {
                       "label": { "name": "self", "position": [8, 12] },
                       "mutable": false,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 5, "name": "Foo" },
+                        "struct": { "moduleId": 6, "name": "Foo" },
                         "typeParams": []
                       }
                     }
@@ -372,7 +372,7 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": []
               }
             }
@@ -386,12 +386,12 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             },
             "node": {
               "kind": "invocation",
-              "invokee": { "moduleId": 5, "name": "Foo" },
+              "invokee": { "moduleId": 6, "name": "Foo" },
               "arguments": [
                 {
                   "token": {
@@ -402,7 +402,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   },
                   "node": {
@@ -417,7 +417,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 5, "name": "Color" }
+                        "enum": { "moduleId": 6, "name": "Color" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -450,7 +450,7 @@
         "node": {
           "kind": "enumDeclaration",
           "enum": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Color", "position": [12, 10] },
             "typeParams": [],
             "variants": [
@@ -504,7 +504,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::toString",
+                  "name": "$root::module_6::Color::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -525,7 +525,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::hash",
+                  "name": "$root::module_6::Color::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -546,7 +546,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Color::eq",
+                  "name": "$root::module_6::Color::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -562,7 +562,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Color" },
+                      "enum": { "moduleId": 6, "name": "Color" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -583,7 +583,7 @@
     ]
   },
   {
-    "id": 6,
+    "id": 7,
     "name": "%TEST_DIR%/typechecker/import/import_type_identifier.2.abra",
     "code": [
       {
@@ -609,11 +609,11 @@
               "mutable": false,
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   }
                 ]
@@ -629,11 +629,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": []
                 }
               ]
@@ -650,7 +650,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -689,11 +689,11 @@
               "mutable": false,
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   }
                 ]
@@ -709,11 +709,11 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 }
               ]

--- a/projects/compiler/test/typechecker/indexing/indexing_array.out.json
+++ b/projects/compiler/test/typechecker/indexing/indexing_array.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/indexing/indexing_array.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -153,7 +153,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -175,7 +175,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -233,7 +233,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -253,7 +253,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -383,7 +383,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -402,7 +402,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -424,7 +424,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -499,7 +499,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -519,7 +519,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -557,7 +557,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -576,7 +576,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -598,7 +598,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -657,7 +657,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -677,7 +677,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -715,7 +715,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -734,7 +734,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -756,7 +756,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -831,7 +831,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -851,7 +851,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/indexing/indexing_map.out.json
+++ b/projects/compiler/test/typechecker/indexing/indexing_map.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/indexing/indexing_map.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -48,7 +48,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -163,7 +163,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -182,7 +182,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -204,7 +204,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Map" },
+                  "struct": { "moduleId": 5, "name": "Map" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -266,7 +266,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -286,7 +286,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -324,7 +324,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -347,7 +347,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -528,7 +528,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -547,7 +547,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -569,7 +569,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Map" },
+                  "struct": { "moduleId": 5, "name": "Map" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -631,7 +631,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -651,7 +651,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/indexing/indexing_string.out.json
+++ b/projects/compiler/test/typechecker/indexing/indexing_string.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/indexing/indexing_string.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/indexing/indexing_tuple.out.json
+++ b/projects/compiler/test/typechecker/indexing/indexing_tuple.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/indexing/indexing_tuple.abra",
   "code": [
     {
@@ -36,7 +36,7 @@
                 },
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -68,7 +68,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -124,7 +124,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -224,7 +224,7 @@
                     },
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -354,7 +354,7 @@
                     },
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -443,7 +443,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -462,7 +462,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -496,7 +496,7 @@
                     },
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -539,7 +539,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -559,7 +559,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/function_as_param.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/function_as_param.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/function_as_param.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "fn", "position": [1, 10] },
@@ -159,7 +159,7 @@
         "function": {
           "label": { "name": "negate", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::negate",
+            "name": "$root::module_6::negate",
             "variables": [
               {
                 "label": { "name": "i", "position": [3, 13] },

--- a/projects/compiler/test/typechecker/invocation/function_as_param.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/function_as_param.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/function_as_param.2.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "fn", "position": [1, 10] },
@@ -159,7 +159,7 @@
         "function": {
           "label": { "name": "negateMaybe", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::negateMaybe",
+            "name": "$root::module_6::negateMaybe",
             "variables": [
               {
                 "label": { "name": "i", "position": [3, 18] },

--- a/projects/compiler/test/typechecker/invocation/function_as_param.3.out.json
+++ b/projects/compiler/test/typechecker/invocation/function_as_param.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/function_as_param.3.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "fn", "position": [1, 10] },
@@ -159,7 +159,7 @@
         "function": {
           "label": { "name": "negativeOne", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::negativeOne",
+            "name": "$root::module_6::negativeOne",
             "variables": [],
             "functions": [],
             "structs": [],

--- a/projects/compiler/test/typechecker/invocation/function_as_param_generic.out.json
+++ b/projects/compiler/test/typechecker/invocation/function_as_param_generic.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/function_as_param_generic.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "fn", "position": [1, 16] },
@@ -191,7 +191,7 @@
         "function": {
           "label": { "name": "negativeOne", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::negativeOne",
+            "name": "$root::module_6::negativeOne",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -427,7 +427,7 @@
         "function": {
           "label": { "name": "bar", "position": [7, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "s", "position": [7, 10] },

--- a/projects/compiler/test/typechecker/invocation/function_value.out.json
+++ b/projects/compiler/test/typechecker/invocation/function_value.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/function_value.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "fn", "position": [1, 10] },

--- a/projects/compiler/test/typechecker/invocation/invocation.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [1, 10] },

--- a/projects/compiler/test/typechecker/invocation/invocation.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation.2.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },

--- a/projects/compiler/test/typechecker/invocation/invocation.3.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation.3.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },

--- a/projects/compiler/test/typechecker/invocation/invocation.4.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation.4.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },

--- a/projects/compiler/test/typechecker/invocation/invocation.5.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation.5.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation.5.abra",
   "code": [
     {
@@ -18,14 +18,14 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [1, 10] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -39,7 +39,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -61,7 +61,7 @@
               "label": { "name": "a", "position": [1, 10] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -76,7 +76,7 @@
               "label": { "name": "b", "position": [1, 20] },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -118,7 +118,7 @@
                 "required": true,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -131,7 +131,7 @@
                 "required": true,
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -157,7 +157,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -179,7 +179,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -236,7 +236,7 @@
                 "required": true,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -249,7 +249,7 @@
                 "required": true,
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -275,7 +275,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -332,7 +332,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -352,7 +352,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",

--- a/projects/compiler/test/typechecker/invocation/invocation_arbitrary_expr.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_arbitrary_expr.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_arbitrary_expr.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [1, 10] },

--- a/projects/compiler/test/typechecker/invocation/invocation_arbitrary_expr.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_arbitrary_expr.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_arbitrary_expr.2.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [1, 10] },
@@ -122,7 +122,7 @@
         "function": {
           "label": { "name": "bar", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },

--- a/projects/compiler/test/typechecker/invocation/invocation_enum_variant.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_enum_variant.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_enum_variant.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "variants": [
@@ -53,7 +53,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -74,7 +74,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -95,7 +95,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -111,7 +111,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Foo" },
+                    "enum": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -152,7 +152,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo" },
+              "enum": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -166,7 +166,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo" },
+            "enum": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {

--- a/projects/compiler/test/typechecker/invocation/invocation_enum_variant.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_enum_variant.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_enum_variant.2.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "variants": [
@@ -65,7 +65,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -86,7 +86,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -107,7 +107,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -123,7 +123,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Foo" },
+                    "enum": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -164,7 +164,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo" },
+              "enum": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -178,7 +178,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo" },
+            "enum": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {

--- a/projects/compiler/test/typechecker/invocation/invocation_enum_variant.3.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_enum_variant.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_enum_variant.3.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [
             "T"
@@ -42,7 +42,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -63,7 +63,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -84,7 +84,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -100,7 +100,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Foo" },
+                    "enum": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -141,7 +141,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo" },
+              "enum": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -160,7 +160,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo" },
+            "enum": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -217,7 +217,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo" },
+              "enum": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -237,7 +237,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo" },
+            "enum": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_enum_variant.4.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_enum_variant.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_enum_variant.4.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [
             "T"
@@ -30,7 +30,7 @@
                   "name": { "name": "a", "position": [2, 7] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -48,7 +48,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -69,7 +69,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -90,7 +90,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -106,7 +106,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Foo" },
+                    "enum": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -147,7 +147,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo" },
+              "enum": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -166,7 +166,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo" },
+            "enum": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -187,7 +187,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -247,7 +247,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Foo" },
+              "enum": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -267,7 +267,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Foo" },
+            "enum": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_field.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_field.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_field.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -45,7 +45,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -66,7 +66,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -87,7 +87,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -103,7 +103,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -144,7 +144,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -227,7 +227,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "node": {

--- a/projects/compiler/test/typechecker/invocation/invocation_field_generics.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_field_generics.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_field_generics.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [
             "T"
@@ -47,7 +47,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -68,7 +68,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -89,7 +89,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -105,7 +105,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -144,7 +144,7 @@
         "function": {
           "label": { "name": "identity", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::identity",
+            "name": "$root::module_6::identity",
             "variables": [
               {
                 "label": { "name": "i", "position": [3, 15] },
@@ -222,7 +222,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -241,7 +241,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -251,7 +251,7 @@
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -362,7 +362,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_generics.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_generics.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_generics.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "t", "position": [1, 13] },

--- a/projects/compiler/test/typechecker/invocation/invocation_generics.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_generics.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_generics.2.abra",
   "code": [
     {
@@ -18,14 +18,14 @@
         "function": {
           "label": { "name": "foo1", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo1",
+            "name": "$root::module_6::foo1",
             "variables": [
               {
                 "label": { "name": "t", "position": [1, 14] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -55,7 +55,7 @@
               "label": { "name": "t", "position": [1, 14] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -69,7 +69,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -88,7 +88,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -128,7 +128,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -147,7 +147,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -166,7 +166,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -178,7 +178,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -198,7 +198,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -257,7 +257,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -277,7 +277,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -315,7 +315,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -334,7 +334,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -353,7 +353,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -365,7 +365,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -385,7 +385,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -444,7 +444,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -464,7 +464,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -495,7 +495,7 @@
         "function": {
           "label": { "name": "foo2", "position": [9, 6] },
           "scope": {
-            "name": "$root::module_5::foo2",
+            "name": "$root::module_6::foo2",
             "variables": [
               {
                 "label": { "name": "t", "position": [9, 14] },
@@ -534,7 +534,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -552,7 +552,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -610,7 +610,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -629,7 +629,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -654,7 +654,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -710,7 +710,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -730,7 +730,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -768,7 +768,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -787,7 +787,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -812,7 +812,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -868,7 +868,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -888,7 +888,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_generics.3.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_generics.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_generics.3.abra",
   "code": [
     {
@@ -18,14 +18,14 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "arr", "position": [1, 13] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -63,7 +63,7 @@
               "label": { "name": "arr", "position": [1, 13] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -86,7 +86,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -105,7 +105,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -145,7 +145,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -164,7 +164,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -183,7 +183,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -202,7 +202,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -222,7 +222,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -280,7 +280,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -300,7 +300,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_generics.4.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_generics.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_generics.4.abra",
   "code": [
     {
@@ -18,14 +18,14 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "arr1", "position": [1, 13] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -39,7 +39,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -69,7 +69,7 @@
               "label": { "name": "arr1", "position": [1, 13] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -84,7 +84,7 @@
               "label": { "name": "arr2", "position": [1, 24] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -98,7 +98,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -117,7 +117,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -157,7 +157,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -176,7 +176,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -195,7 +195,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -208,7 +208,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -220,7 +220,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -240,7 +240,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -262,7 +262,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -303,7 +303,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -323,7 +323,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_generics.5.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_generics.5.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_generics.5.abra",
   "code": [
     {
@@ -18,14 +18,14 @@
         "function": {
           "label": { "name": "arrayMap", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::arrayMap",
+            "name": "$root::module_6::arrayMap",
             "variables": [
               {
                 "label": { "name": "arr", "position": [1, 21] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -82,7 +82,7 @@
               "label": { "name": "arr", "position": [1, 21] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -117,11 +117,11 @@
           ],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -141,11 +141,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -168,7 +168,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -204,7 +204,7 @@
         "function": {
           "label": { "name": "strLen", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::strLen",
+            "name": "$root::module_6::strLen",
             "variables": [
               {
                 "label": { "name": "s", "position": [3, 13] },
@@ -282,11 +282,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -307,11 +307,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -332,7 +332,7 @@
                     "required": true,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -363,11 +363,11 @@
                 ],
                 "returnType": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -389,7 +389,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -511,11 +511,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -537,11 +537,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_instantiation.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_instantiation.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_instantiation.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -41,7 +41,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -62,7 +62,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -83,7 +83,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -99,7 +99,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -140,7 +140,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -154,12 +154,12 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": []
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {

--- a/projects/compiler/test/typechecker/invocation/invocation_instantiation_generics.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_instantiation_generics.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_instantiation_generics.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [
             "T"
@@ -35,7 +35,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -56,7 +56,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -77,7 +77,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -93,7 +93,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -139,7 +139,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -158,7 +158,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -168,7 +168,7 @@
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -215,7 +215,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -235,7 +235,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -273,7 +273,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -292,7 +292,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -302,7 +302,7 @@
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -349,7 +349,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -369,7 +369,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -407,11 +407,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -432,11 +432,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -448,7 +448,7 @@
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -459,7 +459,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -469,7 +469,7 @@
                 },
                 "node": {
                   "kind": "invocation",
-                  "invokee": { "moduleId": 5, "name": "Foo" },
+                  "invokee": { "moduleId": 6, "name": "Foo" },
                   "arguments": [
                     {
                       "token": {
@@ -519,11 +519,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -545,11 +545,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": [
                   {
                     "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_instantiation_generics.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_instantiation_generics.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_instantiation_generics.2.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [
             "T",
@@ -35,7 +35,7 @@
               "name": { "name": "u", "position": [3, 3] },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -52,7 +52,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -72,7 +72,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -92,7 +92,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -113,7 +113,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -134,7 +134,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -150,7 +150,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -193,7 +193,7 @@
         "function": {
           "label": { "name": "foo", "position": [6, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -205,7 +205,7 @@
           "parameters": [],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -227,7 +227,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Foo" },
+                "struct": { "moduleId": 6, "name": "Foo" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -241,7 +241,7 @@
               },
               "node": {
                 "kind": "invocation",
-                "invokee": { "moduleId": 5, "name": "Foo" },
+                "invokee": { "moduleId": 6, "name": "Foo" },
                 "arguments": [
                   {
                     "token": {

--- a/projects/compiler/test/typechecker/invocation/invocation_macro.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_macro.1.out.json
@@ -30,7 +30,7 @@
           "parameters": [],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "InjectedCode" },
+            "struct": { "moduleId": 2, "name": "InjectedCode" },
             "typeParams": []
           },
           "body": [
@@ -43,7 +43,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "InjectedCode" },
+                "struct": { "moduleId": 2, "name": "InjectedCode" },
                 "typeParams": []
               },
               "node": {
@@ -63,7 +63,7 @@
                     ],
                     "returnType": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "InjectedCode" },
+                      "struct": { "moduleId": 2, "name": "InjectedCode" },
                       "typeParams": []
                     }
                   },
@@ -77,7 +77,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "InjectedCode" },
+                      "struct": { "moduleId": 2, "name": "InjectedCode" },
                       "typeParams": []
                     },
                     "node": {
@@ -89,7 +89,7 @@
                           "parameters": [],
                           "returnType": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "InjectedCode" },
+                            "struct": { "moduleId": 2, "name": "InjectedCode" },
                             "typeParams": []
                           }
                         }

--- a/projects/compiler/test/typechecker/invocation/invocation_macro.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_macro.2.out.json
@@ -25,11 +25,11 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Expr" },
+                      "struct": { "moduleId": 2, "name": "Expr" },
                       "typeParams": []
                     }
                   ]
@@ -40,7 +40,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "InjectedCode" },
+                  "struct": { "moduleId": 2, "name": "InjectedCode" },
                   "typeParams": []
                 }
               }
@@ -57,7 +57,7 @@
               "label": { "name": "values", "position": [4, 17] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "Expr" },
+                "struct": { "moduleId": 2, "name": "Expr" },
                 "typeParams": []
               },
               "defaultValue": null,
@@ -66,7 +66,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "InjectedCode" },
+            "struct": { "moduleId": 2, "name": "InjectedCode" },
             "typeParams": []
           },
           "body": [
@@ -93,7 +93,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "InjectedCode" },
+                      "struct": { "moduleId": 2, "name": "InjectedCode" },
                       "typeParams": []
                     }
                   }
@@ -107,7 +107,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "InjectedCode" },
+                    "struct": { "moduleId": 2, "name": "InjectedCode" },
                     "typeParams": []
                   },
                   "node": {
@@ -127,7 +127,7 @@
                         ],
                         "returnType": {
                           "kind": "instance",
-                          "struct": { "moduleId": 5, "name": "InjectedCode" },
+                          "struct": { "moduleId": 2, "name": "InjectedCode" },
                           "typeParams": []
                         }
                       },
@@ -141,7 +141,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 5, "name": "InjectedCode" },
+                          "struct": { "moduleId": 2, "name": "InjectedCode" },
                           "typeParams": []
                         },
                         "node": {
@@ -153,7 +153,7 @@
                               "parameters": [],
                               "returnType": {
                                 "kind": "instance",
-                                "struct": { "moduleId": 5, "name": "InjectedCode" },
+                                "struct": { "moduleId": 2, "name": "InjectedCode" },
                                 "typeParams": []
                               }
                             }
@@ -208,11 +208,11 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 5, "name": "Expr" },
+                        "struct": { "moduleId": 2, "name": "Expr" },
                         "typeParams": []
                       }
                     ]
@@ -233,7 +233,7 @@
                       "mutable": false,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 5, "name": "Expr" },
+                        "struct": { "moduleId": 2, "name": "Expr" },
                         "typeParams": []
                       }
                     }
@@ -257,7 +257,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "InjectedCode" },
+                      "struct": { "moduleId": 2, "name": "InjectedCode" },
                       "typeParams": []
                     },
                     "node": {
@@ -271,14 +271,14 @@
                               "required": true,
                               "type": {
                                 "kind": "instance",
-                                "struct": { "moduleId": 5, "name": "Expr" },
+                                "struct": { "moduleId": 2, "name": "Expr" },
                                 "typeParams": []
                               }
                             }
                           ],
                           "returnType": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "InjectedCode" },
+                            "struct": { "moduleId": 2, "name": "InjectedCode" },
                             "typeParams": []
                           }
                         },
@@ -293,7 +293,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "InjectedCode" },
+                            "struct": { "moduleId": 2, "name": "InjectedCode" },
                             "typeParams": []
                           },
                           "node": {
@@ -313,7 +313,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "Expr" },
+                            "struct": { "moduleId": 2, "name": "Expr" },
                             "typeParams": []
                           },
                           "node": {
@@ -392,11 +392,11 @@
                                 },
                                 "type": {
                                   "kind": "instance",
-                                  "struct": { "moduleId": 4, "name": "Array" },
+                                  "struct": { "moduleId": 5, "name": "Array" },
                                   "typeParams": [
                                     {
                                       "kind": "instance",
-                                      "struct": { "moduleId": 5, "name": "Expr" },
+                                      "struct": { "moduleId": 2, "name": "Expr" },
                                       "typeParams": []
                                     }
                                   ]
@@ -430,7 +430,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "InjectedCode" },
+                            "struct": { "moduleId": 2, "name": "InjectedCode" },
                             "typeParams": []
                           },
                           "node": {
@@ -450,7 +450,7 @@
                                 ],
                                 "returnType": {
                                   "kind": "instance",
-                                  "struct": { "moduleId": 5, "name": "InjectedCode" },
+                                  "struct": { "moduleId": 2, "name": "InjectedCode" },
                                   "typeParams": []
                                 }
                               },
@@ -465,7 +465,7 @@
                                 },
                                 "type": {
                                   "kind": "instance",
-                                  "struct": { "moduleId": 5, "name": "InjectedCode" },
+                                  "struct": { "moduleId": 2, "name": "InjectedCode" },
                                   "typeParams": []
                                 },
                                 "node": {
@@ -511,7 +511,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 5, "name": "InjectedCode" },
+                "struct": { "moduleId": 2, "name": "InjectedCode" },
                 "typeParams": []
               },
               "node": {
@@ -531,7 +531,7 @@
                     ],
                     "returnType": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "InjectedCode" },
+                      "struct": { "moduleId": 2, "name": "InjectedCode" },
                       "typeParams": []
                     }
                   },
@@ -546,7 +546,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "InjectedCode" },
+                      "struct": { "moduleId": 2, "name": "InjectedCode" },
                       "typeParams": []
                     },
                     "node": {

--- a/projects/compiler/test/typechecker/invocation/invocation_method.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_method.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_method.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -33,7 +33,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -54,7 +54,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -75,7 +75,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -91,7 +91,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -107,14 +107,14 @@
             {
               "label": { "name": "foo", "position": [4, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [4, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   },
@@ -181,7 +181,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 5, "name": "Foo" },
+                          "struct": { "moduleId": 6, "name": "Foo" },
                           "typeParams": []
                         },
                         "node": {
@@ -288,7 +288,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -372,7 +372,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": []
                 },
                 "node": {
@@ -527,7 +527,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": []
                 },
                 "node": {

--- a/projects/compiler/test/typechecker/invocation/invocation_method.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_method.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_method.2.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -33,7 +33,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -54,7 +54,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -75,7 +75,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -91,7 +91,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -107,14 +107,14 @@
             {
               "label": { "name": "foo", "position": [4, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [4, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   },
@@ -200,7 +200,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "Foo" },
+                            "struct": { "moduleId": 6, "name": "Foo" },
                             "typeParams": []
                           },
                           "node": {
@@ -293,14 +293,14 @@
             {
               "label": { "name": "bar", "position": [5, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::bar",
+                "name": "$root::module_6::Foo::bar",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [5, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   },
@@ -376,7 +376,7 @@
                           },
                           "type": {
                             "kind": "instance",
-                            "struct": { "moduleId": 5, "name": "Foo" },
+                            "struct": { "moduleId": 6, "name": "Foo" },
                             "typeParams": []
                           },
                           "node": {
@@ -437,14 +437,14 @@
             {
               "label": { "name": "baz", "position": [8, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::baz",
+                "name": "$root::module_6::Foo::baz",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [8, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   },
@@ -534,7 +534,7 @@
                               },
                               "type": {
                                 "kind": "instance",
-                                "struct": { "moduleId": 5, "name": "Foo" },
+                                "struct": { "moduleId": 6, "name": "Foo" },
                                 "typeParams": []
                               },
                               "node": {
@@ -606,7 +606,7 @@
                               },
                               "type": {
                                 "kind": "instance",
-                                "struct": { "moduleId": 5, "name": "Foo" },
+                                "struct": { "moduleId": 6, "name": "Foo" },
                                 "typeParams": []
                               },
                               "node": {
@@ -677,7 +677,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }
@@ -754,7 +754,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": []
                 },
                 "node": {

--- a/projects/compiler/test/typechecker/invocation/invocation_method_generics.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_method_generics.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_method_generics.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [
             "T"
@@ -35,7 +35,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -56,7 +56,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -77,7 +77,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -93,7 +93,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -114,14 +114,14 @@
             {
               "label": { "name": "foo", "position": [4, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [4, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -160,7 +160,7 @@
               ],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -178,7 +178,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -211,7 +211,7 @@
                             },
                             "type": {
                               "kind": "instance",
-                              "struct": { "moduleId": 5, "name": "Foo" },
+                              "struct": { "moduleId": 6, "name": "Foo" },
                               "typeParams": [
                                 {
                                   "kind": "generic",
@@ -285,7 +285,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -304,7 +304,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 5, "name": "Foo" },
+            "struct": { "moduleId": 6, "name": "Foo" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -314,7 +314,7 @@
           },
           "node": {
             "kind": "invocation",
-            "invokee": { "moduleId": 5, "name": "Foo" },
+            "invokee": { "moduleId": 6, "name": "Foo" },
             "arguments": [
               {
                 "token": {
@@ -361,7 +361,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -380,7 +380,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -405,7 +405,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -425,7 +425,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -485,7 +485,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -505,7 +505,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_method_generics.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_method_generics.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_method_generics.2.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [
             "T"
@@ -35,7 +35,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -56,7 +56,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -77,7 +77,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -93,7 +93,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -114,14 +114,14 @@
             {
               "label": { "name": "foo", "position": [4, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [4, 15] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -235,7 +235,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -324,7 +324,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 5, "name": "Foo" },
+                  "struct": { "moduleId": 6, "name": "Foo" },
                   "typeParams": [
                     {
                       "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_variadic.1.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_variadic.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_variadic.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },
@@ -33,7 +33,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -98,7 +98,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -118,7 +118,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -203,7 +203,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -320,7 +320,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -402,7 +402,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -484,7 +484,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -584,7 +584,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/projects/compiler/test/typechecker/invocation/invocation_variadic.2.out.json
+++ b/projects/compiler/test/typechecker/invocation/invocation_variadic.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/invocation/invocation_variadic.2.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 13] },
@@ -33,7 +33,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -106,7 +106,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -126,7 +126,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -211,7 +211,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -328,7 +328,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -410,7 +410,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -492,7 +492,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -592,7 +592,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/projects/compiler/test/typechecker/lambda/lambda.1.out.json
+++ b/projects/compiler/test/typechecker/lambda/lambda.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/lambda/lambda.1.abra",
   "code": [
     {
@@ -81,9 +81,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_1_37", "position": [1, 37] },
+              "label": { "name": "lambda_6_1_37", "position": [1, 37] },
               "scope": {
-                "name": "$root::module_5::lambda_5_1_37",
+                "name": "$root::module_6::lambda_6_1_37",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [1, 31] },
@@ -269,9 +269,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_2_28", "position": [2, 28] },
+              "label": { "name": "lambda_6_2_28", "position": [2, 28] },
               "scope": {
-                "name": "$root::module_5::lambda_5_2_28",
+                "name": "$root::module_6::lambda_6_2_28",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [2, 12] },
@@ -412,7 +412,7 @@
               ],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -443,7 +443,7 @@
             ],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -455,9 +455,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_3_20", "position": [3, 20] },
+              "label": { "name": "lambda_6_3_20", "position": [3, 20] },
               "scope": {
-                "name": "$root::module_5::lambda_5_3_20",
+                "name": "$root::module_6::lambda_6_3_20",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [3, 12] },
@@ -488,7 +488,7 @@
               ],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -506,7 +506,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -545,7 +545,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Option" },
+                          "enum": { "moduleId": 5, "name": "Option" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -565,7 +565,7 @@
                             },
                             "type": {
                               "kind": "enum",
-                              "enum": { "moduleId": 4, "name": "Option" }
+                              "enum": { "moduleId": 5, "name": "Option" }
                             },
                             "node": {
                               "kind": "identifier",
@@ -590,7 +590,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Option" },
+                          "enum": { "moduleId": 5, "name": "Option" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -696,9 +696,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_4_33", "position": [4, 33] },
+              "label": { "name": "lambda_6_4_33", "position": [4, 33] },
               "scope": {
-                "name": "$root::module_5::lambda_5_4_33",
+                "name": "$root::module_6::lambda_6_4_33",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [4, 26] },
@@ -876,9 +876,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_5_36", "position": [5, 36] },
+              "label": { "name": "lambda_6_5_36", "position": [5, 36] },
               "scope": {
-                "name": "$root::module_5::lambda_5_5_36",
+                "name": "$root::module_6::lambda_6_5_36",
                 "variables": [
                   {
                     "label": { "name": "a", "position": [5, 26] },
@@ -1027,7 +1027,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1050,7 +1050,7 @@
             "parameters": [],
             "returnType": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1062,9 +1062,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_7_27", "position": [7, 27] },
+              "label": { "name": "lambda_6_7_27", "position": [7, 27] },
               "scope": {
-                "name": "$root::module_5::lambda_5_7_27",
+                "name": "$root::module_6::lambda_6_7_27",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1076,7 +1076,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1094,7 +1094,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1139,11 +1139,11 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1168,11 +1168,11 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1186,9 +1186,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_8_28", "position": [8, 28] },
+              "label": { "name": "lambda_6_8_28", "position": [8, 28] },
               "scope": {
-                "name": "$root::module_5::lambda_5_8_28",
+                "name": "$root::module_6::lambda_6_8_28",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1200,11 +1200,11 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1224,11 +1224,11 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1251,7 +1251,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -1299,11 +1299,11 @@
               "parameters": [],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1328,11 +1328,11 @@
             "parameters": [],
             "returnType": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1346,9 +1346,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_9_28", "position": [9, 28] },
+              "label": { "name": "lambda_6_9_28", "position": [9, 28] },
               "scope": {
-                "name": "$root::module_5::lambda_5_9_28",
+                "name": "$root::module_6::lambda_6_9_28",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1360,11 +1360,11 @@
               "parameters": [],
               "returnType": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1384,11 +1384,11 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",

--- a/projects/compiler/test/typechecker/lambda/lambda.2.out.json
+++ b/projects/compiler/test/typechecker/lambda/lambda.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/lambda/lambda.2.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -134,7 +134,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -154,7 +154,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -192,7 +192,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -211,7 +211,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -255,7 +255,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -275,7 +275,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -316,9 +316,9 @@
                 "node": {
                   "kind": "lambda",
                   "function": {
-                    "label": { "name": "lambda_5_4_25", "position": [4, 25] },
+                    "label": { "name": "lambda_6_4_25", "position": [4, 25] },
                     "scope": {
-                      "name": "$root::module_5::lambda_5_4_25",
+                      "name": "$root::module_6::lambda_6_4_25",
                       "variables": [
                         {
                           "label": { "name": "x", "position": [4, 22] },
@@ -434,7 +434,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -454,7 +454,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -485,14 +485,14 @@
         "function": {
           "label": { "name": "forEach", "position": [8, 6] },
           "scope": {
-            "name": "$root::module_5::forEach",
+            "name": "$root::module_6::forEach",
             "variables": [
               {
                 "label": { "name": "set", "position": [8, 17] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -543,7 +543,7 @@
               "label": { "name": "set", "position": [8, 17] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Set" },
+                "struct": { "moduleId": 5, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -635,7 +635,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Set" },
+                      "struct": { "moduleId": 5, "name": "Set" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -676,9 +676,9 @@
                     "node": {
                       "kind": "lambda",
                       "function": {
-                        "label": { "name": "lambda_5_9_19", "position": [9, 19] },
+                        "label": { "name": "lambda_6_9_19", "position": [9, 19] },
                         "scope": {
-                          "name": "$root::module_5::forEach::lambda_5_9_19",
+                          "name": "$root::module_6::forEach::lambda_6_9_19",
                           "variables": [
                             {
                               "label": { "name": "key", "position": [9, 15] },
@@ -825,14 +825,14 @@
         "function": {
           "label": { "name": "map", "position": [11, 6] },
           "scope": {
-            "name": "$root::module_5::map",
+            "name": "$root::module_6::map",
             "variables": [
               {
                 "label": { "name": "arr", "position": [11, 16] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -867,7 +867,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -904,7 +904,7 @@
               "label": { "name": "arr", "position": [11, 16] },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -939,7 +939,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -971,7 +971,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -990,7 +990,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -1034,7 +1034,7 @@
                         ],
                         "returnType": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -1054,7 +1054,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -1095,9 +1095,9 @@
                         "node": {
                           "kind": "lambda",
                           "function": {
-                            "label": { "name": "lambda_5_12_26", "position": [12, 26] },
+                            "label": { "name": "lambda_6_12_26", "position": [12, 26] },
                             "scope": {
-                              "name": "$root::module_5::map::lambda_5_12_26",
+                              "name": "$root::module_6::map::lambda_6_12_26",
                               "variables": [
                                 {
                                   "label": { "name": "v", "position": [12, 24] },
@@ -1236,7 +1236,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",

--- a/projects/compiler/test/typechecker/lambda/lambda_generic_inference.1.out.json
+++ b/projects/compiler/test/typechecker/lambda/lambda_generic_inference.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/lambda/lambda_generic_inference.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "fn", "position": [1, 13] },
@@ -28,7 +28,7 @@
                   "parameters": [],
                   "returnType": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -43,7 +43,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -76,7 +76,7 @@
                 "parameters": [],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -91,7 +91,7 @@
           ],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "generic",
@@ -123,7 +123,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -142,7 +142,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -165,7 +165,7 @@
                         "parameters": [],
                         "returnType": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -206,7 +206,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -241,7 +241,7 @@
         "function": {
           "label": { "name": "bar", "position": [6, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -253,7 +253,7 @@
           "parameters": [],
           "returnType": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -271,7 +271,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -329,7 +329,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -348,7 +348,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -370,7 +370,7 @@
                       "parameters": [],
                       "returnType": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "generic",
@@ -383,7 +383,7 @@
                 ],
                 "returnType": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "generic",
@@ -406,7 +406,7 @@
                   "parameters": [],
                   "returnType": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -418,9 +418,9 @@
                 "node": {
                   "kind": "lambda",
                   "function": {
-                    "label": { "name": "lambda_5_8_16", "position": [8, 16] },
+                    "label": { "name": "lambda_6_8_16", "position": [8, 16] },
                     "scope": {
-                      "name": "$root::module_5::lambda_5_8_16",
+                      "name": "$root::module_6::lambda_6_8_16",
                       "variables": [],
                       "functions": [],
                       "structs": [],
@@ -432,7 +432,7 @@
                     "parameters": [],
                     "returnType": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -450,7 +450,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -467,7 +467,7 @@
                               "parameters": [],
                               "returnType": {
                                 "kind": "instance",
-                                "struct": { "moduleId": 4, "name": "Array" },
+                                "struct": { "moduleId": 5, "name": "Array" },
                                 "typeParams": [
                                   {
                                     "kind": "primitive",
@@ -512,7 +512,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -532,7 +532,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/lambda/lambda_generic_inference.2.out.json
+++ b/projects/compiler/test/typechecker/lambda/lambda_generic_inference.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/lambda/lambda_generic_inference.2.abra",
   "code": [
     {
@@ -28,7 +28,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -55,7 +55,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Result" },
+              "enum": { "moduleId": 5, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -71,9 +71,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_1_14", "position": [1, 14] },
+              "label": { "name": "lambda_6_1_14", "position": [1, 14] },
               "scope": {
-                "name": "$root::module_5::lambda_5_1_14",
+                "name": "$root::module_6::lambda_6_1_14",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -85,7 +85,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -152,7 +152,7 @@
                             },
                             "type": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -181,7 +181,7 @@
                                   ],
                                   "returnType": {
                                     "kind": "enumInstance",
-                                    "enum": { "moduleId": 4, "name": "Result" },
+                                    "enum": { "moduleId": 5, "name": "Result" },
                                     "typeParams": [
                                       {
                                         "kind": "generic",
@@ -231,7 +231,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Result" },
+                    "enum": { "moduleId": 5, "name": "Result" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -260,7 +260,7 @@
                         ],
                         "returnType": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "generic",
@@ -327,7 +327,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -355,7 +355,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Result" },
+              "enum": { "moduleId": 5, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -401,7 +401,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -428,7 +428,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Result" },
+              "enum": { "moduleId": 5, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -444,9 +444,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_8_14", "position": [8, 14] },
+              "label": { "name": "lambda_6_8_14", "position": [8, 14] },
               "scope": {
-                "name": "$root::module_5::lambda_5_8_14",
+                "name": "$root::module_6::lambda_6_8_14",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -458,7 +458,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -480,7 +480,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Result" },
+                    "enum": { "moduleId": 5, "name": "Result" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -523,7 +523,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -552,7 +552,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Result" },
+                                "enum": { "moduleId": 5, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -598,7 +598,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -627,7 +627,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Result" },
+                                "enum": { "moduleId": 5, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -697,7 +697,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -725,7 +725,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Result" },
+              "enum": { "moduleId": 5, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -771,7 +771,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -798,7 +798,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Result" },
+              "enum": { "moduleId": 5, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -814,9 +814,9 @@
           "node": {
             "kind": "lambda",
             "function": {
-              "label": { "name": "lambda_5_11_14", "position": [11, 14] },
+              "label": { "name": "lambda_6_11_14", "position": [11, 14] },
               "scope": {
-                "name": "$root::module_5::lambda_5_11_14",
+                "name": "$root::module_6::lambda_6_11_14",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -828,7 +828,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -850,7 +850,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Result" },
+                    "enum": { "moduleId": 5, "name": "Result" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -893,7 +893,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -922,7 +922,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Result" },
+                                "enum": { "moduleId": 5, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -968,7 +968,7 @@
                         },
                         "type": {
                           "kind": "enumInstance",
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -997,7 +997,7 @@
                               ],
                               "returnType": {
                                 "kind": "enumInstance",
-                                "enum": { "moduleId": 4, "name": "Result" },
+                                "enum": { "moduleId": 5, "name": "Result" },
                                 "typeParams": [
                                   {
                                     "kind": "generic",
@@ -1067,7 +1067,7 @@
               "parameters": [],
               "returnType": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1095,7 +1095,7 @@
             "parameters": [],
             "returnType": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Result" },
+              "enum": { "moduleId": 5, "name": "Result" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/projects/compiler/test/typechecker/literals/literals.out.json
+++ b/projects/compiler/test/typechecker/literals/literals.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/literals/literals.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/literals/string_interpolation.out.json
+++ b/projects/compiler/test/typechecker/literals/string_interpolation.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/literals/string_interpolation.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -315,7 +315,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -397,7 +397,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -496,7 +496,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",

--- a/projects/compiler/test/typechecker/map/map.out.json
+++ b/projects/compiler/test/typechecker/map/map.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/map/map.abra",
   "code": [
     {
@@ -11,7 +11,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Map" },
+        "struct": { "moduleId": 5, "name": "Map" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -110,7 +110,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Map" },
+        "struct": { "moduleId": 5, "name": "Map" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -118,7 +118,7 @@
           },
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -126,7 +126,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -168,7 +168,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Map" },
+                "struct": { "moduleId": 5, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -176,7 +176,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -216,7 +216,7 @@
                       },
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -296,7 +296,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Map" },
+                "struct": { "moduleId": 5, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -304,7 +304,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -332,7 +332,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Map" },
+        "struct": { "moduleId": 5, "name": "Map" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -340,7 +340,7 @@
           },
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -348,7 +348,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -390,7 +390,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Map" },
+                "struct": { "moduleId": 5, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -398,7 +398,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -441,7 +441,7 @@
               },
               "type": {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Map" },
+                "struct": { "moduleId": 5, "name": "Map" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -449,7 +449,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -489,7 +489,7 @@
                       },
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -568,7 +568,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -591,7 +591,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -633,7 +633,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -656,7 +656,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -735,11 +735,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -764,11 +764,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -812,11 +812,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -841,11 +841,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -872,7 +872,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -932,7 +932,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -952,7 +952,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 4, "name": "Option" }
+                        "enum": { "moduleId": 5, "name": "Option" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -1012,11 +1012,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1026,11 +1026,11 @@
                 },
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1053,11 +1053,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1067,11 +1067,11 @@
               },
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1096,7 +1096,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1137,11 +1137,11 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1164,7 +1164,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -1191,7 +1191,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1211,7 +1211,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 4, "name": "Option" }
+                        "enum": { "moduleId": 5, "name": "Option" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -1234,11 +1234,11 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1260,7 +1260,7 @@
                       },
                       "type": {
                         "kind": "enum",
-                        "enum": { "moduleId": 4, "name": "Option" }
+                        "enum": { "moduleId": 5, "name": "Option" }
                       },
                       "node": {
                         "kind": "identifier",
@@ -1285,7 +1285,7 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1326,11 +1326,11 @@
                   },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1353,7 +1353,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",
@@ -1433,11 +1433,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Map" },
+              "struct": { "moduleId": 5, "name": "Map" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1447,11 +1447,11 @@
                 },
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1475,11 +1475,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Map" },
+            "struct": { "moduleId": 5, "name": "Map" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1489,11 +1489,11 @@
               },
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/projects/compiler/test/typechecker/match/match_Result.out.json
+++ b/projects/compiler/test/typechecker/match/match_Result.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/match/match_Result.abra",
   "code": [
     {
@@ -18,14 +18,14 @@
         "function": {
           "label": { "name": "addOne", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::addOne",
+            "name": "$root::module_6::addOne",
             "variables": [
               {
                 "label": { "name": "res", "position": [1, 13] },
                 "mutable": false,
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Result" },
+                  "enum": { "moduleId": 5, "name": "Result" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -59,7 +59,7 @@
               "label": { "name": "res", "position": [1, 13] },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -77,7 +77,7 @@
           ],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -141,7 +141,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Result" },
+                        "enum": { "moduleId": 5, "name": "Result" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -163,7 +163,7 @@
                         "kind": {
                           "kind": "enumVariant",
                           "variantIdx": 0,
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "destructuredVariables": [
                             {
                               "label": { "name": "v", "position": [2, 26] },
@@ -200,7 +200,7 @@
                         "kind": {
                           "kind": "enumVariant",
                           "variantIdx": 1,
-                          "enum": { "moduleId": 4, "name": "Result" },
+                          "enum": { "moduleId": 5, "name": "Result" },
                           "destructuredVariables": [
                             {
                               "label": { "name": "e", "position": [2, 38] },
@@ -235,7 +235,7 @@
                                 },
                                 "type": {
                                   "kind": "enumInstance",
-                                  "enum": { "moduleId": 4, "name": "Result" },
+                                  "enum": { "moduleId": 5, "name": "Result" },
                                   "typeParams": [
                                     {
                                       "kind": "primitive",
@@ -264,7 +264,7 @@
                                       ],
                                       "returnType": {
                                         "kind": "enumInstance",
-                                        "enum": { "moduleId": 4, "name": "Result" },
+                                        "enum": { "moduleId": 5, "name": "Result" },
                                         "typeParams": [
                                           {
                                             "kind": "generic",
@@ -317,7 +317,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -346,7 +346,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",

--- a/projects/compiler/test/typechecker/match/match_expr.out.json
+++ b/projects/compiler/test/typechecker/match/match_expr.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/match/match_expr.abra",
   "code": [
     {
@@ -158,7 +158,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -177,7 +177,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -267,7 +267,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -286,7 +286,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -308,7 +308,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -394,7 +394,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -596,7 +596,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -864,7 +864,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1069,7 +1069,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1240,7 +1240,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Color", "position": [34, 6] },
           "typeParams": [],
           "variants": [
@@ -1261,7 +1261,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Color::toString",
+                "name": "$root::module_6::Color::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1282,7 +1282,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Color::hash",
+                "name": "$root::module_6::Color::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1303,7 +1303,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Color::eq",
+                "name": "$root::module_6::Color::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1319,7 +1319,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -1360,11 +1360,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 }
               ]
@@ -1380,11 +1380,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color" },
+                "enum": { "moduleId": 6, "name": "Color" },
                 "typeParams": []
               }
             ]
@@ -1401,7 +1401,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 },
                 "node": {
@@ -1416,7 +1416,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 5, "name": "Color" }
+                      "enum": { "moduleId": 6, "name": "Color" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1439,7 +1439,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 },
                 "node": {
@@ -1454,7 +1454,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 5, "name": "Color" }
+                      "enum": { "moduleId": 6, "name": "Color" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1477,7 +1477,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 },
                 "node": {
@@ -1492,7 +1492,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 5, "name": "Color" }
+                      "enum": { "moduleId": 6, "name": "Color" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -1534,11 +1534,11 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "typeParams": []
                 }
               ]
@@ -1554,11 +1554,11 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color" },
+                "enum": { "moduleId": 6, "name": "Color" },
                 "typeParams": []
               }
             ]
@@ -1577,11 +1577,11 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Color" },
+                      "enum": { "moduleId": 6, "name": "Color" },
                       "typeParams": []
                     }
                   ]
@@ -1636,7 +1636,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color" },
+              "enum": { "moduleId": 6, "name": "Color" },
               "typeParams": []
             }
           }
@@ -1650,7 +1650,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Color" },
+            "enum": { "moduleId": 6, "name": "Color" },
             "typeParams": []
           },
           "node": {
@@ -1666,11 +1666,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   }
                 ]
@@ -1685,7 +1685,7 @@
                 "kind": {
                   "kind": "enumVariant",
                   "variantIdx": 0,
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "destructuredVariables": []
                 },
                 "binding": {
@@ -1693,7 +1693,7 @@
                   "mutable": false,
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   }
                 },
@@ -1708,7 +1708,7 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Color" },
+                      "enum": { "moduleId": 6, "name": "Color" },
                       "typeParams": []
                     },
                     "node": {
@@ -1722,7 +1722,7 @@
                 "kind": {
                   "kind": "enumVariant",
                   "variantIdx": 1,
-                  "enum": { "moduleId": 5, "name": "Color" },
+                  "enum": { "moduleId": 6, "name": "Color" },
                   "destructuredVariables": []
                 },
                 "binding": {
@@ -1730,7 +1730,7 @@
                   "mutable": false,
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color" },
+                    "enum": { "moduleId": 6, "name": "Color" },
                     "typeParams": []
                   }
                 },
@@ -1745,7 +1745,7 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Color" },
+                      "enum": { "moduleId": 6, "name": "Color" },
                       "typeParams": []
                     },
                     "node": {
@@ -1768,7 +1768,7 @@
                     },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Color" },
+                      "enum": { "moduleId": 6, "name": "Color" },
                       "typeParams": []
                     },
                     "node": {
@@ -1783,7 +1783,7 @@
                         },
                         "type": {
                           "kind": "enum",
-                          "enum": { "moduleId": 5, "name": "Color" }
+                          "enum": { "moduleId": 6, "name": "Color" }
                         },
                         "node": {
                           "kind": "identifier",
@@ -1827,7 +1827,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color" },
+              "enum": { "moduleId": 6, "name": "Color" },
               "typeParams": []
             }
           }
@@ -1842,7 +1842,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Color" },
+            "enum": { "moduleId": 6, "name": "Color" },
             "typeParams": []
           },
           "node": {
@@ -1866,7 +1866,7 @@
       "node": {
         "kind": "enumDeclaration",
         "enum": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Color2", "position": [45, 6] },
           "typeParams": [],
           "variants": [
@@ -1908,7 +1908,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Color2::toString",
+                "name": "$root::module_6::Color2::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1929,7 +1929,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Color2::hash",
+                "name": "$root::module_6::Color2::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1950,7 +1950,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Color2::eq",
+                "name": "$root::module_6::Color2::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -1966,7 +1966,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 5, "name": "Color2" },
+                    "enum": { "moduleId": 6, "name": "Color2" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -2007,7 +2007,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 5, "name": "Color2" },
+              "enum": { "moduleId": 6, "name": "Color2" },
               "typeParams": []
             }
           }
@@ -2021,7 +2021,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 5, "name": "Color2" },
+            "enum": { "moduleId": 6, "name": "Color2" },
             "typeParams": []
           },
           "node": {
@@ -2135,7 +2135,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 5, "name": "Color2" },
+                "enum": { "moduleId": 6, "name": "Color2" },
                 "typeParams": []
               },
               "node": {
@@ -2148,7 +2148,7 @@
                 "kind": {
                   "kind": "enumVariant",
                   "variantIdx": 0,
-                  "enum": { "moduleId": 5, "name": "Color2" },
+                  "enum": { "moduleId": 6, "name": "Color2" },
                   "destructuredVariables": [
                     {
                       "label": { "name": "r", "position": [48, 14] },

--- a/projects/compiler/test/typechecker/match/match_expr_terminators.out.json
+++ b/projects/compiler/test/typechecker/match/match_expr_terminators.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/match/match_expr_terminators.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [2, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 10] },
@@ -823,7 +823,7 @@
         "function": {
           "label": { "name": "bar", "position": [31, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [],
             "functions": [],
             "structs": [],

--- a/projects/compiler/test/typechecker/match/match_stmt.out.json
+++ b/projects/compiler/test/typechecker/match/match_stmt.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/match/match_stmt.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/multi_error_reporting/binding_decl.out.json
+++ b/projects/compiler/test/typechecker/multi_error_reporting/binding_decl.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/multi_error_reporting/binding_decl.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "a", "position": [2, 7] },
@@ -100,7 +100,7 @@
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "hole"
@@ -629,7 +629,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "hole"
@@ -647,7 +647,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "hole"
@@ -1046,7 +1046,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "hole"

--- a/projects/compiler/test/typechecker/multi_error_reporting/could_not_resolve_types.out.json
+++ b/projects/compiler/test/typechecker/multi_error_reporting/could_not_resolve_types.out.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 5,
+    "id": 6,
     "name": "%TEST_DIR%/typechecker/multi_error_reporting/_exports.abra",
     "exports": [
       {
@@ -27,7 +27,7 @@
         "node": {
           "kind": "typeDeclaration",
           "struct": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Foo", "position": [1, 10] },
             "typeParams": [],
             "fields": [],
@@ -35,7 +35,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::toString",
+                  "name": "$root::module_6::Foo::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -56,7 +56,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::hash",
+                  "name": "$root::module_6::Foo::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -77,7 +77,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Foo::eq",
+                  "name": "$root::module_6::Foo::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -93,7 +93,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -125,7 +125,7 @@
         "node": {
           "kind": "enumDeclaration",
           "enum": {
-            "moduleId": 5,
+            "moduleId": 6,
             "name": { "name": "Bar", "position": [2, 10] },
             "typeParams": [],
             "variants": [],
@@ -133,7 +133,7 @@
               {
                 "label": { "name": "toString", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Bar::toString",
+                  "name": "$root::module_6::Bar::toString",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -154,7 +154,7 @@
               {
                 "label": { "name": "hash", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Bar::hash",
+                  "name": "$root::module_6::Bar::hash",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -175,7 +175,7 @@
               {
                 "label": { "name": "eq", "position": [0, 0] },
                 "scope": {
-                  "name": "$root::module_5::Bar::eq",
+                  "name": "$root::module_6::Bar::eq",
                   "variables": [],
                   "functions": [],
                   "structs": [],
@@ -191,7 +191,7 @@
                     "label": { "name": "other", "position": [0, 0] },
                     "type": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 5, "name": "Bar" },
+                      "enum": { "moduleId": 6, "name": "Bar" },
                       "typeParams": []
                     },
                     "defaultValue": null,
@@ -212,7 +212,7 @@
     ]
   },
   {
-    "id": 6,
+    "id": 7,
     "name": "%TEST_DIR%/typechecker/multi_error_reporting/could_not_resolve_types.abra",
     "code": [
       {
@@ -231,7 +231,7 @@
           "function": {
             "label": { "name": "bar", "position": [3, 6] },
             "scope": {
-              "name": "$root::module_6::bar",
+              "name": "$root::module_7::bar",
               "variables": [
                 {
                   "label": { "name": "a", "position": [3, 10] },
@@ -358,7 +358,7 @@
                   "mutable": false,
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "could not determine"
@@ -1581,7 +1581,7 @@
                       "mutable": false,
                       "type": {
                         "kind": "instance",
-                        "struct": { "moduleId": 4, "name": "Array" },
+                        "struct": { "moduleId": 5, "name": "Array" },
                         "typeParams": [
                           {
                             "kind": "could not determine"
@@ -1599,7 +1599,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "could not determine"
@@ -2267,7 +2267,7 @@
           "function": {
             "label": { "name": "baz", "position": [49, 6] },
             "scope": {
-              "name": "$root::module_6::baz",
+              "name": "$root::module_7::baz",
               "variables": [
                 {
                   "label": { "name": "try1", "position": [50, 7] },

--- a/projects/compiler/test/typechecker/return/return.1.out.json
+++ b/projects/compiler/test/typechecker/return/return.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/return/return.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "s", "position": [2, 7] },

--- a/projects/compiler/test/typechecker/return/return.2.out.json
+++ b/projects/compiler/test/typechecker/return/return.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/return/return.2.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "s", "position": [2, 7] },

--- a/projects/compiler/test/typechecker/return/return.3.out.json
+++ b/projects/compiler/test/typechecker/return/return.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/return/return.3.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [
               {
                 "label": { "name": "s", "position": [5, 7] },

--- a/projects/compiler/test/typechecker/set/set.out.json
+++ b/projects/compiler/test/typechecker/set/set.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/set/set.abra",
   "code": [
     {
@@ -11,7 +11,7 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "primitive",
@@ -85,11 +85,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Set" },
+            "struct": { "moduleId": 5, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -111,7 +111,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -168,7 +168,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -242,7 +242,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -261,7 +261,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Set" },
+            "struct": { "moduleId": 5, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -299,7 +299,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -318,7 +318,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Set" },
+            "struct": { "moduleId": 5, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -408,11 +408,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -433,11 +433,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Set" },
+            "struct": { "moduleId": 5, "name": "Set" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -459,7 +459,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -500,7 +500,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -520,7 +520,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -543,7 +543,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -603,11 +603,11 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -628,11 +628,11 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Set" },
+            "struct": { "moduleId": 5, "name": "Set" },
             "typeParams": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -654,7 +654,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -674,7 +674,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",
@@ -697,7 +697,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -738,7 +738,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -784,11 +784,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Set" },
+            "struct": { "moduleId": 5, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -810,7 +810,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -867,7 +867,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -889,7 +889,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -949,11 +949,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -975,7 +975,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1016,7 +1016,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1057,7 +1057,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1077,7 +1077,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1100,7 +1100,7 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1144,15 +1144,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Set" },
+                "struct": { "moduleId": 5, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -1176,11 +1176,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1203,7 +1203,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1263,11 +1263,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1290,7 +1290,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1350,11 +1350,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1376,7 +1376,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -1399,11 +1399,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -1426,7 +1426,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1503,15 +1503,15 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1534,15 +1534,15 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Set" },
+                "struct": { "moduleId": 5, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "enumInstance",
-                    "enum": { "moduleId": 4, "name": "Option" },
+                    "enum": { "moduleId": 5, "name": "Option" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -1567,11 +1567,11 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Option" },
+                      "enum": { "moduleId": 5, "name": "Option" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -1593,7 +1593,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -1613,7 +1613,7 @@
                           },
                           "type": {
                             "kind": "enum",
-                            "enum": { "moduleId": 4, "name": "Option" }
+                            "enum": { "moduleId": 5, "name": "Option" }
                           },
                           "node": {
                             "kind": "identifier",
@@ -1644,11 +1644,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1670,7 +1670,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1692,7 +1692,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1749,7 +1749,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1809,11 +1809,11 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Set" },
+            "struct": { "moduleId": 5, "name": "Set" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -1835,7 +1835,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1857,7 +1857,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1914,7 +1914,7 @@
             },
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Set" },
+              "struct": { "moduleId": 5, "name": "Set" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -1974,15 +1974,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Set" },
+                "struct": { "moduleId": 5, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2006,11 +2006,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2033,7 +2033,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2058,11 +2058,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2084,7 +2084,7 @@
                 },
                 "type": {
                   "kind": "enum",
-                  "enum": { "moduleId": 4, "name": "Option" }
+                  "enum": { "moduleId": 5, "name": "Option" }
                 },
                 "node": {
                   "kind": "identifier",
@@ -2107,11 +2107,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2134,7 +2134,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2197,15 +2197,15 @@
       },
       "type": {
         "kind": "instance",
-        "struct": { "moduleId": 4, "name": "Set" },
+        "struct": { "moduleId": 5, "name": "Set" },
         "typeParams": [
           {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Set" },
+                "struct": { "moduleId": 5, "name": "Set" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -2229,11 +2229,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2256,7 +2256,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -2281,11 +2281,11 @@
             },
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Set" },
+                  "struct": { "moduleId": 5, "name": "Set" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -2308,7 +2308,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Set" },
+                    "struct": { "moduleId": 5, "name": "Set" },
                     "typeParams": [
                       {
                         "kind": "primitive",

--- a/projects/compiler/test/typechecker/try/try.1.out.json
+++ b/projects/compiler/test/typechecker/try/try.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/try/try.1.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -30,7 +30,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -52,7 +52,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -81,7 +81,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -136,7 +136,7 @@
         "function": {
           "label": { "name": "bar", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "x", "position": [4, 7] },
@@ -157,7 +157,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -219,7 +219,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Result" },
+                        "enum": { "moduleId": 5, "name": "Result" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -240,7 +240,7 @@
                             "parameters": [],
                             "returnType": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -270,7 +270,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -299,7 +299,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",

--- a/projects/compiler/test/typechecker/try/try.2.out.json
+++ b/projects/compiler/test/typechecker/try/try.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/try/try.2.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "foo", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::foo",
+            "name": "$root::module_6::foo",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -45,11 +45,11 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -59,7 +59,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "generic",
@@ -79,11 +79,11 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -93,7 +93,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "generic",
@@ -120,7 +120,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -144,7 +144,7 @@
                     },
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -180,14 +180,14 @@
         "function": {
           "label": { "name": "bar", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::bar",
+            "name": "$root::module_6::bar",
             "variables": [
               {
                 "label": { "name": "x", "position": [4, 7] },
                 "mutable": false,
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -207,7 +207,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -215,7 +215,7 @@
               },
               {
                 "kind": "instance",
-                "struct": { "moduleId": 4, "name": "Array" },
+                "struct": { "moduleId": 5, "name": "Array" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -249,7 +249,7 @@
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 4, "name": "Array" },
+                      "struct": { "moduleId": 5, "name": "Array" },
                       "typeParams": [
                         {
                           "kind": "primitive",
@@ -268,7 +268,7 @@
                   },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -287,11 +287,11 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Result" },
+                        "enum": { "moduleId": 5, "name": "Result" },
                         "typeParams": [
                           {
                             "kind": "instance",
-                            "struct": { "moduleId": 4, "name": "Array" },
+                            "struct": { "moduleId": 5, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "primitive",
@@ -301,7 +301,7 @@
                           },
                           {
                             "kind": "instance",
-                            "struct": { "moduleId": 4, "name": "Array" },
+                            "struct": { "moduleId": 5, "name": "Array" },
                             "typeParams": [
                               {
                                 "kind": "primitive",
@@ -320,11 +320,11 @@
                             "parameters": [],
                             "returnType": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "instance",
-                                  "struct": { "moduleId": 4, "name": "Array" },
+                                  "struct": { "moduleId": 5, "name": "Array" },
                                   "typeParams": [
                                     {
                                       "kind": "generic",
@@ -334,7 +334,7 @@
                                 },
                                 {
                                   "kind": "instance",
-                                  "struct": { "moduleId": 4, "name": "Array" },
+                                  "struct": { "moduleId": 5, "name": "Array" },
                                   "typeParams": [
                                     {
                                       "kind": "generic",
@@ -362,7 +362,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -370,7 +370,7 @@
                   },
                   {
                     "kind": "instance",
-                    "struct": { "moduleId": 4, "name": "Array" },
+                    "struct": { "moduleId": 5, "name": "Array" },
                     "typeParams": [
                       {
                         "kind": "primitive",
@@ -397,7 +397,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -435,7 +435,7 @@
                         },
                         "type": {
                           "kind": "instance",
-                          "struct": { "moduleId": 4, "name": "Array" },
+                          "struct": { "moduleId": 5, "name": "Array" },
                           "typeParams": [
                             {
                               "kind": "primitive",

--- a/projects/compiler/test/typechecker/try/try.3.out.json
+++ b/projects/compiler/test/typechecker/try/try.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/try/try.3.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "ok", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::ok",
+            "name": "$root::module_6::ok",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -30,7 +30,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -52,7 +52,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -81,7 +81,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -136,7 +136,7 @@
         "function": {
           "label": { "name": "f1", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::f1",
+            "name": "$root::module_6::f1",
             "variables": [
               {
                 "label": { "name": "a", "position": [4, 7] },
@@ -157,7 +157,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -297,7 +297,7 @@
                             },
                             "type": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -318,7 +318,7 @@
                                   "parameters": [],
                                   "returnType": {
                                     "kind": "enumInstance",
-                                    "enum": { "moduleId": 4, "name": "Result" },
+                                    "enum": { "moduleId": 5, "name": "Result" },
                                     "typeParams": [
                                       {
                                         "kind": "primitive",
@@ -445,7 +445,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -474,7 +474,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -529,7 +529,7 @@
         "function": {
           "label": { "name": "f2", "position": [13, 6] },
           "scope": {
-            "name": "$root::module_5::f2",
+            "name": "$root::module_6::f2",
             "variables": [
               {
                 "label": { "name": "a", "position": [14, 7] },
@@ -550,7 +550,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -690,7 +690,7 @@
                             },
                             "type": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -711,7 +711,7 @@
                                   "parameters": [],
                                   "returnType": {
                                     "kind": "enumInstance",
-                                    "enum": { "moduleId": 4, "name": "Result" },
+                                    "enum": { "moduleId": 5, "name": "Result" },
                                     "typeParams": [
                                       {
                                         "kind": "primitive",
@@ -838,7 +838,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -867,7 +867,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",

--- a/projects/compiler/test/typechecker/try/try.4.out.json
+++ b/projects/compiler/test/typechecker/try/try.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/try/try.4.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "ok", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::ok",
+            "name": "$root::module_6::ok",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -30,7 +30,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -52,7 +52,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -81,7 +81,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -136,7 +136,7 @@
         "function": {
           "label": { "name": "f1", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::f1",
+            "name": "$root::module_6::f1",
             "variables": [
               {
                 "label": { "name": "x", "position": [4, 7] },
@@ -157,7 +157,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -219,7 +219,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Result" },
+                        "enum": { "moduleId": 5, "name": "Result" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -240,7 +240,7 @@
                             "parameters": [],
                             "returnType": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -280,7 +280,7 @@
                             },
                             "type": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -309,7 +309,7 @@
                                   ],
                                   "returnType": {
                                     "kind": "enumInstance",
-                                    "enum": { "moduleId": 4, "name": "Result" },
+                                    "enum": { "moduleId": 5, "name": "Result" },
                                     "typeParams": [
                                       {
                                         "kind": "generic",
@@ -360,7 +360,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -389,7 +389,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -477,7 +477,7 @@
         "function": {
           "label": { "name": "f2", "position": [9, 6] },
           "scope": {
-            "name": "$root::module_5::f2",
+            "name": "$root::module_6::f2",
             "variables": [
               {
                 "label": { "name": "x", "position": [10, 7] },
@@ -498,7 +498,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -560,7 +560,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Result" },
+                        "enum": { "moduleId": 5, "name": "Result" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -581,7 +581,7 @@
                             "parameters": [],
                             "returnType": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -621,7 +621,7 @@
                             },
                             "type": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -650,7 +650,7 @@
                                   ],
                                   "returnType": {
                                     "kind": "enumInstance",
-                                    "enum": { "moduleId": 4, "name": "Result" },
+                                    "enum": { "moduleId": 5, "name": "Result" },
                                     "typeParams": [
                                       {
                                         "kind": "generic",
@@ -701,7 +701,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -730,7 +730,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",

--- a/projects/compiler/test/typechecker/try/try.5.out.json
+++ b/projects/compiler/test/typechecker/try/try.5.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/try/try.5.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "ok", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::ok",
+            "name": "$root::module_6::ok",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -30,7 +30,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Result" },
+            "enum": { "moduleId": 5, "name": "Result" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -52,7 +52,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Result" },
+                "enum": { "moduleId": 5, "name": "Result" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -81,7 +81,7 @@
                     ],
                     "returnType": {
                       "kind": "enumInstance",
-                      "enum": { "moduleId": 4, "name": "Result" },
+                      "enum": { "moduleId": 5, "name": "Result" },
                       "typeParams": [
                         {
                           "kind": "generic",
@@ -136,7 +136,7 @@
         "function": {
           "label": { "name": "f1", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::f1",
+            "name": "$root::module_6::f1",
             "variables": [
               {
                 "label": { "name": "x", "position": [4, 7] },
@@ -209,7 +209,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Result" },
+                        "enum": { "moduleId": 5, "name": "Result" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -230,7 +230,7 @@
                             "parameters": [],
                             "returnType": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Result" },
+                              "enum": { "moduleId": 5, "name": "Result" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",

--- a/projects/compiler/test/typechecker/try/try.6.out.json
+++ b/projects/compiler/test/typechecker/try/try.6.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/try/try.6.abra",
   "code": [
     {
@@ -18,7 +18,7 @@
         "function": {
           "label": { "name": "ok", "position": [1, 6] },
           "scope": {
-            "name": "$root::module_5::ok",
+            "name": "$root::module_6::ok",
             "variables": [],
             "functions": [],
             "structs": [],
@@ -30,7 +30,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -48,7 +48,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -100,7 +100,7 @@
         "function": {
           "label": { "name": "f1", "position": [3, 6] },
           "scope": {
-            "name": "$root::module_5::f1",
+            "name": "$root::module_6::f1",
             "variables": [
               {
                 "label": { "name": "x", "position": [4, 7] },
@@ -121,7 +121,7 @@
           "parameters": [],
           "returnType": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -179,7 +179,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -196,7 +196,7 @@
                             "parameters": [],
                             "returnType": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Option" },
+                              "enum": { "moduleId": 5, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",
@@ -222,7 +222,7 @@
               },
               "type": {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -307,7 +307,7 @@
         "function": {
           "label": { "name": "f2", "position": [9, 6] },
           "scope": {
-            "name": "$root::module_5::f2",
+            "name": "$root::module_6::f2",
             "variables": [
               {
                 "label": { "name": "x", "position": [10, 7] },
@@ -380,7 +380,7 @@
                       },
                       "type": {
                         "kind": "enumInstance",
-                        "enum": { "moduleId": 4, "name": "Option" },
+                        "enum": { "moduleId": 5, "name": "Option" },
                         "typeParams": [
                           {
                             "kind": "primitive",
@@ -397,7 +397,7 @@
                             "parameters": [],
                             "returnType": {
                               "kind": "enumInstance",
-                              "enum": { "moduleId": 4, "name": "Option" },
+                              "enum": { "moduleId": 5, "name": "Option" },
                               "typeParams": [
                                 {
                                   "kind": "primitive",

--- a/projects/compiler/test/typechecker/tuple/tuple.out.json
+++ b/projects/compiler/test/typechecker/tuple/tuple.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/tuple/tuple.abra",
   "code": [
     {
@@ -151,7 +151,7 @@
               "types": [
                 {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -179,7 +179,7 @@
             "types": [
               {
                 "kind": "enumInstance",
-                "enum": { "moduleId": 4, "name": "Option" },
+                "enum": { "moduleId": 5, "name": "Option" },
                 "typeParams": [
                   {
                     "kind": "primitive",
@@ -205,7 +205,7 @@
                 },
                 "type": {
                   "kind": "enumInstance",
-                  "enum": { "moduleId": 4, "name": "Option" },
+                  "enum": { "moduleId": 5, "name": "Option" },
                   "typeParams": [
                     {
                       "kind": "primitive",
@@ -225,7 +225,7 @@
                     },
                     "type": {
                       "kind": "enum",
-                      "enum": { "moduleId": 4, "name": "Option" }
+                      "enum": { "moduleId": 5, "name": "Option" }
                     },
                     "node": {
                       "kind": "identifier",

--- a/projects/compiler/test/typechecker/typedecl/typedecl.1.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/typedecl/typedecl.1.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -57,7 +57,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -78,7 +78,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -99,7 +99,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -115,7 +115,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -131,14 +131,14 @@
             {
               "label": { "name": "foo", "position": [5, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [5, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   }
@@ -181,7 +181,7 @@
             {
               "label": { "name": "fooStatic", "position": [6, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::fooStatic",
+                "name": "$root::module_6::Foo::fooStatic",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -243,7 +243,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }

--- a/projects/compiler/test/typechecker/typedecl/typedecl.2.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/typedecl/typedecl.2.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -85,7 +85,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -106,7 +106,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -127,7 +127,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -143,7 +143,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -159,14 +159,14 @@
             {
               "label": { "name": "foo", "position": [4, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [4, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   },
@@ -295,7 +295,7 @@
         "function": {
           "label": { "name": "string", "position": [7, 6] },
           "scope": {
-            "name": "$root::module_5::string",
+            "name": "$root::module_6::string",
             "variables": [
               {
                 "label": { "name": "s", "position": [7, 13] },
@@ -406,7 +406,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }

--- a/projects/compiler/test/typechecker/typedecl/typedecl.3.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/typedecl/typedecl.3.abra",
   "code": [
     {
@@ -16,7 +16,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 6] },
           "typeParams": [],
           "fields": [
@@ -58,7 +58,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -79,7 +79,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -100,7 +100,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -116,7 +116,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,
@@ -132,14 +132,14 @@
             {
               "label": { "name": "foo", "position": [5, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::foo",
+                "name": "$root::module_6::Foo::foo",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [5, 12] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   }
@@ -180,14 +180,14 @@
             {
               "label": { "name": "fooPub", "position": [6, 12] },
               "scope": {
-                "name": "$root::module_5::Foo::fooPub",
+                "name": "$root::module_6::Foo::fooPub",
                 "variables": [
                   {
                     "label": { "name": "self", "position": [6, 19] },
                     "mutable": false,
                     "type": {
                       "kind": "instance",
-                      "struct": { "moduleId": 5, "name": "Foo" },
+                      "struct": { "moduleId": 6, "name": "Foo" },
                       "typeParams": []
                     }
                   }
@@ -230,7 +230,7 @@
             {
               "label": { "name": "fooStatic", "position": [7, 8] },
               "scope": {
-                "name": "$root::module_5::Foo::fooStatic",
+                "name": "$root::module_6::Foo::fooStatic",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -268,7 +268,7 @@
             {
               "label": { "name": "fooStaticPub", "position": [8, 12] },
               "scope": {
-                "name": "$root::module_5::Foo::fooStaticPub",
+                "name": "$root::module_6::Foo::fooStaticPub",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -330,7 +330,7 @@
             "mutable": true,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 5, "name": "Foo" },
+              "struct": { "moduleId": 6, "name": "Foo" },
               "typeParams": []
             }
           }

--- a/projects/compiler/test/typechecker/typedecl/typedecl_exported.out.json
+++ b/projects/compiler/test/typechecker/typedecl/typedecl_exported.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/typedecl/typedecl_exported.abra",
   "exports": [
     {
@@ -22,7 +22,7 @@
       "node": {
         "kind": "typeDeclaration",
         "struct": {
-          "moduleId": 5,
+          "moduleId": 6,
           "name": { "name": "Foo", "position": [1, 10] },
           "typeParams": [],
           "fields": [
@@ -39,7 +39,7 @@
             {
               "label": { "name": "toString", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::toString",
+                "name": "$root::module_6::Foo::toString",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -60,7 +60,7 @@
             {
               "label": { "name": "hash", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::hash",
+                "name": "$root::module_6::Foo::hash",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -81,7 +81,7 @@
             {
               "label": { "name": "eq", "position": [0, 0] },
               "scope": {
-                "name": "$root::module_5::Foo::eq",
+                "name": "$root::module_6::Foo::eq",
                 "variables": [],
                 "functions": [],
                 "structs": [],
@@ -97,7 +97,7 @@
                   "label": { "name": "other", "position": [0, 0] },
                   "type": {
                     "kind": "instance",
-                    "struct": { "moduleId": 5, "name": "Foo" },
+                    "struct": { "moduleId": 6, "name": "Foo" },
                     "typeParams": []
                   },
                   "defaultValue": null,

--- a/projects/compiler/test/typechecker/unary/unary.out.json
+++ b/projects/compiler/test/typechecker/unary/unary.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/unary/unary.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/while/while.1.out.json
+++ b/projects/compiler/test/typechecker/while/while.1.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/while/while.1.abra",
   "code": [
     {

--- a/projects/compiler/test/typechecker/while/while.2.out.json
+++ b/projects/compiler/test/typechecker/while/while.2.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/while/while.2.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -64,7 +64,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 4, "name": "Option" }
+                "enum": { "moduleId": 5, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",
@@ -103,7 +103,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/while/while.3.out.json
+++ b/projects/compiler/test/typechecker/while/while.3.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/while/while.3.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "enumInstance",
-              "enum": { "moduleId": 4, "name": "Option" },
+              "enum": { "moduleId": 5, "name": "Option" },
               "typeParams": [
                 {
                   "kind": "primitive",
@@ -44,7 +44,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",
@@ -64,7 +64,7 @@
               },
               "type": {
                 "kind": "enum",
-                "enum": { "moduleId": 4, "name": "Option" }
+                "enum": { "moduleId": 5, "name": "Option" }
               },
               "node": {
                 "kind": "identifier",
@@ -103,7 +103,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "primitive",

--- a/projects/compiler/test/typechecker/while/while.4.out.json
+++ b/projects/compiler/test/typechecker/while/while.4.out.json
@@ -1,5 +1,5 @@
 {
-  "id": 5,
+  "id": 6,
   "name": "%TEST_DIR%/typechecker/while/while.4.abra",
   "code": [
     {
@@ -25,7 +25,7 @@
             "mutable": false,
             "type": {
               "kind": "instance",
-              "struct": { "moduleId": 4, "name": "Array" },
+              "struct": { "moduleId": 5, "name": "Array" },
               "typeParams": [
                 {
                   "kind": "tuple",
@@ -53,7 +53,7 @@
           },
           "type": {
             "kind": "instance",
-            "struct": { "moduleId": 4, "name": "Array" },
+            "struct": { "moduleId": 5, "name": "Array" },
             "typeParams": [
               {
                 "kind": "tuple",
@@ -220,7 +220,7 @@
           },
           "type": {
             "kind": "enumInstance",
-            "enum": { "moduleId": 4, "name": "Option" },
+            "enum": { "moduleId": 5, "name": "Option" },
             "typeParams": [
               {
                 "kind": "tuple",
@@ -251,7 +251,7 @@
                 },
                 "type": {
                   "kind": "instance",
-                  "struct": { "moduleId": 4, "name": "Array" },
+                  "struct": { "moduleId": 5, "name": "Array" },
                   "typeParams": [
                     {
                       "kind": "tuple",

--- a/projects/lsp/src/language_service.abra
+++ b/projects/lsp/src/language_service.abra
@@ -115,6 +115,24 @@ pub type AbraLanguageService {
           lines
         }
       }
+      IdentifierKindMeta.Macro(params, expanded) => {
+        val lines = [
+          "```abra",
+          "@macro",
+          "func ${ident.name}(${params.join(", ")})",
+          "```",
+          "Expands to:",
+          "```abra",
+          expanded
+            .replaceAll("\\", "\\\\")
+            .replaceAll("\n", "\\n")
+            .replaceAll("\"", "\\\"")
+            .replaceAll("\t", "\\t"),
+          "```"
+        ]
+
+        lines
+      }
       IdentifierKindMeta.Type(isEnum, typeParams) => {
         val prefix = if isEnum "enum" else "type"
         val generics = if typeParams.isEmpty() "" else "<${typeParams.join(", ")}>"

--- a/projects/std/src/libc.abra
+++ b/projects/std/src/libc.abra
@@ -16,10 +16,10 @@ pub func dup2(fd1: Int, fd2: Int): Int
 @external("wait")
 pub func wait(status: Pointer<Int>): Int
 
-@external("fork") 
+@external("fork")
 pub func fork(): Int
 
-@external("execvp") 
+@external("execvp")
 pub func execvp(file: Pointer<Byte>, args: Pointer<Pointer<Byte>>): Int
 
 @external("getenv")

--- a/projects/std/src/meta.abra
+++ b/projects/std/src/meta.abra
@@ -9,7 +9,7 @@ pub type InjectedCode {
   pub func addImport(self, module: String): String {
     if self.imports[module] |alias| return alias
 
-    val alias = "_${String.random(24)}"
+    val alias = "__imp_${module}_${String.random(4)}__"
     self.imports[module] = alias
     alias
   }
@@ -19,8 +19,20 @@ pub type InjectedCode {
     self
   }
 
+  pub func appendln(self, str: String): InjectedCode {
+    self.chunks.push(str)
+    self.chunks.push("\n")
+    self
+  }
+
   pub func appendExpr(self, expr: Expr): InjectedCode {
     self.chunks.push(expr.stringify())
+    self
+  }
+
+  pub func appendExprln(self, expr: Expr): InjectedCode {
+    self.chunks.push(expr.stringify())
+    self.chunks.push("\n")
     self
   }
 }

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -1,35 +1,14 @@
 import "./_intrinsics" as intrinsics
 import Pointer, Byte from "./_intrinsics"
 import "libc" as libc
-// import macro, InjectedCode, Expr from "meta"
+import macro, InjectedCode, Expr from "meta"
 import "process" as process
 
-func stdoutWrite(str = "") {
-  // TODO: uncomment once if-statements are handled by new IR generation
-  // if !str.isEmpty() libc.write(libc.STDOUT_FILENO, str._buffer, str.length)
-  libc.write(libc.STDOUT_FILENO, str._buffer, str.length)
-}
-
+func stdoutWrite(str = "") = libc.write(libc.STDOUT_FILENO, str._buffer, str.length)
 func stdoutWriteln(str = "") {
-  stdoutWrite(str)
-  stdoutWrite("\n")
+  libc.write(libc.STDOUT_FILENO, str._buffer, str.length)
+  libc.write(libc.STDOUT_FILENO, "\n"._buffer, 1)
 }
-
-//func print(*items: Any[]) {
-//  for i in range(0, items.length) {
-//    val item = items._buffer.offset(i).load()
-//    stdoutWrite(item.toString())
-//
-//    if i != items.length - 1 {
-//      stdoutWrite(" ")
-//    }
-//  }
-//}
-//
-//func println(*items: Any[]) {
-//  print(items: items)
-//  stdoutWrite("\n")
-//}
 
 pub enum Option<V> {
   Some(value: V)
@@ -1545,12 +1524,40 @@ pub func todo(message = "") {
   libc.exit(1)
 }
 
-// @macro
-// pub func debug(value: Expr): InjectedCode {
-//   InjectedCode.new()
-//     .append("(if true {")
-//     .append("  val exp = ").appendExpr(value)
-//     .append("  stdoutWriteln(\"").appendExpr(value).append(" = \$").appendExpr(value).append("\")")
-//     .append("  exp")
-//     .append("} else { unreachable(\"will get optimized away\") })")
-// }
+@macro
+pub func debug(value: Expr): InjectedCode {
+  val c = InjectedCode.new()
+  val libcMod = c.addImport("libc")
+
+  c
+    .appendln("(if true {")
+    .append("  val dbg = \"").appendExpr(value).appendln(" = \"")
+    .appendln("  $libcMod.write($libcMod.STDOUT_FILENO, dbg._buffer, dbg.length)")
+    .append("  val exp = ").appendExprln(value)
+    .appendln("  val str = exp.toString()")
+    .appendln("  $libcMod.write($libcMod.STDOUT_FILENO, str._buffer, str.length)")
+    .appendln("  $libcMod.write($libcMod.STDOUT_FILENO, \"\\n\"._buffer, 1)")
+    .appendln("  exp")
+    .appendln("} else { unreachable(\"will get optimized away\") })")
+}
+
+@macro
+pub func println(*values: Expr[]): InjectedCode {
+  val c = InjectedCode.new()
+  val libcMod = c.addImport("libc")
+
+  c.appendln("if true {")
+  for value, idx in values {
+    val isLast = idx == values.length - 1
+
+    c.append("  val _${idx} = (").appendExpr(value).appendln(").toString()")
+    c.appendln("  $libcMod.write($libcMod.STDOUT_FILENO, _${idx}._buffer, _${idx}.length)")
+    if isLast {
+      c.appendln("  $libcMod.write($libcMod.STDOUT_FILENO, \"\\n\"._buffer, 1)")
+    } else {
+      c.appendln("  $libcMod.write($libcMod.STDOUT_FILENO, \" \"._buffer, 1)")
+    }
+  }
+
+  c.appendln("}")
+}


### PR DESCRIPTION
This adds the `println` and `debug` macro to the `prelude` module, the culmination of the big refactoring as well as all of the macro work (which includes the IR generation, as well as the VM). The next PR will see the `stdoutWrite`/`stdoutWriteln` be replaced by `print`/`println` macros in the test suites, followed by the removal of those functions.