### PR TITLE
Cleanup for the `Pointer` intrinsic

### DIFF
--- a/projects/compiler/src/compiler.abra
+++ b/projects/compiler/src/compiler.abra
@@ -2726,24 +2726,6 @@ pub type Compiler {
       "pointer_null" => {
         try self._currentFn.block.buildAdd(Value.Int(0), Value.Int(0)) else |e| return qbeError(e)
       }
-      "pointer_reinterpret" => {
-        val ptr = self._intrinsicArgs1(intrinsicFnName, arguments)
-        val ptrVal = try self._compileExpression(ptr)
-
-        try self._currentFn.block.buildAdd(Value.Int(0), ptrVal) else |e| return qbeError(e)
-      }
-      "pointer_addressof" => {
-        val ptr = self._intrinsicArgs1(intrinsicFnName, arguments)
-        val ptrVal = try self._compileExpression(ptr)
-
-        try self._currentFn.block.buildAdd(Value.Int(0), ptrVal) else |e| return qbeError(e)
-      }
-      "pointer_fromint" => {
-        val ptr = self._intrinsicArgs1(intrinsicFnName, arguments)
-        val ptrVal = try self._compileExpression(ptr)
-
-        try self._currentFn.block.buildAdd(Value.Int(0), ptrVal) else |e| return qbeError(e)
-      }
       "pointer_realloc" => {
         val (ptr, count) = self._intrinsicArgs2(intrinsicFnName, arguments)
         val ptrVal = try self._compileExpression(ptr)
@@ -2911,12 +2893,6 @@ pub type Compiler {
       }
       "functionnames" => {
         try self._currentFn.block.buildAdd(Value.Int(0), self._fnNamesPtr) else |e| return qbeError(e)
-      }
-      "pointer_address" => {
-        val arg = self._intrinsicArgs1(intrinsicFnName, arguments)
-        val argVal = try self._compileExpression(arg)
-
-        try self._currentFn.block.buildAdd(Value.Int(0), argVal) else |e| return qbeError(e)
       }
       _ => unreachable("unsupported intrinsic '$intrinsicFnName'")
     }

--- a/projects/compiler/src/ir.abra
+++ b/projects/compiler/src/ir.abra
@@ -186,7 +186,6 @@ pub enum Builtin {
   Null
   IsNull(ptr: Value)
   Realloc(ptr: Value, count: Value, itemTy: IrType? = None)
-  PointerAddress(ptr: Value),
   Store(ptr: Value, value: Value, offset: Value, itemTy: IrType)
   Load(ptr: Value, offset: Value, itemTy: IrType)
   CopyFrom(dst: Value, dstOffset: Value, src: Value, srcOffset: Value, size: Value, itemTy: IrType)
@@ -726,11 +725,6 @@ pub enum Operation {
               sb.write(", ")
               ty.render(sb)
             }
-          }
-          Builtin.PointerAddress(ptr) => {
-            sb.write("ptr_address, ")
-            ptr.render(sb)
-            sb.write(", ")
           }
           Builtin.Store(ptr, value, offset, itemTy) => {
             sb.write("ptr_store, ")
@@ -3057,14 +3051,6 @@ pub type Generator {
             "pointer_null" => {
               self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.Ptr, builtin: Builtin.Null), dst)
             }
-            "pointer_reinterpret" => {
-              val ptr = self.intrinsicArgs1("pointer_reinterpret", args)
-              self.genExpression(ptr, innerConcreteGenerics, dst)
-            }
-            "pointer_addressof" => {
-              val ptr = self.intrinsicArgs1("pointer_addressof", args)
-              self.genExpression(ptr, innerConcreteGenerics, dst)
-            }
             "byte_from_int" => {
               val arg = self.intrinsicArgs1("byte_from_int", args)
               self.genExpression(arg, innerConcreteGenerics, dst)
@@ -3169,11 +3155,6 @@ pub type Generator {
               val countVal = self.genExpression(count, innerConcreteGenerics)
 
               self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.Ptr, builtin: Builtin.Realloc(ptr: ptrVal, count: countVal, itemTy: Some(itemTy))), dst)
-            }
-            "pointer_address" => {
-              val ptrVal = self.genExpression(selfVal, concreteGenerics)
-
-              self.ssaValue(IrType.Ptr, Operation.Builtin(ret: IrType.Ptr, builtin: Builtin.PointerAddress(ptr: ptrVal)), dst)
             }
             "pointer_store_at" => {
               val ptrVal = self.genExpression(selfVal, concreteGenerics)

--- a/projects/compiler/src/ir_compiler.abra
+++ b/projects/compiler/src/ir_compiler.abra
@@ -923,10 +923,6 @@ pub type Compiler {
 
             self.callRealloc(ptrVal, sizeVal, dst)
           }
-          Builtin.PointerAddress(ptr) => {
-            val ptrVal = self.irValueToQbeValue(ptr)
-            self.currentFn.block.buildCopy(ptrVal, dst)
-          }
           Builtin.Store(ptr, value, offset, itemTy) => {
             val ptrVal = self.irValueToQbeValue(ptr)
             val valueVal = self.irValueToQbeValue(value)

--- a/projects/compiler/src/ir_compiler_js.abra
+++ b/projects/compiler/src/ir_compiler_js.abra
@@ -564,10 +564,6 @@ pub type Compiler {
             self.emitIrValueToJsValue(ptr)
             self.sb.writeln("; // realloc (no-op)")
           }
-          Builtin.PointerAddress => {
-            // this is sort of meaningless for a js target
-            todo("Builtin.PointerAddress")
-          }
           Builtin.Store(ptr, value, offset, _) => {
             self.emitIrValueToJsValue(ptr)
             self.sb.write("[")

--- a/projects/compiler/src/ir_vm.abra
+++ b/projects/compiler/src/ir_vm.abra
@@ -696,9 +696,6 @@ pub type VM {
             }
             self.store(self.expectAssignee(inst), VmValue.Pointer(res))
           }
-          Builtin.PointerAddress(ptr) => {
-            unreachable("pointer_address deprecated")
-          }
           Builtin.Store(ptr, value, offset, itemTy) => {
             val (buffer, isNull) = self.irValueToVmValue(ptr).expectPointer("Builtin.Store ptr")
             if isNull unreachable("Builtin.Store ptr is null")

--- a/projects/std/src/_intrinsics.abra
+++ b/projects/std/src/_intrinsics.abra
@@ -60,31 +60,17 @@ pub type Pointer<T> {
   @intrinsic("pointer_null")
   pub func null<T>(): Pointer<T>
 
-  @intrinsic("pointer_reinterpret")
-  pub func reinterpret<T, U>(orig: Pointer<T>): Pointer<U>
-
-  @intrinsic("pointer_addressof")
-  pub func addressOf<T>(obj: T): Pointer<Byte>
-
-  @intrinsic("pointer_fromint")
-  pub func fromInt<T>(int: Int): Pointer<T>
-
   @intrinsic("pointer_is_null")
   pub func isNullPtr(self): Bool
 
   @intrinsic("pointer_realloc")
   pub func realloc(self, count: Int): Pointer<T>
 
-  @intrinsic("pointer_address")
-  pub func address(self): Int
-
   @intrinsic("pointer_store_at")
   pub func storeAt(self, value: T, offset: Int)
 
   @intrinsic("pointer_load_at")
   pub func loadAt(self, offset: Int): T
-
-  pub func deref(self): T = self.loadAt(offset: 0)
 
   @intrinsic("pointer_copy_from")
   pub func copyFrom(self, dstOffset: Int, srcPtr: Pointer<T>, srcOffset: Int, size: Int)


### PR DESCRIPTION
There were a bunch of methods that I had added to the `Pointer` intrinsic type to support the VM, back when the representation of a `VmValue.Pointer` actually used a raw pointer. Now that that Pointer representation no longer uses raw pointers, we don't need these low-level methods.