### PR TITLE
Ensure tuple/func have base methods

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,7 +1,3 @@
-val m = { (1): "a", (2): "b" }
-
-val v = m.getOrElse(1, () => {
-  println("calling default fn")
-  "c"
-})
-println(v)
+val t = (1, "two", [3])
+stdoutWriteln(t.toString())
+// stdoutWriteln("$t")

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -5009,8 +5009,44 @@ pub type Typechecker {
 
         None
       }
-      TypeKind.Tuple => None
-      TypeKind.Func => None
+      TypeKind.Tuple(types) => {
+        val scope = self.project.preludeModule.rootScope.makeChild("T${types.length}", ScopeKind.Type)
+        val method = if label.name == "toString" {
+          Some(Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(None, true)))
+        } else if label.name == "hash" {
+          Some(Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(None, true)))
+        } else if label.name == "eq" {
+          Some(Function.generated(scope, "eq", [("other", ty)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(None, true)))
+        } else {
+          None
+        }
+
+        if method |method| {
+          Some(AccessorPathSegment.Method(label, method, optSafe, typeHint))
+        } else {
+          None
+        }
+      }
+      TypeKind.Func(paramTypes, retType) => {
+        val isUnit = retType.kind == TypeKind.PrimitiveUnit
+        val name = if isUnit "UnitFunction${paramTypes.length}" else "Function${paramTypes.length}"
+        val scope = self.project.preludeModule.rootScope.makeChild(name, ScopeKind.Type)
+        val method = if label.name == "toString" {
+          Some(Function.generated(scope, "toString", [], Type(kind: TypeKind.PrimitiveString), FunctionKind.InstanceMethod(None, true)))
+        } else if label.name == "hash" {
+          Some(Function.generated(scope, "hash", [], Type(kind: TypeKind.PrimitiveInt), FunctionKind.InstanceMethod(None, true)))
+        } else if label.name == "eq" {
+          Some(Function.generated(scope, "eq", [("other", ty)], Type(kind: TypeKind.PrimitiveBool), FunctionKind.InstanceMethod(None, true)))
+        } else {
+          None
+        }
+
+        if method |method| {
+          Some(AccessorPathSegment.Method(label, method, optSafe, typeHint))
+        } else {
+          None
+        }
+      }
       TypeKind.Type(instanceKind) => {
         // TODO: static fields
 
@@ -5408,8 +5444,11 @@ pub type Typechecker {
         else => return Err(self.internalError(token.position, "if selfVal passed, then FunctionKind must be InstanceMethod"))
       }
 
-      // When instanceKind is not present on FunctionKind.InstanceMethod, that means that the method's selfVal is a generic.
-      // In that case, the template from which to extract generics should just be self's type.
+      // When instanceKind is not present on FunctionKind.InstanceMethod, that means that the method's selfVal is a "virtual" type
+      // (a type that only exists during typechecking, such as a generic, a tuple, or a function type). These types still have
+      // toString/hash/eq methods, but they're implemented as auto-generated builtins during compilation.
+      // In the case where the type is "virtual", the template from which to extract generics should just be self's type; otherwise
+      // the template should be constructed according to the underlying instanceKind.
       val template = if instanceKind |instanceKind| {
         val typeParams = match instanceKind { InstanceKind.Struct(s) => s.typeParams, InstanceKind.Enum(e) => e.typeParams }
         Type(kind: TypeKind.Instance(instanceKind, typeParams.map(name => Type(kind: TypeKind.Generic(name)))))

--- a/projects/compiler/test/compiler/functions.abra
+++ b/projects/compiler/test/compiler/functions.abra
@@ -15,13 +15,13 @@ println(foo(2))
 // Functions, methods, and closures as value (lambdas too)
 func abc(): Int = 24
 /// Expect: <#function>
-println("$abc")
+println(abc)
 val abcVal = abc
 /// Expect: <#function> 24
-println("$abcVal", abcVal())
+println(abcVal, abcVal())
 
 /// Expect: <#function>
-println("${"abc".isEmpty}")
+println("abc".isEmpty)
 
 func def(a: Int): Int = a + 1
 val defVal = def

--- a/projects/compiler/test/compiler/loops.abra
+++ b/projects/compiler/test/compiler/loops.abra
@@ -165,13 +165,13 @@ if true {
   // /// Expect: b 1
   // /// Expect: a 2
   // for ch, idx in #{"a", "b", "c"} {
-  //   println("$ch $idx")
+  //   println(ch, idx)
   // }
 
   /// Expect: ("c", 3) 0
   /// Expect: ("b", 2) 1
   /// Expect: ("a", 1) 2
   for ch, idx in { a: 1, b: 2, c: 3 } {
-    println("$ch", idx)
+    println(ch, idx)
   }
 }

--- a/projects/compiler/test/compiler/tuples.abra
+++ b/projects/compiler/test/compiler/tuples.abra
@@ -1,11 +1,11 @@
 // Instantiation
 val point = (0.5, 1.5, -0.75)
 /// Expect: (0.5, 1.5, -0.75)
-println("$point")
+println(point)
 
 val y = (1, "two", ["three"])
 /// Expect: (1, "two", [three])
-println("$y")
+println(y)
 
 // Indexing
 val quad = (1, "two", ["three"], (2, 3))


### PR DESCRIPTION
Virtual types, like tuples and function types, should have the base toString/hash/eq methods, just like any other type. These methods are implemented during compilation, but need to be available during typechecking.