### PR TITLE
Handling `noreturn` better

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -1,21 +1,14 @@
-// func foo<T>(fn: (Int) => Result<T, String>): Result<T[], String> {
-//   val r1 = try fn(0)
-//   val r2 = try fn(1)
+var cond = true
+// val arr = [1, 2, 3]
 
-//   Ok([r1, r2])
-// }
-
-// val res = foo(i => {
-//   if i == 0 {
-//     Result.Err("asdf")
-//   } else {
-//     Result.Ok(i)
-//   }
-// })
-// println(res)
-
-val fn1 = () => {
-  if true return Err("hello")
-
-  Ok(123)
+var y = 1 + 1
+val x = match y { //arr[0] {
+  1 => if cond {
+    123
+  } else {
+    unreachable("asdf")
+  }
+  // 1 => 123
+  else => 0
 }
+stdoutWriteln(x.toString())

--- a/projects/compiler/src/ir.abra
+++ b/projects/compiler/src/ir.abra
@@ -548,7 +548,7 @@ pub enum Operation {
           v.render(sb)
           sb.write(")")
         }
-        if !elseBlock.body.isEmpty() {
+        if !elseBlock.body.isEmpty() || !!elseBlock.result {
           sb.write(", .${elseBlock.name}")
           if elseBlock.result |v| {
             sb.write(" (")
@@ -2165,6 +2165,7 @@ pub type Generator {
     // Build the root if-operation, optimizing out None-checks and unwrapping. Subsequent cases will be nested within this
     // operation's else-block.
     var elseBlock = Block(name: "case_1", body: [], result: None, terminates: false)
+    var blockOffsetIdx = 0
     val rootOp = if noneCase |(cond, blockFn, innerConcreteType, innerIrType, binding)| {
       // Shift the None case to be first, if there is one. This allows for an optimization - if the subject value is None
       // then control flow enters the block, but if it's non-None then we can preemptively unwrap the subject value for
@@ -2194,6 +2195,8 @@ pub type Generator {
 
         return Value.Unit
       }
+
+      blockOffsetIdx = 1
 
       // If there is no None case, and the subject's type is an Option type, then we can still perform the above optimization.
       // If the subject is None then we don't need to do any of the other case evaluations and we can simply evaluate the else-case;
@@ -2231,17 +2234,12 @@ pub type Generator {
       return Value.Unit
     }
 
-    val result = if resIrType == IrType.Unit {
-      self.emit(Instruction(op: rootOp))
-      None
-    } else {
-      Some(self.ssaValue(resIrType, rootOp, dst))
-    }
-
     // Iterate through all remaining blocks to generate an if-operation for each case. Each operation takes place _within_ the body
     // of the previous if-operation's else-block.
     val prevBlock = self.curCtx.block
     for (condFn, blockFn, binding, isWildcardCase), idx in blocks {
+      if idx < blockOffsetIdx continue
+
       self.curCtx.block = (elseBlock.name, elseBlock.body)
 
       if isWildcardCase {
@@ -2249,12 +2247,9 @@ pub type Generator {
 
         val block = blockFn()
         for instr, idx in block.body {
-          if !isStatement && idx == block.body.length - 1 && !block.terminates {
-            elseBlock.result = Some(self.ssaValue(resIrType, instr.op, None))
-          } else {
-            self.emit(instr)
-          }
+          self.emit(instr)
         }
+        elseBlock.result = block.result
         elseBlock.terminates = block.terminates
       } else {
         val elseBlockNext = Block(name: "case_${idx + 2}", body: [], result: None, terminates: false)
@@ -2277,7 +2272,12 @@ pub type Generator {
     }
     self.curCtx.block = prevBlock
 
-    result ?: Value.Unit
+    if resIrType == IrType.Unit {
+      self.emit(Instruction(op: rootOp))
+      Value.Unit
+    } else {
+      self.ssaValue(resIrType, rootOp, dst)
+    }
   }
 
   func genExpression(self, node: tc.TypedAstNode, concreteGenerics: Map<String, ConcreteType>, dst: String? = None): Value {
@@ -2349,8 +2349,16 @@ pub type Generator {
         val ifBody = self.withinBlock("then", !!ifBlockTerminator, () => {
           if condBinding |binding| self.genConditionBinding(concreteGenerics, optInnerTy, condBindingVal, binding)
           for node, idx in ifBlock {
-            if idx == ifBlock.length - 1 && !ifBlockTerminator {
-              return Some(self.genExpression(node, concreteGenerics))
+            if idx == ifBlock.length - 1 {
+              val terminator = try ifBlockTerminator else {
+                return Some(self.genExpression(node, concreteGenerics))
+              }
+
+              self.genStatement(node, concreteGenerics)
+              if terminator == tc.Terminator.Halting {
+                self.emit(Instruction(op: Operation.Unreachable("halt")))
+              }
+              return None
             } else {
               self.genStatement(node, concreteGenerics)
             }
@@ -2360,8 +2368,16 @@ pub type Generator {
         })
         val elseBody = self.withinBlock("else", !!elseBlockTerminator, () => {
           for node, idx in elseBlock {
-            if idx == elseBlock.length - 1 && !elseBlockTerminator {
-              return Some(self.genExpression(node, concreteGenerics))
+            if idx == elseBlock.length - 1 {
+              val terminator = try elseBlockTerminator else {
+                return Some(self.genExpression(node, concreteGenerics))
+              }
+
+              self.genStatement(node, concreteGenerics)
+              if terminator == tc.Terminator.Halting {
+                self.emit(Instruction(op: Operation.Unreachable("halt")))
+              }
+              return None
             } else {
               self.genStatement(node, concreteGenerics)
             }

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -187,14 +187,24 @@ pub type Variable {
 pub enum Terminator {
   Returning
   NonReturning
+  Halting
+
+  func returns(self): Bool = self != Terminator.NonReturning
 
   func combine(t1: Terminator?, t2: Terminator?): Terminator? {
-    if t1 == Some(Terminator.Returning) && t2 == Some(Terminator.Returning) {
+    val term1 = try t1 else return None
+    val term2 = try t2 else return None
+
+    if term1 == Terminator.Returning && term2 == Terminator.Returning {
       Some(Terminator.Returning)
-    } else if (t1 == Some(Terminator.NonReturning) && !!t2) || (t2 == Some(Terminator.NonReturning) && !!t1) {
-      Some(Terminator.NonReturning)
+    } else if term1 == Terminator.Returning && term2 == Terminator.Halting {
+      Some(Terminator.Returning)
+    } else if term1 == Terminator.Halting && term2 == Terminator.Returning {
+      Some(Terminator.Returning)
+    } else if term1 == Terminator.Halting && term2 == Terminator.Halting {
+      Some(Terminator.Halting)
     } else {
-      None
+      Some(Terminator.NonReturning)
     }
   }
 }
@@ -2873,7 +2883,8 @@ pub type Typechecker {
     }
 
     for node, idx in body {
-      if self.currentScope.terminator == Some(Terminator.Returning) return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
+      val cannotContinue = self.currentScope.terminator?.returns() ?: false
+      if cannotContinue return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
       val typedNode = if idx == body.length - 1 && hasReturnValue {
         val fnName = if fn.isLambda None else Some(fn.label.name)
@@ -4121,7 +4132,7 @@ pub type Typechecker {
     val terminator = self.currentScope.terminator
 
     self.currentScope = prevScope
-    if terminator == Some(Terminator.Returning) {
+    if terminator?.returns() ?: false {
       self.currentScope.terminator = terminator
     }
 
@@ -4217,7 +4228,7 @@ pub type Typechecker {
     val terminator = self.currentScope.terminator
 
     self.currentScope = prevScope
-    if terminator == Some(Terminator.Returning) {
+    if terminator?.returns() ?: false {
       self.currentScope.terminator = terminator
     }
 
@@ -4320,7 +4331,8 @@ pub type Typechecker {
 
     val typedIfBlock: TypedAstNode[] = []
     for node, idx in ifBlock {
-      if self.currentScope.terminator == Some(Terminator.Returning) return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
+      val cannotContinue = self.currentScope.terminator?.returns() ?: false
+      if cannotContinue return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
       if idx == ifBlock.length - 1 && !isStatement {
         val typedNode = try self._typecheckExpressionOrTerminator(node, typeHint)
@@ -4340,7 +4352,8 @@ pub type Typechecker {
     if elseBlock |elseBlock| {
       hasElseBlock = true
       for node, idx in elseBlock {
-        if self.currentScope.terminator == Some(Terminator.Returning) return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
+        val cannotContinue = self.currentScope.terminator?.returns() ?: false
+        if cannotContinue return Err(TypeError(position: node.token.position, kind: TypeErrorKind.UnreachableCode))
 
         if idx == elseBlock.length - 1 && !isStatement {
           val hint = if ifType |t| (if t.hasUnfilledHoles() None else ifType) else None

--- a/projects/compiler/test/compiler/match.abra
+++ b/projects/compiler/test/compiler/match.abra
@@ -60,6 +60,14 @@ if true {
     }
   }
 
+  var v = 1
+  val i = match v {
+    1 => 1
+    else => 0
+  }
+  /// Expect: i: 1
+  println("i: $i")
+
   // TODO: remove this, lambda is unhappy to have a for-loop be the last statement for some reason
   /// Expect: done
   println("done")

--- a/projects/compiler/test/run-tests.js
+++ b/projects/compiler/test/run-tests.js
@@ -746,6 +746,10 @@ const TYPECHECKER_TESTS = [
   { test: "typechecker/decorators/error_unlabeled_args.abra", assertions: "typechecker/decorators/error_unlabeled_args.out" },
   { test: "typechecker/decorators/function_decorator.abra", assertions: "typechecker/decorators/function_decorator.out.json" },
 
+  // Non-returns
+  { test: "typechecker/noreturn/error_unreachable_stmt.abra", assertions: "typechecker/noreturn/error_unreachable_stmt.out" },
+  { test: "typechecker/noreturn/unreachable.abra", assertions: "typechecker/noreturn/unreachable.out.json" },
+
   // Returns
   { test: "typechecker/return/return.1.abra", assertions: "typechecker/return/return.1.out.json" },
   { test: "typechecker/return/return.2.abra", assertions: "typechecker/return/return.2.out.json" },

--- a/projects/compiler/test/typechecker/noreturn/error_unreachable_stmt.abra
+++ b/projects/compiler/test/typechecker/noreturn/error_unreachable_stmt.abra
@@ -1,0 +1,5 @@
+func foo() {
+  unreachable("a")
+
+  val a = 1
+}

--- a/projects/compiler/test/typechecker/noreturn/error_unreachable_stmt.out
+++ b/projects/compiler/test/typechecker/noreturn/error_unreachable_stmt.out
@@ -1,0 +1,5 @@
+Error at %TEST_DIR%/typechecker/noreturn/error_unreachable_stmt.abra:4:3
+Unreachable code
+  |    val a = 1
+       ^
+Control flow exits before this code is reached

--- a/projects/compiler/test/typechecker/noreturn/unreachable.abra
+++ b/projects/compiler/test/typechecker/noreturn/unreachable.abra
@@ -1,0 +1,6 @@
+val x = if true {
+  1
+} else {
+  unreachable("asdf")
+}
+val _: Int = x

--- a/projects/compiler/test/typechecker/noreturn/unreachable.out.json
+++ b/projects/compiler/test/typechecker/noreturn/unreachable.out.json
@@ -1,0 +1,188 @@
+{
+  "id": 6,
+  "name": "%TEST_DIR%/typechecker/noreturn/unreachable.abra",
+  "code": [
+    {
+      "token": {
+        "position": [1, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "x", "position": [1, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "x", "position": [1, 5] },
+            "mutable": false,
+            "type": {
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [1, 9],
+            "kind": {
+              "name": "If"
+            }
+          },
+          "type": {
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "if",
+            "isStatement": false,
+            "condition": {
+              "token": {
+                "position": [1, 12],
+                "kind": {
+                  "name": "Bool",
+                  "value": true
+                }
+              },
+              "type": {
+                "kind": "primitive",
+                "primitive": "Bool"
+              },
+              "node": {
+                "kind": "literal",
+                "value": true
+              }
+            },
+            "conditionBindingPattern": null,
+            "ifBlock": [
+              {
+                "token": {
+                  "position": [2, 3],
+                  "kind": {
+                    "name": "Int",
+                    "value": 1
+                  }
+                },
+                "type": {
+                  "kind": "primitive",
+                  "primitive": "Int"
+                },
+                "node": {
+                  "kind": "literal",
+                  "value": 1
+                }
+              }
+            ],
+            "elseBlock": [
+              {
+                "token": {
+                  "position": [4, 14],
+                  "kind": {
+                    "name": "LParen"
+                  }
+                },
+                "type": {
+                  "kind": "never"
+                },
+                "node": {
+                  "kind": "invocation",
+                  "invokee": {
+                    "function": "unreachable",
+                    "type": {
+                      "kind": "function",
+                      "parameters": [
+                        {
+                          "required": false,
+                          "type": {
+                            "kind": "primitive",
+                            "primitive": "String"
+                          }
+                        }
+                      ],
+                      "returnType": {
+                        "kind": "primitive",
+                        "primitive": "Unit"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "token": {
+                        "position": [4, 15],
+                        "kind": {
+                          "name": "String",
+                          "value": "asdf"
+                        }
+                      },
+                      "type": {
+                        "kind": "primitive",
+                        "primitive": "String"
+                      },
+                      "node": {
+                        "kind": "literal",
+                        "value": "asdf"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "token": {
+        "position": [6, 1],
+        "kind": {
+          "name": "Val"
+        }
+      },
+      "type": {
+        "kind": "primitive",
+        "primitive": "Unit"
+      },
+      "node": {
+        "kind": "bindingDeclaration",
+        "pattern": {
+          "kind": "variable",
+          "label": { "name": "_", "position": [6, 5] }
+        },
+        "variables": [
+          {
+            "label": { "name": "_", "position": [6, 5] },
+            "mutable": false,
+            "type": {
+              "kind": "primitive",
+              "primitive": "Int"
+            }
+          }
+        ],
+        "expr": {
+          "token": {
+            "position": [6, 14],
+            "kind": {
+              "name": "Ident",
+              "value": "x"
+            }
+          },
+          "type": {
+            "kind": "primitive",
+            "primitive": "Int"
+          },
+          "node": {
+            "kind": "identifier",
+            "name": "x"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
When compiling IR for if-operations which contain `noreturn` expressions (eg. `unreachable()`, `libc.exit`, etc) ensure phi instructions are generated properly.