### PR TITLE
Using `#import` special identifier in macros

### DIFF
--- a/projects/compiler/example.abra
+++ b/projects/compiler/example.abra
@@ -8,4 +8,4 @@ val x = #import("libc").STDOUT_FILENO
 println(x)
 
 val n = #import("libc").rand()
-println(n)
+debug(n)

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -5861,10 +5861,7 @@ pub type Typechecker {
           if colStart <= invokeePosition.col && invokeePosition.col <= colEnd {
             match ident.kind {
               IdentifierKindMeta.Function(_, params, _, _) => {
-                val imports = injectedCode.imports.entries()
-                  .map(_i => "import \"${_i[0]}\" as ${_i[1]}")
-                  .join("\n")
-                ident.kind = IdentifierKindMeta.Macro(params, "$imports\n\n$contents")
+                ident.kind = IdentifierKindMeta.Macro(params, contents)
               }
             }
             break

--- a/projects/std/src/prelude.abra
+++ b/projects/std/src/prelude.abra
@@ -1525,17 +1525,14 @@ pub func todo(message = "") {
 
 @macro
 pub func debug(value: Expr): InjectedCode {
-  val c = InjectedCode.new()
-  val libcMod = c.addImport("libc")
-
-  c
+  InjectedCode.new()
     .appendln("(if true {")
     .append("  val dbg = \"").appendExpr(value).appendln(" = \"")
-    .appendln("  $libcMod.write($libcMod.STDOUT_FILENO, dbg._buffer, dbg.length)")
+    .appendln("  #import(\"libc\").write(#import(\"libc\").STDOUT_FILENO, dbg._buffer, dbg.length)")
     .append("  val exp = ").appendExprln(value)
     .appendln("  val str = exp.toString()")
-    .appendln("  $libcMod.write($libcMod.STDOUT_FILENO, str._buffer, str.length)")
-    .appendln("  $libcMod.write($libcMod.STDOUT_FILENO, \"\\n\"._buffer, 1)")
+    .appendln("  #import(\"libc\").write(#import(\"libc\").STDOUT_FILENO, str._buffer, str.length)")
+    .appendln("  #import(\"libc\").write(#import(\"libc\").STDOUT_FILENO, \"\\n\"._buffer, 1)")
     .appendln("  exp")
     .appendln("} else { unreachable(\"will get optimized away\") })")
 }
@@ -1543,18 +1540,16 @@ pub func debug(value: Expr): InjectedCode {
 @macro
 pub func println(*values: Expr[]): InjectedCode {
   val c = InjectedCode.new()
-  val libcMod = c.addImport("libc")
-
   c.appendln("if true {")
   for value, idx in values {
     val isLast = idx == values.length - 1
 
     c.append("  val _${idx} = (").appendExpr(value).appendln(").toString()")
-    c.appendln("  $libcMod.write($libcMod.STDOUT_FILENO, _${idx}._buffer, _${idx}.length)")
+    c.appendln("  #import(\"libc\").write(#import(\"libc\").STDOUT_FILENO, _${idx}._buffer, _${idx}.length)")
     if isLast {
-      c.appendln("  $libcMod.write($libcMod.STDOUT_FILENO, \"\\n\"._buffer, 1)")
+      c.appendln("  #import(\"libc\").write(#import(\"libc\").STDOUT_FILENO, \"\\n\"._buffer, 1)")
     } else {
-      c.appendln("  $libcMod.write($libcMod.STDOUT_FILENO, \" \"._buffer, 1)")
+      c.appendln("  #import(\"libc\").write(#import(\"libc\").STDOUT_FILENO, \" \"._buffer, 1)")
     }
   }
 


### PR DESCRIPTION
Rather than having some hacky mechanism for injecting imports, macros can just use the `#import` special identifier to refer to modules' exports directly. This avoids unnecesary pollution of the top-level namespace with junk identifiers, and also reduced the likelihood of collisions (which has happened before, resulting in flaky tests!).