### PR TITLE
Cleaning up macros

### DIFF
--- a/projects/compiler/src/comptime_evaluator.abra
+++ b/projects/compiler/src/comptime_evaluator.abra
@@ -446,29 +446,5 @@ func unmarshallInjectedCode(value: VmValue): Result<InjectedCode, String> {
     chunks.push(chunk)
   }
 
-  val imports: Map<String, String> = {}
-  val importsValue = instance.expectField(1).expectInstance("InjectedCode imports is Map<String, String>")
-  val importsSize = importsValue.expectField(0).expectInt("Map field 0 is size")
-  if importsSize != 0 {
-    val importsEntries = importsValue.expectField(1).expectInstance("Map field 1 is _entries (MapEntry<String, String>[])")
-    val importsEntriesLength = importsEntries.expectField(0).expectInt("Array field 0 is length")
-    val (importsEntriesItems, _) = importsEntries.expectField(1).expectPointer("Array field 1 is buffer")
-    for i in 0:importsEntriesLength {
-      var next = try importsEntriesItems[i] else unreachable("chunks should be of size $importsEntriesLength but was actually ${importsEntriesItems.length}")
-
-      while next != VmValue.OptionNone {
-        val entry = next.expectInstance("MapEntry is instance")
-        val entryIsEmpty = entry.expectField(3).expectBool("MapEntry field 3 is _empty")
-        if entryIsEmpty break
-
-        val entryKey = try unmarshallString(entry.expectField(0))
-        val entryValue = try unmarshallString(entry.expectField(1))
-        imports[entryKey] = entryValue
-
-        next = entry.expectField(2)
-      }
-    }
-  }
-
-  Ok(InjectedCode(chunks: chunks, imports: imports))
+  Ok(InjectedCode(chunks: chunks))
 }

--- a/projects/compiler/src/typechecker.abra
+++ b/projects/compiler/src/typechecker.abra
@@ -5879,14 +5879,6 @@ pub type Typechecker {
       self.addTypeError(TypeError(position: token.position, kind: kind))
       return TypedAstNode(token: token, ty: Type(kind: TypeKind.CouldNotDetermine), kind: TypedAstNodeKind.Placeholder)
     }
-
-    for (mod, alias) in injectedCode.imports {
-      parsedModule.imports.push(ImportNode(
-        token: Token(position: Position(line: -1, col: -1), kind: TokenKind.Import),
-        kind: ImportKind.Alias(Label(name: alias, position: Position(line: -1, col: -1))),
-        moduleName: Label(name: mod, position: Position(line: -1, col: -1)),
-      ))
-    }
     val imports = try self.typecheckDeclarationsInImportedModules(None, parsedModule) else |position| {
       val kind = TypeErrorKind.ErrorWithinMacroOutput(macroName: fn.label.name, generatedContents: contents, innerError: ErrorWithinMacroOutputKind.TypeError(TypeError(position: position, kind: TypeErrorKind.CircularDependency)))
       self.addTypeError(TypeError(position: token.position, kind: kind))

--- a/projects/std/src/meta.abra
+++ b/projects/std/src/meta.abra
@@ -2,17 +2,8 @@ pub decorator macro { }
 
 pub type InjectedCode {
   pub chunks: String[] = []
-  pub imports: Map<String, String> = {}
 
   pub func new(): InjectedCode = InjectedCode()
-
-  pub func addImport(self, module: String): String {
-    if self.imports[module] |alias| return alias
-
-    val alias = "__imp_${module}_${String.random(4)}__"
-    self.imports[module] = alias
-    alias
-  }
 
   pub func append(self, str: String): InjectedCode {
     self.chunks.push(str)


### PR DESCRIPTION
Now that macros use the `#import` special identifier, the InjectedCode no longer needs to track imports, and the typechecker no longer needs to do weird logic to process imports added in this way.