### PR TITLE
Uncomment the `compiler/process.abra` suite

### DIFF
--- a/projects/compiler/example.html
+++ b/projects/compiler/example.html
@@ -8,13 +8,22 @@
     <script type="module">
       import main from './._abra/_main.mjs';
 
+      const $td = new TextDecoder();
+      const $te = new TextEncoder();
+
+      function _decodeString(buf) {
+        let i = buf.length - 1;
+        while (i >= 0 && buf[i] === 0) { i--; }
+        return $td.decode(buf.slice(0, i + 1));
+      }
+
       const stdout = document.getElementById('stdout');
 
       // The `write` function appends to the #stdout element, and also outputs to the console.
       // When outputting to the console, make sure to disregard newlines and empty strings, since
       // `console` methods always append the newline.
       function write(fd, buf, _count) {
-        let str = buf.join('')
+        let str = _decodeString(buf)
         stdout.innerHTML += str
 
         if (str.endsWith('\n')) { str = str.substring(0, str.length - 1); }
@@ -27,7 +36,18 @@
         }
       }
 
-      main({ write });
+      function strlen(str) {
+        return str.length;
+      }
+
+      function getenv(key) {
+        const keyStr = _decodeString(key)
+        console.log(`getkey('${keyStr}'): unimplemented`)
+        return null;
+      }
+
+      const externs = { write, strlen, getenv };
+      main(externs, []);
     </script>
 
 </head>

--- a/projects/compiler/example.mjs
+++ b/projects/compiler/example.mjs
@@ -1,10 +1,17 @@
 import main from "./._abra/_main.mjs";
 
-function write(fd, buf, _count) {
+const $td = new TextDecoder();
+const $te = new TextEncoder();
+
+function _decodeString(buf) {
   let i = buf.length - 1;
   while (i >= 0 && buf[i] === 0) { i--; }
+  return $td.decode(buf.slice(0, i + 1));
+}
 
-  const str = new TextDecoder().decode(buf.slice(0, i + 1))
+function write(fd, buf, _count) {
+  const str = _decodeString(buf)
+
   if (fd === 1) {
     process.stdout.write(str);
   } else if (fd === 2) {
@@ -12,8 +19,23 @@ function write(fd, buf, _count) {
   }
 }
 
+function strlen(str) {
+  return str.length;
+}
+
+function getenv(key) {
+  const keyStr = _decodeString(key)
+
+  const val = process.env[keyStr];
+  if (!val) return null;
+
+  return $te.encode(val)
+}
+
 const externs = {
   write,
+  strlen,
+  getenv,
 };
 
-main(externs);
+main(externs, process.argv.slice(1));

--- a/projects/compiler/src/comptime_evaluator.abra
+++ b/projects/compiler/src/comptime_evaluator.abra
@@ -23,7 +23,7 @@ pub type ComptimeFunctionEvaluator {
     for f in self.gen.fnQueue { self.gen.genFunction(f) }
 
     val ir = self.gen.getIR()
-    val vm = VM(ir: ir)
+    val vm = VM(ir: ir, args: [])
 
     val marshalledArgs: VmValue[] = []
     for argument, idx in arguments {

--- a/projects/compiler/src/ir.abra
+++ b/projects/compiler/src/ir.abra
@@ -183,7 +183,10 @@ pub enum Value {
 
 pub enum Builtin {
   Malloc(count: Value, itemTy: IrType)
+  Null
+  IsNull(ptr: Value)
   Realloc(ptr: Value, count: Value, itemTy: IrType? = None)
+  PointerAddress(ptr: Value),
   Store(ptr: Value, value: Value, offset: Value, itemTy: IrType)
   Load(ptr: Value, offset: Value, itemTy: IrType)
   CopyFrom(dst: Value, dstOffset: Value, src: Value, srcOffset: Value, size: Value, itemTy: IrType)
@@ -198,6 +201,8 @@ pub enum Builtin {
   FloatRound(floatVal: Value)
   FloatBitsToInt(floatVal: Value)
   Uninitialized
+  Argc
+  Argv
   Callstack
   CallstackPtr
   ModuleNames
@@ -704,6 +709,13 @@ pub enum Operation {
             sb.write(", ")
             itemTy.render(sb)
           }
+          Builtin.Null => {
+            sb.write("ptr_null")
+          }
+          Builtin.IsNull(ptr) => {
+            sb.write("ptr_is_null, ")
+            ptr.render(sb)
+          }
           Builtin.Realloc(ptr, count, itemTy) => {
             sb.write("realloc, ")
             ptr.render(sb)
@@ -713,6 +725,11 @@ pub enum Operation {
               sb.write(", ")
               ty.render(sb)
             }
+          }
+          Builtin.PointerAddress(ptr) => {
+            sb.write("ptr_address, ")
+            ptr.render(sb)
+            sb.write(", ")
           }
           Builtin.Store(ptr, value, offset, itemTy) => {
             sb.write("ptr_store, ")
@@ -786,9 +803,13 @@ pub enum Operation {
             sb.write("float_bits_to_int, ")
             float.render(sb)
           }
-          Builtin.Uninitialized => {
-            sb.write("uninitialized")
-          }
+          Builtin.Uninitialized => sb.write("uninitialized")
+          Builtin.Argc => sb.write("argc")
+          Builtin.Argv => sb.write("argv")
+          Builtin.Callstack => sb.write("callstack")
+          Builtin.CallstackPtr => sb.write("callstack_ptr")
+          Builtin.ModuleNames => sb.write("module_names")
+          Builtin.FunctionNames => sb.write("function_names")
         }
         sb.write(")")
       }
@@ -2015,6 +2036,7 @@ pub type Generator {
     var subjVal = self.genExpression(subjectNode, concreteGenerics)
     val subjValOrig = subjVal
     val subjectConcreteType = self.getConcreteTypeFromType(subjectNode.ty, concreteGenerics)
+    val subjectConcreteGenerics = self.extractConcreteGenericsFromConcreteType(subjectConcreteType)
     val subjectOptInnerType = if self.project.typeIsOption(subjectNode.ty) |innerType| {
       val innerConcreteType = self.getConcreteTypeFromType(innerType, concreteGenerics)
       val innerIrType = self.getIrTypeForConcreteType(innerConcreteType)
@@ -2040,12 +2062,12 @@ pub type Generator {
 
               for field, idx in fields {
                 val variable = try destructuredVariables[idx] else unreachable("fields.length != destructuredVariables.length")
-                val fieldConcreteType = self.getConcreteTypeFromType(field.ty, concreteGenerics)
+                val fieldConcreteType = self.getConcreteTypeFromType(field.ty, subjectConcreteGenerics)
                 val fieldIrType = self.getIrTypeForConcreteType(fieldConcreteType)
 
                 val offset = (idx + 1) * ALIGNMENT
                 val fieldSubject = self.ssaValue(fieldIrType, Operation.LoadField(ty: fieldIrType, mem: subjVal, name: field.name.name, offset: offset), None)
-                self.genBindingPattern(BindingPattern.Variable(variable.label), vars, Some((fieldSubject, fieldConcreteType)), concreteGenerics)
+                self.genBindingPattern(BindingPattern.Variable(variable.label), vars, Some((fieldSubject, fieldConcreteType)), subjectConcreteGenerics)
               }
             }
           }
@@ -2081,7 +2103,7 @@ pub type Generator {
             }
 
             val vars = { (variable.label.name): variable }
-            self.genBindingPattern(BindingPattern.Variable(variable.label), vars, Some((variableSubject, concreteTy)), concreteGenerics)
+            self.genBindingPattern(BindingPattern.Variable(variable.label), vars, Some((variableSubject, concreteTy)), subjectConcreteGenerics)
           }
 
           for node, idx in case.body {
@@ -2974,11 +2996,20 @@ pub type Generator {
           (fnName, concreteReturnType)
         } else if self.getIntrinsicDecName(fn) |intrinsicName| {
           return match intrinsicName {
+            "argc" => {
+              self.ssaValue(IrType.I64, Operation.Builtin(ret: IrType.I64, builtin: Builtin.Argc), dst)
+            }
+            "argv" => {
+              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.Ptr, builtin: Builtin.Argv), dst)
+            }
             "pointer_malloc" => {
               val count = self.genExpression(self.intrinsicArgs1("pointer_malloc", args), innerConcreteGenerics)
               val itemTy = self.getIrTypeForConcreteType(try innerConcreteGenerics["T"] else unreachable("(pointer_malloc) could not resolve T for Pointer<T>"))
 
               self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.Ptr, builtin: Builtin.Malloc(count: count, itemTy: itemTy)), dst)
+            }
+            "pointer_null" => {
+              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.Ptr, builtin: Builtin.Null), dst)
             }
             "byte_from_int" => {
               val arg = self.intrinsicArgs1("byte_from_int", args)
@@ -3067,6 +3098,11 @@ pub type Generator {
           todo("Unimplemented external method '$fnName'")
         } else if self.getIntrinsicDecName(fn) |intrinsicName| {
           return match intrinsicName {
+            "pointer_is_null" => {
+              val ptrVal = self.genExpression(selfVal, concreteGenerics)
+
+              self.ssaValue(IrType.Bool, Operation.Builtin(ret: IrType.Bool, builtin: Builtin.IsNull(ptr: ptrVal)), dst)
+            }
             "pointer_realloc" => {
               val ptrVal = self.genExpression(selfVal, concreteGenerics)
               val count = self.intrinsicArgs1("pointer_realloc", args)
@@ -3075,6 +3111,11 @@ pub type Generator {
               val countVal = self.genExpression(count, innerConcreteGenerics)
 
               self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.Ptr, builtin: Builtin.Realloc(ptr: ptrVal, count: countVal, itemTy: Some(itemTy))), dst)
+            }
+            "pointer_address" => {
+              val ptrVal = self.genExpression(selfVal, concreteGenerics)
+
+              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.Ptr, builtin: Builtin.PointerAddress(ptr: ptrVal)), dst)
             }
             "pointer_store_at" => {
               val ptrVal = self.genExpression(selfVal, concreteGenerics)

--- a/projects/compiler/src/ir_compiler.abra
+++ b/projects/compiler/src/ir_compiler.abra
@@ -31,6 +31,8 @@ pub type Compiler {
   ir: IR
   builder: ModuleBuilder
   currentFn: qbe.QbeFunction
+  argcPtr: qbe.Value
+  argvPtr: qbe.Value
   currentFnEnv: qbe.Value? = None
   numTemps: Int = 0
   loopStack: (/* start: */ qbe.Label, /* end: */ qbe.Label)[] = []
@@ -45,10 +47,15 @@ pub type Compiler {
   pub func compile(ir: IR): CompilationResult {
     val builder = ModuleBuilder()
 
+    val (argcPtr, _) = builder.addData(qbe.QbeData(name: "__argc", kind: qbe.QbeDataKind.Constants([(QbeType.U64, qbe.Value.Int(0))])))
+    val (argvPtr, _) = builder.addData(qbe.QbeData(name: "__argv", kind: qbe.QbeDataKind.Constants([(QbeType.U64, qbe.Value.Int(0))])))
+
     val compiler = Compiler(
       ir: ir,
       builder: builder,
       currentFn: qbe.QbeFunction.spec(name: "dummy"),
+      argcPtr: argcPtr,
+      argvPtr: argvPtr,
     )
 
     compiler.compileMainFunction(ir.mainFunction)
@@ -85,11 +92,13 @@ pub type Compiler {
     val f = self.builder.buildFunction(name: fn.name, returnType: Some(qbe.QbeType.U64), exported: true)
     self.currentFn = f
 
-    // TODO: persist to globals
-    val argcVal = f.addParameter("argc", qbe.QbeType.U64)
-    val argvVal = f.addParameter("argv", qbe.QbeType.U64)
+    val argcParam = f.addParameter("argc", qbe.QbeType.U64)
+    val argvParam = f.addParameter("argv", qbe.QbeType.U64)
 
     f.block.buildVoidCallRaw("GC_init", [])
+
+    f.block.buildStoreL(argcParam, self.argcPtr)
+    f.block.buildStoreL(argvParam, self.argvPtr)
 
     for inst in fn.block[1] {
       self.compileInstruction(inst)
@@ -880,12 +889,26 @@ pub type Compiler {
         }
 
         match builtin {
+          Builtin.Argc => {
+            self.currentFn.block.buildLoadL(self.argcPtr, dst)
+          }
+          Builtin.Argv => {
+            self.currentFn.block.buildLoadL(self.argvPtr, dst)
+          }
           Builtin.Malloc(count, itemTy) => {
             val countVal = self.irValueToQbeValue(count)
             val (size, _) = sizeOfType(itemTy)
             val sizeVal = try self.currentFn.block.buildMul(qbe.Value.Int(size), countVal, Some(self.nextTemp())) else |e| unreachable(e)
 
             self.callMalloc(sizeVal, dst)
+          }
+          Builtin.Null => {
+            self.currentFn.block.buildCopy(qbe.Value.Int(0), dst)
+          }
+          Builtin.IsNull(ptr) => {
+            val ptrVal = self.irValueToQbeValue(ptr)
+
+            try self.currentFn.block.buildCompareEq(qbe.Value.Int(0), ptrVal, dst) else |e| unreachable(e)
           }
           Builtin.Realloc(ptr, count, itemTy) => {
             val ptrVal = self.irValueToQbeValue(ptr)
@@ -898,6 +921,10 @@ pub type Compiler {
             }
 
             self.callRealloc(ptrVal, sizeVal, dst)
+          }
+          Builtin.PointerAddress(ptr) => {
+            val ptrVal = self.irValueToQbeValue(ptr)
+            self.currentFn.block.buildCopy(ptrVal, dst)
           }
           Builtin.Store(ptr, value, offset, itemTy) => {
             val ptrVal = self.irValueToQbeValue(ptr)

--- a/projects/compiler/src/ir_compiler_js.abra
+++ b/projects/compiler/src/ir_compiler_js.abra
@@ -32,7 +32,7 @@ pub type Compiler {
 
     val compiler = Compiler(ir: ir, sb: sb)
 
-    sb.writeln("export default function(externs) {")
+    sb.writeln("export default function(externs, args) {")
     sb.write("const { ")
     for fn in ir.functions {
       if !fn.extern continue
@@ -42,6 +42,8 @@ pub type Compiler {
     sb.writeln("} = externs;")
 
     sb.writeln(builtins)
+
+    sb.writeln("const \$\$args = args.map(a => \$te.encode(a));")
 
     for g in ir.globals {
       compiler.compileGlobal(g)
@@ -524,6 +526,12 @@ pub type Compiler {
       }
       Operation.Builtin(ret, builtin) => {
         match builtin {
+          Builtin.Argc => {
+            self.sb.writeln("const $dst = \$\$args.length;")
+          }
+          Builtin.Argv => {
+            self.sb.writeln("const $dst = \$\$args;")
+          }
           Builtin.Malloc(count, itemTy) => {
             self.sb.write("const $dst = ")
             // If there's no type being malloc'd, then it can be modeled as an object. If the type is Byte then it's
@@ -543,10 +551,22 @@ pub type Compiler {
             }
             self.sb.writeln(" // builtin(malloc)")
           }
+          Builtin.Null => {
+            self.sb.writeln("const $dst = null; // pointer_null")
+          }
+          Builtin.IsNull(ptr) => {
+            self.sb.write("const $dst = ")
+            self.emitIrValueToJsValue(ptr)
+            self.sb.writeln(" === null; // pointer_is_null")
+          }
           Builtin.Realloc(ptr, count, _) => {
             self.sb.write("const $dst = ")
             self.emitIrValueToJsValue(ptr)
             self.sb.writeln("; // realloc (no-op)")
+          }
+          Builtin.PointerAddress => {
+            // this is sort of meaningless for a js target
+            todo("Builtin.PointerAddress")
           }
           Builtin.Store(ptr, value, offset, _) => {
             self.emitIrValueToJsValue(ptr)

--- a/projects/compiler/src/ir_vm.abra
+++ b/projects/compiler/src/ir_vm.abra
@@ -73,6 +73,7 @@ enum ControlFlag {
 
 pub type VM {
   pub ir: ir.IR
+  pub args: String[]
   externs: Map<String, (VmValue[]) => VmValue> = {}
   locals: VmValue[] = []
   globals: Map<String, VmValue> = {}
@@ -82,8 +83,8 @@ pub type VM {
   whileLoopCond: ir.Instruction[]? = None
   curFnName: String = ""
 
-  pub func evalIR(intermediateRepresentation: ir.IR): VmValue {
-    val vm = VM(ir: intermediateRepresentation)
+  pub func evalIR(intermediateRepresentation: ir.IR, programArgs: String[]): VmValue {
+    val vm = VM(ir: intermediateRepresentation, args: programArgs)
     vm.initGlobals()
     vm.evalFunctionCall(intermediateRepresentation.mainFunction, [])
   }
@@ -629,6 +630,16 @@ pub type VM {
       }
       Operation.Builtin(ret, builtin) => {
         match builtin {
+          Builtin.Argc => {
+            self.store(self.expectAssignee(inst), VmValue.Int(self.args.length))
+          }
+          Builtin.Argv => {
+            val argv = Pointer.malloc<VmValue>(self.args.length)
+            for arg, idx in self.args {
+              argv.storeAt(VmValue.Pointer(arg._buffer), idx)
+            }
+            self.store(self.expectAssignee(inst), VmValue.Pointer(Pointer.reinterpret(argv)))
+          }
           Builtin.Malloc(count, itemTy) => {
             val countVal = self.irValueToVmValue(count).expectInt("Builtin.Malloc count")
             val v = match ret {
@@ -644,6 +655,13 @@ pub type VM {
             }
             self.store(self.expectAssignee(inst), v)
           }
+          Builtin.Null => {
+            self.store(self.expectAssignee(inst), VmValue.Pointer(Pointer.null()))
+          }
+          Builtin.IsNull(ptr) => {
+            val ptrVal = self.irValueToVmValue(ptr).expectPointer("Builtin.IsNull ptr")
+            self.store(self.expectAssignee(inst), VmValue.Bool(ptrVal.isNullPtr()))
+          }
           Builtin.Realloc(ptr, count, itemTy) => {
             val ptrVal = self.irValueToVmValue(ptr).expectPointer("Builtin.Realloc ptr")
             val countVal = self.irValueToVmValue(count).expectInt("Builtin.Realloc count")
@@ -651,6 +669,10 @@ pub type VM {
             val numBytes = countVal * itemSize
             val res = ptrVal.realloc(numBytes)
             self.store(self.expectAssignee(inst), VmValue.Pointer(res))
+          }
+          Builtin.PointerAddress(ptr) => {
+            val ptrVal = self.irValueToVmValue(ptr).expectPointer("Builtin.PointerAddress ptr")
+            self.store(self.expectAssignee(inst), VmValue.Int(ptrVal.address()))
           }
           Builtin.Store(ptr, value, offset, itemTy) => {
             val pointer = self.irValueToVmValue(ptr).expectPointer("Builtin.Store ptr")
@@ -722,6 +744,7 @@ pub type VM {
               IrType.Unit => unreachable("values cannot be of type unit")
               IrType.Byte => dstVal.copyFrom(dstOffsetVal, srcVal, srcOffsetVal, sizeVal)
               IrType.I64 => dstVal.copyFrom(dstOffsetVal * 8, srcVal, srcOffsetVal * 8, sizeVal * 8)
+              IrType.Composite => dstVal.copyFrom(dstOffsetVal * 8, srcVal, srcOffsetVal * 8, sizeVal * 8)
               else v => todo("CopyFrom: $v")
             }
           }
@@ -776,6 +799,8 @@ pub type VM {
     match name {
       "write" => self.externWrite(args)
       "rand" => self.externRand(args)
+      "strlen" => self.externStrlen(args)
+      "getenv" => self.externGetenv(args)
       else => {
         if self.externs[name] |fn| {
           self.returnValue = fn(args)
@@ -786,7 +811,7 @@ pub type VM {
     }
   }
 
-  pub func externWrite(self, args: VmValue[]) {
+  func externWrite(self, args: VmValue[]) {
     val arg0 = try args[0] else unreachable("write(fd: Int, buf: Pointer<Byte>, count: Int)")
     val fd = arg0.expectInt("externWrite fd")
 
@@ -800,8 +825,24 @@ pub type VM {
     self.returnValue = VmValue.Int(res)
   }
 
-  pub func externRand(self, args: VmValue[]) {
+  func externRand(self, args: VmValue[]) {
     val res = libc.rand()
     self.returnValue = VmValue.Int(res)
+  }
+
+  func externStrlen(self, args: VmValue[]) {
+    val arg0 = try args[0] else unreachable("strlen(buf: Pointer<Byte>)")
+    val strPtr = arg0.expectPointer("externStrlen strPtr")
+
+    val res = libc.strlen(strPtr)
+    self.returnValue = VmValue.Int(res)
+  }
+
+  func externGetenv(self, args: VmValue[]) {
+    val arg0 = try args[0] else unreachable("getenv(name: Pointer<Byte>)")
+    val strPtr = arg0.expectPointer("externGetenv strPtr")
+
+    val res = libc.getenv(strPtr)
+    self.returnValue = VmValue.Pointer(res)
   }
 }

--- a/projects/compiler/src/ir_vm.test.abra
+++ b/projects/compiler/src/ir_vm.test.abra
@@ -74,12 +74,7 @@ func main() {
     }
 
     val ir = Generator.generateIR(project, foldConstants: true)
-    VM.evalIR(ir)
-
-    // val fn = try ir.functions.find(f => f.name.endsWith("shout")) else unreachable()
-    // val res = VM(ir: ir).evalFunctionCall(fn, [])
-    // val str = try unmarshallString(res) else |e| unreachable(e)
-    // stdoutWriteln(str)
+    VM.evalIR(ir, args[1:])
   } else {
     stdoutWriteln("Missing required argument <file-name>")
     process.exit(1)

--- a/projects/compiler/test/run-tests.js
+++ b/projects/compiler/test/run-tests.js
@@ -865,7 +865,7 @@ const IR_COMPILER_TESTS = [
   { test: "compiler/match.abra" },
   { test: "compiler/try_result.abra" },
   { test: "compiler/try_option.abra" },
-  // { test: "compiler/process.abra", args: ['-f', 'bar', '--baz', 'qux'], env: { FOO: 'bar' } },
+  { test: "compiler/process.abra", args: ['-f', 'bar', '--baz', 'qux'], env: { FOO: 'bar' } },
   // { test: "compiler/process_callstack.abra" },
   { test: "compiler/json.abra" },
 ]

--- a/projects/compiler/test/test-runner.js
+++ b/projects/compiler/test/test-runner.js
@@ -81,7 +81,7 @@ class TestRunner {
         await runCommand(compilerBin, [testFilePath, testName])
         return runCommand('node', [`${process.cwd()}/._abra/${testName}_harness.mjs`, ...args], env)
       } else if (target === 'vm') {
-        return runCommand(compilerBin, [testFilePath])
+        return runCommand(compilerBin, [testFilePath, ...args], env)
       } else if (target === 'native') {
         await runCommand('abra', ['build', '-o', testName, testFilePath], { COMPILER_BIN: compilerBin })
         return runCommand(`${process.cwd()}/._abra/${testName}`, args, env)


### PR DESCRIPTION
There were a handful of builtins that needed to be implemented across the IR compilation targets in order to unlock this test suite. Additionally, there were a handful of bugs that I caught along the way. There were some bugs that I fixed along the way, and I also realized that I hadn't updated the html-based js runtime harness in a while.